### PR TITLE
   1. Changed the coverage job to use skipITs (instead of skipITs=fal…

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "MAVEN_ARGS=${{ env.MAVEN_ARGS_BUILD }}" >> $GITHUB_ENV
 
       - name: Full clean install (framework + examples)
-        run: ./mvnw $MAVEN_ARGS clean install -DskipITs=false -DskipNative=true -Dquarkus.container-image.build=false
+        run: ./mvnw $MAVEN_ARGS clean install -DskipITs=true -DskipNative=true -Dquarkus.container-image.build=false
 
   ##################################################################
   # 1.5) Generate aggregate JaCoCo coverage report
@@ -59,8 +59,8 @@ jobs:
 
       - name: Generate JaCoCo aggregate report
         run: |
-          # Build with coverage profile enabled to collect coverage data
-          ./mvnw $MAVEN_ARGS clean verify -Pcoverage -DskipITs=false -DskipNative=true
+          # Build with coverage profile enabled to collect coverage data from unit tests only
+          ./mvnw $MAVEN_ARGS clean verify -Pcoverage -DskipITs -DskipNative=true
 
           # Generate an aggregated report (this will aggregate across all modules that produced coverage data)
           ./mvnw $MAVEN_ARGS org.jacoco:jacoco-maven-plugin:report-aggregate


### PR DESCRIPTION
… so that integration tests don't run during the

      coverage collection phase
   2. This ensures that coverage data comes only from unit tests (Surefire) as per the TESTING.md guidelines
   3. Integration tests will still run in the dedicated integration-tests job where Docker images are built and available
   4. This maintains the efficiency of the workflow without incurring unnecessary build times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration workflow now skips integration tests during the build and installation process.
  * Code coverage metrics are now calculated from unit tests only, providing more focused coverage analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->