### PR TITLE
Linux CI enforces host file permissions on bind mounts, my local setu…

### DIFF
--- a/examples/csv-payments/output-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsOutputFileService.java
+++ b/examples/csv-payments/output-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsOutputFileService.java
@@ -129,16 +129,16 @@ public class ProcessCsvPaymentsOutputFileService
 
                                       return Uni.createFrom().item(file);
                                   } catch (IOException e) {
-                                      logger.errorf("Failed to create output file: %s", inputFile, e);
+                                      logger.errorf(e, "Failed to create output file: %s", inputFile);
                                       return Uni.createFrom().nullItem();
                                   } catch (CsvDataTypeMismatchException e) {
-                                      logger.errorf("CSV data type mismatch: %s", inputFile, e);
+                                      logger.errorf(e, "CSV data type mismatch: %s", inputFile);
                                       return Uni.createFrom().nullItem();
                                   } catch (CsvRequiredFieldEmptyException e) {
-                                      logger.errorf("A required field is empty: %s", inputFile, e);
+                                      logger.errorf(e, "A required field is empty: %s", inputFile);
                                       return Uni.createFrom().nullItem();
                                   } catch (Exception e) {
-                                      logger.errorf("Failed to write output file: %s", inputFile, e);
+                                      logger.errorf(e, "Failed to write output file: %s", inputFile);
                                       return Uni.createFrom().nullItem();
                                   }
                               });


### PR DESCRIPTION
…p didn’t.

On macOS (Docker Desktop/OrbStack), bind mounts are permissive and UID/GID mapping is “fuzzy,” so a container running as user 1001 can still read files owned by your host user even if they’re not world‑readable. On GitHub Actions (Linux), the bind mount preserves real POSIX perms. The keystores were created 600 (or similar), owned by the runner user, and the container user 1001 got AccessDenied.

So it’s not Jib vs non‑Jib per se — it’s host filesystem semantics. Making the certs 644 (or doing a chown to match container UID) fixes it reliably across CI. And the same applies to writing CSV output files to the output folder, which is this particular fix.