### PR TITLE
Fix local side-effect bean generation across deployment roles

### DIFF
--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -1104,6 +1104,9 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
      */
     private org.pipelineframework.processor.ir.DeploymentRole resolveClientRole(
             org.pipelineframework.processor.ir.DeploymentRole serverRole) {
+        if (serverRole == null) {
+            return org.pipelineframework.processor.ir.DeploymentRole.ORCHESTRATOR_CLIENT;
+        }
         return switch (serverRole) {
             case PLUGIN_SERVER -> org.pipelineframework.processor.ir.DeploymentRole.PLUGIN_CLIENT;
             case PIPELINE_SERVER -> org.pipelineframework.processor.ir.DeploymentRole.ORCHESTRATOR_CLIENT;

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineGenerationPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineGenerationPhaseTest.java
@@ -110,4 +110,16 @@ class PipelineGenerationPhaseTest {
         String outer = (String) method.invoke(phase, descriptor);
         assertEquals("Baz", outer);
     }
+
+    @Test
+    void resolveClientRoleDefaultsToOrchestratorClientWhenNull() throws Exception {
+        PipelineGenerationPhase phase = new PipelineGenerationPhase();
+        java.lang.reflect.Method method = PipelineGenerationPhase.class.getDeclaredMethod(
+            "resolveClientRole",
+            org.pipelineframework.processor.ir.DeploymentRole.class);
+        method.setAccessible(true);
+
+        Object role = method.invoke(phase, new Object[]{null});
+        assertEquals(org.pipelineframework.processor.ir.DeploymentRole.ORCHESTRATOR_CLIENT, role);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broadened side-effect bean generation so it applies in more deployment scenarios and no longer limited by prior role checks.
  * Side-effect creation now respects the model's deployment role when present, improving alignment with actual deployment needs.

* **Bug Fix**
  * Handle missing/undefined client role gracefully by defaulting to the orchestrator client role.

* **Tests**
  * Added unit test covering null client-role resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->