### PR TITLE
Harden csv pipeline-runtime E2E timeout handling

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -123,7 +123,7 @@ jobs:
           ./mvnw "${maven_args[@]}" -f examples/csv-payments/pom.pipeline-runtime.xml \
             -pl orchestrator-svc \
             -Dcsv.runtime.layout=pipeline-runtime \
-            -Dcsv.e2e.pipeline.wait.seconds=120 \
+            -Dcsv.e2e.pipeline.wait.seconds=240 \
             -Dtest=PipelineRuntimeTopologyTest \
             -Dit.test=CsvPaymentsPipelineRuntimeEndToEndIT \
             verify

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -75,7 +75,7 @@ abstract class AbstractCsvPaymentsEndToEnd {
     private static final long ORCHESTRATOR_WAIT_TIMEOUT_SECONDS =
             Long.getLong("csv.e2e.orchestrator.wait.seconds", 300L);
     private static final long PIPELINE_WAIT_TIMEOUT_SECONDS =
-            Long.getLong("csv.e2e.pipeline.wait.seconds", 120L);
+            resolvePipelineWaitTimeoutSeconds();
     private static final long PIPELINE_WAIT_POLL_MILLIS = 1000L;
     private static final String PIPELINE_RUNTIME_IMAGE = resolvePipelineRuntimeImage();
 
@@ -87,6 +87,14 @@ abstract class AbstractCsvPaymentsEndToEnd {
     static GenericContainer<?> paymentStatusService;
     static GenericContainer<?> outputCsvService;
     static GenericContainer<?> pipelineRuntimeService;
+
+    private static long resolvePipelineWaitTimeoutSeconds() {
+        long configured = Long.getLong("csv.e2e.pipeline.wait.seconds", 120L);
+        if (PIPELINE_RUNTIME_LAYOUT) {
+            return Math.max(configured, 240L);
+        }
+        return configured;
+    }
 
     private static String resolvePipelineRuntimeImage() {
         String explicitImage = System.getenv("PIPELINE_RUNTIME_IMAGE");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Increased end-to-end test timeout window to improve test reliability and reduce false failures due to timing constraints.

* **Chores**
  * Updated CI/CD pipeline configuration to align with extended test timing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->