### PR TITLE
Harden csv pipeline-runtime IT and add failure diagnostics

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -168,8 +168,14 @@ jobs:
         run: |
           echo "=== Failsafe reports ==="
           find . -path "*/target/failsafe-reports/*.txt" -print -exec tail -n 200 {} \;
+          echo "=== Failsafe dumpstreams ==="
+          find . -path "*/target/failsafe-reports/*.dumpstream" -print -exec tail -n 400 {} \;
+          echo "=== Failsafe dumps ==="
+          find . -path "*/target/failsafe-reports/*.dump" -print -exec tail -n 200 {} \;
           echo "=== Surefire reports ==="
           find . -path "*/target/surefire-reports/*.txt" -print -exec tail -n 200 {} \;
+          echo "=== csv-payments test-e2e directories ==="
+          find examples/csv-payments -type d -path "*/target/test-e2e" -print -exec sh -c 'ls -la "$1"' _ {} \;
 
       - name: Upload test reports on failure
         if: failure()
@@ -181,6 +187,9 @@ jobs:
             **/target/surefire-reports/*.xml
             **/target/failsafe-reports/*.txt
             **/target/failsafe-reports/*.xml
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+            examples/csv-payments/**/target/test-e2e/**
           retention-days: 7
           if-no-files-found: warn
 


### PR DESCRIPTION
## Summary
- enforce a higher minimum wait window for pipeline-runtime E2E in the IT harness
- align CI pipeline-runtime lane timeout to 240s
- add deep timeout diagnostics in AbstractCsvPaymentsEndToEnd (test-e2e dir snapshot + container log tails)
- expand workflow failure dump/upload to include failsafe dumpstream/dump and test-e2e artifacts

## Why
The pipeline-runtime E2E occasionally times out in CI with no .out files. This PR both reduces false negatives from slow startup and adds actionable diagnostics for any remaining intermittent failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced end-to-end test diagnostics with detailed timeout logging, including container logs and test directory snapshots.

* **Chores**
  * Updated CI/CD workflows to capture and report additional test artifacts on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->