### PR TITLE
Queue GA PR1: transport-native async parity (gRPC/function) + docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -105,6 +105,7 @@ const mainSidebar = [
         text: 'Operate',
         collapsed: true,
         items: [
+            {text: 'Orchestrator Runtime Modes', link: '/guide/development/orchestrator-runtime'},
             {text: 'Error Handling & DLQ', link: '/guide/operations/error-handling'},
             {text: 'In-flight Probe', link: '/guide/operations/in-flight-probe'},
             {text: 'Operators', link: '/guide/operations/operators'},
@@ -189,6 +190,7 @@ const mainSidebar = [
             {text: 'Testing Guidelines', link: '/guide/evolve/testing-guidelines'},
             {text: 'Gotchas & Pitfalls', link: '/guide/evolve/gotchas-pitfalls'},
             {text: 'Proto Descriptor Integration', link: '/guide/evolve/protobuf-integration-descriptor-res'},
+            {text: 'Protobuf-over-HTTP Dispatch Design', link: '/guide/evolve/protobuf-over-http-dispatch-design'},
             {
                 text: 'Aspects',
                 collapsed: true,

--- a/docs/guide/build/configuration/index.md
+++ b/docs/guide/build/configuration/index.md
@@ -181,6 +181,34 @@ Prefix: `pipeline`
 | `pipeline.parallelism`     | string  | `AUTO`  | Parallelism policy: `SEQUENTIAL`, `AUTO`, or `PARALLEL`.    |
 | `pipeline.max-concurrency` | integer | `128`   | Per-step maximum in-flight items when parallel execution is enabled. |
 
+### Orchestrator Queue-Async
+
+Prefix: `pipeline.orchestrator`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `pipeline.orchestrator.mode` | enum | `SYNC` | Orchestrator mode (`SYNC`, `QUEUE_ASYNC`). |
+| `pipeline.orchestrator.default-tenant` | string | `default` | Fallback tenant when caller omits tenant id. |
+| `pipeline.orchestrator.execution-ttl-days` | int | `7` | Execution state retention in days. |
+| `pipeline.orchestrator.lease-ms` | long | `30000` | Lease duration for claimed executions. |
+| `pipeline.orchestrator.max-retries` | int | `3` | Max execution-level retries before terminal failure. |
+| `pipeline.orchestrator.retry-delay` | duration | `PT10S` | Base retry delay. |
+| `pipeline.orchestrator.retry-multiplier` | double | `2.0` | Retry backoff multiplier. |
+| `pipeline.orchestrator.sweep-interval` | duration | `PT30S` | Interval for due-execution sweep/re-dispatch. |
+| `pipeline.orchestrator.sweep-limit` | int | `100` | Max due executions swept per pass. |
+| `pipeline.orchestrator.idempotency-policy` | enum | `OPTIONAL_CLIENT_KEY` | `OPTIONAL_CLIENT_KEY`, `CLIENT_KEY_REQUIRED`, `SERVER_KEY_ONLY`. |
+| `pipeline.orchestrator.state-provider` | string | `memory` | `ExecutionStateStore` provider selector. |
+| `pipeline.orchestrator.dispatcher-provider` | string | `event` | `WorkDispatcher` provider selector. |
+| `pipeline.orchestrator.dlq-provider` | string | `log` | `DeadLetterPublisher` provider selector. |
+| `pipeline.orchestrator.queue-url` | string | none | Queue URL for external dispatcher providers. |
+| `pipeline.orchestrator.strict-startup` | boolean | `true` | Fail startup if queue mode prerequisites are invalid. |
+
+Queue mode notes:
+
+1. `QUEUE_ASYNC` rejects async streaming output for this milestone.
+2. Keep `strict-startup=true` in production so invalid provider wiring fails fast.
+3. In-memory providers are for local/dev only; use durable providers for HA.
+
 ### Telemetry
 
 Prefix: `pipeline.telemetry`

--- a/docs/guide/development/orchestrator-runtime.md
+++ b/docs/guide/development/orchestrator-runtime.md
@@ -1,44 +1,65 @@
 # Orchestrator Runtime
 
-The Pipeline Framework generates a single orchestrator runtime that coordinates the pipeline flow. It provisions inputs, invokes step clients, and handles the final outputs.
+The orchestrator runtime coordinates step execution for a pipeline and exposes generated transport entrypoints.
 
-<Callout type="tip" title="Canvas First">
-Configure the orchestrator flow in the Canvas at <a href="https://app.pipelineframework.org" target="_blank">https://app.pipelineframework.org</a>, then customize the generated runtime as needed.
-</Callout>
+## Runtime Modes
 
-## What It Does
+TPF supports two orchestrator runtime modes:
 
-1. Initiates pipeline execution
-2. Provides input data
-3. Coordinates step-to-step flow
-4. Handles final outputs
+1. `SYNC` (default): in-process request/response execution.
+2. `QUEUE_ASYNC`: queue-driven async job execution with durable execution state providers.
+
+Set mode with:
+
+```properties
+pipeline.orchestrator.mode=SYNC
+# or
+pipeline.orchestrator.mode=QUEUE_ASYNC
+```
+
+## Transport Surfaces
+
+Generated orchestrator endpoints are transport-native:
+
+1. REST:
+   - `POST /pipeline/run`
+   - `POST /pipeline/run-async`
+   - `GET /pipeline/executions/{executionId}`
+   - `GET /pipeline/executions/{executionId}/result`
+   - `POST /pipeline/ingest`
+   - `GET /pipeline/subscribe`
+2. gRPC:
+   - `Run`
+   - `RunAsync`
+   - `GetExecutionStatus`
+   - `GetExecutionResult`
+   - `Ingest`
+   - `Subscribe`
+3. Function/Lambda:
+   - `PipelineRunFunctionHandler`
+   - `PipelineRunAsyncFunctionHandler`
+   - `PipelineExecutionStatusFunctionHandler`
+   - `PipelineExecutionResultFunctionHandler`
+
+## Queue-Async Semantics
+
+In `QUEUE_ASYNC` mode:
+
+1. committed execution state transitions are exactly-once (OCC/conditional-write guarded),
+2. dispatch and operator invocation are at-least-once,
+3. duplicate invocation can occur and must be handled with idempotency keys,
+4. streaming outputs are rejected for async execution in this milestone.
 
 ## Generated Structure
 
 ```text
 orchestrator-svc/
-├── pom.xml
-├── src/main/java/
-│   └── com/example/app/orchestrator/
-│       └── OrchestratorApplication.java
-└── src/main/resources/
-    └── application.properties
+├── src/main/java/<base>/orchestrator/service/
+│   ├── PipelineRunResource.java
+│   ├── OrchestratorGrpcService.java
+│   ├── PipelineRunFunctionHandler.java
+│   ├── PipelineRunAsyncFunctionHandler.java
+│   ├── PipelineExecutionStatusFunctionHandler.java
+│   └── PipelineExecutionResultFunctionHandler.java
+└── src/main/resources/application.properties
 ```
-
-The generated `OrchestratorApplication` is annotated with `@PipelineOrchestrator` so the annotation processor
-can generate the server endpoint (REST or gRPC, based on `pipeline-config.yaml`) at compile time.
-
-## Input Options
-
-The generated runtime supports several ways to specify input:
-
-1. **CLI argument**: `-i` / `--input`
-2. **Environment variable**: `PIPELINE_INPUT`
-3. **Quarkus config**: `quarkus.pipeline.input`
-4. **System property**: `-Dquarkus.pipeline.input=/path`
-
-The CLI argument takes precedence, followed by environment variable and config sources.
-
-## Customizing Input
-
-Implement the `getInputMulti()` stub in the generated `OrchestratorApplication` to map inputs to domain types and feed the pipeline.

--- a/docs/guide/evolve/architecture.md
+++ b/docs/guide/evolve/architecture.md
@@ -6,6 +6,17 @@ The Pipeline Framework is designed as a modular, extensible system for building 
 
 - [Annotation Processor Guide](/guide/evolve/annotation-processor/): Deep dive into build-time phases, IR, bindings, and renderers
 
+## Orchestrator Control Plane (Current)
+
+Current GA direction is a queue-driven async control plane with:
+
+1. transport-native async contracts (REST/gRPC/function),
+2. optimistic concurrency + lease-claim state transitions,
+3. due-execution sweep/re-dispatch recovery,
+4. at-least-once dispatch/operator invocation semantics.
+
+This is intentionally not a full event-sourced runtime in the current milestone.
+
 ## Core Concepts
 
 ### Pipeline

--- a/docs/guide/evolve/protobuf-over-http-dispatch-design.md
+++ b/docs/guide/evolve/protobuf-over-http-dispatch-design.md
@@ -3,6 +3,12 @@
 ## Scope
 This document defines orchestrator-side dispatch changes required to make Protobuf-over-HTTP replay-safe under at-least-once delivery and multi-instance deployments.
 
+Status in current GA track:
+
+1. Contract parity is being aligned across REST, gRPC, Function, and Protobuf-over-HTTP.
+2. Async control-plane semantics are shared across transports (same transition identity and retry model).
+3. Event-sourced dispatch journaling remains a future evolution path, not a GA blocker.
+
 ## Dispatch Metadata Generation
 For every outbound dispatch, orchestrator must emit:
 - `x-tpf-correlation-id`

--- a/docs/guide/operations/error-handling.md
+++ b/docs/guide/operations/error-handling.md
@@ -95,6 +95,23 @@ Best practices:
 
 The Pipeline Framework provides comprehensive error handling with multiple recovery strategies.
 
+### Queue-Async Crash Matrix
+
+For `pipeline.orchestrator.mode=QUEUE_ASYNC`, crash behavior is:
+
+| Crash point | Behavior after restart/recovery | Duplicate risk | Required safeguard |
+|---|---|---|---|
+| Before transition state persist | Work is redelivered and re-executed | High | Idempotent operator boundary (`executionId:stepIndex:attempt`) |
+| After persist, before next dispatch | Execution can stall until sweeper re-dispatches | Low | Due-execution sweeper + durable state |
+| During retry scheduling | Retry may be replayed from last durable version | Medium | Persist retry intent before enqueue |
+| Worker dies while lease held | Lease expiry allows takeover | Low | Short leases + conditional lease claim |
+
+Semantics summary:
+
+1. Execution state commit is atomic (conditional write).
+2. External side effects are at-least-once.
+3. Duplicate operator invocation is expected under failure and must be idempotent.
+
 ### Retry Mechanisms
 
 Built-in retry with exponential backoff:

--- a/docs/guide/operations/observability/alerting.md
+++ b/docs/guide/operations/observability/alerting.md
@@ -32,4 +32,11 @@ Start with:
 3. Buffer queued stays high for 5 minutes (warning)
 4. DLQ growth sustained for 5 minutes (critical)
 
+Queue-async additions:
+
+5. Due-sweeper recoveries stop while due backlog rises (critical)
+6. Lease conflict/stale-commit rate spikes above baseline (warning)
+7. Retry-saturation exceeds threshold (warning/critical by tenant tier)
+8. Queue age/lag exceeds execution SLO budget (critical)
+
 When using New Relic, derive these from `tpf.pipeline.run` spans and `tpf.step.*` metrics.

--- a/docs/guide/operations/observability/metrics.md
+++ b/docs/guide/operations/observability/metrics.md
@@ -94,6 +94,19 @@ Counter success = registry.counter("payment.processing.success");
 return timer.recordCallable(() -> processPayment(record));
 ```
 
+## Orchestrator Queue-Async Signals
+
+For `QUEUE_ASYNC`, include control-plane metrics in addition to step metrics:
+
+1. lease claim conflicts (OCC contention),
+2. stale commit rejections,
+3. retry scheduling rate and retry-saturation ratio,
+4. due-sweeper recovery count (persisted-before-dispatch gap recovery),
+5. DLQ publish count and backlog depth,
+6. queue depth and worker lag.
+
+Use these to separate dependency outages (high retries, low success) from coordination issues (high stale/lease conflicts).
+
 ## Design Tips
 
 1. Prefer low-cardinality labels

--- a/docs/guide/operations/operators-playbook.md
+++ b/docs/guide/operations/operators-playbook.md
@@ -84,12 +84,29 @@ FTGo reference command paths:
 
 ## Recovery Playbook
 
+### Queue-Async execution triage (`QUEUE_ASYNC`)
+
+Use this flow when orchestrator async executions stall or fail:
+
+1. Check execution status via transport-native status API (`/executions/{id}` or `GetExecutionStatus`).
+2. Confirm whether status is `WAIT_RETRY`, `FAILED`, or `DLQ`.
+3. Inspect latest retry attempt and error classification.
+4. If execution is due but not progressing, verify sweeper activity and dispatcher health.
+5. Re-drive only after validating idempotency at downstream operator boundaries.
+
 ### Retry exhaustion
 
 1. Identify the failing step and failure type (transient vs non-retryable).
 2. Confirm whether the failure is dependency/systemic or payload/data specific.
 3. If systemic: stabilise dependency first, then replay.
 4. If data-specific: isolate failing payloads and route to DLQ (Dead Letter Queue)/parking investigation.
+
+### DLQ re-drive guidance
+
+1. Treat DLQ payloads as at-least-once replays.
+2. Preserve the original transition identity when replaying.
+3. Re-drive in bounded batches and monitor duplicate suppression metrics/logs.
+4. Do not bulk replay until downstream idempotency controls are validated.
 
 ### Parking growth
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -497,6 +497,15 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
                     roleMetadataGenerator.recordClassWithRole(
                         OrchestratorFunctionHandlerRenderer.handlerFqcn(binding.basePackage()),
                         role.name());
+                    roleMetadataGenerator.recordClassWithRole(
+                        OrchestratorFunctionHandlerRenderer.runAsyncHandlerFqcn(binding.basePackage()),
+                        role.name());
+                    roleMetadataGenerator.recordClassWithRole(
+                        OrchestratorFunctionHandlerRenderer.statusHandlerFqcn(binding.basePackage()),
+                        role.name());
+                    roleMetadataGenerator.recordClassWithRole(
+                        OrchestratorFunctionHandlerRenderer.resultHandlerFqcn(binding.basePackage()),
+                        role.name());
                 }
             } else if (!local) {
                 org.pipelineframework.processor.ir.DeploymentRole role = org.pipelineframework.processor.ir.DeploymentRole.PIPELINE_SERVER;

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRenderer.java
@@ -24,6 +24,11 @@ import org.pipelineframework.processor.ir.OrchestratorBinding;
 public class OrchestratorFunctionHandlerRenderer implements PipelineRenderer<OrchestratorBinding> {
 
     public static final String HANDLER_CLASS = "PipelineRunFunctionHandler";
+    public static final String RUN_ASYNC_HANDLER_CLASS = "PipelineRunAsyncFunctionHandler";
+    public static final String STATUS_HANDLER_CLASS = "PipelineExecutionStatusFunctionHandler";
+    public static final String RESULT_HANDLER_CLASS = "PipelineExecutionResultFunctionHandler";
+    private static final String RUN_ASYNC_REQUEST_CLASS = "PipelineRunAsyncRequest";
+    private static final String EXECUTION_LOOKUP_REQUEST_CLASS = "PipelineExecutionLookupRequest";
     private static final String API_VERSION = "v1";
     private static final String ORCHESTRATOR_PREFIX = "orchestrator.";
     private static final String UNKNOWN_REQUEST = "unknown-request";
@@ -86,6 +91,36 @@ public class OrchestratorFunctionHandlerRenderer implements PipelineRenderer<Orc
      */
     public static String handlerFqcn(String basePackage) {
         return basePackage + ".orchestrator.service." + HANDLER_CLASS;
+    }
+
+    /**
+     * Resolve fully-qualified async run function handler class name for a base package.
+     *
+     * @param basePackage base package
+     * @return generated handler FQCN
+     */
+    public static String runAsyncHandlerFqcn(String basePackage) {
+        return basePackage + ".orchestrator.service." + RUN_ASYNC_HANDLER_CLASS;
+    }
+
+    /**
+     * Resolve fully-qualified execution status function handler class name for a base package.
+     *
+     * @param basePackage base package
+     * @return generated handler FQCN
+     */
+    public static String statusHandlerFqcn(String basePackage) {
+        return basePackage + ".orchestrator.service." + STATUS_HANDLER_CLASS;
+    }
+
+    /**
+     * Resolve fully-qualified execution result function handler class name for a base package.
+     *
+     * @param basePackage base package
+     * @return generated handler FQCN
+     */
+    public static String resultHandlerFqcn(String basePackage) {
+        return basePackage + ".orchestrator.service." + RESULT_HANDLER_CLASS;
     }
 
     /**
@@ -205,6 +240,166 @@ public class OrchestratorFunctionHandlerRenderer implements PipelineRenderer<Orc
         handler.addMethod(handleRequest);
 
         JavaFile.builder(binding.basePackage() + ".orchestrator.service", handler.build())
+            .build()
+            .writeTo(ctx.outputDir());
+
+        renderAsyncHandlers(binding, ctx, inputDto, outputDto, streamingInput, streamingOutput);
+    }
+
+    private void renderAsyncHandlers(
+        OrchestratorBinding binding,
+        GenerationContext ctx,
+        ClassName inputDto,
+        ClassName outputDto,
+        boolean streamingInput,
+        boolean streamingOutput
+    ) throws IOException {
+        ClassName executionService = ClassName.get("org.pipelineframework", "PipelineExecutionService");
+        ClassName runAsyncAcceptedDto = ClassName.get("org.pipelineframework.orchestrator.dto", "RunAsyncAcceptedDto");
+        ClassName executionStatusDto = ClassName.get("org.pipelineframework.orchestrator.dto", "ExecutionStatusDto");
+        ClassName list = ClassName.get(List.class);
+        TypeName runAsyncRequestType =
+            ClassName.get(binding.basePackage() + ".orchestrator.service", RUN_ASYNC_REQUEST_CLASS);
+        TypeName executionLookupRequestType =
+            ClassName.get(binding.basePackage() + ".orchestrator.service", EXECUTION_LOOKUP_REQUEST_CLASS);
+        TypeName asyncResultType = streamingOutput
+            ? ParameterizedTypeName.get(list, outputDto)
+            : outputDto;
+
+        TypeSpec runAsyncRequest = TypeSpec.classBuilder(RUN_ASYNC_REQUEST_CLASS)
+            .addModifiers(Modifier.PUBLIC)
+            .addField(FieldSpec.builder(inputDto, "input", Modifier.PUBLIC).build())
+            .addField(FieldSpec.builder(ParameterizedTypeName.get(list, inputDto), "inputBatch", Modifier.PUBLIC).build())
+            .addField(FieldSpec.builder(String.class, "tenantId", Modifier.PUBLIC).build())
+            .addField(FieldSpec.builder(String.class, "idempotencyKey", Modifier.PUBLIC).build())
+            .build();
+        TypeSpec executionLookupRequest = TypeSpec.classBuilder(EXECUTION_LOOKUP_REQUEST_CLASS)
+            .addModifiers(Modifier.PUBLIC)
+            .addField(FieldSpec.builder(String.class, "tenantId", Modifier.PUBLIC).build())
+            .addField(FieldSpec.builder(String.class, "executionId", Modifier.PUBLIC).build())
+            .build();
+
+        MethodSpec runAsyncHandleRequest = MethodSpec.methodBuilder("handleRequest")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(runAsyncAcceptedDto)
+            .addParameter(runAsyncRequestType, "request")
+            .addParameter(LAMBDA_CONTEXT, "context")
+            .addStatement("$T executionInput", Object.class)
+            .beginControlFlow("if ($L)", streamingInput)
+            .beginControlFlow("if (request != null && request.inputBatch != null && !request.inputBatch.isEmpty())")
+            .addStatement("executionInput = $T.createFrom().iterable(request.inputBatch)", MULTI)
+            .nextControlFlow("else if (request != null && request.input != null)")
+            .addStatement("executionInput = $T.createFrom().item(request.input)", MULTI)
+            .nextControlFlow("else")
+            .addStatement("executionInput = $T.createFrom().empty()", MULTI)
+            .endControlFlow()
+            .nextControlFlow("else")
+            .beginControlFlow("if (request != null && request.input != null)")
+            .addStatement("executionInput = request.input")
+            .nextControlFlow("else if (request != null && request.inputBatch != null && !request.inputBatch.isEmpty())")
+            .addStatement("executionInput = request.inputBatch.get(0)")
+            .nextControlFlow("else")
+            .addStatement("executionInput = null")
+            .endControlFlow()
+            .endControlFlow()
+            .addStatement("String tenantId = request == null ? null : request.tenantId")
+            .addStatement("String idempotencyKey = request == null ? null : request.idempotencyKey")
+            .addStatement(
+                "return pipelineExecutionService.executePipelineAsync(executionInput, tenantId, idempotencyKey, $L)"
+                    + ".await().indefinitely()",
+                streamingOutput)
+            .build();
+
+        TypeSpec runAsyncHandler = TypeSpec.classBuilder(RUN_ASYNC_HANDLER_CLASS)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(APPLICATION_SCOPED)
+            .addAnnotation(AnnotationSpec.builder(NAMED)
+                .addMember("value", "$S", RUN_ASYNC_HANDLER_CLASS)
+                .build())
+            .addAnnotation(AnnotationSpec.builder(GENERATED_ROLE)
+                .addMember("value", "$T.$L", ROLE_ENUM, "REST_SERVER")
+                .build())
+            .addSuperinterface(ParameterizedTypeName.get(REQUEST_HANDLER, runAsyncRequestType, runAsyncAcceptedDto))
+            .addField(FieldSpec.builder(executionService, "pipelineExecutionService", Modifier.PRIVATE)
+                .addAnnotation(INJECT)
+                .build())
+            .addMethod(runAsyncHandleRequest)
+            .build();
+
+        MethodSpec statusHandleRequest = MethodSpec.methodBuilder("handleRequest")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(executionStatusDto)
+            .addParameter(executionLookupRequestType, "request")
+            .addParameter(LAMBDA_CONTEXT, "context")
+            .beginControlFlow("if (request == null || request.executionId == null || request.executionId.isBlank())")
+            .addStatement("throw new $T($S)", IllegalArgumentException.class, "executionId is required")
+            .endControlFlow()
+            .addStatement("return pipelineExecutionService.getExecutionStatus(request.tenantId, request.executionId).await().indefinitely()")
+            .build();
+
+        TypeSpec statusHandler = TypeSpec.classBuilder(STATUS_HANDLER_CLASS)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(APPLICATION_SCOPED)
+            .addAnnotation(AnnotationSpec.builder(NAMED)
+                .addMember("value", "$S", STATUS_HANDLER_CLASS)
+                .build())
+            .addAnnotation(AnnotationSpec.builder(GENERATED_ROLE)
+                .addMember("value", "$T.$L", ROLE_ENUM, "REST_SERVER")
+                .build())
+            .addSuperinterface(ParameterizedTypeName.get(REQUEST_HANDLER, executionLookupRequestType, executionStatusDto))
+            .addField(FieldSpec.builder(executionService, "pipelineExecutionService", Modifier.PRIVATE)
+                .addAnnotation(INJECT)
+                .build())
+            .addMethod(statusHandleRequest)
+            .build();
+
+        MethodSpec resultHandleRequest = MethodSpec.methodBuilder("handleRequest")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(asyncResultType)
+            .addParameter(executionLookupRequestType, "request")
+            .addParameter(LAMBDA_CONTEXT, "context")
+            .beginControlFlow("if (request == null || request.executionId == null || request.executionId.isBlank())")
+            .addStatement("throw new $T($S)", IllegalArgumentException.class, "executionId is required")
+            .endControlFlow()
+            .addStatement(
+                "return pipelineExecutionService.getExecutionResult(request.tenantId, request.executionId, $T.class, $L)"
+                    + ".await().indefinitely()",
+                outputDto,
+                streamingOutput)
+            .build();
+
+        TypeSpec resultHandler = TypeSpec.classBuilder(RESULT_HANDLER_CLASS)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(APPLICATION_SCOPED)
+            .addAnnotation(AnnotationSpec.builder(NAMED)
+                .addMember("value", "$S", RESULT_HANDLER_CLASS)
+                .build())
+            .addAnnotation(AnnotationSpec.builder(GENERATED_ROLE)
+                .addMember("value", "$T.$L", ROLE_ENUM, "REST_SERVER")
+                .build())
+            .addSuperinterface(ParameterizedTypeName.get(REQUEST_HANDLER, executionLookupRequestType, asyncResultType))
+            .addField(FieldSpec.builder(executionService, "pipelineExecutionService", Modifier.PRIVATE)
+                .addAnnotation(INJECT)
+                .build())
+            .addMethod(resultHandleRequest)
+            .build();
+
+        JavaFile.builder(binding.basePackage() + ".orchestrator.service", runAsyncRequest)
+            .build()
+            .writeTo(ctx.outputDir());
+        JavaFile.builder(binding.basePackage() + ".orchestrator.service", executionLookupRequest)
+            .build()
+            .writeTo(ctx.outputDir());
+        JavaFile.builder(binding.basePackage() + ".orchestrator.service", runAsyncHandler)
+            .build()
+            .writeTo(ctx.outputDir());
+        JavaFile.builder(binding.basePackage() + ".orchestrator.service", statusHandler)
+            .build()
+            .writeTo(ctx.outputDir());
+        JavaFile.builder(binding.basePackage() + ".orchestrator.service", resultHandler)
             .build()
             .writeTo(ctx.outputDir());
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.processor.renderer;
 
 import java.io.IOException;
+import java.util.List;
 import javax.lang.model.element.Modifier;
 
 import com.google.protobuf.DescriptorProtos;
@@ -25,6 +26,11 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
     private static final String GRPC_CLASS = "OrchestratorGrpcService";
     private static final String ORCHESTRATOR_SERVICE = "OrchestratorService";
     private static final String ORCHESTRATOR_METHOD = OrchestratorRpcConstants.RUN_METHOD;
+    private static final String ORCHESTRATOR_RUN_ASYNC_METHOD = OrchestratorRpcConstants.RUN_ASYNC_METHOD;
+    private static final String ORCHESTRATOR_GET_EXECUTION_STATUS_METHOD =
+        OrchestratorRpcConstants.GET_EXECUTION_STATUS_METHOD;
+    private static final String ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD =
+        OrchestratorRpcConstants.GET_EXECUTION_RESULT_METHOD;
     private static final String ORCHESTRATOR_INGEST_METHOD = OrchestratorRpcConstants.INGEST_METHOD;
     private static final String ORCHESTRATOR_SUBSCRIBE_METHOD = OrchestratorRpcConstants.SUBSCRIBE_METHOD;
 
@@ -65,8 +71,8 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         ClassName outputBus = ClassName.get("org.pipelineframework", "PipelineOutputBus");
         ClassName pipelineContextHolder = ClassName.get("org.pipelineframework.context", "PipelineContextHolder");
 
-        OrchestratorGrpcBindingResolver resolver = new OrchestratorGrpcBindingResolver();
-        var grpcBinding = safeResolveBinding(binding, descriptorSet, ctx);
+        var grpcBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_METHOD, binding.inputStreaming(), binding.outputStreaming());
         if (grpcBinding == null) {
             return;
         }
@@ -86,6 +92,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 "Mutiny" + ORCHESTRATOR_SERVICE + "Grpc",
                 ORCHESTRATOR_SERVICE + "ImplBase");
         }
+        var runAsyncBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_RUN_ASYNC_METHOD, false, false);
+        var statusBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_GET_EXECUTION_STATUS_METHOD, false, false);
+        var resultBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD, false, false);
 
         FieldSpec executionField = FieldSpec.builder(executionService, "pipelineExecutionService", Modifier.PRIVATE)
             .addAnnotation(inject)
@@ -247,7 +259,29 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 ClassName.get("io.grpc", "Status"))
             .build();
 
-        TypeSpec service = TypeSpec.classBuilder(GRPC_CLASS)
+        MethodSpec runAsyncMethod = buildRunAsyncMethod(
+            binding,
+            typeResolver,
+            ctx,
+            runAsyncBinding,
+            inputType,
+            outputType,
+            uni,
+            multi);
+        MethodSpec executionStatusMethod = buildExecutionStatusMethod(
+            typeResolver,
+            ctx,
+            statusBinding,
+            uni);
+        MethodSpec executionResultMethod = buildExecutionResultMethod(
+            binding,
+            typeResolver,
+            ctx,
+            resultBinding,
+            outputType,
+            uni);
+
+        TypeSpec.Builder serviceBuilder = TypeSpec.classBuilder(GRPC_CLASS)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(grpcServiceAnnotation)
             .superclass(implBase)
@@ -255,8 +289,18 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .addField(outputBusField)
             .addMethod(runMethod.build())
             .addMethod(ingestMethod)
-            .addMethod(subscribeMethod)
-            .build();
+            .addMethod(subscribeMethod);
+        if (runAsyncMethod != null) {
+            serviceBuilder.addMethod(runAsyncMethod);
+        }
+        if (executionStatusMethod != null) {
+            serviceBuilder.addMethod(executionStatusMethod);
+        }
+        if (executionResultMethod != null) {
+            serviceBuilder.addMethod(executionResultMethod);
+        }
+
+        TypeSpec service = serviceBuilder.build();
 
         JavaFile.builder(binding.basePackage() + ".orchestrator.service", service)
             .build()
@@ -266,15 +310,18 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
     private org.pipelineframework.processor.ir.GrpcBinding safeResolveBinding(
         OrchestratorBinding binding,
         DescriptorProtos.FileDescriptorSet descriptorSet,
-        GenerationContext ctx
+        GenerationContext ctx,
+        String methodName,
+        boolean inputStreaming,
+        boolean outputStreaming
     ) {
         try {
             return new OrchestratorGrpcBindingResolver().resolve(
                 binding.model(),
                 descriptorSet,
-                ORCHESTRATOR_METHOD,
-                binding.inputStreaming(),
-                binding.outputStreaming(),
+                methodName,
+                inputStreaming,
+                outputStreaming,
                 ctx.processingEnv().getMessager());
         } catch (IllegalStateException e) {
             ctx.processingEnv().getMessager().printMessage(
@@ -282,5 +329,230 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 "Skipping orchestrator gRPC generation: " + e.getMessage());
             return null;
         }
+    }
+
+    private MethodSpec buildRunAsyncMethod(
+        OrchestratorBinding binding,
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding runAsyncBinding,
+        ClassName inputType,
+        ClassName outputType,
+        ClassName uni,
+        ClassName multi
+    ) {
+        if (runAsyncBinding == null) {
+            return null;
+        }
+        var asyncTypes = typeResolver.resolve(runAsyncBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = asyncTypes.grpcParameterType();
+        ClassName responseType = asyncTypes.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+        MethodSpec.Builder method = MethodSpec.methodBuilder("runAsync")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()");
+
+        if (binding.inputStreaming()) {
+            method.addCode("""
+                $T asyncInput = request.getInputBatchCount() > 0
+                    ? $T.createFrom().iterable(request.getInputBatchList())
+                    : $T.createFrom().item(request.getInput());
+                return pipelineExecutionService.executePipelineAsync(
+                        asyncInput,
+                        request.getTenantId(),
+                        request.getIdempotencyKey(),
+                        $L)
+                    .onItem().transform(accepted -> $T.newBuilder()
+                        .setExecutionId(accepted.executionId())
+                        .setDuplicate(accepted.duplicate())
+                        .setStatusUrl(accepted.statusUrl() == null ? $S : accepted.statusUrl())
+                        .setAcceptedAtEpochMs(accepted.submittedAtEpochMs())
+                        .build())
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                Object.class,
+                multi,
+                multi,
+                binding.outputStreaming(),
+                responseType,
+                "",
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_RUN_ASYNC_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_RUN_ASYNC_METHOD,
+                ClassName.get("io.grpc", "Status"));
+        } else {
+            method.addCode("""
+                $T asyncInput = request.getInputBatchCount() > 0 ? request.getInputBatch(0) : request.getInput();
+                return pipelineExecutionService.executePipelineAsync(
+                        asyncInput,
+                        request.getTenantId(),
+                        request.getIdempotencyKey(),
+                        $L)
+                    .onItem().transform(accepted -> $T.newBuilder()
+                        .setExecutionId(accepted.executionId())
+                        .setDuplicate(accepted.duplicate())
+                        .setStatusUrl(accepted.statusUrl() == null ? $S : accepted.statusUrl())
+                        .setAcceptedAtEpochMs(accepted.submittedAtEpochMs())
+                        .build())
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                Object.class,
+                binding.outputStreaming(),
+                responseType,
+                "",
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_RUN_ASYNC_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_RUN_ASYNC_METHOD,
+                ClassName.get("io.grpc", "Status"));
+        }
+
+        return method.build();
+    }
+
+    private MethodSpec buildExecutionStatusMethod(
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding statusBinding,
+        ClassName uni
+    ) {
+        if (statusBinding == null) {
+            return null;
+        }
+        var statusTypes = typeResolver.resolve(statusBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = statusTypes.grpcParameterType();
+        ClassName responseType = statusTypes.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+
+        return MethodSpec.methodBuilder("getExecutionStatus")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()")
+            .addCode("""
+                return pipelineExecutionService.getExecutionStatus(request.getTenantId(), request.getExecutionId())
+                    .onItem().transform(status -> $T.newBuilder()
+                        .setExecutionId(status.executionId())
+                        .setStatus(status.status().name())
+                        .setCurrentStepIndex(status.stepIndex())
+                        .setAttempt(status.attempt())
+                        .setVersion(status.version())
+                        .setNextDueEpochMs(status.nextDueAtEpochMs())
+                        .setUpdatedAtEpochMs(status.updatedAtEpochMs())
+                        .setErrorCode(status.errorCode() == null ? $S : status.errorCode())
+                        .setErrorMessage(status.errorMessage() == null ? $S : status.errorMessage())
+                        .build())
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                responseType,
+                "",
+                "",
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_GET_EXECUTION_STATUS_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_GET_EXECUTION_STATUS_METHOD,
+                ClassName.get("io.grpc", "Status"))
+            .build();
+    }
+
+    private MethodSpec buildExecutionResultMethod(
+        OrchestratorBinding binding,
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding resultBinding,
+        ClassName outputType,
+        ClassName uni
+    ) {
+        if (resultBinding == null) {
+            return null;
+        }
+        var resultTypes = typeResolver.resolve(resultBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = resultTypes.grpcParameterType();
+        ClassName responseType = resultTypes.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+
+        MethodSpec.Builder method = MethodSpec.methodBuilder("getExecutionResult")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()");
+
+        if (binding.outputStreaming()) {
+            TypeName outputListType = ParameterizedTypeName.get(ClassName.get(List.class), outputType);
+            method.addCode("""
+                return pipelineExecutionService.<$T>getExecutionResult(
+                        request.getTenantId(), request.getExecutionId(), $T.class, true)
+                    .onItem().transform(items -> $T.newBuilder().addAllItems(items).build())
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                outputListType,
+                outputType,
+                responseType,
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD,
+                ClassName.get("io.grpc", "Status"));
+        } else {
+            method.addCode("""
+                return pipelineExecutionService.<$T>getExecutionResult(
+                        request.getTenantId(), request.getExecutionId(), $T.class, false)
+                    .onItem().transform(result -> {
+                        $T.Builder builder = $T.newBuilder();
+                        if (result != null) {
+                            builder.addItems(result);
+                        }
+                        return builder.build();
+                    })
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                outputType,
+                outputType,
+                responseType,
+                responseType,
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD,
+                ClassName.get("io.grpc", "Status"));
+        }
+        return method.build();
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorGrpcBindingResolver.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorGrpcBindingResolver.java
@@ -15,6 +15,9 @@ import org.pipelineframework.processor.ir.PipelineStepModel;
 public class OrchestratorGrpcBindingResolver {
     private static final Set<String> ALLOWED_METHODS = Set.of(
         OrchestratorRpcConstants.RUN_METHOD,
+        OrchestratorRpcConstants.RUN_ASYNC_METHOD,
+        OrchestratorRpcConstants.GET_EXECUTION_STATUS_METHOD,
+        OrchestratorRpcConstants.GET_EXECUTION_RESULT_METHOD,
         OrchestratorRpcConstants.INGEST_METHOD,
         OrchestratorRpcConstants.SUBSCRIBE_METHOD);
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorRpcConstants.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorRpcConstants.java
@@ -12,6 +12,9 @@ public final class OrchestratorRpcConstants {
     }
 
     public static final String RUN_METHOD = "Run";
+    public static final String RUN_ASYNC_METHOD = "RunAsync";
+    public static final String GET_EXECUTION_STATUS_METHOD = "GetExecutionStatus";
+    public static final String GET_EXECUTION_RESULT_METHOD = "GetExecutionResult";
     public static final String INGEST_METHOD = "Ingest";
     public static final String SUBSCRIBE_METHOD = "Subscribe";
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRendererTest.java
@@ -100,6 +100,32 @@ class OrchestratorFunctionHandlerRendererTest {
             () -> "expected FunctionTransportBridge.invokeManyToMany invocation missing. source:\n" + source);
     }
 
+    @Test
+    void rendersAsyncFunctionHandlers() throws IOException {
+        renderAndReadSource(buildBinding());
+
+        Path runAsyncPath = tempDir.resolve("com/example/orchestrator/service/PipelineRunAsyncFunctionHandler.java");
+        Path statusPath = tempDir.resolve("com/example/orchestrator/service/PipelineExecutionStatusFunctionHandler.java");
+        Path resultPath = tempDir.resolve("com/example/orchestrator/service/PipelineExecutionResultFunctionHandler.java");
+        Path runAsyncRequestPath = tempDir.resolve("com/example/orchestrator/service/PipelineRunAsyncRequest.java");
+        Path lookupRequestPath = tempDir.resolve("com/example/orchestrator/service/PipelineExecutionLookupRequest.java");
+
+        assertTrue(Files.exists(runAsyncPath));
+        assertTrue(Files.exists(statusPath));
+        assertTrue(Files.exists(resultPath));
+        assertTrue(Files.exists(runAsyncRequestPath));
+        assertTrue(Files.exists(lookupRequestPath));
+
+        String runAsyncSource = Files.readString(runAsyncPath);
+        String statusSource = Files.readString(statusPath);
+        String resultSource = Files.readString(resultPath);
+        assertTrue(runAsyncSource.contains("implements RequestHandler<PipelineRunAsyncRequest, RunAsyncAcceptedDto>"));
+        assertTrue(runAsyncSource.contains("pipelineExecutionService.executePipelineAsync"));
+        assertTrue(statusSource.contains("implements RequestHandler<PipelineExecutionLookupRequest, ExecutionStatusDto>"));
+        assertTrue(statusSource.contains("pipelineExecutionService.getExecutionStatus"));
+        assertTrue(resultSource.contains("pipelineExecutionService.getExecutionResult"));
+    }
+
     private String renderAndReadSource(OrchestratorBinding binding) throws IOException {
         ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
         when(processingEnv.getFiler()).thenReturn(new TestFiler(tempDir));

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRendererTest.java
@@ -39,6 +39,10 @@ class OrchestratorGrpcRendererTest {
         assertTrue(source.contains("extends MutinyOrchestratorServiceGrpc.OrchestratorServiceImplBase"));
         assertTrue(source.contains("public Uni<OutputType> run(InputType input)"));
         assertTrue(source.contains("executePipelineUnary"));
+        assertTrue(source.contains("public Uni<RunAsyncResponse> runAsync(RunAsyncRequest request)"));
+        assertTrue(source.contains("executePipelineAsync"));
+        assertTrue(source.contains("public Uni<GetExecutionStatusResponse> getExecutionStatus(GetExecutionStatusRequest request)"));
+        assertTrue(source.contains("public Uni<GetExecutionResultResponse> getExecutionResult(GetExecutionResultRequest request)"));
         assertTrue(source.contains("public Multi<OutputType> ingest(Multi<InputType> input)"));
         assertTrue(source.contains("public Multi<OutputType> subscribe("));
         assertTrue(source.contains("pipelineOutputBus"));
@@ -61,6 +65,8 @@ class OrchestratorGrpcRendererTest {
 
         assertTrue(source.contains("public Multi<OutputType> run(Multi<InputType> input)"));
         assertTrue(source.contains("executePipelineStreaming"));
+        assertTrue(source.contains("public Uni<RunAsyncResponse> runAsync(RunAsyncRequest request)"));
+        assertTrue(source.contains("executePipelineAsync"));
         assertTrue(source.contains("public Multi<OutputType> ingest(Multi<InputType> input)"));
         assertTrue(source.contains("public Multi<OutputType> subscribe("));
         assertTrue(source.contains("pipelineOutputBus"));
@@ -111,6 +117,43 @@ class OrchestratorGrpcRendererTest {
                 .setName("InputType"))
             .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
                 .setName("OutputType"))
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("RunAsyncRequest")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("input")
+                    .setNumber(1)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                    .setTypeName(".com.example.grpc.InputType"))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("input_batch")
+                    .setNumber(2)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                    .setTypeName(".com.example.grpc.InputType"))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("tenant_id")
+                    .setNumber(3)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("idempotency_key")
+                    .setNumber(4)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)))
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("RunAsyncResponse"))
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GetExecutionStatusRequest"))
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GetExecutionStatusResponse"))
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GetExecutionResultRequest"))
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GetExecutionResultResponse")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("items")
+                    .setNumber(1)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                    .setTypeName(".com.example.grpc.OutputType")))
             .addService(DescriptorProtos.ServiceDescriptorProto.newBuilder()
                 .setName("OrchestratorService")
                 .addMethod(DescriptorProtos.MethodDescriptorProto.newBuilder()
@@ -125,6 +168,18 @@ class OrchestratorGrpcRendererTest {
                     .setOutputType(".com.example.grpc.OutputType")
                     .setClientStreaming(true)
                     .setServerStreaming(true))
+                .addMethod(DescriptorProtos.MethodDescriptorProto.newBuilder()
+                    .setName("RunAsync")
+                    .setInputType(".com.example.grpc.RunAsyncRequest")
+                    .setOutputType(".com.example.grpc.RunAsyncResponse"))
+                .addMethod(DescriptorProtos.MethodDescriptorProto.newBuilder()
+                    .setName("GetExecutionStatus")
+                    .setInputType(".com.example.grpc.GetExecutionStatusRequest")
+                    .setOutputType(".com.example.grpc.GetExecutionStatusResponse"))
+                .addMethod(DescriptorProtos.MethodDescriptorProto.newBuilder()
+                    .setName("GetExecutionResult")
+                    .setInputType(".com.example.grpc.GetExecutionResultRequest")
+                    .setOutputType(".com.example.grpc.GetExecutionResultResponse"))
                 .addMethod(DescriptorProtos.MethodDescriptorProto.newBuilder()
                     .setName("Subscribe")
                     .setInputType(".com.example.grpc.InputType")

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -385,6 +385,40 @@ public class PipelineProtoGenerator {
         }
         builder.append("import \"google/protobuf/empty.proto\";\n");
         builder.append('\n');
+        builder.append("message RunAsyncRequest {\n");
+        builder.append("  ").append(first.inputTypeName()).append(" input = 1;\n");
+        builder.append("  repeated ").append(first.inputTypeName()).append(" input_batch = 2;\n");
+        builder.append("  string tenant_id = 3;\n");
+        builder.append("  string idempotency_key = 4;\n");
+        builder.append("}\n\n");
+        builder.append("message RunAsyncResponse {\n");
+        builder.append("  string execution_id = 1;\n");
+        builder.append("  bool duplicate = 2;\n");
+        builder.append("  string status_url = 3;\n");
+        builder.append("  int64 accepted_at_epoch_ms = 4;\n");
+        builder.append("}\n\n");
+        builder.append("message GetExecutionStatusRequest {\n");
+        builder.append("  string tenant_id = 1;\n");
+        builder.append("  string execution_id = 2;\n");
+        builder.append("}\n\n");
+        builder.append("message GetExecutionStatusResponse {\n");
+        builder.append("  string execution_id = 1;\n");
+        builder.append("  string status = 2;\n");
+        builder.append("  int32 current_step_index = 3;\n");
+        builder.append("  int32 attempt = 4;\n");
+        builder.append("  int64 version = 5;\n");
+        builder.append("  int64 next_due_epoch_ms = 6;\n");
+        builder.append("  int64 updated_at_epoch_ms = 7;\n");
+        builder.append("  string error_code = 8;\n");
+        builder.append("  string error_message = 9;\n");
+        builder.append("}\n\n");
+        builder.append("message GetExecutionResultRequest {\n");
+        builder.append("  string tenant_id = 1;\n");
+        builder.append("  string execution_id = 2;\n");
+        builder.append("}\n\n");
+        builder.append("message GetExecutionResultResponse {\n");
+        builder.append("  repeated ").append(last.outputTypeName()).append(" items = 1;\n");
+        builder.append("}\n\n");
         builder.append("service OrchestratorService {\n");
         builder.append("  rpc Run (");
         if (shape.inputStreaming()) {
@@ -402,6 +436,11 @@ public class PipelineProtoGenerator {
             .append(") returns (stream ")
             .append(last.outputTypeName())
             .append(");\n");
+        builder.append("  rpc RunAsync (RunAsyncRequest) returns (RunAsyncResponse);\n");
+        builder.append(
+            "  rpc GetExecutionStatus (GetExecutionStatusRequest) returns (GetExecutionStatusResponse);\n");
+        builder.append(
+            "  rpc GetExecutionResult (GetExecutionResultRequest) returns (GetExecutionResultResponse);\n");
         builder.append("  rpc Subscribe (google.protobuf.Empty) returns (stream ")
             .append(last.outputTypeName())
             .append(");\n");

--- a/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
@@ -109,6 +109,17 @@ class PipelineProtoGeneratorTest {
         assertTrue(orchestratorProto.contains("service OrchestratorService"));
         assertTrue(orchestratorProto.contains("rpc Run (FooInput) returns (stream BarOutput);"));
         assertTrue(orchestratorProto.contains("rpc Ingest (stream FooInput) returns (stream BarOutput);"));
+        assertTrue(orchestratorProto.contains("message RunAsyncRequest"));
+        assertTrue(orchestratorProto.contains("message RunAsyncResponse"));
+        assertTrue(orchestratorProto.contains("message GetExecutionStatusRequest"));
+        assertTrue(orchestratorProto.contains("message GetExecutionStatusResponse"));
+        assertTrue(orchestratorProto.contains("message GetExecutionResultRequest"));
+        assertTrue(orchestratorProto.contains("message GetExecutionResultResponse"));
+        assertTrue(orchestratorProto.contains("rpc RunAsync (RunAsyncRequest) returns (RunAsyncResponse);"));
+        assertTrue(orchestratorProto.contains(
+            "rpc GetExecutionStatus (GetExecutionStatusRequest) returns (GetExecutionStatusResponse);"));
+        assertTrue(orchestratorProto.contains(
+            "rpc GetExecutionResult (GetExecutionResultRequest) returns (GetExecutionResultResponse);"));
         assertTrue(orchestratorProto.contains("rpc Subscribe (google.protobuf.Empty) returns (stream BarOutput);"));
     }
 
@@ -180,5 +191,10 @@ class PipelineProtoGeneratorTest {
         assertTrue(orchestratorProto.contains("import \"index-svc.proto\";"));
         assertTrue(orchestratorProto.contains("service OrchestratorService"));
         assertTrue(orchestratorProto.contains("rpc Run (DocInput) returns (IndexAck);"));
+        assertTrue(orchestratorProto.contains("rpc RunAsync (RunAsyncRequest) returns (RunAsyncResponse);"));
+        assertTrue(orchestratorProto.contains(
+            "rpc GetExecutionStatus (GetExecutionStatusRequest) returns (GetExecutionStatusResponse);"));
+        assertTrue(orchestratorProto.contains(
+            "rpc GetExecutionResult (GetExecutionResultRequest) returns (GetExecutionResultResponse);"));
     }
 }


### PR DESCRIPTION
## Summary\n- add native async orchestrator RPCs to generated gRPC service: , , \n- extend generated orchestrator proto contract with async request/response messages and RPCs\n- add native function handlers for async orchestration (, status, result) and register role metadata\n- align orchestrator config/operations/evolve docs for queue-async mode and crash/idempotency semantics\n\n## Validation\n- [INFO] Scanning for projects...
[INFO] Inspecting build with total of 2 modules
[INFO] Installing Central Publishing features
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] The Pipeline Framework Extension (Runtime)                         [jar]
[INFO] The Pipeline Framework Extension (Deployment)                      [jar]
[INFO] 
[INFO] --------------< org.pipelineframework:pipelineframework >---------------
[INFO] Building The Pipeline Framework Extension (Runtime) 26.2.5-SNAPSHOT [1/2]
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (prepare-agent) @ pipelineframework ---
[INFO] surefireArgLine set to -javaagent:/Users/mari/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/mari/tpf3/framework/target/jacoco.exec
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ pipelineframework ---
[INFO] Copying 3 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- flatten:1.7.3:flatten (flatten) @ pipelineframework ---
[INFO] Flatten skipped.
[INFO] 
[INFO] --- quarkus:3.31.3:generate-code (default) @ pipelineframework ---
[WARNING] [io.quarkus.deployment.CodeGenerator] The following services are not (yet) available and will be disabled during configuration initialization at the current build phase:

[INFO] 
[INFO] --- quarkus-extension:3.31.3:extension-descriptor (default) @ pipelineframework ---
[INFO] 
[INFO] --- compiler:3.14.0:compile (default-compile) @ pipelineframework ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- jandex:3.5.0:jandex (make-index) @ pipelineframework ---
[INFO] Saving Jandex index: /Users/mari/tpf3/framework/runtime/target/classes/META-INF/jandex.idx
[INFO] 
[INFO] --- quarkus:3.31.3:generate-code-tests (default) @ pipelineframework ---
[WARNING] [io.quarkus.deployment.CodeGenerator] The following services are not (yet) available and will be disabled during configuration initialization at the current build phase:

[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ pipelineframework ---
[INFO] Copying 3 resources from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ pipelineframework ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.1:test (default-test) @ pipelineframework ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.pipelineframework.proto.PipelineProtoGeneratorTest
[PipelineProtoGenerator] wrote /var/folders/3y/d0mtt_1x2j98fgz0p6ljdpz80000gn/T/junit-9234577685852960165/proto-out/process-foo-svc.proto
[PipelineProtoGenerator] wrote /var/folders/3y/d0mtt_1x2j98fgz0p6ljdpz80000gn/T/junit-9234577685852960165/proto-out/process-bar-svc.proto
[PipelineProtoGenerator] wrote /var/folders/3y/d0mtt_1x2j98fgz0p6ljdpz80000gn/T/junit-9234577685852960165/proto-out/orchestrator.proto
[PipelineProtoGenerator] wrote /var/folders/3y/d0mtt_1x2j98fgz0p6ljdpz80000gn/T/junit-3835054933079793832/proto-alias-out/tokenize-svc.proto
[PipelineProtoGenerator] wrote /var/folders/3y/d0mtt_1x2j98fgz0p6ljdpz80000gn/T/junit-3835054933079793832/proto-alias-out/index-svc.proto
[PipelineProtoGenerator] wrote /var/folders/3y/d0mtt_1x2j98fgz0p6ljdpz80000gn/T/junit-3835054933079793832/proto-alias-out/orchestrator.proto
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.084 s -- in org.pipelineframework.proto.PipelineProtoGeneratorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] ---------< org.pipelineframework:pipelineframework-deployment >---------
[INFO] Building The Pipeline Framework Extension (Deployment) 26.2.5-SNAPSHOT [2/2]
[INFO]   from /Users/mari/tpf3/framework/deployment/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (prepare-agent) @ pipelineframework-deployment ---
[INFO] surefireArgLine set to -javaagent:/Users/mari/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/mari/tpf3/framework/target/jacoco.exec
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ pipelineframework-deployment ---
[INFO] Copying 3 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- flatten:1.7.3:flatten (flatten) @ pipelineframework-deployment ---
[INFO] Flatten skipped.
[INFO] 
[INFO] --- compiler:3.14.0:compile (default-compile) @ pipelineframework-deployment ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ pipelineframework-deployment ---
[INFO] Copying 4 resources from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ pipelineframework-deployment ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 59 source files with javac [debug preview release 21] to target/test-classes
[WARNING] The following options were not recognized by any processor: '[pipeline.platform, pipeline.parallelism, pipeline.transport]'
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java:[37,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java:[91,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java:[153,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java:[55,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineOrchestratorTest.java:[78,64] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineOrchestratorTest.java:[149,64] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelinePluginTest.java:[93,64] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelinePluginTest.java:[281,64] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[189,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[189,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[199,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[199,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[207,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[207,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[214,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[214,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[262,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[262,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[391,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[391,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[499,9] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[499,52] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[658,68] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java:[762,68] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PluginHostAspectFilteringTest.java:[66,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PluginProducerGenerationTest.java:[59,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[WARNING] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/RestBindingSkipTest.java:[51,33] org.pipelineframework.processor.PipelineStepProcessor in org.pipelineframework.processor has been deprecated and marked for removal
[INFO] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java: Some input files use unchecked or unsafe operations.
[INFO] /Users/mari/tpf3/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- surefire:3.5.1:test (default-test) @ pipelineframework-deployment ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.pipelineframework.processor.PipelineOrchestratorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.769 s -- in org.pipelineframework.processor.PipelineOrchestratorTest
[INFO] Running org.pipelineframework.processor.renderer.OrchestratorFunctionHandlerRendererTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.371 s -- in org.pipelineframework.processor.renderer.OrchestratorFunctionHandlerRendererTest
[INFO] Running org.pipelineframework.processor.renderer.OrchestratorGrpcRendererTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.083 s -- in org.pipelineframework.processor.renderer.OrchestratorGrpcRendererTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for The Pipeline Framework Extension (Runtime) 26.2.5-SNAPSHOT:
[INFO] 
[INFO] The Pipeline Framework Extension (Runtime) ......... SUCCESS [  4.537 s]
[INFO] The Pipeline Framework Extension (Deployment) ...... SUCCESS [  4.309 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.133 s
[INFO] Finished at: 2026-03-05T01:40:16+01:00
[INFO] ------------------------------------------------------------------------\n\n## Notes\n- stacked on \n- no tenant-core SaaS controls in this PR