### PR TITLE
Queue GA PR2: harden async input contract validation

### DIFF
--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRenderer.java
@@ -297,6 +297,10 @@ public class OrchestratorFunctionHandlerRenderer implements PipelineRenderer<Orc
             .nextControlFlow("else")
             .beginControlFlow("if (request != null && request.input != null)")
             .addStatement("executionInput = request.input")
+            .nextControlFlow("else if (request != null && request.inputBatch != null && request.inputBatch.size() > 1)")
+            .addStatement("throw new $T($S)",
+                IllegalArgumentException.class,
+                "RunAsync unary handlers accept at most one item in inputBatch")
             .nextControlFlow("else if (request != null && request.inputBatch != null && !request.inputBatch.isEmpty())")
             .addStatement("executionInput = request.inputBatch.get(0)")
             .nextControlFlow("else")

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -393,7 +393,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 ClassName.get("io.grpc", "Status"));
         } else {
             method.addCode("""
-                $T asyncInput = request.getInputBatchCount() > 0 ? request.getInputBatch(0) : request.getInput();
+                if (request.getInputBatchCount() > 1) {
+                    return $T.createFrom().failure(new $T($S));
+                }
+                $T asyncInput = request.getInputBatchCount() == 1 ? request.getInputBatch(0) : request.getInput();
                 return pipelineExecutionService.executePipelineAsync(
                         asyncInput,
                         request.getTenantId(),
@@ -409,6 +412,9 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                     .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
                         System.nanoTime() - startTime));
                 """,
+                uni,
+                IllegalArgumentException.class,
+                "RunAsync unary pipelines accept at most one item in input_batch.",
                 Object.class,
                 binding.outputStreaming(),
                 responseType,
@@ -448,6 +454,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .returns(ParameterizedTypeName.get(uni, responseType))
             .addParameter(requestType, "request")
             .addStatement("long startTime = System.nanoTime()")
+            .beginControlFlow("if (request.getExecutionId() == null || request.getExecutionId().isBlank())")
+            .addStatement("return $T.createFrom().failure(new $T($S))",
+                uni,
+                IllegalArgumentException.class,
+                "executionId is required")
+            .endControlFlow()
             .addCode("""
                 return pipelineExecutionService.getExecutionStatus(request.getTenantId(), request.getExecutionId())
                     .onItem().transform(status -> $T.newBuilder()
@@ -503,6 +515,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .returns(ParameterizedTypeName.get(uni, responseType))
             .addParameter(requestType, "request")
             .addStatement("long startTime = System.nanoTime()");
+        method.beginControlFlow("if (request.getExecutionId() == null || request.getExecutionId().isBlank())")
+            .addStatement("return $T.createFrom().failure(new $T($S))",
+                uni,
+                IllegalArgumentException.class,
+                "executionId is required")
+            .endControlFlow();
 
         if (binding.outputStreaming()) {
             TypeName outputListType = ParameterizedTypeName.get(ClassName.get(List.class), outputType);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorFunctionHandlerRendererTest.java
@@ -121,6 +121,7 @@ class OrchestratorFunctionHandlerRendererTest {
         String resultSource = Files.readString(resultPath);
         assertTrue(runAsyncSource.contains("implements RequestHandler<PipelineRunAsyncRequest, RunAsyncAcceptedDto>"));
         assertTrue(runAsyncSource.contains("pipelineExecutionService.executePipelineAsync"));
+        assertTrue(runAsyncSource.contains("RunAsync unary handlers accept at most one item in inputBatch"));
         assertTrue(statusSource.contains("implements RequestHandler<PipelineExecutionLookupRequest, ExecutionStatusDto>"));
         assertTrue(statusSource.contains("pipelineExecutionService.getExecutionStatus"));
         assertTrue(resultSource.contains("pipelineExecutionService.getExecutionResult"));

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRendererTest.java
@@ -41,8 +41,10 @@ class OrchestratorGrpcRendererTest {
         assertTrue(source.contains("executePipelineUnary"));
         assertTrue(source.contains("public Uni<RunAsyncResponse> runAsync(RunAsyncRequest request)"));
         assertTrue(source.contains("executePipelineAsync"));
+        assertTrue(source.contains("RunAsync unary pipelines accept at most one item in input_batch."));
         assertTrue(source.contains("public Uni<GetExecutionStatusResponse> getExecutionStatus(GetExecutionStatusRequest request)"));
         assertTrue(source.contains("public Uni<GetExecutionResultResponse> getExecutionResult(GetExecutionResultRequest request)"));
+        assertTrue(source.contains("executionId is required"));
         assertTrue(source.contains("public Multi<OutputType> ingest(Multi<InputType> input)"));
         assertTrue(source.contains("public Multi<OutputType> subscribe("));
         assertTrue(source.contains("pipelineOutputBus"));

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
@@ -65,6 +65,16 @@ class PipelineExecutionServiceTest {
     }
 
     @Test
+    void executePipelineAsyncRejectsStreamingOutputFlagInQueueMode() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+
+        Uni<?> result = service.executePipelineAsync("input", "tenant-1", "idem-1", true);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
+        assertTrue(error.getMessage().contains("does not support streaming pipeline outputs"));
+    }
+
+    @Test
     void getExecutionStatusReturnsRecordStateInQueueMode() throws Exception {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         setField("executionStateStore", executionStateStore);


### PR DESCRIPTION
## Summary
- harden generated gRPC async contract handling by rejecting invalid unary `input_batch` payloads (>1 item)
- add explicit `executionId` required validation in generated gRPC async status/result methods
- harden generated function async run handler to reject ambiguous unary `inputBatch` payloads
- add runtime test coverage that queue-async rejects streaming outputs when `outputStreaming=true`

## Validation
- `./mvnw -f framework/pom.xml -pl runtime,deployment -Dtest=PipelineExecutionServiceTest,OrchestratorGrpcRendererTest,OrchestratorFunctionHandlerRendererTest test`

## Stack
- base: `codex/queue-ga-transport-parity-pr1` (PR #181)
