### PR TITLE
Queue GA PR3: provider startup-readiness and strict fail-fast

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -222,6 +222,22 @@ public class PipelineExecutionService {
     executionStateStore = selectExecutionStateStore(orchestratorConfig.stateProvider());
     workDispatcher = selectWorkDispatcher(orchestratorConfig.dispatcherProvider());
     deadLetterPublisher = selectDeadLetterPublisher(orchestratorConfig.dlqProvider());
+
+    List<String> providerReadinessErrors = new ArrayList<>();
+    executionStateStore.startupValidationError(orchestratorConfig)
+        .ifPresent(error -> providerReadinessErrors.add("ExecutionStateStore(" + executionStateStore.providerName() + "): " + error));
+    workDispatcher.startupValidationError(orchestratorConfig)
+        .ifPresent(error -> providerReadinessErrors.add("WorkDispatcher(" + workDispatcher.providerName() + "): " + error));
+    deadLetterPublisher.startupValidationError(orchestratorConfig)
+        .ifPresent(error -> providerReadinessErrors.add("DeadLetterPublisher(" + deadLetterPublisher.providerName() + "): " + error));
+    if (!providerReadinessErrors.isEmpty()) {
+      String readinessMessage = "Queue async provider startup validation failed: " + String.join("; ", providerReadinessErrors);
+      if (orchestratorConfig.strictStartup()) {
+        throw new IllegalStateException(readinessMessage);
+      }
+      LOG.warn(readinessMessage);
+    }
+
     if (orchestratorConfig.strictStartup()
         && orchestratorConfig.idempotencyPolicy() == OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY) {
       throw new IllegalStateException(

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DeadLetterPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DeadLetterPublisher.java
@@ -1,5 +1,7 @@
 package org.pipelineframework.orchestrator;
 
+import java.util.Optional;
+
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -26,6 +28,19 @@ public interface DeadLetterPublisher {
      */
     default int priority() {
         return 0;
+    }
+
+    /**
+     * Validates provider readiness for queue-async orchestrator mode startup.
+     *
+     * <p>Return a non-empty value when the provider is selected but cannot safely operate
+     * with the current runtime configuration.</p>
+     *
+     * @param config orchestrator configuration
+     * @return optional startup validation error
+     */
+    default Optional<String> startupValidationError(PipelineOrchestratorConfig config) {
+        return Optional.empty();
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
@@ -30,6 +30,11 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
     }
 
     @Override
+    public Optional<String> startupValidationError(PipelineOrchestratorConfig config) {
+        return Optional.of(ERROR);
+    }
+
+    @Override
     public Uni<CreateExecutionResult> createOrGetExecution(ExecutionCreateCommand command) {
         return Uni.createFrom().failure(new UnsupportedOperationException(ERROR));
     }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
@@ -31,6 +31,19 @@ public interface ExecutionStateStore {
     }
 
     /**
+     * Validates provider readiness for queue-async orchestrator mode startup.
+     *
+     * <p>Return a non-empty value when the provider is selected but cannot safely operate
+     * with the current runtime configuration.</p>
+     *
+     * @param config orchestrator configuration
+     * @return optional startup validation error
+     */
+    default Optional<String> startupValidationError(PipelineOrchestratorConfig config) {
+        return Optional.empty();
+    }
+
+    /**
      * Creates a new execution or returns an existing one for the same execution key.
      *
      * @param command create command

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/SqsWorkDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/SqsWorkDispatcher.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.orchestrator;
 
 import java.time.Duration;
+import java.util.Optional;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.smallrye.mutiny.Uni;
@@ -26,6 +27,11 @@ public class SqsWorkDispatcher implements WorkDispatcher {
     @Override
     public int priority() {
         return -1000;
+    }
+
+    @Override
+    public Optional<String> startupValidationError(PipelineOrchestratorConfig config) {
+        return Optional.of(ERROR);
     }
 
     @Override

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/WorkDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/WorkDispatcher.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.orchestrator;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.smallrye.mutiny.Uni;
 
@@ -29,6 +30,19 @@ public interface WorkDispatcher {
      */
     default int priority() {
         return 0;
+    }
+
+    /**
+     * Validates provider readiness for queue-async orchestrator mode startup.
+     *
+     * <p>Return a non-empty value when the provider is selected but cannot safely operate
+     * with the current runtime configuration.</p>
+     *
+     * @param config orchestrator configuration
+     * @return optional startup validation error
+     */
+    default Optional<String> startupValidationError(PipelineOrchestratorConfig config) {
+        return Optional.empty();
     }
 
     /**

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,10 +17,14 @@ import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.ExecutionStateStore;
 import org.pipelineframework.orchestrator.ExecutionStatus;
-import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.EventWorkDispatcher;
+import org.pipelineframework.orchestrator.LoggingDeadLetterPublisher;
 import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
+import org.pipelineframework.orchestrator.OrchestratorMode;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,6 +48,15 @@ class PipelineExecutionServiceTest {
 
     @Mock
     private WorkDispatcher workDispatcher;
+
+    @Mock
+    private Instance<ExecutionStateStore> executionStateStores;
+
+    @Mock
+    private Instance<WorkDispatcher> workDispatchers;
+
+    @Mock
+    private Instance<DeadLetterPublisher> deadLetterPublishers;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -72,6 +86,27 @@ class PipelineExecutionServiceTest {
 
         IllegalStateException error = assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
         assertTrue(error.getMessage().contains("does not support streaming pipeline outputs"));
+    }
+
+    @Test
+    void initializeQueueModeFailsFastWhenSelectedProviderReportsStartupError() throws Exception {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.stateProvider()).thenReturn("dynamo");
+        when(orchestratorConfig.dispatcherProvider()).thenReturn("event");
+        when(orchestratorConfig.dlqProvider()).thenReturn("log");
+        when(orchestratorConfig.strictStartup()).thenReturn(true);
+
+        when(executionStateStores.stream()).thenReturn(java.util.stream.Stream.of(new DynamoExecutionStateStore()));
+        when(workDispatchers.stream()).thenReturn(java.util.stream.Stream.of(new EventWorkDispatcher()));
+        when(deadLetterPublishers.stream()).thenReturn(java.util.stream.Stream.of(new LoggingDeadLetterPublisher()));
+        setField("executionStateStores", executionStateStores);
+        setField("workDispatchers", workDispatchers);
+        setField("deadLetterPublishers", deadLetterPublishers);
+
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            this::invokeInitializeQueueMode);
+        assertTrue(error.getMessage().contains("ExecutionStateStore(dynamo)"));
     }
 
     @Test
@@ -184,5 +219,18 @@ class PipelineExecutionServiceTest {
         var field = PipelineExecutionService.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(service, value);
+    }
+
+    private void invokeInitializeQueueMode() throws Exception {
+        var method = PipelineExecutionService.class.getDeclaredMethod("initializeQueueMode");
+        method.setAccessible(true);
+        try {
+            method.invoke(service);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            if (e.getCause() instanceof Exception exception) {
+                throw exception;
+            }
+            throw e;
+        }
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/DynamoExecutionStateStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/DynamoExecutionStateStoreTest.java
@@ -97,4 +97,14 @@ class DynamoExecutionStateStoreTest {
             assertTrue(e.getMessage().contains("not implemented"));
         }
     }
+
+    @Test
+    void startupValidationReportsMissingImplementation() {
+        PipelineOrchestratorConfig config = org.mockito.Mockito.mock(PipelineOrchestratorConfig.class);
+
+        var validationError = store.startupValidationError(config);
+
+        assertTrue(validationError.isPresent());
+        assertTrue(validationError.get().contains("not implemented"));
+    }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/SqsWorkDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/SqsWorkDispatcherTest.java
@@ -1,0 +1,26 @@
+package org.pipelineframework.orchestrator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SqsWorkDispatcherTest {
+
+    @Test
+    void providerNameIsSqs() {
+        SqsWorkDispatcher dispatcher = new SqsWorkDispatcher();
+        assertEquals("sqs", dispatcher.providerName());
+    }
+
+    @Test
+    void startupValidationReportsMissingImplementation() {
+        SqsWorkDispatcher dispatcher = new SqsWorkDispatcher();
+        PipelineOrchestratorConfig config = org.mockito.Mockito.mock(PipelineOrchestratorConfig.class);
+
+        var validationError = dispatcher.startupValidationError(config);
+
+        assertTrue(validationError.isPresent());
+        assertTrue(validationError.get().contains("not implemented"));
+    }
+}


### PR DESCRIPTION
## Summary
- add startup-readiness validation hook to orchestrator provider SPIs:
  - `ExecutionStateStore.startupValidationError(...)`
  - `WorkDispatcher.startupValidationError(...)`
  - `DeadLetterPublisher.startupValidationError(...)`
- enforce readiness checks in `PipelineExecutionService.initializeQueueMode()`
  - `strict-startup=true`: fail fast with detailed provider-specific message
  - `strict-startup=false`: log warning and continue
- mark placeholder providers as not startup-ready (`dynamo`, `sqs`) so queue mode cannot silently boot into runtime failures
- add tests for provider validation and strict fail-fast wiring

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=PipelineExecutionServiceTest,DynamoExecutionStateStoreTest,SqsWorkDispatcherTest,EventWorkDispatcherTest,DeadLetterPublisherTest test`

## Stack
- base: `codex/queue-ga-async-contract-validation-pr2` (PR #182)
