### PR TITLE
runtime: refactor PipelineExecutionService into focused collaborators

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionFailureHandler.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionFailureHandler.java
@@ -1,0 +1,165 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.config.pipeline.PipelinePlatformResourceLoader;
+import org.pipelineframework.orchestrator.DeadLetterEnvelope;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.step.NonRetryableException;
+
+/**
+ * Retry and terminal-failure policy for async execution transitions.
+ */
+@ApplicationScoped
+class ExecutionFailureHandler {
+
+  private static final String ORCHESTRATOR_SERVICE = "OrchestratorService";
+  private static final String ORCHESTRATOR_METHOD = "Run";
+
+  @Inject
+  PipelineOrchestratorConfig orchestratorConfig;
+
+  Uni<Void> handleExecutionFailure(
+      ExecutionRecord<Object, Object> record,
+      String transitionKey,
+      Throwable failure,
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      DeadLetterPublisher deadLetterPublisher) {
+    long now = System.currentTimeMillis();
+    int nextAttempt = record.attempt() + 1;
+    FailureClassification classification = classifyFailure(failure);
+    Throwable classifiedFailure = classification.classifiedThrowable();
+    boolean retryableFailure = classification.retryable();
+    boolean retryAllowed = nextAttempt <= orchestratorConfig.maxRetries();
+
+    if (retryAllowed && retryableFailure) {
+      long nextDue = now + retryDelayMillis(nextAttempt);
+      return executionStateStore.scheduleRetry(
+              record.tenantId(),
+              record.executionId(),
+              record.version(),
+              nextAttempt,
+              nextDue,
+              transitionKey,
+              classifiedFailure.getClass().getSimpleName(),
+              classifiedFailure.getMessage(),
+              now)
+          .onItem().transformToUni(updated -> {
+            if (updated.isEmpty()) {
+              return Uni.createFrom().voidItem();
+            }
+            Duration delay = Duration.ofMillis(Math.max(0L, nextDue - System.currentTimeMillis()));
+            return workDispatcher.enqueueDelayed(
+                new ExecutionWorkItem(record.tenantId(), record.executionId()),
+                delay);
+          });
+    }
+
+    return executionStateStore.markTerminalFailure(
+            record.tenantId(),
+            record.executionId(),
+            record.version(),
+            ExecutionStatus.FAILED,
+            transitionKey,
+            classifiedFailure.getClass().getSimpleName(),
+            classifiedFailure.getMessage(),
+            now)
+        .onItem().transformToUni(updated -> {
+          if (updated.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          PipelinePlatformResourceLoader.PlatformMetadata platformMetadata = PipelinePlatformResourceLoader
+              .loadPlatform()
+              .orElse(null);
+          DeadLetterEnvelope envelope = DeadLetterEnvelope.builder()
+              .tenantId(record.tenantId())
+              .executionId(record.executionId())
+              .executionKey(record.executionKey())
+              .correlationId(record.executionKey())
+              .transitionKey(transitionKey)
+              .resourceType("tpf.orchestrator.execution")
+              .resourceName(ORCHESTRATOR_SERVICE + "/" + ORCHESTRATOR_METHOD)
+              .transport(resolveTransport(platformMetadata))
+              .platform(resolvePlatform(platformMetadata))
+              .terminalStatus(ExecutionStatus.FAILED.name())
+              .terminalReason(retryableFailure ? "retry_exhausted" : "non_retryable")
+              .errorCode(classifiedFailure.getClass().getSimpleName())
+              .errorMessage(classifiedFailure.getMessage())
+              .retryable(retryableFailure)
+              .retriesObserved(record.attempt())
+              .createdAtEpochMs(now)
+              .build();
+          return deadLetterPublisher.publish(envelope);
+        });
+  }
+
+  long retryDelayMillis(int nextAttempt) {
+    long base = Math.max(0L, orchestratorConfig.retryDelay().toMillis());
+    double multiplier = Math.max(1.0d, orchestratorConfig.retryMultiplier());
+    double calculated = base * Math.pow(multiplier, Math.max(0, nextAttempt - 1));
+    return Math.min((long) calculated, TimeUnit.MINUTES.toMillis(30));
+  }
+
+  private static String resolveTransport(PipelinePlatformResourceLoader.PlatformMetadata metadata) {
+    String candidate = metadata == null ? System.getProperty("pipeline.transport") : metadata.transport();
+    if (candidate == null || candidate.isBlank()) {
+      return "UNKNOWN";
+    }
+    return candidate.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static String resolvePlatform(PipelinePlatformResourceLoader.PlatformMetadata metadata) {
+    String candidate = metadata == null ? System.getProperty("pipeline.platform") : metadata.platform();
+    if (candidate == null || candidate.isBlank()) {
+      return "UNKNOWN";
+    }
+    return candidate.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static FailureClassification classifyFailure(Throwable failure) {
+    if (failure == null) {
+      Throwable classified = new IllegalStateException("Unknown failure");
+      return new FailureClassification(false, classified);
+    }
+    Throwable nonRetryable = findThrowable(failure, NonRetryableException.class);
+    if (nonRetryable != null) {
+      return new FailureClassification(false, nonRetryable);
+    }
+    return new FailureClassification(true, failure);
+  }
+
+  private static Throwable findThrowable(Throwable failure, Class<? extends Throwable> targetType) {
+    java.util.ArrayDeque<Throwable> queue = new java.util.ArrayDeque<>();
+    java.util.Set<Throwable> seen = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+    queue.add(failure);
+    while (!queue.isEmpty()) {
+      Throwable current = queue.removeFirst();
+      if (!seen.add(current)) {
+        continue;
+      }
+      if (targetType.isInstance(current)) {
+        return current;
+      }
+      Throwable cause = current.getCause();
+      if (cause != null && cause != current) {
+        queue.add(cause);
+      }
+    }
+    return null;
+  }
+
+  record FailureClassification(boolean retryable, Throwable classifiedThrowable) {
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionHooks.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionHooks.java
@@ -1,0 +1,272 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.grpc.Status;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.AbstractMultiOperator;
+import io.smallrye.mutiny.operators.multi.MultiOperatorProcessor;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import org.apache.commons.lang3.time.StopWatch;
+import org.jboss.logging.Logger;
+import org.pipelineframework.telemetry.ApmCompatibilityMetrics;
+import org.pipelineframework.telemetry.PipelineTelemetry;
+import org.pipelineframework.telemetry.RetryAmplificationGuard;
+import org.pipelineframework.telemetry.RetryAmplificationGuardMode;
+import org.pipelineframework.telemetry.RpcMetrics;
+
+/**
+ * Lifecycle hooks and retry-amplification guards for sync pipeline executions.
+ */
+@ApplicationScoped
+class ExecutionHooks {
+
+  private static final Logger LOG = Logger.getLogger(ExecutionHooks.class);
+  private static final String ORCHESTRATOR_SERVICE = "OrchestratorService";
+  private static final String ORCHESTRATOR_METHOD = "Run";
+
+  @Inject
+  PipelineTelemetry telemetry;
+
+  private final ScheduledExecutorService killSwitchExecutor = Executors.newSingleThreadScheduledExecutor(
+      runnable -> {
+        Thread thread = new Thread(runnable, "tpf-kill-switch");
+        thread.setDaemon(true);
+        return thread;
+      });
+
+  @PreDestroy
+  void shutdownKillSwitchExecutor() {
+    killSwitchExecutor.shutdownNow();
+  }
+
+  <T> Multi<T> attachMultiHooks(Multi<T> multi, StopWatch watch) {
+    Multi<T> guarded = attachRetryAmplificationGuard(multi);
+    long[] startTime = new long[1];
+    return guarded
+        .onSubscription().invoke(ignored -> {
+          LOG.info("PIPELINE BEGINS processing");
+          startTime[0] = System.nanoTime();
+          watch.start();
+        })
+        .onCompletion().invoke(() -> {
+          watch.stop();
+          long durationNanos = System.nanoTime() - startTime[0];
+          RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.OK, durationNanos);
+          ApmCompatibilityMetrics.recordOrchestratorSuccess(durationNanos / 1_000_000d);
+          LOG.infof("✅ PIPELINE FINISHED processing in %s seconds", watch.getTime(TimeUnit.SECONDS));
+        })
+        .onFailure().invoke(failure -> {
+          watch.stop();
+          long durationNanos = System.nanoTime() - startTime[0];
+          RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.fromThrowable(failure),
+              durationNanos);
+          ApmCompatibilityMetrics.recordOrchestratorFailure(durationNanos / 1_000_000d);
+          LOG.errorf(failure, "❌ PIPELINE FAILED after %s seconds", watch.getTime(TimeUnit.SECONDS));
+        });
+  }
+
+  <T> Uni<T> attachUniHooks(Uni<T> uni, StopWatch watch) {
+    Uni<T> guarded = attachRetryAmplificationGuard(uni);
+    long[] startTime = new long[1];
+    return guarded
+        .onSubscription().invoke(ignored -> {
+          LOG.info("PIPELINE BEGINS processing");
+          startTime[0] = System.nanoTime();
+          watch.start();
+        })
+        .onItemOrFailure().invoke((item, failure) -> {
+          watch.stop();
+          long durationNanos = System.nanoTime() - startTime[0];
+          if (failure == null) {
+            RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.OK, durationNanos);
+            ApmCompatibilityMetrics.recordOrchestratorSuccess(durationNanos / 1_000_000d);
+            LOG.infof("✅ PIPELINE FINISHED processing in %s seconds", watch.getTime(TimeUnit.SECONDS));
+          } else {
+            RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.fromThrowable(failure),
+                durationNanos);
+            ApmCompatibilityMetrics.recordOrchestratorFailure(durationNanos / 1_000_000d);
+            LOG.errorf(failure, "❌ PIPELINE FAILED after %s seconds", watch.getTime(TimeUnit.SECONDS));
+          }
+        });
+  }
+
+  private <T> Multi<T> attachRetryAmplificationGuard(Multi<T> multi) {
+    if (telemetry == null || !telemetry.retryAmplificationGuardEnabled()) {
+      return multi;
+    }
+    Duration interval = telemetry.retryAmplificationCheckInterval();
+    RetryAmplificationGuardMode mode = telemetry.retryAmplificationMode();
+    return multi.plug(upstream -> new RetryAmplificationGuardMulti<>(upstream, interval, mode));
+  }
+
+  private <T> Uni<T> attachRetryAmplificationGuard(Uni<T> uni) {
+    if (telemetry == null || !telemetry.retryAmplificationGuardEnabled()) {
+      return uni;
+    }
+    Duration interval = telemetry.retryAmplificationCheckInterval();
+    RetryAmplificationGuardMode mode = telemetry.retryAmplificationMode();
+    AtomicBoolean logged = new AtomicBoolean(false);
+    return Uni.createFrom().emitter(emitter -> {
+      AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
+      AtomicReference<ScheduledFuture<?>> futureRef = new AtomicReference<>();
+      Cancellable cancellable = uni.subscribe().with(
+          item -> {
+            ScheduledFuture<?> scheduled = futureRef.get();
+            if (scheduled != null) {
+              scheduled.cancel(false);
+            }
+            emitter.complete(item);
+          },
+          failure -> {
+            ScheduledFuture<?> scheduled = futureRef.get();
+            if (scheduled != null) {
+              scheduled.cancel(false);
+            }
+            emitter.fail(failure);
+          });
+      cancellableRef.set(cancellable);
+      ScheduledFuture<?> future = killSwitchExecutor.scheduleAtFixedRate(() -> {
+        telemetry.retryAmplificationTrigger().ifPresent(trigger -> {
+          if (!logged.compareAndSet(false, true)) {
+            return;
+          }
+          logRetryAmplificationTrigger(trigger, mode);
+          if (mode == RetryAmplificationGuardMode.FAIL_FAST) {
+            emitter.fail(PipelineKillSwitchException.retryAmplification(trigger));
+            Cancellable active = cancellableRef.get();
+            if (active != null) {
+              active.cancel();
+            }
+          } else {
+            ScheduledFuture<?> scheduled = futureRef.get();
+            if (scheduled != null) {
+              scheduled.cancel(false);
+            }
+          }
+        });
+      }, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+      futureRef.set(future);
+      emitter.onTermination(() -> {
+        ScheduledFuture<?> scheduled = futureRef.get();
+        if (scheduled != null) {
+          scheduled.cancel(false);
+        }
+      });
+    });
+  }
+
+  private void logRetryAmplificationTrigger(
+      RetryAmplificationGuard.Trigger trigger,
+      RetryAmplificationGuardMode mode) {
+    String action = mode == RetryAmplificationGuardMode.FAIL_FAST ? "aborting" : "logging";
+    LOG.errorf(
+        "Retry amplification guard triggered for step %s (inflight slope %.2f > %.2f, retry rate %.2f) over %s (sustain samples %d); %s pipeline run.",
+        trigger.step(),
+        trigger.inflightSlope(),
+        trigger.inflightSlopeThreshold(),
+        trigger.retryRate(),
+        trigger.window(),
+        trigger.sustainSamples(),
+        action);
+  }
+
+  private final class RetryAmplificationGuardMulti<T> extends AbstractMultiOperator<T, T> {
+    private final Duration interval;
+    private final RetryAmplificationGuardMode mode;
+
+    private RetryAmplificationGuardMulti(
+        Multi<? extends T> upstream,
+        Duration interval,
+        RetryAmplificationGuardMode mode) {
+      super(upstream);
+      this.interval = interval;
+      this.mode = mode;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> downstream) {
+      RetryAmplificationProcessor<T> processor =
+          new RetryAmplificationProcessor<>(downstream, interval, mode);
+      upstream().subscribe(processor);
+    }
+  }
+
+  private final class RetryAmplificationProcessor<T> extends MultiOperatorProcessor<T, T> {
+    private final RetryAmplificationGuardMode mode;
+    private final AtomicBoolean logged;
+    private final ScheduledFuture<?> future;
+
+    private RetryAmplificationProcessor(
+        MultiSubscriber<? super T> downstream,
+        Duration interval,
+        RetryAmplificationGuardMode mode) {
+      super(downstream);
+      this.mode = mode;
+      this.logged = new AtomicBoolean(false);
+      this.future = killSwitchExecutor.scheduleAtFixedRate(
+          this::checkGuard,
+          interval.toMillis(),
+          interval.toMillis(),
+          TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void onItem(T item) {
+      if (!isDone()) {
+        downstream.onItem(item);
+      }
+    }
+
+    @Override
+    public void onFailure(Throwable failure) {
+      cancelFuture();
+      super.onFailure(failure);
+    }
+
+    @Override
+    public void onCompletion() {
+      cancelFuture();
+      super.onCompletion();
+    }
+
+    @Override
+    public void cancel() {
+      cancelFuture();
+      super.cancel();
+    }
+
+    private void checkGuard() {
+      telemetry.retryAmplificationTrigger().ifPresent(trigger -> {
+        if (!logged.compareAndSet(false, true)) {
+          return;
+        }
+        logRetryAmplificationTrigger(trigger, mode);
+        cancelFuture();
+        if (mode == RetryAmplificationGuardMode.FAIL_FAST) {
+          if (isDone()) {
+            return;
+          }
+          super.onFailure(PipelineKillSwitchException.retryAmplification(trigger));
+        }
+      });
+    }
+
+    private void cancelFuture() {
+      if (future != null) {
+        future.cancel(false);
+      }
+    }
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionInputPolicy.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionInputPolicy.java
@@ -1,0 +1,117 @@
+package org.pipelineframework;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.text.MessageFormat;
+import java.util.Base64;
+import java.util.List;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+
+/**
+ * Input normalization and idempotency-key policy for queue orchestration paths.
+ */
+@ApplicationScoped
+class ExecutionInputPolicy {
+
+  @Inject
+  PipelineOrchestratorConfig orchestratorConfig;
+
+  RuntimeException validateInputShape(Object input) {
+    if (input instanceof Uni<?> || input instanceof Multi<?>) {
+      return null;
+    }
+    return new IllegalArgumentException(MessageFormat.format(
+        "Pipeline input must be Uni or Multi, got: {0}",
+        input == null ? "null" : input.getClass().getName()));
+  }
+
+  Object normalizeExecutionInput(Object input) {
+    if (input instanceof Uni<?> || input instanceof Multi<?>) {
+      return input;
+    }
+    return Uni.createFrom().item(input);
+  }
+
+  Uni<ExecutionInputSnapshot> resolveExecutionInputPayload(Object input) {
+    if (input instanceof Uni<?> uni) {
+      return uni.onItem().transform(item -> new ExecutionInputSnapshot(ExecutionInputShape.UNI, item));
+    }
+    if (input instanceof Multi<?> multi) {
+      return multi.collect().asList().onItem().transform(list ->
+          new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(list)));
+    }
+    return Uni.createFrom().item(new ExecutionInputSnapshot(ExecutionInputShape.RAW, input));
+  }
+
+  String normalizeTenant(String tenantId) {
+    if (tenantId == null || tenantId.isBlank()) {
+      return orchestratorConfig.defaultTenant();
+    }
+    return tenantId.trim();
+  }
+
+  String resolveExecutionKey(String tenantId, Object input, String clientKey) {
+    OrchestratorIdempotencyPolicy policy = orchestratorConfig.idempotencyPolicy();
+    String normalizedClientKey = normalizeOptional(clientKey);
+    if (policy == OrchestratorIdempotencyPolicy.CLIENT_KEY_REQUIRED) {
+      if (normalizedClientKey == null) {
+        throw new IllegalArgumentException("Idempotency-Key header is required.");
+      }
+      return normalizedClientKey;
+    }
+    if (policy == OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY && normalizedClientKey != null) {
+      return normalizedClientKey;
+    }
+    return deriveServerExecutionKey(tenantId, input);
+  }
+
+  Object toReplayInput(Object inputPayload) {
+    if (inputPayload instanceof ExecutionInputSnapshot snapshot) {
+      if (snapshot.shape() == ExecutionInputShape.MULTI) {
+        Object payload = snapshot.payload();
+        if (payload == null) {
+          return Multi.createFrom().empty();
+        }
+        if (payload instanceof Iterable<?> iterable) {
+          return Multi.createFrom().iterable(iterable);
+        }
+        return Multi.createFrom().item(payload);
+      }
+      return Uni.createFrom().item(snapshot.payload());
+    }
+    // Backward-compatible replay for records persisted before shape metadata.
+    if (inputPayload instanceof List<?> list) {
+      return Multi.createFrom().iterable(list);
+    }
+    return Uni.createFrom().item(inputPayload);
+  }
+
+  private String normalizeOptional(String value) {
+    if (value == null) {
+      return null;
+    }
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  String deriveServerExecutionKey(String tenantId, Object input) {
+    try {
+      byte[] payloadBytes = org.pipelineframework.config.pipeline.PipelineJson.mapper().writeValueAsBytes(input);
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      digest.update(tenantId.getBytes(StandardCharsets.UTF_8));
+      digest.update((byte) ':');
+      digest.update(payloadBytes);
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(digest.digest());
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to derive deterministic execution key.", e);
+    }
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -18,70 +18,25 @@ package org.pipelineframework;
 
 import java.text.MessageFormat;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.Locale;
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.ObservesAsync;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
 
-import io.grpc.Status;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.operators.multi.AbstractMultiOperator;
-import io.smallrye.mutiny.operators.multi.MultiOperatorProcessor;
-import io.smallrye.mutiny.subscription.MultiSubscriber;
-import io.smallrye.mutiny.subscription.Cancellable;
 import lombok.Getter;
 import org.apache.commons.lang3.time.StopWatch;
 import org.jboss.logging.Logger;
 import org.pipelineframework.config.PipelineConfig;
-import org.pipelineframework.config.pipeline.PipelineOrderResourceLoader;
-import org.pipelineframework.config.pipeline.PipelinePlatformResourceLoader;
-import org.pipelineframework.orchestrator.CreateExecutionResult;
-import org.pipelineframework.orchestrator.DeadLetterEnvelope;
-import org.pipelineframework.orchestrator.DeadLetterPublisher;
-import org.pipelineframework.orchestrator.ExecutionRecord;
-import org.pipelineframework.orchestrator.ExecutionStateStore;
-import org.pipelineframework.orchestrator.ExecutionStatus;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
-import org.pipelineframework.orchestrator.ExecutionCreateCommand;
-import org.pipelineframework.orchestrator.ExecutionInputShape;
-import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
-import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
-import org.pipelineframework.orchestrator.OrchestratorMode;
-import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
-import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
-import org.pipelineframework.step.NonRetryableException;
-import org.pipelineframework.telemetry.ApmCompatibilityMetrics;
-import org.pipelineframework.telemetry.PipelineTelemetry;
-import org.pipelineframework.telemetry.RetryAmplificationGuard;
-import org.pipelineframework.telemetry.RetryAmplificationGuardMode;
-import org.pipelineframework.telemetry.RpcMetrics;
 
 /**
  * Service responsible for executing pipeline logic.
@@ -92,8 +47,6 @@ import org.pipelineframework.telemetry.RpcMetrics;
 public class PipelineExecutionService {
 
   private static final Logger LOG = Logger.getLogger(PipelineExecutionService.class);
-  private static final String ORCHESTRATOR_SERVICE = "OrchestratorService";
-  private static final String ORCHESTRATOR_METHOD = "Run";
 
   /** Pipeline configuration for this service. */
   @Inject
@@ -107,49 +60,20 @@ public class PipelineExecutionService {
   @Inject
   protected HealthCheckService healthCheckService;
 
-  /** Telemetry helper for guard evaluation. */
   @Inject
-  protected PipelineTelemetry telemetry;
+  PipelineStepResolver pipelineStepResolver;
 
-  /** Queue mode orchestration configuration. */
   @Inject
-  protected PipelineOrchestratorConfig orchestratorConfig;
+  ExecutionHooks executionHooks;
 
-  /** Available execution state stores. */
   @Inject
-  Instance<ExecutionStateStore> executionStateStores;
+  QueueAsyncCoordinator queueAsyncCoordinator;
 
-  /** Available work dispatchers. */
-  @Inject
-  Instance<WorkDispatcher> workDispatchers;
-
-  /** Available dead-letter publishers. */
-  @Inject
-  Instance<DeadLetterPublisher> deadLetterPublishers;
-
-  private final ScheduledExecutorService killSwitchExecutor = Executors.newSingleThreadScheduledExecutor(
-      runnable -> {
-        Thread thread = new Thread(runnable, "tpf-kill-switch");
-        thread.setDaemon(true);
-        return thread;
-      });
-  private final ScheduledExecutorService queueSweepExecutor = Executors.newSingleThreadScheduledExecutor(
-      runnable -> {
-        Thread thread = new Thread(runnable, "tpf-queue-sweeper");
-        thread.setDaemon(true);
-        return thread;
-      });
-
-  private final AtomicReference<StartupHealthState> startupHealthState =
-      new AtomicReference<>(StartupHealthState.PENDING);
+  private final java.util.concurrent.atomic.AtomicReference<StartupHealthState> startupHealthState =
+      new java.util.concurrent.atomic.AtomicReference<>(StartupHealthState.PENDING);
   private volatile CompletableFuture<Boolean> startupHealthFuture = new CompletableFuture<>();
   @Getter
   private volatile String startupHealthError;
-  private volatile ExecutionStateStore executionStateStore;
-  private volatile WorkDispatcher workDispatcher;
-  private volatile DeadLetterPublisher deadLetterPublisher;
-  private volatile ScheduledFuture<?> queueSweepFuture;
-  private final String queueWorkerId = "worker-" + UUID.randomUUID();
 
   /**
    * Startup health check state for dependent services.
@@ -173,7 +97,7 @@ public class PipelineExecutionService {
 
   @PostConstruct
   void runStartupHealthChecks() {
-    initializeQueueMode();
+    queueAsyncCoordinator.initializeQueueMode();
     List<Object> steps;
     try {
       steps = loadPipelineSteps();
@@ -200,7 +124,7 @@ public class PipelineExecutionService {
 
     CompletableFuture<Boolean> healthCheckFuture = CompletableFuture.supplyAsync(
         () -> healthCheckService.checkHealthOfDependentServices(steps),
-            Infrastructure.getDefaultExecutor());
+        Infrastructure.getDefaultExecutor());
     startupHealthFuture = healthCheckFuture;
     healthCheckFuture.whenComplete((result, throwable) -> {
       if (throwable != null) {
@@ -218,102 +142,8 @@ public class PipelineExecutionService {
     });
   }
 
-  private void initializeQueueMode() {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return;
-    }
-    executionStateStore = selectExecutionStateStore(orchestratorConfig.stateProvider());
-    workDispatcher = selectWorkDispatcher(orchestratorConfig.dispatcherProvider());
-    deadLetterPublisher = selectDeadLetterPublisher(orchestratorConfig.dlqProvider());
-
-    List<String> providerReadinessErrors = new ArrayList<>();
-    executionStateStore.startupValidationError(orchestratorConfig)
-        .ifPresent(error -> providerReadinessErrors.add("ExecutionStateStore(" + executionStateStore.providerName() + "): " + error));
-    workDispatcher.startupValidationError(orchestratorConfig)
-        .ifPresent(error -> providerReadinessErrors.add("WorkDispatcher(" + workDispatcher.providerName() + "): " + error));
-    deadLetterPublisher.startupValidationError(orchestratorConfig)
-        .ifPresent(error -> providerReadinessErrors.add("DeadLetterPublisher(" + deadLetterPublisher.providerName() + "): " + error));
-    if (!providerReadinessErrors.isEmpty()) {
-      String readinessMessage = "Queue async provider startup validation failed: " + String.join("; ", providerReadinessErrors);
-      if (orchestratorConfig.strictStartup()) {
-        throw new IllegalStateException(readinessMessage);
-      }
-      LOG.warn(readinessMessage);
-    }
-
-    if (orchestratorConfig.strictStartup()
-        && orchestratorConfig.idempotencyPolicy() == OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY) {
-      throw new IllegalStateException(
-          "pipeline.orchestrator.idempotency-policy must be explicitly configured for queue mode when strict startup is enabled.");
-    }
-    Duration interval = orchestratorConfig.sweepInterval();
-    long intervalMs = Math.max(1000L, interval == null ? 30000L : interval.toMillis());
-    queueSweepFuture = queueSweepExecutor.scheduleAtFixedRate(
-        this::sweepDueExecutions,
-        intervalMs,
-        intervalMs,
-        TimeUnit.MILLISECONDS);
-    LOG.infof("Queue async mode enabled: stateProvider=%s dispatcherProvider=%s dlqProvider=%s",
-        executionStateStore.providerName(),
-        workDispatcher.providerName(),
-        deadLetterPublisher.providerName());
-  }
-
-  private ExecutionStateStore selectExecutionStateStore(String providerName) {
-    return executionStateStores.stream()
-        .filter(store -> providerMatches(store.providerName(), providerName))
-        .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
-        .findFirst()
-        .orElseThrow(() -> new IllegalStateException(
-            "No ExecutionStateStore provider found for '" + providerName + "'"));
-  }
-
-  private WorkDispatcher selectWorkDispatcher(String providerName) {
-    return workDispatchers.stream()
-        .filter(dispatcher -> providerMatches(dispatcher.providerName(), providerName))
-        .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
-        .findFirst()
-        .orElseThrow(() -> new IllegalStateException(
-            "No WorkDispatcher provider found for '" + providerName + "'"));
-  }
-
-  private DeadLetterPublisher selectDeadLetterPublisher(String providerName) {
-    return deadLetterPublishers.stream()
-        .filter(publisher -> providerMatches(publisher.providerName(), providerName))
-        .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
-        .findFirst()
-        .orElseThrow(() -> new IllegalStateException(
-            "No DeadLetterPublisher provider found for '" + providerName + "'"));
-  }
-
-  private static boolean providerMatches(String availableName, String configuredName) {
-    if (configuredName == null || configuredName.isBlank()) {
-      return true;
-    }
-    return configuredName.equalsIgnoreCase(availableName);
-  }
-
-  @PreDestroy
-  void shutdownKillSwitchExecutor() {
-    killSwitchExecutor.shutdownNow();
-    if (queueSweepFuture != null) {
-      queueSweepFuture.cancel(false);
-    }
-    queueSweepExecutor.shutdownNow();
-  }
-
   /**
    * Execute the configured pipeline using the provided input.
-   * <p>
-   * Relies on the startup health check of dependent services before running the pipeline. If the health check fails,
-   * returns a failed Multi with a RuntimeException. If the pipeline runner returns null or an unexpected
-   * type, returns a failed Multi with an IllegalStateException. On success returns the Multi produced by
-   * the pipeline (a Uni is converted to a Multi) with lifecycle hooks attached for timing and logging.
-   *
-   * @param input the input Multi supplied to the pipeline steps
-   * @return the pipeline result as a Multi; if dependent services are unhealthy the Multi fails with a
-   *         RuntimeException, and if the runner returns null or an unexpected type the Multi fails with
-   *         an IllegalStateException
    */
   public Multi<?> executePipeline(Multi<?> input) {
     return executePipelineStreaming(input);
@@ -321,14 +151,6 @@ public class PipelineExecutionService {
 
   /**
    * Execute the configured pipeline and return a streaming result.
-   *
-   * <p>Accepts either a {@code Uni} or {@code Multi} input. If the pipeline produces a {@code Uni},
-   * it is converted to a {@code Multi}. Health checks and logging hooks mirror those in
-   * {@link #executePipeline(Multi)}.</p>
-   *
-   * @param input the input Uni or Multi supplied to the pipeline steps
-   * @param <T> the expected output type
-   * @return the pipeline result as a Multi with lifecycle hooks attached
    */
   @SuppressWarnings("unchecked")
   public <T> Multi<T> executePipelineStreaming(Object input) {
@@ -337,13 +159,6 @@ public class PipelineExecutionService {
 
   /**
    * Execute the configured pipeline and return a unary result.
-   *
-   * <p>Accepts either a {@code Uni} or {@code Multi} input. If the pipeline produces a stream,
-   * the result is a failed {@code Uni} indicating a shape mismatch.</p>
-   *
-   * @param input the input Uni or Multi supplied to the pipeline steps
-   * @param <T> the expected output type
-   * @return the pipeline result as a Uni with lifecycle hooks attached
    */
   @SuppressWarnings("unchecked")
   public <T> Uni<T> executePipelineUnary(Object input) {
@@ -352,11 +167,6 @@ public class PipelineExecutionService {
 
   /**
    * Submits an asynchronous orchestrator execution.
-   *
-   * @param input execution input payload
-   * @param tenantId tenant id from caller context
-   * @param idempotencyKey optional caller idempotency key
-   * @return accepted response payload
    */
   public Uni<RunAsyncAcceptedDto> executePipelineAsync(Object input, String tenantId, String idempotencyKey) {
     return executePipelineAsync(input, tenantId, idempotencyKey, false);
@@ -364,187 +174,53 @@ public class PipelineExecutionService {
 
   /**
    * Submits an asynchronous orchestrator execution.
-   *
-   * @param input execution input payload
-   * @param tenantId tenant id from caller context
-   * @param idempotencyKey optional caller idempotency key
-   * @param outputStreaming whether the pipeline output is streaming
-   * @return accepted response payload
    */
   public Uni<RunAsyncAcceptedDto> executePipelineAsync(
       Object input,
       String tenantId,
       String idempotencyKey,
       boolean outputStreaming) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    if (outputStreaming) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode does not support streaming pipeline outputs yet."));
-    }
-    Object executionInput = normalizeExecutionInput(input);
-    RuntimeException inputFailure = validateInputShape(executionInput);
-    if (inputFailure != null) {
-      return Uni.createFrom().failure(inputFailure);
-    }
-    String resolvedTenant = normalizeTenant(tenantId);
-    long now = System.currentTimeMillis();
-    long ttlEpochS = Instant.ofEpochMilli(now)
-        .plus(Duration.ofDays(Math.max(1, orchestratorConfig.executionTtlDays())))
-        .getEpochSecond();
-    return resolveExecutionInputPayload(executionInput)
-        .onItem().transformToUni(snapshot -> {
-          String executionKey;
-          try {
-            executionKey = resolveExecutionKey(resolvedTenant, snapshot.payload(), idempotencyKey);
-          } catch (IllegalArgumentException e) {
-            return Uni.createFrom().failure(new BadRequestException(e.getMessage()));
-          }
-          ExecutionCreateCommand command = new ExecutionCreateCommand(
-              resolvedTenant,
-              executionKey,
-              snapshot,
-              now,
-              ttlEpochS);
-          return executionStateStore.createOrGetExecution(command)
-              .onItem().transformToUni(created -> {
-                Uni<Void> enqueue = created.duplicate()
-                    ? Uni.createFrom().voidItem()
-                    : workDispatcher.enqueueNow(new ExecutionWorkItem(
-                        created.record().tenantId(),
-                        created.record().executionId()));
-                return enqueue.onItem().transform(ignored -> toRunAccepted(created, now));
-              });
-        });
+    return queueAsyncCoordinator.executePipelineAsync(input, tenantId, idempotencyKey, outputStreaming);
   }
 
   /**
    * Reads asynchronous execution status.
-   *
-   * @param tenantId tenant id from caller context
-   * @param executionId execution id
-   * @return execution status
    */
   public Uni<ExecutionStatusDto> getExecutionStatus(String tenantId, String executionId) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    String resolvedTenant = normalizeTenant(tenantId);
-    return executionStateStore.getExecution(resolvedTenant, executionId)
-        .onItem().transform(optional -> optional
-            .map(PipelineExecutionService::toStatusDto)
-            .orElseThrow(() -> new NotFoundException("Execution not found: " + executionId)));
+    return queueAsyncCoordinator.getExecutionStatus(tenantId, executionId);
   }
 
   /**
    * Reads asynchronous execution result.
-   *
-   * @param tenantId tenant id from caller context
-   * @param executionId execution id
-   * @param outputType expected output type
-   * @param outputStreaming whether the configured pipeline output is streaming
-   * @param <T> output type
-   * @return execution result payload
    */
-  @SuppressWarnings("unchecked")
   public <T> Uni<T> getExecutionResult(String tenantId, String executionId, Class<?> outputType, boolean outputStreaming) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    String resolvedTenant = normalizeTenant(tenantId);
-    return executionStateStore.getExecution(resolvedTenant, executionId)
-        .onItem().transform(optional -> optional.orElseThrow(
-            () -> new NotFoundException("Execution not found: " + executionId)))
-        .onItem().transform(record -> {
-          if (record.status() == ExecutionStatus.SUCCEEDED) {
-            if (record.resultPayload() == null) {
-              return null;
-            }
-            if (outputStreaming) {
-              return (T) record.resultPayload();
-            }
-            List<?> items = (List<?>) record.resultPayload();
-            if (items.isEmpty()) {
-              return null;
-            }
-            Object first = items.get(0);
-            if (outputType != null && first != null && !outputType.isInstance(first)) {
-              throw new IllegalStateException("Stored result type mismatch for execution " + executionId);
-            }
-            return (T) first;
-          }
-          if (record.status().terminal()) {
-            throw new IllegalStateException("Execution finished without a successful result: " + record.status());
-          }
-          throw new IllegalStateException("Execution is not complete yet: " + record.status());
-        });
+    return queueAsyncCoordinator.getExecutionResult(tenantId, executionId, outputType, outputStreaming);
   }
 
   /**
    * Handles queue-dispatched work items when using the local event dispatcher.
-   *
-   * @param workItem execution work item
    */
   void onExecutionWork(@ObservesAsync ExecutionWorkItem workItem) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
+    if (workItem == null) {
       return;
     }
     processExecutionWorkItem(workItem)
         .subscribe()
         .with(
-            ignored -> { },
+            ignored -> {
+            },
             failure -> LOG.errorf(failure, "Failed processing async execution work item %s", workItem));
   }
 
   /**
    * Processes one execution work item and advances lifecycle state.
-   *
-   * @param workItem work item
-   * @return completion signal
    */
   public Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().voidItem();
-    }
-    long now = System.currentTimeMillis();
-    return executionStateStore.claimLease(
-            workItem.tenantId(),
-            workItem.executionId(),
-            queueWorkerId,
-            now,
-            orchestratorConfig.leaseMs())
-        .onItem().transformToUni(claimed -> {
-          if (claimed.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          ExecutionRecord<Object, Object> record = claimed.get();
-          String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-          return runAsyncExecution(record.inputPayload())
-              .onItem().transformToUni(resultPayload -> executionStateStore.markSucceeded(
-                  record.tenantId(),
-                  record.executionId(),
-                  record.version(),
-                  transitionKey,
-                  resultPayload,
-                  System.currentTimeMillis()))
-              .onItem().transformToUni(updated -> {
-                if (updated.isPresent()) {
-                  return Uni.createFrom().voidItem();
-                }
-                return Uni.createFrom().voidItem();
-              })
-              .onFailure().recoverWithUni(failure -> handleExecutionFailure(record, transitionKey, failure));
-        });
+    return queueAsyncCoordinator.processExecutionWorkItem(workItem, this::executePipelineStreaming);
   }
 
   /**
    * Returns the current startup health state.
-   *
-   * @return the current startup health state
    */
   public StartupHealthState getStartupHealthState() {
     return startupHealthState.get();
@@ -552,9 +228,6 @@ public class PipelineExecutionService {
 
   /**
    * Block until startup health checks complete, or throw if they fail or time out.
-   *
-   * @param timeout maximum time to wait for health checks
-   * @return the resulting startup health state
    */
   public StartupHealthState awaitStartupHealth(Duration timeout) {
     CompletableFuture<Boolean> future = startupHealthFuture;
@@ -597,8 +270,8 @@ public class PipelineExecutionService {
       Object result = pipelineRunner.run(input, steps);
       return switch (result) {
         case null -> Multi.createFrom().failure(new IllegalStateException("PipelineRunner returned null"));
-        case Multi<?> multi -> attachMultiHooks(multi, watch);
-        case Uni<?> uni -> attachMultiHooks(uni.toMulti(), watch);
+        case Multi<?> multi -> executionHooks.attachMultiHooks(multi, watch);
+        case Uni<?> uni -> executionHooks.attachMultiHooks(uni.toMulti(), watch);
         default -> Multi.createFrom().failure(new IllegalStateException(
             MessageFormat.format("PipelineRunner returned unexpected type: {0}", result.getClass().getName())));
       };
@@ -624,7 +297,7 @@ public class PipelineExecutionService {
       Object result = pipelineRunner.run(input, steps);
       return switch (result) {
         case null -> Uni.createFrom().failure(new IllegalStateException("PipelineRunner returned null"));
-        case Uni<?> uni -> attachUniHooks(uni, watch);
+        case Uni<?> uni -> executionHooks.attachUniHooks(uni, watch);
         case Multi<?> ignored -> Uni.createFrom().failure(new IllegalStateException(
             "PipelineRunner returned stream output where unary output was expected"));
         default -> Uni.createFrom().failure(new IllegalStateException(
@@ -659,7 +332,7 @@ public class PipelineExecutionService {
     return null;
   }
 
-  private RuntimeException validateInputShape(Object input) {
+  RuntimeException validateInputShape(Object input) {
     if (input instanceof Uni<?> || input instanceof Multi<?>) {
       return null;
     }
@@ -668,662 +341,31 @@ public class PipelineExecutionService {
         input == null ? "null" : input.getClass().getName()));
   }
 
-  private static Object normalizeExecutionInput(Object input) {
-    if (input instanceof Uni<?> || input instanceof Multi<?>) {
-      return input;
-    }
-    return Uni.createFrom().item(input);
-  }
-
-  private static Uni<ExecutionInputSnapshot> resolveExecutionInputPayload(Object input) {
-    if (input instanceof Uni<?> uni) {
-      return uni.onItem().transform(item -> new ExecutionInputSnapshot(ExecutionInputShape.UNI, item));
-    }
-    if (input instanceof Multi<?> multi) {
-      return multi.collect().asList().onItem().transform(list ->
-          new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(list)));
-    }
-    return Uni.createFrom().item(new ExecutionInputSnapshot(ExecutionInputShape.RAW, input));
-  }
-
-  private String normalizeTenant(String tenantId) {
-    if (tenantId == null || tenantId.isBlank()) {
-      return orchestratorConfig.defaultTenant();
-    }
-    return tenantId.trim();
-  }
-
-  private String resolveExecutionKey(String tenantId, Object input, String clientKey) {
-    OrchestratorIdempotencyPolicy policy = orchestratorConfig.idempotencyPolicy();
-    String normalizedClientKey = normalizeOptional(clientKey);
-    if (policy == OrchestratorIdempotencyPolicy.CLIENT_KEY_REQUIRED) {
-      if (normalizedClientKey == null) {
-        throw new IllegalArgumentException("Idempotency-Key header is required.");
-      }
-      return normalizedClientKey;
-    }
-    if (policy == OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY && normalizedClientKey != null) {
-      return normalizedClientKey;
-    }
-    return deriveServerExecutionKey(tenantId, input);
-  }
-
-  private static String normalizeOptional(String value) {
-    if (value == null) {
-      return null;
-    }
-    String normalized = value.trim();
-    return normalized.isEmpty() ? null : normalized;
-  }
-
-  private static String deriveServerExecutionKey(String tenantId, Object input) {
-    try {
-      byte[] payloadBytes = org.pipelineframework.config.pipeline.PipelineJson.mapper().writeValueAsBytes(input);
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      digest.update(tenantId.getBytes(StandardCharsets.UTF_8));
-      digest.update((byte) ':');
-      digest.update(payloadBytes);
-      return Base64.getUrlEncoder().withoutPadding().encodeToString(digest.digest());
-    } catch (Exception e) {
-      throw new IllegalStateException("Failed to derive deterministic execution key.", e);
-    }
-  }
-
-  private static RunAsyncAcceptedDto toRunAccepted(CreateExecutionResult created, long nowEpochMs) {
-    String executionId = created.record().executionId();
-    return new RunAsyncAcceptedDto(
-        executionId,
-        created.duplicate(),
-        "/pipeline/executions/" + executionId,
-        nowEpochMs);
-  }
-
-  private static ExecutionStatusDto toStatusDto(ExecutionRecord<Object, Object> record) {
-    return new ExecutionStatusDto(
-        record.executionId(),
-        record.status(),
-        record.currentStepIndex(),
-        record.attempt(),
-        record.version(),
-        record.nextDueEpochMs(),
-        record.updatedAtEpochMs(),
-        record.errorCode(),
-        record.errorMessage());
-  }
-
-  private static String transitionKey(String executionId, int stepIndex, int attempt) {
-    return executionId + ":" + stepIndex + ":" + attempt;
-  }
-
-  private Uni<List<?>> runAsyncExecution(Object inputPayload) {
-    Object reactiveInput = toReplayInput(inputPayload);
-    return executePipelineStreaming(reactiveInput)
-        .select().first(2)
-        .collect().asList()
-        .onItem().transformToUni(items -> {
-          if (items.size() > 1) {
-            return Uni.createFrom().failure(
-                new IllegalStateException("Async queue mode does not support streaming pipeline outputs yet."));
-          }
-          return Uni.createFrom().item((List<?>) List.copyOf(items));
-        });
-  }
-
-  private Object toReplayInput(Object inputPayload) {
-    if (inputPayload instanceof ExecutionInputSnapshot snapshot) {
-      if (snapshot.shape() == ExecutionInputShape.MULTI) {
-        Object payload = snapshot.payload();
-        if (payload == null) {
-          return Multi.createFrom().empty();
-        }
-        if (payload instanceof Iterable<?> iterable) {
-          return Multi.createFrom().iterable(iterable);
-        }
-        return Multi.createFrom().item(payload);
-      }
-      return Uni.createFrom().item(snapshot.payload());
-    }
-    // Backward-compatible replay for records persisted before shape metadata.
-    if (inputPayload instanceof List<?> list) {
-      return Multi.createFrom().iterable(list);
-    }
-    return Uni.createFrom().item(inputPayload);
-  }
-
-  private Uni<Void> handleExecutionFailure(
-      ExecutionRecord<Object, Object> record,
-      String transitionKey,
-      Throwable failure) {
-    long now = System.currentTimeMillis();
-    int nextAttempt = record.attempt() + 1;
-    FailureClassification classification = classifyFailure(failure);
-    Throwable classifiedFailure = classification.classifiedThrowable();
-    boolean retryableFailure = classification.retryable();
-    boolean retryAllowed = nextAttempt <= orchestratorConfig.maxRetries();
-    if (retryAllowed && retryableFailure) {
-      long nextDue = now + retryDelayMillis(nextAttempt);
-          return executionStateStore.scheduleRetry(
-                  record.tenantId(),
-                  record.executionId(),
-                  record.version(),
-              nextAttempt,
-              nextDue,
-              transitionKey,
-              classifiedFailure.getClass().getSimpleName(),
-                  classifiedFailure.getMessage(),
-                  now)
-              .onItem().transformToUni(updated -> {
-                if (updated.isEmpty()) {
-                  return Uni.createFrom().voidItem();
-                }
-                Duration delay = Duration.ofMillis(Math.max(0L, nextDue - System.currentTimeMillis()));
-                return workDispatcher.enqueueDelayed(
-                    new ExecutionWorkItem(record.tenantId(), record.executionId()),
-                    delay);
-          });
-    }
-
-    return executionStateStore.markTerminalFailure(
-            record.tenantId(),
-            record.executionId(),
-            record.version(),
-            ExecutionStatus.FAILED,
-            transitionKey,
-            classifiedFailure.getClass().getSimpleName(),
-            classifiedFailure.getMessage(),
-            now)
-        .onItem().transformToUni(updated -> {
-          if (updated.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          PipelinePlatformResourceLoader.PlatformMetadata platformMetadata = PipelinePlatformResourceLoader
-              .loadPlatform()
-              .orElse(null);
-          DeadLetterEnvelope envelope = DeadLetterEnvelope.builder()
-              .tenantId(record.tenantId())
-              .executionId(record.executionId())
-              .executionKey(record.executionKey())
-              .correlationId(record.executionKey())
-              .transitionKey(transitionKey)
-              .resourceType("tpf.orchestrator.execution")
-              .resourceName(ORCHESTRATOR_SERVICE + "/" + ORCHESTRATOR_METHOD)
-              .transport(resolveTransport(platformMetadata))
-              .platform(resolvePlatform(platformMetadata))
-              .terminalStatus(ExecutionStatus.FAILED.name())
-              .terminalReason(retryableFailure ? "retry_exhausted" : "non_retryable")
-              .errorCode(classifiedFailure.getClass().getSimpleName())
-              .errorMessage(classifiedFailure.getMessage())
-              .retryable(retryableFailure)
-              .retriesObserved(record.attempt())
-              .createdAtEpochMs(now)
-              .build();
-          return deadLetterPublisher.publish(envelope);
-        });
-  }
-
-  private static String resolveTransport(PipelinePlatformResourceLoader.PlatformMetadata metadata) {
-    String candidate = metadata == null ? System.getProperty("pipeline.transport") : metadata.transport();
-    if (candidate == null || candidate.isBlank()) {
-      return "UNKNOWN";
-    }
-    return candidate.trim().toUpperCase(Locale.ROOT);
-  }
-
-  private static String resolvePlatform(PipelinePlatformResourceLoader.PlatformMetadata metadata) {
-    String candidate = metadata == null ? System.getProperty("pipeline.platform") : metadata.platform();
-    if (candidate == null || candidate.isBlank()) {
-      return "UNKNOWN";
-    }
-    return candidate.trim().toUpperCase(Locale.ROOT);
-  }
-
-  private static FailureClassification classifyFailure(Throwable failure) {
-    if (failure == null) {
-      Throwable classified = new IllegalStateException("Unknown failure");
-      return new FailureClassification(false, classified);
-    }
-    Throwable nonRetryable = findThrowable(failure, NonRetryableException.class);
-    if (nonRetryable != null) {
-      return new FailureClassification(false, nonRetryable);
-    }
-    return new FailureClassification(true, failure);
-  }
-
-  private static Throwable findThrowable(Throwable failure, Class<? extends Throwable> targetType) {
-    java.util.ArrayDeque<Throwable> queue = new java.util.ArrayDeque<>();
-    java.util.Set<Throwable> seen = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
-    queue.add(failure);
-    while (!queue.isEmpty()) {
-      Throwable current = queue.removeFirst();
-      if (!seen.add(current)) {
-        continue;
-      }
-      if (targetType.isInstance(current)) {
-        return current;
-      }
-      Throwable cause = current.getCause();
-      if (cause != null && cause != current) {
-        queue.add(cause);
-      }
-    }
-    return null;
-  }
-
-  private record FailureClassification(boolean retryable, Throwable classifiedThrowable) {
-  }
-
-  private long retryDelayMillis(int nextAttempt) {
-    long base = Math.max(0L, orchestratorConfig.retryDelay().toMillis());
-    double multiplier = Math.max(1.0d, orchestratorConfig.retryMultiplier());
-    double calculated = base * Math.pow(multiplier, Math.max(0, nextAttempt - 1));
-    return Math.min((long) calculated, TimeUnit.MINUTES.toMillis(30));
-  }
-
-  private void sweepDueExecutions() {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || executionStateStore == null || workDispatcher == null) {
-      return;
-    }
-    long now = System.currentTimeMillis();
-    executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit())
-        .onItem().transformToUni(due -> {
-          if (due.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          List<Uni<Void>> enqueueOperations = new ArrayList<>(due.size());
-          for (ExecutionRecord<Object, Object> record : due) {
-            enqueueOperations.add(workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
-                .onFailure().transform(failure -> new IllegalStateException(
-                    "Failed to re-dispatch due execution " + record.executionId(),
-                    failure)));
-          }
-          return Uni.join().all(enqueueOperations).andCollectFailures().replaceWithVoid();
-        })
-        .subscribe()
-        .with(
-            ignored -> { },
-            failure -> LOG.errorf(failure, "Failed sweeping due async executions"));
-  }
-
-  private <T> Multi<T> attachRetryAmplificationGuard(Multi<T> multi) {
-    if (telemetry == null || !telemetry.retryAmplificationGuardEnabled()) {
-      return multi;
-    }
-    Duration interval = telemetry.retryAmplificationCheckInterval();
-    RetryAmplificationGuardMode mode = telemetry.retryAmplificationMode();
-    return multi.plug(upstream -> new RetryAmplificationGuardMulti<>(upstream, interval, mode));
-  }
-
-  private <T> Uni<T> attachRetryAmplificationGuard(Uni<T> uni) {
-    if (telemetry == null || !telemetry.retryAmplificationGuardEnabled()) {
-      return uni;
-    }
-    Duration interval = telemetry.retryAmplificationCheckInterval();
-    RetryAmplificationGuardMode mode = telemetry.retryAmplificationMode();
-    AtomicBoolean logged = new AtomicBoolean(false);
-    return Uni.createFrom().emitter(emitter -> {
-      AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
-      AtomicReference<ScheduledFuture<?>> futureRef = new AtomicReference<>();
-      Cancellable cancellable = uni.subscribe().with(
-          item -> {
-            ScheduledFuture<?> scheduled = futureRef.get();
-            if (scheduled != null) {
-              scheduled.cancel(false);
-            }
-            emitter.complete(item);
-          },
-          failure -> {
-            ScheduledFuture<?> scheduled = futureRef.get();
-            if (scheduled != null) {
-              scheduled.cancel(false);
-            }
-            emitter.fail(failure);
-          });
-      cancellableRef.set(cancellable);
-      ScheduledFuture<?> future = killSwitchExecutor.scheduleAtFixedRate(() -> {
-        telemetry.retryAmplificationTrigger().ifPresent(trigger -> {
-          if (!logged.compareAndSet(false, true)) {
-            return;
-          }
-          logRetryAmplificationTrigger(trigger, mode);
-          if (mode == RetryAmplificationGuardMode.FAIL_FAST) {
-            emitter.fail(PipelineKillSwitchException.retryAmplification(trigger));
-            Cancellable active = cancellableRef.get();
-            if (active != null) {
-              active.cancel();
-            }
-          } else {
-            ScheduledFuture<?> scheduled = futureRef.get();
-            if (scheduled != null) {
-              scheduled.cancel(false);
-            }
-          }
-        });
-      }, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
-      futureRef.set(future);
-      emitter.onTermination(() -> {
-        ScheduledFuture<?> scheduled = futureRef.get();
-        if (scheduled != null) {
-          scheduled.cancel(false);
-        }
-      });
-    });
-  }
-
-  private final class RetryAmplificationGuardMulti<T> extends AbstractMultiOperator<T, T> {
-    private final Duration interval;
-    private final RetryAmplificationGuardMode mode;
-
-    private RetryAmplificationGuardMulti(
-        Multi<? extends T> upstream,
-        Duration interval,
-        RetryAmplificationGuardMode mode) {
-      super(upstream);
-      this.interval = interval;
-      this.mode = mode;
-    }
-
-    @Override
-    public void subscribe(MultiSubscriber<? super T> downstream) {
-      RetryAmplificationProcessor<T> processor =
-          new RetryAmplificationProcessor<>(downstream, interval, mode);
-      upstream().subscribe(processor);
-    }
-  }
-
-  private final class RetryAmplificationProcessor<T> extends MultiOperatorProcessor<T, T> {
-    private final RetryAmplificationGuardMode mode;
-    private final AtomicBoolean logged;
-    private final ScheduledFuture<?> future;
-
-    private RetryAmplificationProcessor(
-        MultiSubscriber<? super T> downstream,
-        Duration interval,
-        RetryAmplificationGuardMode mode) {
-      super(downstream);
-      this.mode = mode;
-      this.logged = new AtomicBoolean(false);
-      this.future = killSwitchExecutor.scheduleAtFixedRate(
-          this::checkGuard,
-          interval.toMillis(),
-          interval.toMillis(),
-          TimeUnit.MILLISECONDS);
-    }
-
-    @Override
-    public void onItem(T item) {
-      if (!isDone()) {
-        downstream.onItem(item);
-      }
-    }
-
-    @Override
-    public void onFailure(Throwable failure) {
-      cancelFuture();
-      super.onFailure(failure);
-    }
-
-    @Override
-    public void onCompletion() {
-      cancelFuture();
-      super.onCompletion();
-    }
-
-    @Override
-    public void cancel() {
-      cancelFuture();
-      super.cancel();
-    }
-
-    private void checkGuard() {
-      telemetry.retryAmplificationTrigger().ifPresent(trigger -> {
-        if (!logged.compareAndSet(false, true)) {
-          return;
-        }
-        logRetryAmplificationTrigger(trigger, mode);
-        cancelFuture();
-        if (mode == RetryAmplificationGuardMode.FAIL_FAST) {
-          if (isDone()) {
-            return;
-          }
-          super.onFailure(PipelineKillSwitchException.retryAmplification(trigger));
-        }
-      });
-    }
-
-    private void cancelFuture() {
-      if (future != null) {
-        future.cancel(false);
-      }
-    }
-  }
-
-  private void logRetryAmplificationTrigger(
-      RetryAmplificationGuard.Trigger trigger,
-      RetryAmplificationGuardMode mode) {
-    String action = mode == RetryAmplificationGuardMode.FAIL_FAST ? "aborting" : "logging";
-    LOG.errorf(
-        "Retry amplification guard triggered for step %s (inflight slope %.2f > %.2f, retry rate %.2f) over %s (sustain samples %d); %s pipeline run.",
-        trigger.step(),
-        trigger.inflightSlope(),
-        trigger.inflightSlopeThreshold(),
-        trigger.retryRate(),
-        trigger.window(),
-        trigger.sustainSamples(),
-        action);
-  }
-
-  private <T> Multi<T> attachMultiHooks(Multi<T> multi, StopWatch watch) {
-    Multi<T> guarded = attachRetryAmplificationGuard(multi);
-    long[] startTime = new long[1];
-    return guarded
-        .onSubscription().invoke(ignored -> {
-          LOG.info("PIPELINE BEGINS processing");
-          startTime[0] = System.nanoTime();
-          watch.start();
-        })
-        .onCompletion().invoke(() -> {
-          watch.stop();
-          long durationNanos = System.nanoTime() - startTime[0];
-          RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.OK, durationNanos);
-          ApmCompatibilityMetrics.recordOrchestratorSuccess(durationNanos / 1_000_000d);
-          LOG.infof("✅ PIPELINE FINISHED processing in %s seconds", watch.getTime(TimeUnit.SECONDS));
-        })
-        .onFailure().invoke(failure -> {
-          watch.stop();
-          long durationNanos = System.nanoTime() - startTime[0];
-          RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.fromThrowable(failure),
-              durationNanos);
-          ApmCompatibilityMetrics.recordOrchestratorFailure(durationNanos / 1_000_000d);
-          LOG.errorf(failure, "❌ PIPELINE FAILED after %s seconds", watch.getTime(TimeUnit.SECONDS));
-        });
-  }
-
-  private <T> Uni<T> attachUniHooks(Uni<T> uni, StopWatch watch) {
-    Uni<T> guarded = attachRetryAmplificationGuard(uni);
-    long[] startTime = new long[1];
-    return guarded
-        .onSubscription().invoke(ignored -> {
-          LOG.info("PIPELINE BEGINS processing");
-          startTime[0] = System.nanoTime();
-          watch.start();
-        })
-        .onItemOrFailure().invoke((item, failure) -> {
-          watch.stop();
-          long durationNanos = System.nanoTime() - startTime[0];
-          if (failure == null) {
-            RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.OK, durationNanos);
-            ApmCompatibilityMetrics.recordOrchestratorSuccess(durationNanos / 1_000_000d);
-            LOG.infof("✅ PIPELINE FINISHED processing in %s seconds", watch.getTime(TimeUnit.SECONDS));
-          } else {
-            RpcMetrics.recordGrpcServer(ORCHESTRATOR_SERVICE, ORCHESTRATOR_METHOD, Status.fromThrowable(failure),
-                durationNanos);
-            ApmCompatibilityMetrics.recordOrchestratorFailure(durationNanos / 1_000_000d);
-            LOG.errorf(failure, "❌ PIPELINE FAILED after %s seconds", watch.getTime(TimeUnit.SECONDS));
-          }
-        });
-  }
-
-  private static double durationMillis(long startNanos) {
-    return (System.nanoTime() - startNanos) / 1_000_000d;
-  }
-
-  /**
-   * Load configured pipeline steps, instantiate them as CDI-managed beans and return them in execution order.
-   *
-   * <p>If configuration cannot be read or an error occurs while instantiating steps, an exception is thrown to
-   * indicate the failure, except when no steps are configured (empty stepConfigs map), which returns an empty list.
-   *
-   * @return the instantiated pipeline step objects in execution order, or an empty list if no steps are configured
-   * @throws PipelineConfigurationException if there are configuration or instantiation failures
-   */
-  private List<Object> loadPipelineSteps() {
-    try {
-      // Use the structured configuration mapping to get all pipeline steps
-      java.util.Optional<List<String>> resourceOrder = PipelineOrderResourceLoader.loadOrder();
-      if (resourceOrder.isEmpty()) {
-        if (PipelineOrderResourceLoader.requiresOrder()) {
-          throw new PipelineConfigurationException(
-              "Pipeline order metadata not found. Ensure META-INF/pipeline/order.json is generated at build time.");
-        }
-        return Collections.emptyList();
-      }
-      List<String> orderedStepNames = resourceOrder.get();
-      if (orderedStepNames.isEmpty()) {
-        throw new PipelineConfigurationException(
-            "Pipeline order metadata is empty. Ensure pipeline.yaml defines steps for order generation.");
-      }
-      if (LOG.isInfoEnabled()) {
-        LOG.infof("Loaded pipeline step order (%d steps): %s", orderedStepNames.size(), orderedStepNames);
-      }
-      return instantiateStepsInOrder(orderedStepNames);
-    } catch (Exception e) {
-      LOG.errorf(e, "Failed to load configuration: %s", e.getMessage());
-      throw new PipelineConfigurationException("Failed to load pipeline configuration: " + e.getMessage(), e);
-    }
-  }
-
-  private List<Object> instantiateStepsInOrder(List<String> orderedStepNames) {
-    List<Object> steps = new ArrayList<>();
-    List<String> failedSteps = new ArrayList<>();
-    for (String stepClassName : orderedStepNames) {
-      Object step = createStepFromConfig(stepClassName);
-      if (step != null) {
-        steps.add(step);
-      } else {
-        failedSteps.add(stepClassName);
-      }
-    }
-
-    if (!failedSteps.isEmpty()) {
-      String message = String.format("Failed to instantiate %d step(s): %s",
-        failedSteps.size(), String.join(", ", failedSteps));
-      LOG.error(message);
-      throw new PipelineConfigurationException(message);
-    }
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debugf("Loaded %d pipeline steps from generated order metadata", steps.size());
-    }
-    return steps;
-  }
-
-
-  private List<Object> instantiateStepsFromConfig(
-    Map<String, org.pipelineframework.config.PipelineStepConfig.StepConfig> stepConfigs) {
-    List<String> orderedStepNames = stepConfigs.keySet().stream()
-      .sorted()
-      .toList();
-
-    List<Object> steps = new ArrayList<>();
-    List<String> failedSteps = new ArrayList<>();
-    for (String stepClassName : orderedStepNames) {
-      Object step = createStepFromConfig(stepClassName);
-      if (step != null) {
-        steps.add(step);
-      } else {
-        failedSteps.add(stepClassName);
-      }
-    }
-
-    if (!failedSteps.isEmpty()) {
-      String message = String.format("Failed to instantiate %d step(s): %s",
-        failedSteps.size(), String.join(", ", failedSteps));
-      LOG.error(message);
-      throw new PipelineConfigurationException(message);
-    }
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debugf("Loaded %d pipeline steps from application properties", steps.size());
-    }
-    return steps;
-  }
-
-  /**
-   * Instantiates a pipeline step class and returns the CDI-managed bean.
-   *
-   * @param stepClassName the fully qualified class name of the pipeline step
-   * @return the CDI-managed instance of the step, or null if instantiation fails
-   */
-  private Object createStepFromConfig(String stepClassName) {
-    try {
-      ClassLoader[] candidates = new ClassLoader[] {
-        Thread.currentThread().getContextClassLoader(),
-        PipelineExecutionService.class.getClassLoader(),
-        ClassLoader.getSystemClassLoader()
-      };
-
-      Class<?> stepClass = null;
-      for (ClassLoader candidate : candidates) {
-        if (candidate == null) {
-          continue;
-        }
-        try {
-          stepClass = Class.forName(stepClassName, true, candidate);
-          break;
-        } catch (ClassNotFoundException ignored) {
-          // try next loader
-        }
-      }
-
-      if (stepClass == null) {
-        throw new ClassNotFoundException(stepClassName);
-      }
-      io.quarkus.arc.InstanceHandle<?> handle = io.quarkus.arc.Arc.container().instance(stepClass);
-      if (!handle.isAvailable()) {
-        int beanCount = io.quarkus.arc.Arc.container().beanManager().getBeans(stepClass).size();
-        ClassLoader loader = stepClass.getClassLoader();
-        LOG.errorf("No CDI bean available for pipeline step %s (beans=%d, loader=%s)",
-            stepClassName, beanCount, loader);
-        return null;
-      }
-      return handle.get();
-    } catch (Exception e) {
-      LOG.errorf(e, "Failed to instantiate pipeline step: %s, error: %s", stepClassName, e.getMessage());
-      return null;
-    }
+  List<Object> loadPipelineSteps() {
+    return pipelineStepResolver.loadPipelineSteps();
   }
 
   /**
    * Exception thrown when there are configuration issues related to pipeline setup.
    */
   public static class PipelineConfigurationException extends RuntimeException {
-      /**
-       * Constructs a new PipelineConfigurationException with the specified detail message.
-       *
-       * @param message the detail message
-       */
-      public PipelineConfigurationException(String message) {
-          super(message);
-      }
+    /**
+     * Constructs a new PipelineConfigurationException with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public PipelineConfigurationException(String message) {
+      super(message);
+    }
 
-      /**
-       * Constructs a new PipelineConfigurationException with the specified detail message and cause.
-       *
-       * @param message the detail message
-       * @param cause the cause
-       */
-      public PipelineConfigurationException(String message, Throwable cause) {
-          super(message, cause);
-      }
+    /**
+     * Constructs a new PipelineConfigurationException with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public PipelineConfigurationException(String message, Throwable cause) {
+      super(message, cause);
+    }
   }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineStepResolver.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineStepResolver.java
@@ -1,0 +1,139 @@
+package org.pipelineframework;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+import org.pipelineframework.config.PipelineStepConfig;
+import org.pipelineframework.config.pipeline.PipelineOrderResourceLoader;
+
+/**
+ * Resolves, orders, and instantiates pipeline steps from generated metadata.
+ */
+@ApplicationScoped
+class PipelineStepResolver {
+
+  private static final Logger LOG = Logger.getLogger(PipelineStepResolver.class);
+
+  List<Object> loadPipelineSteps() {
+    try {
+      java.util.Optional<List<String>> resourceOrder = PipelineOrderResourceLoader.loadOrder();
+      if (resourceOrder.isEmpty()) {
+        if (PipelineOrderResourceLoader.requiresOrder()) {
+          throw new PipelineExecutionService.PipelineConfigurationException(
+              "Pipeline order metadata not found. Ensure META-INF/pipeline/order.json is generated at build time.");
+        }
+        return Collections.emptyList();
+      }
+      List<String> orderedStepNames = resourceOrder.get();
+      if (orderedStepNames.isEmpty()) {
+        throw new PipelineExecutionService.PipelineConfigurationException(
+            "Pipeline order metadata is empty. Ensure pipeline.yaml defines steps for order generation.");
+      }
+      if (LOG.isInfoEnabled()) {
+        LOG.infof("Loaded pipeline step order (%d steps): %s", orderedStepNames.size(), orderedStepNames);
+      }
+      return instantiateStepsInOrder(orderedStepNames);
+    } catch (PipelineExecutionService.PipelineConfigurationException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.errorf(e, "Failed to load configuration: %s", e.getMessage());
+      throw new PipelineExecutionService.PipelineConfigurationException(
+          "Failed to load pipeline configuration: " + e.getMessage(),
+          e);
+    }
+  }
+
+  List<Object> instantiateStepsFromConfig(Map<String, PipelineStepConfig.StepConfig> stepConfigs) {
+    List<String> orderedStepNames = stepConfigs.keySet().stream().sorted().toList();
+
+    List<Object> steps = new ArrayList<>();
+    List<String> failedSteps = new ArrayList<>();
+    for (String stepClassName : orderedStepNames) {
+      Object step = createStepFromConfig(stepClassName);
+      if (step != null) {
+        steps.add(step);
+      } else {
+        failedSteps.add(stepClassName);
+      }
+    }
+
+    if (!failedSteps.isEmpty()) {
+      String message = String.format("Failed to instantiate %d step(s): %s", failedSteps.size(), String.join(", ", failedSteps));
+      LOG.error(message);
+      throw new PipelineExecutionService.PipelineConfigurationException(message);
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debugf("Loaded %d pipeline steps from application properties", steps.size());
+    }
+    return steps;
+  }
+
+  private List<Object> instantiateStepsInOrder(List<String> orderedStepNames) {
+    List<Object> steps = new ArrayList<>();
+    List<String> failedSteps = new ArrayList<>();
+    for (String stepClassName : orderedStepNames) {
+      Object step = createStepFromConfig(stepClassName);
+      if (step != null) {
+        steps.add(step);
+      } else {
+        failedSteps.add(stepClassName);
+      }
+    }
+
+    if (!failedSteps.isEmpty()) {
+      String message = String.format("Failed to instantiate %d step(s): %s", failedSteps.size(), String.join(", ", failedSteps));
+      LOG.error(message);
+      throw new PipelineExecutionService.PipelineConfigurationException(message);
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debugf("Loaded %d pipeline steps from generated order metadata", steps.size());
+    }
+    return steps;
+  }
+
+  private Object createStepFromConfig(String stepClassName) {
+    try {
+      ClassLoader[] candidates = new ClassLoader[] {
+          Thread.currentThread().getContextClassLoader(),
+          PipelineExecutionService.class.getClassLoader(),
+          ClassLoader.getSystemClassLoader() };
+
+      Class<?> stepClass = null;
+      for (ClassLoader candidate : candidates) {
+        if (candidate == null) {
+          continue;
+        }
+        try {
+          stepClass = Class.forName(stepClassName, true, candidate);
+          break;
+        } catch (ClassNotFoundException ignored) {
+          // try next loader
+        }
+      }
+
+      if (stepClass == null) {
+        throw new ClassNotFoundException(stepClassName);
+      }
+      io.quarkus.arc.InstanceHandle<?> handle = io.quarkus.arc.Arc.container().instance(stepClass);
+      if (!handle.isAvailable()) {
+        int beanCount = io.quarkus.arc.Arc.container().beanManager().getBeans(stepClass).size();
+        ClassLoader loader = stepClass.getClassLoader();
+        LOG.errorf("No CDI bean available for pipeline step %s (beans=%d, loader=%s)",
+            stepClassName,
+            beanCount,
+            loader);
+        return null;
+      }
+      return handle.get();
+    } catch (Exception e) {
+      LOG.errorf(e, "Failed to instantiate pipeline step: %s, error: %s", stepClassName, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -1,0 +1,363 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+
+/**
+ * Coordinates queue-mode orchestration lifecycle and provider interactions.
+ */
+@ApplicationScoped
+class QueueAsyncCoordinator {
+
+  private static final Logger LOG = Logger.getLogger(QueueAsyncCoordinator.class);
+
+  @Inject
+  PipelineOrchestratorConfig orchestratorConfig;
+
+  @Inject
+  Instance<ExecutionStateStore> executionStateStores;
+
+  @Inject
+  Instance<WorkDispatcher> workDispatchers;
+
+  @Inject
+  Instance<DeadLetterPublisher> deadLetterPublishers;
+
+  @Inject
+  ExecutionInputPolicy executionInputPolicy;
+
+  @Inject
+  ExecutionFailureHandler executionFailureHandler;
+
+  private final ScheduledExecutorService queueSweepExecutor = Executors.newSingleThreadScheduledExecutor(
+      runnable -> {
+        Thread thread = new Thread(runnable, "tpf-queue-sweeper");
+        thread.setDaemon(true);
+        return thread;
+      });
+
+  private volatile ScheduledFuture<?> queueSweepFuture;
+  volatile ExecutionStateStore executionStateStore;
+  volatile WorkDispatcher workDispatcher;
+  volatile DeadLetterPublisher deadLetterPublisher;
+  private final String queueWorkerId = "worker-" + UUID.randomUUID();
+
+  void initializeQueueMode() {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return;
+    }
+    executionStateStore = selectExecutionStateStore(orchestratorConfig.stateProvider());
+    workDispatcher = selectWorkDispatcher(orchestratorConfig.dispatcherProvider());
+    deadLetterPublisher = selectDeadLetterPublisher(orchestratorConfig.dlqProvider());
+
+    List<String> providerReadinessErrors = new ArrayList<>();
+    executionStateStore.startupValidationError(orchestratorConfig)
+        .ifPresent(error -> providerReadinessErrors
+            .add("ExecutionStateStore(" + executionStateStore.providerName() + "): " + error));
+    workDispatcher.startupValidationError(orchestratorConfig)
+        .ifPresent(error -> providerReadinessErrors
+            .add("WorkDispatcher(" + workDispatcher.providerName() + "): " + error));
+    deadLetterPublisher.startupValidationError(orchestratorConfig)
+        .ifPresent(error -> providerReadinessErrors
+            .add("DeadLetterPublisher(" + deadLetterPublisher.providerName() + "): " + error));
+    if (!providerReadinessErrors.isEmpty()) {
+      String readinessMessage = "Queue async provider startup validation failed: " + String.join("; ",
+          providerReadinessErrors);
+      if (orchestratorConfig.strictStartup()) {
+        throw new IllegalStateException(readinessMessage);
+      }
+      LOG.warn(readinessMessage);
+    }
+
+    if (orchestratorConfig.strictStartup()
+        && orchestratorConfig.idempotencyPolicy() == OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY) {
+      throw new IllegalStateException(
+          "pipeline.orchestrator.idempotency-policy must be explicitly configured for queue mode when strict startup is enabled.");
+    }
+    Duration interval = orchestratorConfig.sweepInterval();
+    long intervalMs = Math.max(1000L, interval == null ? 30000L : interval.toMillis());
+    queueSweepFuture = queueSweepExecutor.scheduleAtFixedRate(
+        this::sweepDueExecutions,
+        intervalMs,
+        intervalMs,
+        TimeUnit.MILLISECONDS);
+    LOG.infof("Queue async mode enabled: stateProvider=%s dispatcherProvider=%s dlqProvider=%s",
+        executionStateStore.providerName(),
+        workDispatcher.providerName(),
+        deadLetterPublisher.providerName());
+  }
+
+  @PreDestroy
+  void shutdownQueueSweepExecutor() {
+    if (queueSweepFuture != null) {
+      queueSweepFuture.cancel(false);
+    }
+    queueSweepExecutor.shutdownNow();
+  }
+
+  Uni<RunAsyncAcceptedDto> executePipelineAsync(
+      Object input,
+      String tenantId,
+      String idempotencyKey,
+      boolean outputStreaming) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    if (outputStreaming) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode does not support streaming pipeline outputs yet."));
+    }
+    Object executionInput = executionInputPolicy.normalizeExecutionInput(input);
+    RuntimeException inputFailure = executionInputPolicy.validateInputShape(executionInput);
+    if (inputFailure != null) {
+      return Uni.createFrom().failure(inputFailure);
+    }
+    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+    long now = System.currentTimeMillis();
+    long ttlEpochS = Instant.ofEpochMilli(now)
+        .plus(Duration.ofDays(Math.max(1, orchestratorConfig.executionTtlDays())))
+        .getEpochSecond();
+
+    return executionInputPolicy.resolveExecutionInputPayload(executionInput)
+        .onItem().transformToUni(snapshot -> {
+          String executionKey;
+          try {
+            executionKey = executionInputPolicy.resolveExecutionKey(resolvedTenant, snapshot.payload(), idempotencyKey);
+          } catch (IllegalArgumentException e) {
+            return Uni.createFrom().failure(new BadRequestException(e.getMessage()));
+          }
+          ExecutionCreateCommand command = new ExecutionCreateCommand(
+              resolvedTenant,
+              executionKey,
+              snapshot,
+              now,
+              ttlEpochS);
+          return executionStateStore.createOrGetExecution(command)
+              .onItem().transformToUni(created -> {
+                Uni<Void> enqueue = created.duplicate()
+                    ? Uni.createFrom().voidItem()
+                    : workDispatcher.enqueueNow(new ExecutionWorkItem(
+                        created.record().tenantId(),
+                        created.record().executionId()));
+                return enqueue.onItem().transform(ignored -> toRunAccepted(created, now));
+              });
+        });
+  }
+
+  Uni<ExecutionStatusDto> getExecutionStatus(String tenantId, String executionId) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+    return executionStateStore.getExecution(resolvedTenant, executionId)
+        .onItem().transform(optional -> optional
+            .map(QueueAsyncCoordinator::toStatusDto)
+            .orElseThrow(() -> new NotFoundException("Execution not found: " + executionId)));
+  }
+
+  @SuppressWarnings("unchecked")
+  <T> Uni<T> getExecutionResult(String tenantId, String executionId, Class<?> outputType, boolean outputStreaming) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+    return executionStateStore.getExecution(resolvedTenant, executionId)
+        .onItem().transform(optional -> optional.orElseThrow(
+            () -> new NotFoundException("Execution not found: " + executionId)))
+        .onItem().transform(record -> {
+          if (record.status() == ExecutionStatus.SUCCEEDED) {
+            if (record.resultPayload() == null) {
+              return null;
+            }
+            if (outputStreaming) {
+              return (T) record.resultPayload();
+            }
+            List<?> items = (List<?>) record.resultPayload();
+            if (items.isEmpty()) {
+              return null;
+            }
+            Object first = items.get(0);
+            if (outputType != null && first != null && !outputType.isInstance(first)) {
+              throw new IllegalStateException("Stored result type mismatch for execution " + executionId);
+            }
+            return (T) first;
+          }
+          if (record.status().terminal()) {
+            throw new IllegalStateException("Execution finished without a successful result: " + record.status());
+          }
+          throw new IllegalStateException("Execution is not complete yet: " + record.status());
+        });
+  }
+
+  Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, Function<Object, Multi<?>> executeStreaming) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
+      return Uni.createFrom().voidItem();
+    }
+    long now = System.currentTimeMillis();
+    return executionStateStore.claimLease(
+            workItem.tenantId(),
+            workItem.executionId(),
+            queueWorkerId,
+            now,
+            orchestratorConfig.leaseMs())
+        .onItem().transformToUni(claimed -> {
+          if (claimed.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          ExecutionRecord<Object, Object> record = claimed.get();
+          String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
+          return runAsyncExecution(record.inputPayload(), executeStreaming)
+              .onItem().transformToUni(resultPayload -> executionStateStore.markSucceeded(
+                  record.tenantId(),
+                  record.executionId(),
+                  record.version(),
+                  transitionKey,
+                  resultPayload,
+                  System.currentTimeMillis()))
+              .onItem().transformToUni(updated -> Uni.createFrom().voidItem())
+              .onFailure().recoverWithUni(
+                  failure -> executionFailureHandler.handleExecutionFailure(
+                      record,
+                      transitionKey,
+                      failure,
+                      executionStateStore,
+                      workDispatcher,
+                      deadLetterPublisher));
+        });
+  }
+
+  void sweepDueExecutions() {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || executionStateStore == null || workDispatcher == null) {
+      return;
+    }
+    long now = System.currentTimeMillis();
+    executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit())
+        .onItem().transformToUni(due -> {
+          if (due.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          List<Uni<Void>> enqueueOperations = new ArrayList<>(due.size());
+          for (ExecutionRecord<Object, Object> record : due) {
+            enqueueOperations.add(workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
+                .onFailure().transform(failure -> new IllegalStateException(
+                    "Failed to re-dispatch due execution " + record.executionId(),
+                    failure)));
+          }
+          return Uni.join().all(enqueueOperations).andCollectFailures().replaceWithVoid();
+        })
+        .subscribe()
+        .with(
+            ignored -> {
+            },
+            failure -> LOG.errorf(failure, "Failed sweeping due async executions"));
+  }
+
+  private Uni<List<?>> runAsyncExecution(Object inputPayload, Function<Object, Multi<?>> executeStreaming) {
+    Object reactiveInput = executionInputPolicy.toReplayInput(inputPayload);
+    return executeStreaming.apply(reactiveInput)
+        .select().first(2)
+        .collect().asList()
+        .onItem().transformToUni(items -> {
+          if (items.size() > 1) {
+            return Uni.createFrom().failure(
+                new IllegalStateException("Async queue mode does not support streaming pipeline outputs yet."));
+          }
+          return Uni.createFrom().item((List<?>) List.copyOf(items));
+        });
+  }
+
+  private ExecutionStateStore selectExecutionStateStore(String providerName) {
+    return executionStateStores.stream()
+        .filter(store -> providerMatches(store.providerName(), providerName))
+        .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "No ExecutionStateStore provider found for '" + providerName + "'"));
+  }
+
+  private WorkDispatcher selectWorkDispatcher(String providerName) {
+    return workDispatchers.stream()
+        .filter(dispatcher -> providerMatches(dispatcher.providerName(), providerName))
+        .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "No WorkDispatcher provider found for '" + providerName + "'"));
+  }
+
+  private DeadLetterPublisher selectDeadLetterPublisher(String providerName) {
+    return deadLetterPublishers.stream()
+        .filter(publisher -> providerMatches(publisher.providerName(), providerName))
+        .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "No DeadLetterPublisher provider found for '" + providerName + "'"));
+  }
+
+  private static boolean providerMatches(String availableName, String configuredName) {
+    if (configuredName == null || configuredName.isBlank()) {
+      return true;
+    }
+    return configuredName.equalsIgnoreCase(availableName);
+  }
+
+  private static RunAsyncAcceptedDto toRunAccepted(CreateExecutionResult created, long nowEpochMs) {
+    String executionId = created.record().executionId();
+    return new RunAsyncAcceptedDto(
+        executionId,
+        created.duplicate(),
+        "/pipeline/executions/" + executionId,
+        nowEpochMs);
+  }
+
+  private static ExecutionStatusDto toStatusDto(ExecutionRecord<Object, Object> record) {
+    return new ExecutionStatusDto(
+        record.executionId(),
+        record.status(),
+        record.currentStepIndex(),
+        record.attempt(),
+        record.version(),
+        record.nextDueEpochMs(),
+        record.updatedAtEpochMs(),
+        record.errorCode(),
+        record.errorMessage());
+  }
+
+  private static String transitionKey(String executionId, int stepIndex, int attempt) {
+    return executionId + ":" + stepIndex + ":" + attempt;
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ExecutionHooksTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ExecutionHooksTest.java
@@ -1,0 +1,42 @@
+package org.pipelineframework;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.apache.commons.lang3.time.StopWatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.telemetry.PipelineTelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutionHooksTest {
+
+    private ExecutionHooks hooks;
+
+    @Mock
+    private PipelineTelemetry telemetry;
+
+    @BeforeEach
+    void setUp() {
+        hooks = new ExecutionHooks();
+        hooks.telemetry = telemetry;
+        when(telemetry.retryAmplificationGuardEnabled()).thenReturn(false);
+    }
+
+    @Test
+    void attachUniHooksReturnsWrappedUniWhenGuardDisabled() {
+        Uni<String> wrapped = hooks.attachUniHooks(Uni.createFrom().item("ok"), new StopWatch());
+        assertNotNull(wrapped);
+    }
+
+    @Test
+    void attachMultiHooksReturnsWrappedMultiWhenGuardDisabled() {
+        Multi<String> wrapped = hooks.attachMultiHooks(Multi.createFrom().items("a", "b"), new StopWatch());
+        assertNotNull(wrapped);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ExecutionInputPolicyTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ExecutionInputPolicyTest.java
@@ -1,0 +1,82 @@
+package org.pipelineframework;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutionInputPolicyTest {
+
+    private ExecutionInputPolicy policy;
+
+    @Mock
+    private PipelineOrchestratorConfig orchestratorConfig;
+
+    @BeforeEach
+    void setUp() {
+        policy = new ExecutionInputPolicy();
+        policy.orchestratorConfig = orchestratorConfig;
+    }
+
+    @Test
+    void rejectsMissingClientKeyWhenRequired() {
+        when(orchestratorConfig.idempotencyPolicy()).thenReturn(OrchestratorIdempotencyPolicy.CLIENT_KEY_REQUIRED);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> policy.resolveExecutionKey("tenant", "payload", null));
+
+        assertTrue(ex.getMessage().contains("Idempotency-Key header is required"));
+    }
+
+    @Test
+    void prefersProvidedClientKeyWhenOptionalPolicy() {
+        when(orchestratorConfig.idempotencyPolicy()).thenReturn(OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY);
+
+        String key = policy.resolveExecutionKey("tenant", "payload", " my-key ");
+
+        assertEquals("my-key", key);
+    }
+
+    @Test
+    void derivesDeterministicServerKeyWhenNoClientKey() {
+        when(orchestratorConfig.idempotencyPolicy()).thenReturn(OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY);
+
+        String keyA = policy.resolveExecutionKey("tenant", java.util.Map.of("a", 1), null);
+        String keyB = policy.resolveExecutionKey("tenant", java.util.Map.of("a", 1), null);
+
+        assertEquals(keyA, keyB);
+        assertNotNull(keyA);
+    }
+
+    @Test
+    void validateInputShapeAcceptsReactiveTypesOnly() {
+        assertNotNull(policy.validateInputShape("plain"));
+        assertEquals(null, policy.validateInputShape(Uni.createFrom().item("x")));
+        assertEquals(null, policy.validateInputShape(Multi.createFrom().items("x", "y")));
+    }
+
+    @Test
+    void resolvesMultiSnapshotAndReplaysAsMulti() {
+        ExecutionInputSnapshot snapshot = policy.resolveExecutionInputPayload(Multi.createFrom().items("x", "y"))
+            .await().indefinitely();
+        assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
+
+        Object replay = policy.toReplayInput(snapshot);
+        java.util.List<?> replayed = ((Multi<?>) replay).collect().asList().await().indefinitely();
+        assertEquals(java.util.List.of("x", "y"), replayed);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
@@ -1,37 +1,17 @@
 package org.pipelineframework;
 
-import java.util.Optional;
-
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.pipelineframework.orchestrator.CreateExecutionResult;
-import org.pipelineframework.orchestrator.ExecutionInputShape;
-import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
-import org.pipelineframework.orchestrator.ExecutionRecord;
-import org.pipelineframework.orchestrator.ExecutionStateStore;
-import org.pipelineframework.orchestrator.ExecutionStatus;
-import org.pipelineframework.orchestrator.EventWorkDispatcher;
-import org.pipelineframework.orchestrator.LoggingDeadLetterPublisher;
-import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
-import org.pipelineframework.orchestrator.OrchestratorMode;
-import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
-import org.pipelineframework.orchestrator.WorkDispatcher;
-import org.pipelineframework.orchestrator.DeadLetterPublisher;
-import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,27 +21,12 @@ class PipelineExecutionServiceTest {
     private PipelineExecutionService service;
 
     @Mock
-    private PipelineOrchestratorConfig orchestratorConfig;
-
-    @Mock
-    private ExecutionStateStore executionStateStore;
-
-    @Mock
-    private WorkDispatcher workDispatcher;
-
-    @Mock
-    private Instance<ExecutionStateStore> executionStateStores;
-
-    @Mock
-    private Instance<WorkDispatcher> workDispatchers;
-
-    @Mock
-    private Instance<DeadLetterPublisher> deadLetterPublishers;
+    private QueueAsyncCoordinator queueAsyncCoordinator;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         service = new PipelineExecutionService();
-        setField("orchestratorConfig", orchestratorConfig);
+        service.queueAsyncCoordinator = queueAsyncCoordinator;
     }
 
     @Test
@@ -70,167 +35,51 @@ class PipelineExecutionServiceTest {
     }
 
     @Test
-    void executePipelineAsyncRequiresQueueMode() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+    void executePipelineAsyncDefaultsToUnaryOutputMode() {
+        RunAsyncAcceptedDto expected = new RunAsyncAcceptedDto("exec-1", false, "/pipeline/executions/exec-1", 1L);
+        when(queueAsyncCoordinator.executePipelineAsync("input", "tenant-1", "idem-1", false))
+            .thenReturn(Uni.createFrom().item(expected));
 
-        Uni<?> result = service.executePipelineAsync("input", "tenant-1", "idem-1");
+        RunAsyncAcceptedDto actual = service.executePipelineAsync("input", "tenant-1", "idem-1")
+            .await().indefinitely();
 
-        assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
+        assertEquals(expected.executionId(), actual.executionId());
+        verify(queueAsyncCoordinator).executePipelineAsync("input", "tenant-1", "idem-1", false);
     }
 
     @Test
-    void executePipelineAsyncRejectsStreamingOutputFlagInQueueMode() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    void executePipelineAsyncPassesOutputStreamingFlag() {
+        RunAsyncAcceptedDto expected = new RunAsyncAcceptedDto("exec-2", false, "/pipeline/executions/exec-2", 2L);
+        when(queueAsyncCoordinator.executePipelineAsync("input", "tenant-1", "idem-1", true))
+            .thenReturn(Uni.createFrom().item(expected));
 
-        Uni<?> result = service.executePipelineAsync("input", "tenant-1", "idem-1", true);
+        RunAsyncAcceptedDto actual = service.executePipelineAsync("input", "tenant-1", "idem-1", true)
+            .await().indefinitely();
 
-        IllegalStateException error = assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
-        assertTrue(error.getMessage().contains("does not support streaming pipeline outputs"));
+        assertEquals(expected.executionId(), actual.executionId());
+        verify(queueAsyncCoordinator).executePipelineAsync("input", "tenant-1", "idem-1", true);
     }
 
     @Test
-    void initializeQueueModeFailsFastWhenSelectedProviderReportsStartupError() throws Exception {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        when(orchestratorConfig.stateProvider()).thenReturn("dynamo");
-        when(orchestratorConfig.dispatcherProvider()).thenReturn("event");
-        when(orchestratorConfig.dlqProvider()).thenReturn("log");
-        when(orchestratorConfig.strictStartup()).thenReturn(true);
+    void getExecutionStatusDelegatesToCoordinator() {
+        ExecutionStatusDto expected = new ExecutionStatusDto("exec-3", null, 0, 0, 1L, 0L, 0L, null, null);
+        when(queueAsyncCoordinator.getExecutionStatus("tenant-1", "exec-3"))
+            .thenReturn(Uni.createFrom().item(expected));
 
-        when(executionStateStores.stream()).thenReturn(java.util.stream.Stream.of(new DynamoExecutionStateStore()));
-        when(workDispatchers.stream()).thenReturn(java.util.stream.Stream.of(new EventWorkDispatcher()));
-        when(deadLetterPublishers.stream()).thenReturn(java.util.stream.Stream.of(new LoggingDeadLetterPublisher()));
-        setField("executionStateStores", executionStateStores);
-        setField("workDispatchers", workDispatchers);
-        setField("deadLetterPublishers", deadLetterPublishers);
+        ExecutionStatusDto actual = service.getExecutionStatus("tenant-1", "exec-3").await().indefinitely();
 
-        IllegalStateException error = assertThrows(
-            IllegalStateException.class,
-            this::invokeInitializeQueueMode);
-        assertTrue(error.getMessage().contains("ExecutionStateStore(dynamo)"));
+        assertEquals("exec-3", actual.executionId());
+        verify(queueAsyncCoordinator).getExecutionStatus("tenant-1", "exec-3");
     }
 
     @Test
-    void getExecutionStatusReturnsRecordStateInQueueMode() throws Exception {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        setField("executionStateStore", executionStateStore);
-        ExecutionRecord<Object, Object> record = new ExecutionRecord<>(
-            "tenant-1",
-            "exec-1",
-            "key-1",
-            ExecutionStatus.RUNNING,
-            1L,
-            0,
-            0,
-            null,
-            0L,
-            0L,
-            null,
-            "input",
-            null,
-            null,
-            null,
-            1L,
-            1L,
-            99999999L);
-        when(executionStateStore.getExecution("tenant-1", "exec-1"))
-            .thenReturn(Uni.createFrom().item(Optional.of(record)));
+    void processExecutionWorkItemDelegatesToCoordinator() {
+        ExecutionWorkItem item = new ExecutionWorkItem("tenant-1", "exec-4");
+        when(queueAsyncCoordinator.processExecutionWorkItem(eq(item), org.mockito.ArgumentMatchers.any()))
+            .thenReturn(Uni.createFrom().voidItem());
 
-        ExecutionStatusDto dto = service.getExecutionStatus("tenant-1", "exec-1").await().indefinitely();
+        service.processExecutionWorkItem(item).await().indefinitely();
 
-        assertNotNull(dto);
-        assertEquals("exec-1", dto.executionId());
-        assertEquals(ExecutionStatus.RUNNING, dto.status());
-        verify(executionStateStore).getExecution("tenant-1", "exec-1");
-    }
-
-    @Test
-    void executePipelineAsyncPersistsUniInputShapeForPlainArrayPayload() throws Exception {
-        configureQueueModeDefaults();
-        setField("executionStateStore", executionStateStore);
-        setField("workDispatcher", workDispatcher);
-        when(executionStateStore.createOrGetExecution(any()))
-            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
-                createRecord("tenant-1", "exec-uni", "key-uni"),
-                true)));
-
-        service.executePipelineAsync(java.util.List.of("a", "b"), "tenant-1", null).await().indefinitely();
-
-        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
-            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
-        verify(executionStateStore).createOrGetExecution(captor.capture());
-        Object persisted = captor.getValue().inputPayload();
-        assertTrue(persisted instanceof ExecutionInputSnapshot);
-        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) persisted;
-        assertEquals(ExecutionInputShape.UNI, snapshot.shape());
-        assertEquals(java.util.List.of("a", "b"), snapshot.payload());
-    }
-
-    @Test
-    void executePipelineAsyncPersistsMultiInputShapeForStreamingPayload() throws Exception {
-        configureQueueModeDefaults();
-        setField("executionStateStore", executionStateStore);
-        setField("workDispatcher", workDispatcher);
-        when(executionStateStore.createOrGetExecution(any()))
-            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
-                createRecord("tenant-1", "exec-multi", "key-multi"),
-                true)));
-
-        service.executePipelineAsync(Multi.createFrom().items("x", "y"), "tenant-1", null).await().indefinitely();
-
-        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
-            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
-        verify(executionStateStore).createOrGetExecution(captor.capture());
-        Object persisted = captor.getValue().inputPayload();
-        assertTrue(persisted instanceof ExecutionInputSnapshot);
-        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) persisted;
-        assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
-        assertEquals(java.util.List.of("x", "y"), snapshot.payload());
-    }
-
-    private void configureQueueModeDefaults() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        when(orchestratorConfig.executionTtlDays()).thenReturn(7);
-        when(orchestratorConfig.idempotencyPolicy()).thenReturn(OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY);
-    }
-
-    private ExecutionRecord<Object, Object> createRecord(String tenantId, String executionId, String executionKey) {
-        return new ExecutionRecord<>(
-            tenantId,
-            executionId,
-            executionKey,
-            ExecutionStatus.QUEUED,
-            0L,
-            0,
-            0,
-            null,
-            0L,
-            0L,
-            null,
-            null,
-            null,
-            null,
-            null,
-            1L,
-            1L,
-            99999999L);
-    }
-
-    private void setField(String fieldName, Object value) throws Exception {
-        var field = PipelineExecutionService.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(service, value);
-    }
-
-    private void invokeInitializeQueueMode() throws Exception {
-        var method = PipelineExecutionService.class.getDeclaredMethod("initializeQueueMode");
-        method.setAccessible(true);
-        try {
-            method.invoke(service);
-        } catch (java.lang.reflect.InvocationTargetException e) {
-            if (e.getCause() instanceof Exception exception) {
-                throw exception;
-            }
-            throw e;
-        }
+        verify(queueAsyncCoordinator).processExecutionWorkItem(eq(item), org.mockito.ArgumentMatchers.any());
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepResolverTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepResolverTest.java
@@ -1,0 +1,32 @@
+package org.pipelineframework;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.PipelineStepConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PipelineStepResolverTest {
+
+    @Test
+    void instantiateStepsFromConfigReturnsEmptyWhenNoStepsConfigured() {
+        PipelineStepResolver resolver = new PipelineStepResolver();
+
+        java.util.List<Object> steps = resolver.instantiateStepsFromConfig(Map.of());
+
+        assertEquals(0, steps.size());
+    }
+
+    @Test
+    void instantiateStepsFromConfigFailsWhenStepClassCannotBeResolved() {
+        PipelineStepResolver resolver = new PipelineStepResolver();
+
+        Map<String, PipelineStepConfig.StepConfig> configs = new java.util.HashMap<>();
+        configs.put("com.example.DoesNotExist", null);
+
+        assertThrows(PipelineExecutionService.PipelineConfigurationException.class,
+            () -> resolver.instantiateStepsFromConfig(configs));
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -1,0 +1,243 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.EventWorkDispatcher;
+import org.pipelineframework.orchestrator.LoggingDeadLetterPublisher;
+import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
+import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAsyncCoordinatorTest {
+
+    private QueueAsyncCoordinator coordinator;
+    private ExecutionInputPolicy inputPolicy;
+    private ExecutionFailureHandler failureHandler;
+
+    @Mock
+    private PipelineOrchestratorConfig orchestratorConfig;
+
+    @Mock
+    private ExecutionStateStore executionStateStore;
+
+    @Mock
+    private WorkDispatcher workDispatcher;
+
+    @Mock
+    private DeadLetterPublisher deadLetterPublisher;
+
+    @Mock
+    private Instance<ExecutionStateStore> executionStateStores;
+
+    @Mock
+    private Instance<WorkDispatcher> workDispatchers;
+
+    @Mock
+    private Instance<DeadLetterPublisher> deadLetterPublishers;
+
+    @BeforeEach
+    void setUp() {
+        inputPolicy = new ExecutionInputPolicy();
+        inputPolicy.orchestratorConfig = orchestratorConfig;
+
+        failureHandler = new ExecutionFailureHandler();
+        failureHandler.orchestratorConfig = orchestratorConfig;
+
+        coordinator = new QueueAsyncCoordinator();
+        coordinator.orchestratorConfig = orchestratorConfig;
+        coordinator.executionStateStore = executionStateStore;
+        coordinator.workDispatcher = workDispatcher;
+        coordinator.deadLetterPublisher = deadLetterPublisher;
+        coordinator.executionStateStores = executionStateStores;
+        coordinator.workDispatchers = workDispatchers;
+        coordinator.deadLetterPublishers = deadLetterPublishers;
+        coordinator.executionInputPolicy = inputPolicy;
+        coordinator.executionFailureHandler = failureHandler;
+    }
+
+    @Test
+    void executePipelineAsyncRequiresQueueMode() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+
+        Uni<?> result = coordinator.executePipelineAsync("input", "tenant-1", "idem-1", false);
+
+        assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
+    }
+
+    @Test
+    void executePipelineAsyncRejectsStreamingOutputFlagInQueueMode() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+
+        Uni<?> result = coordinator.executePipelineAsync("input", "tenant-1", "idem-1", true);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
+        assertTrue(error.getMessage().contains("does not support streaming pipeline outputs"));
+    }
+
+    @Test
+    void initializeQueueModeFailsFastWhenSelectedProviderReportsStartupError() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.stateProvider()).thenReturn("dynamo");
+        when(orchestratorConfig.dispatcherProvider()).thenReturn("event");
+        when(orchestratorConfig.dlqProvider()).thenReturn("log");
+        when(orchestratorConfig.strictStartup()).thenReturn(true);
+
+        when(executionStateStores.stream()).thenReturn(Stream.of(new DynamoExecutionStateStore()));
+        when(workDispatchers.stream()).thenReturn(Stream.of(new EventWorkDispatcher()));
+        when(deadLetterPublishers.stream()).thenReturn(Stream.of(new LoggingDeadLetterPublisher()));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, coordinator::initializeQueueMode);
+        assertTrue(error.getMessage().contains("ExecutionStateStore(dynamo)"));
+    }
+
+    @Test
+    void getExecutionStatusReturnsRecordStateInQueueMode() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        ExecutionRecord<Object, Object> record = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionStatus.RUNNING,
+            1L,
+            0,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            null,
+            null,
+            null,
+            1L,
+            1L,
+            99999999L);
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(record)));
+
+        ExecutionStatusDto dto = coordinator.getExecutionStatus("tenant-1", "exec-1").await().indefinitely();
+
+        assertNotNull(dto);
+        assertEquals("exec-1", dto.executionId());
+        assertEquals(ExecutionStatus.RUNNING, dto.status());
+        verify(executionStateStore).getExecution("tenant-1", "exec-1");
+    }
+
+    @Test
+    void executePipelineAsyncPersistsUniInputShapeForPlainArrayPayload() {
+        configureQueueModeDefaults();
+        when(executionStateStore.createOrGetExecution(any()))
+            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
+                createRecord("tenant-1", "exec-uni", "key-uni"),
+                true)));
+
+        coordinator.executePipelineAsync(java.util.List.of("a", "b"), "tenant-1", null, false)
+            .await().indefinitely();
+
+        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
+            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
+        verify(executionStateStore).createOrGetExecution(captor.capture());
+        Object persisted = captor.getValue().inputPayload();
+        assertTrue(persisted instanceof ExecutionInputSnapshot);
+        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) persisted;
+        assertEquals(ExecutionInputShape.UNI, snapshot.shape());
+        assertEquals(java.util.List.of("a", "b"), snapshot.payload());
+    }
+
+    @Test
+    void executePipelineAsyncPersistsMultiInputShapeForStreamingPayload() {
+        configureQueueModeDefaults();
+        when(executionStateStore.createOrGetExecution(any()))
+            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
+                createRecord("tenant-1", "exec-multi", "key-multi"),
+                true)));
+
+        coordinator.executePipelineAsync(Multi.createFrom().items("x", "y"), "tenant-1", null, false)
+            .await().indefinitely();
+
+        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
+            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
+        verify(executionStateStore).createOrGetExecution(captor.capture());
+        Object persisted = captor.getValue().inputPayload();
+        assertTrue(persisted instanceof ExecutionInputSnapshot);
+        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) persisted;
+        assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
+        assertEquals(java.util.List.of("x", "y"), snapshot.payload());
+    }
+
+    @Test
+    void sweepRedispatchesPersistedDueExecutions() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyInt()))
+            .thenReturn(Uni.createFrom().item(java.util.List.of(
+                createRecord("tenant-a", "exec-5", "key-5"),
+                createRecord("tenant-b", "exec-6", "key-6"))));
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+        coordinator.sweepDueExecutions();
+
+        ArgumentCaptor<ExecutionWorkItem> itemCaptor = ArgumentCaptor.forClass(ExecutionWorkItem.class);
+        verify(workDispatcher, timeout(500).times(2)).enqueueNow(itemCaptor.capture());
+    }
+
+    private void configureQueueModeDefaults() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.executionTtlDays()).thenReturn(7);
+        when(orchestratorConfig.idempotencyPolicy()).thenReturn(OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY);
+    }
+
+    private ExecutionRecord<Object, Object> createRecord(String tenantId, String executionId, String executionKey) {
+        return new ExecutionRecord<>(
+            tenantId,
+            executionId,
+            executionKey,
+            ExecutionStatus.QUEUED,
+            0L,
+            0,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            null,
+            null,
+            null,
+            null,
+            1L,
+            1L,
+            99999999L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncFailureMatrixTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncFailureMatrixTest.java
@@ -1,8 +1,6 @@
 package org.pipelineframework;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 
 import io.smallrye.mutiny.Uni;
@@ -18,22 +16,27 @@ import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.ExecutionStateStore;
 import org.pipelineframework.orchestrator.ExecutionStatus;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
-import org.pipelineframework.orchestrator.OrchestratorMode;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.step.NonRetryableException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class QueueAsyncFailureMatrixTest {
 
-    private PipelineExecutionService service;
+    private ExecutionFailureHandler failureHandler;
 
     @Mock
     private PipelineOrchestratorConfig orchestratorConfig;
@@ -48,16 +51,13 @@ class QueueAsyncFailureMatrixTest {
     private DeadLetterPublisher deadLetterPublisher;
 
     @BeforeEach
-    void setUp() throws Exception {
-        service = new PipelineExecutionService();
-        setField("orchestratorConfig", orchestratorConfig);
-        setField("executionStateStore", executionStateStore);
-        setField("workDispatcher", workDispatcher);
-        setField("deadLetterPublisher", deadLetterPublisher);
+    void setUp() {
+        failureHandler = new ExecutionFailureHandler();
+        failureHandler.orchestratorConfig = orchestratorConfig;
     }
 
     @Test
-    void retryPathCommitsAndEnqueuesDelayedWork() throws Exception {
+    void retryPathCommitsAndEnqueuesDelayedWork() {
         configureRetryDefaults();
         ExecutionRecord<Object, Object> record = record("tenant-a", "exec-1", 0L, 0);
         when(executionStateStore.scheduleRetry(
@@ -66,7 +66,13 @@ class QueueAsyncFailureMatrixTest {
         when(workDispatcher.enqueueDelayed(any(), any()))
             .thenReturn(Uni.createFrom().voidItem());
 
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(record, "exec-1:0:0", new RuntimeException("boom")));
+        assertDoesNotThrow(() -> failureHandler.handleExecutionFailure(
+            record,
+            "exec-1:0:0",
+            new RuntimeException("boom"),
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher).await().atMost(Duration.ofSeconds(3)));
 
         verify(executionStateStore).scheduleRetry(
             eq("tenant-a"),
@@ -83,68 +89,7 @@ class QueueAsyncFailureMatrixTest {
     }
 
     @Test
-    void retryPathWithStaleCommitSkipsReenqueue() throws Exception {
-        configureRetryDefaults();
-        ExecutionRecord<Object, Object> record = record("tenant-a", "exec-2", 1L, 1);
-        when(executionStateStore.scheduleRetry(
-            anyString(), anyString(), anyLong(), anyInt(), anyLong(), anyString(), anyString(), anyString(), anyLong()))
-            .thenReturn(Uni.createFrom().item(Optional.empty()));
-
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(record, "exec-2:1:1", new RuntimeException("retry")));
-
-        verify(executionStateStore).scheduleRetry(
-            eq("tenant-a"),
-            eq("exec-2"),
-            eq(1L),
-            eq(2),
-            anyLong(),
-            eq("exec-2:1:1"),
-            eq("RuntimeException"),
-            eq("retry"),
-            anyLong());
-        verify(workDispatcher, never()).enqueueDelayed(any(), any());
-    }
-
-    @Test
-    void terminalPathPublishesDeadLetterOnCommit() throws Exception {
-        when(orchestratorConfig.maxRetries()).thenReturn(0);
-        ExecutionRecord<Object, Object> record = record("tenant-a", "exec-3", 2L, 0);
-        when(executionStateStore.markTerminalFailure(
-            anyString(), anyString(), anyLong(), any(), anyString(), anyString(), anyString(), anyLong()))
-            .thenReturn(Uni.createFrom().item(Optional.of(record)));
-        when(deadLetterPublisher.publish(any())).thenReturn(Uni.createFrom().voidItem());
-
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(record, "exec-3:0:0", new IllegalStateException("final")));
-
-        ArgumentCaptor<DeadLetterEnvelope> envelopeCaptor = ArgumentCaptor.forClass(DeadLetterEnvelope.class);
-        verify(deadLetterPublisher).publish(envelopeCaptor.capture());
-        DeadLetterEnvelope envelope = envelopeCaptor.getValue();
-        assertEquals("tenant-a", envelope.tenantId());
-        assertEquals("exec-3", envelope.executionId());
-        assertEquals("exec-3-key", envelope.executionKey());
-        assertEquals("exec-3-key", envelope.correlationId());
-        assertEquals("exec-3:0:0", envelope.transitionKey());
-        assertEquals("FAILED", envelope.terminalStatus());
-        assertEquals("retry_exhausted", envelope.terminalReason());
-        assertTrue(envelope.retryable());
-        assertEquals(0, envelope.retriesObserved());
-    }
-
-    @Test
-    void terminalPathWithStaleCommitSkipsDeadLetterPublish() throws Exception {
-        when(orchestratorConfig.maxRetries()).thenReturn(0);
-        ExecutionRecord<Object, Object> record = record("tenant-a", "exec-4", 3L, 0);
-        when(executionStateStore.markTerminalFailure(
-            anyString(), anyString(), anyLong(), any(), anyString(), anyString(), anyString(), anyLong()))
-            .thenReturn(Uni.createFrom().item(Optional.empty()));
-
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(record, "exec-4:0:0", new IllegalStateException("stale")));
-
-        verify(deadLetterPublisher, never()).publish(any());
-    }
-
-    @Test
-    void terminalPathClassifiesNonRetryableFailure() throws Exception {
+    void terminalPathClassifiesNonRetryableFailure() {
         when(orchestratorConfig.maxRetries()).thenReturn(0);
         ExecutionRecord<Object, Object> record = record("tenant-a", "exec-9", 3L, 0);
         when(executionStateStore.markTerminalFailure(
@@ -152,10 +97,13 @@ class QueueAsyncFailureMatrixTest {
             .thenReturn(Uni.createFrom().item(Optional.of(record)));
         when(deadLetterPublisher.publish(any())).thenReturn(Uni.createFrom().voidItem());
 
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(
+        assertDoesNotThrow(() -> failureHandler.handleExecutionFailure(
             record,
             "exec-9:0:0",
-            new NonRetryableException("bad payload")));
+            new NonRetryableException("bad payload"),
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher).await().atMost(Duration.ofSeconds(3)));
 
         ArgumentCaptor<DeadLetterEnvelope> envelopeCaptor = ArgumentCaptor.forClass(DeadLetterEnvelope.class);
         verify(deadLetterPublisher).publish(envelopeCaptor.capture());
@@ -166,34 +114,7 @@ class QueueAsyncFailureMatrixTest {
     }
 
     @Test
-    void nonRetryableFailureSkipsScheduleRetryEvenWhenBudgetRemains() throws Exception {
-        when(orchestratorConfig.maxRetries()).thenReturn(3);
-        ExecutionRecord<Object, Object> record = record("tenant-a", "exec-10", 3L, 0);
-        when(executionStateStore.markTerminalFailure(
-            anyString(), anyString(), anyLong(), any(), anyString(), anyString(), anyString(), anyLong()))
-            .thenReturn(Uni.createFrom().item(Optional.of(record)));
-        when(deadLetterPublisher.publish(any())).thenReturn(Uni.createFrom().voidItem());
-
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(
-            record,
-            "exec-10:0:0",
-            new NonRetryableException("bad payload")));
-
-        verify(executionStateStore, never()).scheduleRetry(
-            anyString(), anyString(), anyLong(), anyInt(), anyLong(), anyString(), anyString(), anyString(), anyLong());
-        verify(executionStateStore).markTerminalFailure(
-            eq("tenant-a"),
-            eq("exec-10"),
-            eq(3L),
-            eq(ExecutionStatus.FAILED),
-            eq("exec-10:0:0"),
-            eq("NonRetryableException"),
-            eq("bad payload"),
-            anyLong());
-    }
-
-    @Test
-    void wrappedNonRetryableFailureUsesClassifiedThrowableMetadata() throws Exception {
+    void wrappedNonRetryableFailureUsesClassifiedThrowableMetadata() {
         when(orchestratorConfig.maxRetries()).thenReturn(3);
         ExecutionRecord<Object, Object> record = record("tenant-a", "exec-11", 4L, 0);
         when(executionStateStore.markTerminalFailure(
@@ -202,7 +123,13 @@ class QueueAsyncFailureMatrixTest {
         when(deadLetterPublisher.publish(any())).thenReturn(Uni.createFrom().voidItem());
 
         RuntimeException wrapped = new RuntimeException("wrapper", new NonRetryableException("inner-non-retryable"));
-        assertDoesNotThrow(() -> invokeHandleExecutionFailure(record, "exec-11:0:0", wrapped));
+        assertDoesNotThrow(() -> failureHandler.handleExecutionFailure(
+            record,
+            "exec-11:0:0",
+            wrapped,
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher).await().atMost(Duration.ofSeconds(3)));
 
         verify(executionStateStore, never()).scheduleRetry(
             anyString(), anyString(), anyLong(), anyInt(), anyLong(), anyString(), anyString(), anyString(), anyLong());
@@ -226,50 +153,33 @@ class QueueAsyncFailureMatrixTest {
     }
 
     @Test
-    void sweepRedispatchesPersistedDueExecutions() throws Exception {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        when(orchestratorConfig.sweepLimit()).thenReturn(100);
-        when(executionStateStore.findDueExecutions(anyLong(), eq(100)))
-            .thenReturn(Uni.createFrom().item(List.of(
-                record("tenant-a", "exec-5", 0L, 0),
-                record("tenant-b", "exec-6", 0L, 0))));
-        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+    void retryableFailureWithNoBudgetPublishesRetryExhaustedTerminal() {
+        when(orchestratorConfig.maxRetries()).thenReturn(0);
+        ExecutionRecord<Object, Object> record = record("tenant-a", "exec-12", 5L, 0);
+        when(executionStateStore.markTerminalFailure(
+            anyString(), anyString(), anyLong(), any(), anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(record)));
+        when(deadLetterPublisher.publish(any())).thenReturn(Uni.createFrom().voidItem());
 
-        invokeSweepDueExecutions();
+        assertDoesNotThrow(() -> failureHandler.handleExecutionFailure(
+            record,
+            "exec-12:0:0",
+            new IllegalStateException("terminal"),
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher).await().atMost(Duration.ofSeconds(3)));
 
-        ArgumentCaptor<ExecutionWorkItem> itemCaptor = ArgumentCaptor.forClass(ExecutionWorkItem.class);
-        verify(workDispatcher, timeout(500).times(2)).enqueueNow(itemCaptor.capture());
-        List<ExecutionWorkItem> items = itemCaptor.getAllValues();
-        assertTrue(items.stream().anyMatch(item -> "tenant-a".equals(item.tenantId()) && "exec-5".equals(item.executionId())));
-        assertTrue(items.stream().anyMatch(item -> "tenant-b".equals(item.tenantId()) && "exec-6".equals(item.executionId())));
+        ArgumentCaptor<DeadLetterEnvelope> envelopeCaptor = ArgumentCaptor.forClass(DeadLetterEnvelope.class);
+        verify(deadLetterPublisher).publish(envelopeCaptor.capture());
+        DeadLetterEnvelope envelope = envelopeCaptor.getValue();
+        assertTrue(envelope.retryable());
+        assertEquals("retry_exhausted", envelope.terminalReason());
     }
 
     private void configureRetryDefaults() {
         when(orchestratorConfig.maxRetries()).thenReturn(3);
         when(orchestratorConfig.retryDelay()).thenReturn(Duration.ofSeconds(5));
         when(orchestratorConfig.retryMultiplier()).thenReturn(2.0d);
-    }
-
-    private void invokeHandleExecutionFailure(
-        ExecutionRecord<Object, Object> record,
-        String transitionKey,
-        Throwable failure
-    ) throws Exception {
-        Method method = PipelineExecutionService.class.getDeclaredMethod(
-            "handleExecutionFailure",
-            ExecutionRecord.class,
-            String.class,
-            Throwable.class);
-        method.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Uni<Void> result = (Uni<Void>) method.invoke(service, record, transitionKey, failure);
-        result.await().atMost(Duration.ofSeconds(3));
-    }
-
-    private void invokeSweepDueExecutions() throws Exception {
-        Method method = PipelineExecutionService.class.getDeclaredMethod("sweepDueExecutions");
-        method.setAccessible(true);
-        method.invoke(service);
     }
 
     private static ExecutionRecord<Object, Object> record(String tenantId, String executionId, long version, int attempt) {
@@ -292,11 +202,5 @@ class QueueAsyncFailureMatrixTest {
             System.currentTimeMillis(),
             System.currentTimeMillis(),
             System.currentTimeMillis() / 1000 + 3600);
-    }
-
-    private void setField(String fieldName, Object value) throws Exception {
-        var field = PipelineExecutionService.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(service, value);
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/pipeline/PipelineOrderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/pipeline/PipelineOrderTest.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package org.pipelineframework.pipeline;
+package org.pipelineframework;
 
-import java.lang.reflect.Method;
 import java.util.List;
 import jakarta.inject.Inject;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
-import org.pipelineframework.PipelineExecutionService;
 import org.pipelineframework.pipeline.order.OrderedStepA;
 import org.pipelineframework.pipeline.order.OrderedStepB;
 
@@ -35,12 +33,8 @@ class PipelineOrderTest {
     PipelineExecutionService pipelineExecutionService;
 
     @Test
-    void loadsStepsInPipelineOrder() throws Exception {
-        Method method = PipelineExecutionService.class.getDeclaredMethod("loadPipelineSteps");
-        method.setAccessible(true);
-
-        @SuppressWarnings("unchecked")
-        List<Object> steps = (List<Object>) method.invoke(pipelineExecutionService);
+    void loadsStepsInPipelineOrder() {
+        List<Object> steps = pipelineExecutionService.loadPipelineSteps();
 
         List<Class<?>> stepTypes = steps.stream()
             .map(step -> {
@@ -53,5 +47,4 @@ class PipelineOrderTest {
             List.of(OrderedStepA.class, OrderedStepB.class, OrderedStepA.class),
             stepTypes);
     }
-
 }


### PR DESCRIPTION
## Summary
Refactors `PipelineExecutionService` into a thin orchestration facade while preserving behavior and public API.

## What changed
- Added focused runtime collaborators:
  - `PipelineStepResolver`
  - `ExecutionInputPolicy`
  - `ExecutionFailureHandler`
  - `QueueAsyncCoordinator`
  - `ExecutionHooks`
- Reduced `PipelineExecutionService` to delegate execution-policy concerns to these collaborators.
- Kept `PipelineConfigurationException` in `PipelineExecutionService` for compatibility.
- Updated tests to remove reflection against private internals and validate behavior through facade/collaborator seams.
- Added new collaborator tests:
  - `QueueAsyncCoordinatorTest`
  - `ExecutionInputPolicyTest`
  - `PipelineStepResolverTest`
  - `ExecutionHooksTest`

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=PipelineExecutionServiceTest,QueueAsyncFailureMatrixTest,QueueAsyncCoordinatorTest,ExecutionInputPolicyTest,PipelineStepResolverTest,ExecutionHooksTest,PipelineOrderTest test`
- `./mvnw -f framework/pom.xml -pl runtime test`

Both commands pass on this branch (`624` tests run, `0` failures/errors, `1` skipped in full runtime suite).
