### PR TITLE
Follow up IDL v2 review fixes

### DIFF
--- a/docs/guide/build/operators.md
+++ b/docs/guide/build/operators.md
@@ -65,7 +65,7 @@ steps:
 
 Rules:
 - Remote execution is available only in `version: 2`.
-- Only unary `ONE_TO_ONE` remote execution is supported in this slice.
+- Only unary `ONE_TO_ONE` remote execution is supported currently.
 - Exactly one of `execution.target.url` or `execution.target.urlConfigKey` must be set.
 - `execution.target.urlConfigKey` resolves at runtime startup, not at compile time.
 - `pipeline.transport` and the remote operator protocol are orthogonal. TPF can expose the pipeline over REST, gRPC, or local transport while invoking the remote operator over Protobuf-over-HTTP.

--- a/docs/guide/development/operators.md
+++ b/docs/guide/development/operators.md
@@ -84,15 +84,16 @@ When application domain types differ from operator I/O types, mapper coverage is
 - gRPC flow requires descriptor + mapper-compatible bindings.
 - Mapper fallback policies are configuration-driven; implicit conversion is not enabled by default.
 
-Remote v2 operators use the step contract directly. The generated adapter still uses the normal mapper model to bridge domain types to generated protobuf message types. It does not resolve a Java operator implementation, and it does not use the FUNCTION remote adapter’s `BytesValue` + JSON contract.
+Remote v2 operators use the step contract directly. The generated adapter still uses the normal mapper model to bridge domain types to generated protobuf message types. It does not resolve a Java operator implementation. It does not use the FUNCTION remote adapter’s `BytesValue` + JSON contract.
 
 ## Remote Operator Constraints
 
 - Remote operators are v2-only.
-- Only `ONE_TO_ONE` is supported in this slice.
-- `execution.target.urlConfigKey` is resolved at runtime startup. Missing or blank values fail startup.
+- Only `ONE_TO_ONE` is supported currently.
+- The generated adapter sends its HTTP `POST` to the fully configured target URL. If you use `execution.target.url`, include the full path to call. If you use `execution.target.urlConfigKey`, the configured value must also be the full target URL, including any path segment.
+- The value of `execution.target.urlConfigKey` is resolved at application startup; if it is missing or blank, the application will fail to start.
 - `execution.timeoutMs`, when set, caps the outbound HTTP call. The runtime also applies the propagated deadline if one is present, using the smaller of the two budgets.
-- Retries and duplicate dispatch are possible. Remote operators are expected to be idempotent and to honor `x-tpf-idempotency-key`.
+- Retries and duplicate dispatch are possible. Duplicate dispatch includes automatic retries, transport-layer or network duplicates, and manual replays that can all deliver the same request more than once. For example, an automatic retry after a timeout can race with the original in-flight request. Remote operators are expected to be idempotent and to honour `x-tpf-idempotency-key` across those cases.
 
 ## Example: AI Pipeline Chain
 

--- a/docs/guide/evolve/data-types.md
+++ b/docs/guide/evolve/data-types.md
@@ -34,7 +34,14 @@ Supported built-ins in v2:
 - `currency`
 - `uri`
 - `path`
+
+Structural type:
+
 - `map`
+
+`map` is a parameterised collection type, not an atomic scalar. It must declare `keyType` and `valueType`.
+
+Enums are not a first-class canonical v2 type in the current schema. Model them with named messages and string-backed fields for now, or keep legacy enum handling in v1 compatibility paths until explicit enum support is added.
 
 PascalCase type tokens are treated as references to top-level named messages.
 
@@ -126,7 +133,7 @@ Breaking changes fail compatibility checks when they:
 
 - renumber fields
 - change canonical field types
-- change repeated/map/message-reference structure
+- change structural shape, such as adding `repeated: true` to a singular field, changing a map key or value type, switching a field to a different message reference, or changing between optional and required semantics
 - remove fields without reserving the old number and name
 - reuse reserved numbers or names
 

--- a/docs/guide/evolve/template-generator.md
+++ b/docs/guide/evolve/template-generator.md
@@ -16,7 +16,7 @@ The template generator creates a complete Maven multi-module pipeline project fr
 - the orchestrator module
 - runtime config and test scaffolding
 
-The generator emits **IDL v2** sample configs by default (`generateSampleConfig`), while user-provided configs loaded via `loadConfig` are treated as v1 when `version` is not explicitly set.
+The `sample-config` command emits **IDL v2** sample configs by default (internal: `generateSampleConfig`), while user-provided configs passed through `--config` are treated as v1 when `version` is not explicitly set (internal: `loadConfig`).
 
 ## Schema Reference
 
@@ -85,6 +85,8 @@ node template-generator-node/bin/generate.js sample-config
 
 This produces a v2 sample config with top-level `messages`.
 
+Use the Node.js `sample-config` command when you want a lightweight v2 config scaffold. Use the Java JAR when you need the full runnable Maven and Java project structure.
+
 ## Generating an Application
 
 Generate the complete application from your config:
@@ -122,7 +124,7 @@ Common semantic types:
 - `duration`
 - `currency`
 - `uri`
-- `path`
+- `path` (filesystem path semantics, not a web/resource identifier)
 - `bytes`
 - `map`
 
@@ -138,6 +140,12 @@ Map fields use `keyType` and `valueType` to define the entry contract:
 
 PascalCase type tokens are treated as named message references.
 
+```yaml
+- number: 5
+  name: paymentDetails
+  type: PaymentInput # PaymentInput is a referenced message type
+```
+
 ## Advanced Overrides
 
 Overrides are available, but they are an advanced escape hatch:
@@ -151,7 +159,7 @@ Overrides are available, but they are an advanced escape hatch:
       encoding: string
 ```
 
-Unsafe overrides are rejected during loading/normalization.
+Unsafe overrides are rejected during loading/normalization. That includes lossy type changes, overrides that break canonical invariants, unsupported encodings, and overrides that conflict with message or map structure. For example, `decimal` with `overrides.proto.encoding: double` is rejected, while `decimal` with `overrides.proto.encoding: string` remains valid.
 
 ## Compatibility Checking
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
@@ -73,6 +73,10 @@ public record PipelineStepModel(
      * @throws IllegalArgumentException if any parameter documented as 'must not be null' is null
      */
     @SuppressWarnings("ConstantValue")
+    /**
+     * @deprecated prefer {@link Builder} for construction.
+     */
+    @Deprecated
     public PipelineStepModel(String serviceName,
             String generatedName,
             String servicePackage,
@@ -129,6 +133,10 @@ public record PipelineStepModel(
         this.remoteExecution = remoteExecution;
     }
 
+    /**
+     * @deprecated prefer {@link Builder} for construction.
+     */
+    @Deprecated
     public PipelineStepModel(String serviceName,
             String generatedName,
             String servicePackage,
@@ -165,6 +173,10 @@ public record PipelineStepModel(
             null);
     }
 
+    /**
+     * @deprecated prefer {@link Builder} for construction.
+     */
+    @Deprecated
     public PipelineStepModel(String serviceName,
             String generatedName,
             String servicePackage,
@@ -538,18 +550,18 @@ public record PipelineStepModel(
                 throw new IllegalStateException("deploymentRole is required");
 
             return new PipelineStepModel(serviceName,
-                    generatedName,
-                    servicePackage,
-                    serviceClassName,
-                    inputMapping,
-                    outputMapping,
-                    streamingShape,
-                    enabledTargets,
-                    executionMode,
-                    deploymentRole,
-                    sideEffect,
-                    cacheKeyGenerator,
-                    orderingRequirement,
+                generatedName,
+                servicePackage,
+                serviceClassName,
+                inputMapping,
+                outputMapping,
+                streamingShape,
+                enabledTargets,
+                executionMode,
+                deploymentRole,
+                sideEffect,
+                cacheKeyGenerator,
+                orderingRequirement,
                 threadSafety,
                 delegateService,
                 externalMapper,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
@@ -26,7 +26,7 @@ import org.pipelineframework.config.template.PipelineTemplateStepExecution;
  * This model drives the generation of step clients based on YAML declarations.
  *
  * @param name The name of the step
- * @param kind The kind of step (INTERNAL or DELEGATED)
+ * @param kind The kind of step (INTERNAL, DELEGATED, or REMOTE)
  * @param executionClass The class that provides the execution implementation
  * @param remoteExecution remote execution metadata for REMOTE steps
  * @param externalMapper The operator mapper class for mapping between domain and operator types (nullable)
@@ -56,7 +56,8 @@ public record StepDefinition(
         @Nullable ClassName outputType,
         @Nullable StreamingShape streamingShapeHint
     ) {
-        this(name, kind, executionClass, null, externalMapper, mapperFallback, inputType, outputType, streamingShapeHint);
+        this(name, requireNonRemoteKind(kind), executionClass, null, externalMapper, mapperFallback, inputType, outputType,
+            streamingShapeHint);
     }
 
     public StepDefinition {
@@ -65,11 +66,27 @@ public record StepDefinition(
             throw new IllegalArgumentException("Name cannot be blank");
         }
         Objects.requireNonNull(kind, "Kind cannot be null");
+        if (executionClass != null && remoteExecution != null) {
+            throw new IllegalArgumentException("executionClass and remoteExecution are mutually exclusive");
+        }
         if (kind == StepKind.REMOTE) {
             Objects.requireNonNull(remoteExecution, "Remote execution cannot be null for REMOTE steps");
+            if (executionClass != null) {
+                throw new IllegalArgumentException("REMOTE steps must not define an execution class");
+            }
         } else {
             Objects.requireNonNull(executionClass, "Execution class cannot be null");
+            if (remoteExecution != null) {
+                throw new IllegalArgumentException("Only REMOTE steps may define remoteExecution");
+            }
         }
         mapperFallback = mapperFallback == null ? MapperFallbackMode.NONE : mapperFallback;
+    }
+
+    private static StepKind requireNonRemoteKind(StepKind kind) {
+        if (kind == StepKind.REMOTE) {
+            throw new IllegalArgumentException("Convenience constructor cannot be used for StepKind.REMOTE; provide remoteExecution");
+        }
+        return kind;
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -400,17 +400,15 @@ public class StepDefinitionParser {
             parseOptionalPositiveInteger(executionMap.get("timeoutMs"), stepName, "execution.timeoutMs"),
             target);
         validateRemoteExecution(stepName, execution);
-        if (!execution.isRemote()) {
-            String message = "Skipping step '" + stepName
-                + "': execution block is present but execution.mode must be REMOTE";
-            LOG.warn(message);
-            report(Diagnostic.Kind.ERROR, message);
-            throw new IllegalArgumentException(message);
-        }
         return execution;
     }
 
     private PipelineTemplateRemoteTarget parseRemoteTarget(Object targetObj) {
+        if (targetObj != null && !(targetObj instanceof Map<?, ?>)) {
+            LOG.warnf("Ignoring invalid remote target block of type %s: %s",
+                targetObj.getClass().getName(), targetObj);
+            return null;
+        }
         if (!(targetObj instanceof Map<?, ?> rawTargetMap)) {
             return null;
         }
@@ -462,9 +460,20 @@ public class StepDefinitionParser {
             return null;
         }
         try {
-            int parsed = rawValue instanceof Number number
-                ? number.intValue()
-                : Integer.parseInt(String.valueOf(rawValue).trim());
+            int parsed;
+            if (rawValue instanceof Number number) {
+                double value = number.doubleValue();
+                if (value != Math.rint(value)) {
+                    String message = "Skipping step '" + stepName + "': " + fieldName
+                        + " must be a whole integer value, got '" + rawValue + "'";
+                    LOG.warn(message);
+                    report(Diagnostic.Kind.ERROR, message);
+                    throw new IllegalArgumentException(message);
+                }
+                parsed = (int) value;
+            } else {
+                parsed = Integer.parseInt(String.valueOf(rawValue).trim());
+            }
             if (parsed <= 0) {
                 String message = "Skipping step '" + stepName + "': " + fieldName + " must be > 0";
                 LOG.warn(message);
@@ -487,9 +496,24 @@ public class StepDefinitionParser {
             return 1;
         }
         if (rawVersion instanceof Number number) {
-            return number.intValue();
+            double value = number.doubleValue();
+            if (value != Math.rint(value)) {
+                String message = "Invalid template version: '" + rawVersion + "'";
+                LOG.warn(message);
+                report(Diagnostic.Kind.ERROR, message);
+                throw new IllegalArgumentException(message);
+            }
+            return (int) value;
+        }
+        if (rawVersion instanceof String text) {
+            try {
+                return Integer.parseInt(text.trim());
+            } catch (NumberFormatException ignored) {
+                // fall through
+            }
         }
         String message = "Invalid template version: '" + rawVersion + "'";
+        LOG.warn(message);
         report(Diagnostic.Kind.ERROR, message);
         throw new IllegalArgumentException(message);
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -5,9 +5,10 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -18,7 +19,6 @@ import javax.lang.model.util.Types;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
-import org.pipelineframework.config.template.PipelineTemplateStepExecution;
 import org.pipelineframework.annotation.PipelineStep;
 import org.pipelineframework.parallelism.OrderingRequirement;
 import org.pipelineframework.parallelism.ThreadSafety;
@@ -44,6 +44,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
     private static final String MAPPER_FALLBACK_GLOBAL_OPTION = "pipeline.mapper.fallback.enabled";
 
     private final ModelContextRoleEnricher contextRoleEnricher;
+    private Consumer<String> ctxWarningLogger;
 
     /**
      * Creates a new ModelExtractionPhase.
@@ -78,6 +79,11 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
      */
     @Override
     public void execute(PipelineCompilationContext ctx) throws Exception {
+        this.ctxWarningLogger = message -> {
+            if (ctx.getProcessingEnv() != null && ctx.getProcessingEnv().getMessager() != null) {
+                ctx.getProcessingEnv().getMessager().printMessage(javax.tools.Diagnostic.Kind.WARNING, message);
+            }
+        };
         List<org.pipelineframework.processor.ir.StepDefinition> stepDefinitions = ctx.getStepDefinitions();
         boolean hasYamlStepDefinitions = stepDefinitions != null && !stepDefinitions.isEmpty();
 
@@ -361,6 +367,10 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             if (packageName.endsWith(suffix)) {
                 return packageName.substring(0, packageName.length() - suffix.length()) + ".service";
             }
+        }
+        if (ctxWarningLogger != null) {
+            ctxWarningLogger.accept("Falling back to default service package 'org.pipelineframework.pipeline.service' "
+                + "for domain type '" + domainType + "'");
         }
         return "org.pipelineframework.pipeline.service";
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.processor.phase;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -111,10 +112,11 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      * @return a set of GenerationTarget values applicable to the given step model
      */
     private Set<GenerationTarget> resolveTargetsForModel(PipelineStepModel model, TransportMode transportMode) {
-        if (model.remoteExecution() != null && model.remoteExecution().isRemote()) {
+        var remoteExecution = model.remoteExecution();
+        if (remoteExecution != null && remoteExecution.isRemote()) {
             Set<GenerationTarget> targets = new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode));
             targets.add(GenerationTarget.REMOTE_OPERATOR_ADAPTER);
-            return Set.copyOf(targets);
+            return Collections.unmodifiableSet(targets);
         }
         if (model.delegateService() != null) {
             // Delegated steps only resolve local client target here.
@@ -126,6 +128,6 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             && model.deploymentRole() == DeploymentRole.PLUGIN_SERVER) {
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
-        return resolveTargetsForRole(model.deploymentRole(), transportMode);
+        return Collections.unmodifiableSet(new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode)));
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -244,7 +244,7 @@ class StepArtifactGenerationService {
                     if (grpcBinding == null) {
                         ctx.getProcessingEnv().getMessager().printMessage(javax.tools.Diagnostic.Kind.WARNING,
                             "Skipping remote operator adapter generation for '" + model.generatedName()
-                                + "' because no protobuf binding is available.");
+                                + "' because no gRPC binding is available.");
                         break;
                     }
                     String adapterClassName = model.servicePackage() + PIPELINE_DOT + model.serviceClassName().simpleName();

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRenderer.java
@@ -17,6 +17,7 @@
 package org.pipelineframework.processor.renderer;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Modifier;
@@ -78,10 +79,23 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
         }
 
         GrpcJavaTypeResolver.GrpcJavaTypes grpcTypes = GRPC_TYPE_RESOLVER.resolve(binding, messager);
-        TypeName domainInputType = model.inboundDomainType() != null ? model.inboundDomainType() : ClassName.OBJECT;
-        TypeName domainOutputType = model.outboundDomainType() != null ? model.outboundDomainType() : ClassName.OBJECT;
-        TypeName protoInputType = grpcTypes.grpcParameterType() != null ? grpcTypes.grpcParameterType() : ClassName.OBJECT;
-        TypeName protoOutputType = grpcTypes.grpcReturnType() != null ? grpcTypes.grpcReturnType() : ClassName.OBJECT;
+        TypeName domainInputType = Objects.requireNonNull(model.inboundDomainType(),
+            "Remote operator adapter requires a non-null inbound domain type for " + model.generatedName());
+        TypeName domainOutputType = Objects.requireNonNull(model.outboundDomainType(),
+            "Remote operator adapter requires a non-null outbound domain type for " + model.generatedName());
+        TypeName protoInputType = grpcTypes.grpcParameterType();
+        TypeName protoOutputType = grpcTypes.grpcReturnType();
+        if (protoInputType == null || ClassName.OBJECT.equals(protoInputType)
+            || protoOutputType == null || ClassName.OBJECT.equals(protoOutputType)) {
+            throw new IllegalStateException(
+                "Remote operator adapter requires resolved gRPC protobuf input/output types for " + model.generatedName());
+        }
+        if (model.remoteExecution().target() == null
+            || (model.remoteExecution().target().url() == null && model.remoteExecution().target().urlConfigKey() == null)) {
+            throw new IllegalStateException(
+                "Remote operator adapter requires either execution.target.url or execution.target.urlConfigKey for "
+                    + model.generatedName());
+        }
 
         TypeSpec.Builder builder = TypeSpec.classBuilder(model.serviceClassName().simpleName())
             .addModifiers(Modifier.PUBLIC)
@@ -137,7 +151,7 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
         builder.addMethod(buildValidateTargetMethod(model));
         builder.addMethod(buildResolveTargetUrlMethod(model));
         builder.addMethod(buildDecodeResponseMethod(protoOutputType));
-        builder.addMethod(buildProcessMethod(model, protoInputType));
+        builder.addMethod(buildProcessMethod(model, domainInputType, domainOutputType, protoInputType));
 
         return builder.build();
     }
@@ -184,24 +198,26 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
             .build();
     }
 
-    private MethodSpec buildProcessMethod(PipelineStepModel model, TypeName protoInputType) {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("process")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), model.outboundDomainType()))
-            .addParameter(model.inboundDomainType(), "input");
-
-        if (model.executionMode() == org.pipelineframework.processor.ir.ExecutionMode.VIRTUAL_THREADS) {
-            builder.addAnnotation(ClassName.get("io.smallrye.common.annotation", "RunOnVirtualThread"));
-        }
-
-        if (model.outboundDomainType() == null || model.inboundDomainType() == null) {
-            throw new IllegalStateException("Remote operator adapter requires domain input and output types");
-        }
+    private MethodSpec buildProcessMethod(
+        PipelineStepModel model,
+        TypeName domainInputType,
+        TypeName domainOutputType,
+        TypeName protoInputType
+    ) {
         if (model.remoteExecution() == null || model.remoteExecution().operatorId() == null) {
             throw new IllegalStateException("Remote operator adapter requires a non-null remote execution operatorId");
         }
         Integer timeoutMs = model.remoteExecution().timeoutMs();
+
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("process")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), domainOutputType))
+            .addParameter(domainInputType, "input");
+
+        if (model.executionMode() == org.pipelineframework.processor.ir.ExecutionMode.VIRTUAL_THREADS) {
+            builder.addAnnotation(ClassName.get("io.smallrye.common.annotation", "RunOnVirtualThread"));
+        }
 
         builder.addStatement("$T request = requestMapper.toExternal(input)", protoInputType)
             .addStatement("return remoteOperatorClient.invoke(resolveTargetUrl(), $S, request.toByteArray(), $L)"

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -433,7 +433,9 @@ class StepDefinitionParserTest {
 
     @Test
     void rejectsRemoteExecutionOnLegacyVersion() throws IOException {
-        List<StepDefinition> steps = parse("""
+        List<String> diagnostics = new ArrayList<>();
+        Path file = tempDir.resolve("pipeline.yaml");
+        Files.writeString(file, """
             appName: "Test"
             basePackage: "com.example"
             steps:
@@ -448,8 +450,13 @@ class StepDefinitionParserTest {
                   target:
                     url: "https://example.com/operators/charge-card"
             """);
+        List<StepDefinition> steps = new StepDefinitionParser((kind, message) ->
+            diagnostics.add(kind + ":" + message)).parseStepDefinitions(file);
 
         assertTrue(steps.isEmpty());
+        String errorSummary = diagnostics.stream().collect(Collectors.joining(" | "));
+        assertTrue(errorSummary.contains(Diagnostic.Kind.ERROR.name()));
+        assertTrue(errorSummary.contains("execution blocks require version: 2"));
     }
 
     @Test
@@ -484,7 +491,9 @@ class StepDefinitionParserTest {
 
     @Test
     void rejectsRemoteExecutionWhenCardinalityIsNotUnary() throws IOException {
-        List<StepDefinition> steps = parse("""
+        List<String> diagnostics = new ArrayList<>();
+        Path file = tempDir.resolve("pipeline.yaml");
+        Files.writeString(file, """
             version: 2
             appName: "Test"
             basePackage: "com.example"
@@ -500,8 +509,13 @@ class StepDefinitionParserTest {
                   target:
                     url: "https://example.com/operators/charge-card"
             """);
+        List<StepDefinition> steps = new StepDefinitionParser((kind, message) ->
+            diagnostics.add(kind + ":" + message)).parseStepDefinitions(file);
 
         assertTrue(steps.isEmpty());
+        String errorSummary = diagnostics.stream().collect(Collectors.joining(" | "));
+        assertTrue(errorSummary.contains(Diagnostic.Kind.ERROR.name()));
+        assertTrue(errorSummary.contains("currently supports only ONE_TO_ONE"));
     }
 
     @Test

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/ModelExtractionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/ModelExtractionPhaseTest.java
@@ -290,7 +290,7 @@ class ModelExtractionPhaseTest {
             StepKind.INTERNAL,
             ClassName.get("org.pipelineframework.csv.service", "ProcessAckPaymentSentService"),
             null,
-            null,
+            null, // no explicit mapper
             MapperFallbackMode.NONE,
             ClassName.get("org.pipelineframework.csv.common.domain", "AckPaymentSent"),
             ClassName.get("org.pipelineframework.csv.common.domain", "PaymentStatus"),

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -188,6 +188,7 @@ class PipelineTargetResolutionPhaseTest {
         assertEquals(
             Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.REMOTE_OPERATOR_ADAPTER),
             updated.enabledTargets());
+        assertEquals(updated.enabledTargets(), context.getResolvedTargets());
     }
 
     @Test

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepArtifactGenerationServiceTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepArtifactGenerationServiceTest.java
@@ -11,6 +11,7 @@ import com.squareup.javapoet.ClassName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.pipelineframework.config.template.PipelineTemplateRemoteTarget;
@@ -26,6 +27,7 @@ import org.pipelineframework.processor.ir.TypeMapping;
 import org.pipelineframework.processor.util.RoleMetadataGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
@@ -106,6 +108,7 @@ class StepArtifactGenerationServiceTest {
             .enabledTargets(Set.of(GenerationTarget.REMOTE_OPERATOR_ADAPTER))
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .sideEffect(false)
             .remoteExecution(new PipelineTemplateStepExecution(
                 "REMOTE",
                 "charge-card",
@@ -120,7 +123,7 @@ class StepArtifactGenerationServiceTest {
         service.generateArtifactsForModel(
             ctx,
             model,
-            grpcBinding(model),
+            grpcBinding(),
             null,
             null,
             new java.util.HashSet<>(),
@@ -137,7 +140,12 @@ class StepArtifactGenerationServiceTest {
             renderer
         );
 
-        verify(renderer).render(any(GrpcBinding.class), any(org.pipelineframework.processor.renderer.GenerationContext.class));
+        ArgumentCaptor<GrpcBinding> bindingCaptor = ArgumentCaptor.forClass(GrpcBinding.class);
+        ArgumentCaptor<org.pipelineframework.processor.renderer.GenerationContext> contextCaptor =
+            ArgumentCaptor.forClass(org.pipelineframework.processor.renderer.GenerationContext.class);
+        verify(renderer).render(bindingCaptor.capture(), contextCaptor.capture());
+        assertEquals("ChargeCard", ((Descriptors.ServiceDescriptor) bindingCaptor.getValue().serviceDescriptor()).getName());
+        assertEquals(DeploymentRole.PIPELINE_SERVER, contextCaptor.getValue().role());
     }
 
     private void invokeGenerateArtifacts(PipelineCompilationContext ctx, PipelineStepModel model) throws Exception {
@@ -162,10 +170,23 @@ class StepArtifactGenerationServiceTest {
         );
     }
 
-    private GrpcBinding grpcBinding(PipelineStepModel model) {
+    private GrpcBinding grpcBinding() {
         Descriptors.FileDescriptor fileDescriptor = buildFileDescriptor();
         Descriptors.ServiceDescriptor serviceDescriptor = fileDescriptor.findServiceByName("ChargeCard");
         Descriptors.MethodDescriptor methodDescriptor = serviceDescriptor.findMethodByName("remoteProcess");
+        PipelineStepModel model = new PipelineStepModel.Builder()
+            .serviceName("ChargeCard")
+            .generatedName("ChargeCard")
+            .servicePackage("com.example.checkout")
+            .serviceClassName(ClassName.get("com.example.checkout.pipeline", "ChargeCardRemoteOperatorAdapter"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.checkout.domain", "ChargeRequest"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.checkout.domain", "ChargeResult"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.REMOTE_OPERATOR_ADAPTER))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .sideEffect(false)
+            .build();
         return new GrpcBinding(model, serviceDescriptor, methodDescriptor);
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineIdlCompatibilityChecker.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineIdlCompatibilityChecker.java
@@ -37,6 +37,8 @@ public final class PipelineIdlCompatibilityChecker {
      * @return a list of compatibility error messages; empty if there are no violations
      */
     public List<String> compare(PipelineIdlSnapshot baseline, PipelineIdlSnapshot current) {
+        Objects.requireNonNull(baseline, "baseline must not be null");
+        Objects.requireNonNull(current, "current must not be null");
         List<String> errors = new ArrayList<>();
         compareSteps(baseline.steps(), current.steps(), errors);
         compareMessages(baseline.messages(), current.messages(), errors);
@@ -191,9 +193,13 @@ public final class PipelineIdlCompatibilityChecker {
             errors.add("Message '" + messageName + "' changed message reference for field '" + baselineField.name()
                 + "' from '" + baselineField.messageRef() + "' to '" + currentField.messageRef() + "'");
         }
-        if (!Objects.equals(baselineField.keyType(), currentField.keyType())
-            || !Objects.equals(baselineField.valueType(), currentField.valueType())) {
-            errors.add("Message '" + messageName + "' changed map structure for field '" + baselineField.name() + "'");
+        if (!Objects.equals(baselineField.keyType(), currentField.keyType())) {
+            errors.add("Message '" + messageName + "' changed map key type for field '" + baselineField.name()
+                + "' from '" + baselineField.keyType() + "' to '" + currentField.keyType() + "'");
+        }
+        if (!Objects.equals(baselineField.valueType(), currentField.valueType())) {
+            errors.add("Message '" + messageName + "' changed map value type for field '" + baselineField.name()
+                + "' from '" + baselineField.valueType() + "' to '" + currentField.valueType() + "'");
         }
         if (baselineField.repeated() != currentField.repeated()) {
             errors.add("Message '" + messageName + "' changed repeated structure for field '" + baselineField.name() + "'");

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineIdlSnapshot.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineIdlSnapshot.java
@@ -54,16 +54,17 @@ public record PipelineIdlSnapshot(
      * @return a PipelineIdlSnapshot containing normalized messages and steps extracted from the config
      */
     public static PipelineIdlSnapshot from(PipelineTemplateConfig config) {
+        List<PipelineTemplateStep> configSteps = config.steps() == null ? List.of() : config.steps();
         Map<String, MessageSnapshot> messages = new LinkedHashMap<>();
         if (config.messages() != null && !config.messages().isEmpty()) {
             for (Map.Entry<String, PipelineTemplateMessage> entry : config.messages().entrySet()) {
                 messages.put(entry.getKey(), toMessageSnapshot(entry.getValue()));
             }
         } else {
-            collectLegacyMessages(messages, config.steps());
+            collectLegacyMessages(messages, configSteps);
         }
         List<StepSnapshot> steps = new ArrayList<>();
-        for (PipelineTemplateStep step : config.steps()) {
+        for (PipelineTemplateStep step : configSteps) {
             steps.add(new StepSnapshot(step.name(), step.inputTypeName(), step.outputTypeName()));
         }
         return new PipelineIdlSnapshot(config.version(), config.appName(), config.basePackage(), messages, steps);
@@ -139,8 +140,12 @@ public record PipelineIdlSnapshot(
      * @throws IllegalStateException if any field in the template message does not have a number
      */
     private static MessageSnapshot toMessageSnapshot(PipelineTemplateMessage message) {
+        List<PipelineTemplateField> messageFields = message.fields() == null ? List.of() : message.fields();
+        PipelineTemplateReserved reserved = message.reserved() == null
+            ? new PipelineTemplateReserved(List.of(), List.of())
+            : message.reserved();
         List<FieldSnapshot> fields = new ArrayList<>();
-        for (PipelineTemplateField field : message.fields()) {
+        for (PipelineTemplateField field : messageFields) {
             if (field.number() == null) {
                 throw new IllegalStateException(
                     "Message '" + message.name() + "' field '" + field.name() + "' is missing required field number");
@@ -160,8 +165,8 @@ public record PipelineIdlSnapshot(
         return new MessageSnapshot(
             message.name(),
             fields,
-            message.reserved().numbers(),
-            message.reserved().names());
+            reserved.numbers(),
+            reserved.names());
     }
 
     public record MessageSnapshot(

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfig.java
@@ -44,10 +44,41 @@ public record PipelineTemplateConfig(
     Map<String, PipelineTemplateAspect> aspects
 ) {
     public PipelineTemplateConfig {
+        if (version <= 0) {
+            throw new IllegalArgumentException("version must be > 0");
+        }
+        requireText(appName, "appName");
+        requireText(basePackage, "basePackage");
+        requireText(transport, "transport");
+        if (platform == null) {
+            throw new IllegalArgumentException("platform must not be null");
+        }
+        validateMap(messages, "messages");
+        validateMap(aspects, "aspects");
         messages = messages == null ? Map.of() : Map.copyOf(messages);
         // Preserve null step placeholders so downstream phases/tests can explicitly skip them.
         steps = steps == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(steps));
         aspects = aspects == null ? Map.of() : Map.copyOf(aspects);
+    }
+
+    private static void requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+    }
+
+    private static void validateMap(Map<?, ?> values, String fieldName) {
+        if (values == null) {
+            return;
+        }
+        for (Map.Entry<?, ?> entry : values.entrySet()) {
+            if (entry.getKey() == null) {
+                throw new IllegalArgumentException(fieldName + " must not contain null keys");
+            }
+            if (entry.getValue() == null) {
+                throw new IllegalArgumentException(fieldName + " must not contain null values");
+            }
+        }
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateField.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateField.java
@@ -93,7 +93,8 @@ public record PipelineTemplateField(
     /**
      * Determines if this field is a reference to another message.
      *
-     * @return `true` if the field's canonical type is "message" and a message reference name is present, `false` otherwise.
+     * @return {@code true} if the field's canonical type is {@code "message"} and a message reference name is present,
+     *         {@code false} otherwise.
      */
     public boolean isMessageReference() {
         return "message".equals(canonicalType) && messageRef != null;

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateFieldOverrides.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateFieldOverrides.java
@@ -19,7 +19,7 @@ package org.pipelineframework.config.template;
 /**
  * Optional advanced override metadata for a template field.
  *
- * @param proto protobuf-specific override settings
+ * @param proto optional protobuf-specific override settings; may be {@code null} when no override is declared
  */
 public record PipelineTemplateFieldOverrides(
     PipelineTemplateProtoOverride proto

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateMessage.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateMessage.java
@@ -31,6 +31,9 @@ public record PipelineTemplateMessage(
     PipelineTemplateReserved reserved
 ) {
     public PipelineTemplateMessage {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null");
+        }
         fields = fields == null ? List.of() : List.copyOf(fields);
         reserved = reserved == null ? new PipelineTemplateReserved(List.of(), List.of()) : reserved;
     }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateProtoOverride.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateProtoOverride.java
@@ -19,7 +19,7 @@ package org.pipelineframework.config.template;
 /**
  * Optional protobuf-specific override settings for a field.
  *
- * @param encoding explicit protobuf encoding override
+ * @param encoding explicit protobuf encoding override; may be {@code null} when no encoding override is declared
  */
 public record PipelineTemplateProtoOverride(
     String encoding

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateRemoteTarget.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateRemoteTarget.java
@@ -19,6 +19,8 @@ package org.pipelineframework.config.template;
 /**
  * Remote operator target definition.
  *
+ * <p>Exactly one of {@code url} or {@code urlConfigKey} must be provided.
+ *
  * @param url literal target URL
  * @param urlConfigKey configuration key resolved at runtime startup to the target URL
  */
@@ -31,6 +33,9 @@ public record PipelineTemplateRemoteTarget(
         urlConfigKey = normalize(urlConfigKey);
         if (url == null && urlConfigKey == null) {
             throw new IllegalArgumentException("PipelineTemplateRemoteTarget requires either url or urlConfigKey");
+        }
+        if (url != null && urlConfigKey != null) {
+            throw new IllegalArgumentException("Specify either url or urlConfigKey, not both");
         }
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateStepExecution.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateStepExecution.java
@@ -33,9 +33,12 @@ public record PipelineTemplateStepExecution(
     PipelineTemplateRemoteTarget target
 ) {
     public PipelineTemplateStepExecution {
-        mode = normalize(mode);
+        mode = defaultMode(mode);
         operatorId = normalize(operatorId);
         protocol = normalize(protocol);
+        if (timeoutMs != null && timeoutMs <= 0) {
+            throw new IllegalArgumentException("timeoutMs must be positive");
+        }
     }
 
     public boolean isRemote() {
@@ -44,5 +47,10 @@ public record PipelineTemplateStepExecution(
 
     private static String normalize(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static String defaultMode(String value) {
+        String normalized = normalize(value);
+        return normalized == null ? "LOCAL" : normalized;
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateTypeMappings.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateTypeMappings.java
@@ -312,15 +312,19 @@ final class PipelineTemplateTypeMappings {
         String javaType = declaredType;
         String protoType = field.protoType();
         if (isLegacyListType(declaredType)) {
-            canonicalType = canonicalForLegacySimple(listInnerType(declaredType));
+            String innerType = listInnerType(declaredType);
+            canonicalType = canonicalForLegacySimple(innerType);
+            if ("message".equals(canonicalType)) {
+                messageRef = innerType;
+            }
             javaType = declaredType;
-            protoType = protoScalarForToken(listInnerType(declaredType), false);
+            protoType = protoScalarForToken(innerType, false);
             return new PipelineTemplateField(
                 null,
                 field.name(),
                 declaredType,
                 canonicalType,
-                null,
+                messageRef,
                 javaType,
                 protoType,
                 null,
@@ -334,8 +338,9 @@ final class PipelineTemplateTypeMappings {
                 null);
         }
         if (isLegacyMapType(declaredType)) {
-            String keyType = mapParts(declaredType).get(0);
-            String valueType = mapParts(declaredType).get(1);
+            List<String> parts = mapParts(declaredType);
+            String keyType = parts.get(0);
+            String valueType = parts.get(1);
             javaType = declaredType;
             protoType = "map<" + protoScalarForToken(keyType, true) + ", " + protoScalarForToken(valueType, false) + ">";
             return new PipelineTemplateField(
@@ -517,9 +522,27 @@ final class PipelineTemplateTypeMappings {
      */
     private static List<String> mapParts(String type) {
         String inner = type.substring(4, type.length() - 1);
-        String[] parts = inner.split(",");
-        String key = parts.length > 0 ? parts[0].trim() : "String";
-        String value = parts.length > 1 ? parts[1].trim() : "String";
+        int depth = 0;
+        int splitIndex = -1;
+        for (int i = 0; i < inner.length(); i++) {
+            char ch = inner.charAt(i);
+            if (ch == '<') {
+                depth++;
+            } else if (ch == '>') {
+                depth = Math.max(0, depth - 1);
+            } else if (ch == ',' && depth == 0) {
+                splitIndex = i;
+                break;
+            }
+        }
+        String key = splitIndex >= 0 ? inner.substring(0, splitIndex).trim() : inner.trim();
+        String value = splitIndex >= 0 ? inner.substring(splitIndex + 1).trim() : "String";
+        if (key.isBlank()) {
+            key = "String";
+        }
+        if (value.isBlank()) {
+            value = "String";
+        }
         return List.of(key, value);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -37,6 +38,7 @@ import org.pipelineframework.config.template.PipelineTemplateConfig;
 import org.pipelineframework.config.template.PipelineTemplateConfigLoader;
 import org.pipelineframework.config.template.PipelineTemplateField;
 import org.pipelineframework.config.template.PipelineTemplateMessage;
+import org.pipelineframework.config.template.PipelineTemplateReserved;
 import org.pipelineframework.config.template.PipelineTemplateStep;
 
 /**
@@ -270,7 +272,10 @@ public class PipelineProtoGenerator {
             .append(basePackage)
             .append(".grpc\";\n\n");
         boolean first = true;
-        for (PipelineTemplateMessage message : messages.values()) {
+        List<String> messageNames = new ArrayList<>(messages.keySet());
+        Collections.sort(messageNames);
+        for (String messageName : messageNames) {
+            PipelineTemplateMessage message = messages.get(messageName);
             if (!first) {
                 builder.append('\n');
             }
@@ -346,28 +351,32 @@ public class PipelineProtoGenerator {
      */
     private void renderMessage(StringBuilder builder, PipelineTemplateMessage message) {
         builder.append("message ").append(message.name()).append(" {\n");
-        if (!message.reserved().numbers().isEmpty()) {
+        PipelineTemplateReserved reserved = message.reserved();
+        List<PipelineTemplateField> fields = message.fields() == null ? List.of() : message.fields();
+        if (reserved != null && reserved.numbers() != null && !reserved.numbers().isEmpty()) {
             builder.append("  reserved ");
-            for (int i = 0; i < message.reserved().numbers().size(); i++) {
+            for (int i = 0; i < reserved.numbers().size(); i++) {
                 if (i > 0) {
                     builder.append(", ");
                 }
-                builder.append(message.reserved().numbers().get(i));
+                builder.append(reserved.numbers().get(i));
             }
             builder.append(";\n");
         }
-        if (!message.reserved().names().isEmpty()) {
+        if (reserved != null && reserved.names() != null && !reserved.names().isEmpty()) {
             builder.append("  reserved ");
-            for (int i = 0; i < message.reserved().names().size(); i++) {
+            for (int i = 0; i < reserved.names().size(); i++) {
                 if (i > 0) {
                     builder.append(", ");
                 }
-                builder.append('"').append(message.reserved().names().get(i)).append('"');
+                builder.append('"').append(reserved.names().get(i)).append('"');
             }
             builder.append(";\n");
         }
-        for (PipelineTemplateField field : message.fields()) {
-            renderFieldLine(builder, field);
+        for (PipelineTemplateField field : fields) {
+            if (field != null) {
+                renderFieldLine(builder, field);
+            }
         }
         builder.append("}\n");
     }
@@ -457,10 +466,11 @@ public class PipelineProtoGenerator {
      * @return the protobuf type string, prefixed with "repeated " if the field is repeated; `"string"` if the field's protoType is null or blank, otherwise the field's protoType
      */
     private String renderLegacyFieldType(PipelineTemplateField field) {
+        String baseType = field.protoType() == null || field.protoType().isBlank() ? "string" : field.protoType();
         if (field.repeated()) {
-            return "repeated " + field.protoType();
+            return "repeated " + baseType;
         }
-        return field.protoType() == null || field.protoType().isBlank() ? "string" : field.protoType();
+        return baseType;
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/transport/http/ProtobufHttpRemoteOperatorClient.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/transport/http/ProtobufHttpRemoteOperatorClient.java
@@ -18,6 +18,7 @@ package org.pipelineframework.transport.http;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpTimeoutException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -101,6 +102,8 @@ public class ProtobufHttpRemoteOperatorClient {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Remote operator invocation was interrupted", e);
+        } catch (HttpTimeoutException e) {
+            throw new IllegalStateException("Remote operator invocation timed out", e);
         } catch (IOException e) {
             throw new IllegalStateException("Remote operator invocation failed", e);
         }
@@ -195,8 +198,10 @@ public class ProtobufHttpRemoteOperatorClient {
         if (body.length > 0) {
             try {
                 Status status = Status.parseFrom(body);
+                Code code = Code.forNumber(status.getCode());
+                String codeLabel = code == null ? "code=" + status.getCode() : code.name();
                 String message = "Remote operator '" + operatorId + "' failed with HTTP " + response.statusCode()
-                    + " at " + targetUrl + " (" + Code.forNumber(status.getCode()) + ": " + status.getMessage() + ")";
+                    + " at " + targetUrl + " (" + codeLabel + ": " + status.getMessage() + ")";
                 if (ProtobufHttpStatusMapper.isRetryable(status)) {
                     return new IllegalStateException(message);
                 }

--- a/framework/runtime/src/main/java/org/pipelineframework/transport/http/ProtobufHttpStatusMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/transport/http/ProtobufHttpStatusMapper.java
@@ -127,7 +127,8 @@ public final class ProtobufHttpStatusMapper {
             return true;
         }
         return switch (code) {
-            case INVALID_ARGUMENT,
+            case OK,
+                INVALID_ARGUMENT,
                 FAILED_PRECONDITION,
                 NOT_FOUND,
                 ALREADY_EXISTS,

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineIdlCompatibilityCheckerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineIdlCompatibilityCheckerTest.java
@@ -91,7 +91,8 @@ class PipelineIdlCompatibilityCheckerTest {
 
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed canonical type")));
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed canonical type")),
+            "expected errors containing 'changed canonical type', got: " + errors);
     }
 
     @Test
@@ -103,7 +104,8 @@ class PipelineIdlCompatibilityCheckerTest {
 
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed message reference")));
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed message reference")),
+            "expected errors containing 'changed message reference', got: " + errors);
     }
 
     @Test
@@ -115,7 +117,8 @@ class PipelineIdlCompatibilityCheckerTest {
 
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed map structure")));
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed map value type")),
+            "expected errors containing 'changed map value type', got: " + errors);
     }
 
     @Test
@@ -127,7 +130,8 @@ class PipelineIdlCompatibilityCheckerTest {
 
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed repeated structure")));
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed repeated structure")),
+            "expected errors containing 'changed repeated structure', got: " + errors);
     }
 
     @Test
@@ -139,7 +143,8 @@ class PipelineIdlCompatibilityCheckerTest {
 
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed optionality")));
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("changed optionality")),
+            "expected errors containing 'changed optionality', got: " + errors);
     }
 
     @Test
@@ -173,8 +178,10 @@ class PipelineIdlCompatibilityCheckerTest {
 
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("reused reserved field number")));
-        assertTrue(errors.stream().anyMatch(msg -> msg.contains("reused reserved field name")));
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("reused reserved field number")),
+            "expected errors containing 'reused reserved field number', got: " + errors);
+        assertTrue(errors.stream().anyMatch(msg -> msg.contains("reused reserved field name")),
+            "expected errors containing 'reused reserved field name', got: " + errors);
     }
 
     private PipelineIdlSnapshot snapshot(List<PipelineIdlSnapshot.FieldSnapshot> fields) {
@@ -216,6 +223,21 @@ class PipelineIdlCompatibilityCheckerTest {
         boolean optional,
         boolean repeated
     ) {
+        return field(number, name, canonicalType, messageRef, keyType, valueType, optional, repeated, false, "string");
+    }
+
+    private PipelineIdlSnapshot.FieldSnapshot field(
+        int number,
+        String name,
+        String canonicalType,
+        String messageRef,
+        String keyType,
+        String valueType,
+        boolean optional,
+        boolean repeated,
+        boolean deprecated,
+        String protoType
+    ) {
         return new PipelineIdlSnapshot.FieldSnapshot(
             number,
             name,
@@ -225,7 +247,7 @@ class PipelineIdlCompatibilityCheckerTest {
             valueType,
             optional,
             repeated,
-            false,
-            "string");
+            deprecated,
+            protoType);
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
@@ -338,10 +338,10 @@ class PipelineTemplateConfigLoaderTest {
         Path configPath = tempDir.resolve("pipeline-config-v2-remote-invalid-target.yaml");
         Files.writeString(configPath, yaml);
 
-        IllegalStateException ex = assertThrows(
-            IllegalStateException.class,
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
             () -> new PipelineTemplateConfigLoader().load(configPath));
-        assertTrue(ex.getMessage().contains("exactly one"));
+        assertTrue(ex.getMessage().contains("Specify either url or urlConfigKey"));
     }
 
     @Test
@@ -398,7 +398,7 @@ class PipelineTemplateConfigLoaderTest {
     }
 
     @Test
-    void rejectsDuplicateFieldNumbersAndNamesWithinMessage() throws Exception {
+    void rejectsDuplicateFieldNumbersWithinMessage() throws Exception {
         String yaml = """
             version: 2
             appName: "IDL v2"
@@ -413,9 +413,6 @@ class PipelineTemplateConfigLoaderTest {
                   - number: 1
                     name: "paymentRef"
                     type: "uuid"
-                  - number: 2
-                    name: "paymentId"
-                    type: "string"
             steps:
               - name: "Charge Card"
                 cardinality: "ONE_TO_ONE"
@@ -428,8 +425,38 @@ class PipelineTemplateConfigLoaderTest {
         IllegalStateException ex = assertThrows(
             IllegalStateException.class,
             () -> new PipelineTemplateConfigLoader().load(configPath));
-        assertTrue(ex.getMessage().contains("Duplicate field number")
-            || ex.getMessage().contains("Duplicate field name"));
+        assertTrue(ex.getMessage().contains("Duplicate field number"));
+    }
+
+    @Test
+    void rejectsDuplicateFieldNamesWithinMessage() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "IDL v2"
+            basePackage: "com.example.v2"
+            transport: "GRPC"
+            messages:
+              ChargeResult:
+                fields:
+                  - number: 1
+                    name: "paymentId"
+                    type: "uuid"
+                  - number: 2
+                    name: "paymentId"
+                    type: "string"
+            steps:
+              - name: "Charge Card"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "ChargeResult"
+                outputTypeName: "ChargeResult"
+            """;
+        Path configPath = tempDir.resolve("pipeline-config-v2-duplicate-field-names.yaml");
+        Files.writeString(configPath, yaml);
+
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineTemplateConfigLoader().load(configPath));
+        assertTrue(ex.getMessage().contains("Duplicate field name"));
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
@@ -353,7 +353,7 @@ class PipelineProtoGeneratorTest {
 
         PipelineProtoGenerator generator = new PipelineProtoGenerator();
 
-        assertThrows(IllegalStateException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
             generator.generate(tempDir, configPath, outputDir));
     }
 
@@ -529,7 +529,7 @@ class PipelineProtoGeneratorTest {
 
     @Test
     @ClearSystemProperty(key = "tpf.idl.compat.baseline")
-    void failsCompatibilityCheckWhenFieldNumberIsReusedWithoutReserve() throws Exception {
+    void failsCompatibilityCheckWhenFieldNameChangesAtExistingNumber() throws Exception {
         String baselineJson = """
             {
               "version": 2,

--- a/framework/runtime/src/test/java/org/pipelineframework/transport/http/ProtobufHttpRemoteOperatorClientTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/transport/http/ProtobufHttpRemoteOperatorClientTest.java
@@ -106,6 +106,7 @@ class ProtobufHttpRemoteOperatorClientTest {
 
     @Test
     void rejectsExpiredDeadlineBeforeSending() {
+        PipelineContextHolder.set(new PipelineContext("v1", null, null));
         TransportDispatchMetadataHolder.set(new TransportDispatchMetadata(
             "corr-1",
             "exec-1",
@@ -131,6 +132,9 @@ class ProtobufHttpRemoteOperatorClientTest {
             .build();
 
         try (ServerHandle server = startServer(exchange -> respondStatus(exchange, 400, status))) {
+            PipelineContextHolder.set(new PipelineContext("v1", null, null));
+            TransportDispatchMetadataHolder.set(new TransportDispatchMetadata(
+                "corr-1", "exec-1", "idem-1", 0, null, System.currentTimeMillis(), null));
             ProtobufHttpRemoteOperatorClient client = new ProtobufHttpRemoteOperatorClient();
             NonRetryableException ex = assertThrows(
                 NonRetryableException.class,
@@ -149,6 +153,9 @@ class ProtobufHttpRemoteOperatorClientTest {
             .build();
 
         try (ServerHandle server = startServer(exchange -> respondStatus(exchange, 503, status))) {
+            PipelineContextHolder.set(new PipelineContext("v1", null, null));
+            TransportDispatchMetadataHolder.set(new TransportDispatchMetadata(
+                "corr-1", "exec-1", "idem-1", 0, null, System.currentTimeMillis(), null));
             ProtobufHttpRemoteOperatorClient client = new ProtobufHttpRemoteOperatorClient();
             IllegalStateException ex = assertThrows(
                 IllegalStateException.class,

--- a/template-generator-node/__tests__/map-type-validation.test.js
+++ b/template-generator-node/__tests__/map-type-validation.test.js
@@ -145,6 +145,99 @@ describe('Map Type Validation', () => {
     expect(validate(v2Config)).toBe(true);
   });
 
+  test('invalid v2 semantic map keyType/valueType should fail', () => {
+    const v2Config = {
+      version: 2,
+      appName: 'TestApp',
+      basePackage: 'com.example.test',
+      messages: {
+        TestInput: {
+          fields: [
+            {
+              number: 1,
+              name: 'attributes',
+              type: 'map',
+              keyType: 'float32',
+              valueType: 'flot32'
+            }
+          ]
+        }
+      },
+      steps: [
+        {
+          name: 'Test Step',
+          cardinality: 'ONE_TO_ONE',
+          inputTypeName: 'TestInput',
+          outputTypeName: 'TestInput'
+        }
+      ]
+    };
+
+    expect(validate(v2Config)).toBe(false);
+  });
+
+  test('missing map keyType/valueType should fail', () => {
+    const v2Config = {
+      version: 2,
+      appName: 'TestApp',
+      basePackage: 'com.example.test',
+      messages: {
+        TestInput: {
+          fields: [
+            {
+              number: 1,
+              name: 'attributes',
+              type: 'map'
+            }
+          ]
+        }
+      },
+      steps: [
+        {
+          name: 'Test Step',
+          cardinality: 'ONE_TO_ONE',
+          inputTypeName: 'TestInput',
+          outputTypeName: 'TestInput'
+        }
+      ]
+    };
+
+    expect(validate(v2Config)).toBe(false);
+  });
+
+  test('invalid reserved config should fail', () => {
+    const v2Config = {
+      version: 2,
+      appName: 'TestApp',
+      basePackage: 'com.example.test',
+      messages: {
+        TestInput: {
+          fields: [
+            {
+              number: 1,
+              name: 'status',
+              type: 'string'
+            }
+          ],
+          reserved: {
+            numbers: ['four'],
+            names: [1]
+          }
+        }
+      },
+      steps: [
+        {
+          name: 'Test Step',
+          cardinality: 'ONE_TO_ONE',
+          inputTypeName: 'TestInput',
+          outputTypeName: 'TestInput'
+        }
+      ]
+    };
+
+    expect(validate(v2Config)).toBe(false);
+  });
+
   test('invalid Map types should fail validation', () => {
     // Invalid Map types that should fail
     const invalidConfigs = [

--- a/template-generator-node/src/pipeline-generator.js
+++ b/template-generator-node/src/pipeline-generator.js
@@ -140,6 +140,9 @@ class PipelineGenerator {
         if (typeof config.transport === 'string') {
             config.transport = config.transport.trim().toUpperCase();
         }
+        if (config.version === 2 && Array.isArray(config.steps)) {
+            config.steps = config.steps.map((step) => this.normalizeV2Step(step));
+        }
         
         // Validate the configuration against the schema
         const ajv = new Ajv();
@@ -188,17 +191,9 @@ class PipelineGenerator {
             throw new Error(`Missing message definition for '${typeName}'`);
         }
         if (topLevel && Array.isArray(inlineFields)) {
-            const sortFields = (fields) => [...fields].sort((left, right) => {
-                const leftNumber = Number.isFinite(left.number) ? left.number : Number.MAX_SAFE_INTEGER;
-                const rightNumber = Number.isFinite(right.number) ? right.number : Number.MAX_SAFE_INTEGER;
-                if (leftNumber !== rightNumber) {
-                    return leftNumber - rightNumber;
-                }
-                return String(left.name || '').localeCompare(String(right.name || ''));
-            });
-            const topLevelNormalized = sortFields(topLevel.map((field) => this.toScaffoldField(field)));
-            const inlineNormalized = sortFields(inlineFields.map((field) => this.toScaffoldField(field)));
-            if (JSON.stringify(topLevelNormalized) !== JSON.stringify(inlineNormalized)) {
+            const topLevelNormalized = this.canonicalizeFields(topLevel.map((field) => this.toScaffoldField(field)));
+            const inlineNormalized = this.canonicalizeFields(inlineFields.map((field) => this.toScaffoldField(field)));
+            if (!this.deepEqual(topLevelNormalized, inlineNormalized)) {
                 throw new Error(`Conflicting inline vs top-level field definitions for '${typeName}'`);
             }
         }
@@ -248,12 +243,10 @@ class PipelineGenerator {
         // This avoids forcing Optional<T> import/converter changes across existing templates;
         // mapper/runtime layers handle presence semantics from field metadata.
         if (field.repeated) {
-            const repeatedJavaType = this.isMessageReferenceType(authoredType) ? authoredType : javaType;
-            const repeatedProtoType = this.isMessageReferenceType(authoredType) ? authoredType : protoType;
             return {
                 ...field,
-                type: `List<${repeatedJavaType}>`,
-                protoType: repeatedProtoType
+                type: `List<${javaType}>`,
+                protoType
             };
         }
         return {
@@ -261,6 +254,68 @@ class PipelineGenerator {
             type: javaType,
             protoType
         };
+    }
+
+    normalizeV2Step(step) {
+        if (!step || typeof step !== 'object') {
+            return step;
+        }
+        const normalized = { ...step };
+        if (normalized.execution && typeof normalized.execution === 'object') {
+            normalized.execution = { ...normalized.execution };
+            if (typeof normalized.execution.mode === 'string') {
+                normalized.execution.mode = normalized.execution.mode.trim().toUpperCase();
+            }
+            if (typeof normalized.execution.protocol === 'string') {
+                normalized.execution.protocol = normalized.execution.protocol.trim().toUpperCase();
+            }
+        }
+        return normalized;
+    }
+
+    canonicalizeFields(fields) {
+        return [...fields]
+            .map((field) => this.canonicalizeValue(field))
+            .sort((left, right) => {
+                const leftNumber = Number.isFinite(left.number) ? left.number : Number.MAX_SAFE_INTEGER;
+                const rightNumber = Number.isFinite(right.number) ? right.number : Number.MAX_SAFE_INTEGER;
+                if (leftNumber !== rightNumber) {
+                    return leftNumber - rightNumber;
+                }
+                return String(left.name || '').localeCompare(String(right.name || ''));
+            });
+    }
+
+    canonicalizeValue(value) {
+        if (Array.isArray(value)) {
+            return value.map((item) => this.canonicalizeValue(item));
+        }
+        if (value && typeof value === 'object') {
+            return Object.keys(value)
+                .sort()
+                .reduce((acc, key) => {
+                    acc[key] = this.canonicalizeValue(value[key]);
+                    return acc;
+                }, {});
+        }
+        return value;
+    }
+
+    deepEqual(left, right) {
+        if (left === right) {
+            return true;
+        }
+        if (Array.isArray(left) && Array.isArray(right)) {
+            return left.length === right.length && left.every((value, index) => this.deepEqual(value, right[index]));
+        }
+        if (left && right && typeof left === 'object' && typeof right === 'object') {
+            const leftKeys = Object.keys(left);
+            const rightKeys = Object.keys(right);
+            return leftKeys.length === rightKeys.length
+                && leftKeys.every((key) => Object.prototype.hasOwnProperty.call(right, key)
+                    && this.deepEqual(left[key], right[key]));
+        }
+        return false;
     }
 
     isMessageReferenceType(type) {

--- a/template-generator-node/src/pipeline-template-schema.json
+++ b/template-generator-node/src/pipeline-template-schema.json
@@ -96,7 +96,7 @@
         },
         "keyType": {
           "type": "string",
-          "enum": ["string", "bool", "int32", "int64", "float32", "float64", "decimal", "uuid", "timestamp", "datetime", "date", "duration", "bytes", "currency", "uri", "path"]
+          "enum": ["string", "bool", "int32", "int64"]
         },
         "valueType": {
           "type": "string",
@@ -237,7 +237,7 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["LOCAL", "REMOTE", "local", "remote"]
+          "enum": ["LOCAL", "REMOTE"]
         },
         "operatorId": {
           "type": "string",
@@ -245,7 +245,7 @@
         },
         "protocol": {
           "type": "string",
-          "enum": ["PROTOBUF_HTTP_V1", "protobuf_http_v1"]
+          "enum": ["PROTOBUF_HTTP_V1"]
         },
         "timeoutMs": {
           "type": "integer",
@@ -260,7 +260,7 @@
           "if": {
             "properties": {
               "mode": {
-                "enum": ["REMOTE", "remote"]
+                "enum": ["REMOTE"]
               }
             },
             "required": ["mode"]
@@ -273,7 +273,7 @@
           "if": {
             "properties": {
               "mode": {
-                "enum": ["LOCAL", "local"]
+                "enum": ["LOCAL"]
               }
             },
             "required": ["mode"]
@@ -592,20 +592,7 @@
     },
     "steps": {
       "type": "array",
-      "description": "List of pipeline steps.",
-      "items": {
-        "oneOf": [
-          {
-            "$ref": "#/$defs/legacyTemplateStep"
-          },
-          {
-            "$ref": "#/$defs/v2TemplateStep"
-          },
-          {
-            "$ref": "#/$defs/delegatedOrInternalStep"
-          }
-        ]
-      }
+      "description": "List of pipeline steps."
     },
     "aspects": {
       "type": "object",


### PR DESCRIPTION
## Summary
- apply the remaining post-merge IDL v2 review fixes across runtime, deployment, docs, and the Node generator
- tighten remote operator validation and generation guards, plus related parser and compatibility checks
- align schema/generator behavior and add the missing tests and documentation clarifications

## Validation
- ./mvnw -pl framework/runtime -Dtest=PipelineTemplateConfigLoaderTest,PipelineIdlCompatibilityCheckerTest,PipelineProtoGeneratorTest,ProtobufHttpRemoteOperatorClientTest test
- ./mvnw -pl framework/deployment -am -Dtest=StepDefinitionParserTest,PipelineTargetResolutionPhaseTest,StepArtifactGenerationServiceTest,ModelExtractionPhaseTest,RemoteOperatorAdapterRendererTest -Dsurefire.failIfNoSpecifiedTests=false test
- cd template-generator-node && npm test -- --runInBand pipeline-generator-v2.test.js map-type-validation.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified remote operator constraints and current support limitations.
  * Expanded guidance on map types, enums, and v2 compatibility.
  * Enhanced documentation for template generation and configuration.

* **Bug Fixes**
  * Improved error handling and validation for remote execution configurations.
  * Enhanced HTTP timeout exception handling with clearer error messages.

* **Chores**
  * Strengthened configuration validation with more explicit error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->