### PR TITLE
Enhance version parsing and sorting for snapshot documentation

### DIFF
--- a/docs/guide/evolve/publishing.md
+++ b/docs/guide/evolve/publishing.md
@@ -69,7 +69,7 @@ This ensures that all modules in the multimodule project are updated consistentl
 
 ### Documentation Snapshot (Hybrid Versioning)
 
-For major/minor releases, snapshot the docs into `docs/versions/`:
+For released docs versions, snapshot the docs into `docs/versions/`:
 
 ```bash
 cd docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test ./scripts/*.test.js",
     "dev": "vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview",

--- a/docs/scripts/snapshot-docs.js
+++ b/docs/scripts/snapshot-docs.js
@@ -199,21 +199,48 @@ export function updateVersionsPageContent(content, versionValue) {
   const nextHeadingIndex = content.indexOf('\n## ', sectionStart)
   const sectionEnd = nextHeadingIndex === -1 ? content.length : nextHeadingIndex
   const section = content.slice(sectionStart, sectionEnd)
-  const versions = Array.from(
-    section.matchAll(/^- \[([^\]]+)\]\(\/versions\/[^)]+\/\) - Snapshot of the .+ docs$/gm),
-    match => match[1]
-  )
+  const versionLinePattern = /^- \[([^\]]+)\]\(\/versions\/[^)]+\/\) - Snapshot of the .+ docs$/
+  const sectionLines = section.split('\n')
 
-  if (versions.includes(normalizedVersion)) {
+  const existingVersions = []
+  for (const line of sectionLines) {
+    const match = line.match(versionLinePattern)
+    if (match) {
+      existingVersions.push(match[1])
+    }
+  }
+
+  if (existingVersions.includes(normalizedVersion)) {
     return content
   }
 
-  const sortedVersions = [...versions, normalizedVersion].sort(compareVersionsDesc)
-  const entries = sortedVersions
-    .map(name => `- [${name}](/versions/${name}/) - Snapshot of the ${name} docs`)
-    .join('\n')
+  const sortedVersions = [...existingVersions, normalizedVersion].sort(compareVersionsDesc)
+  const newVersionLine = `- [${normalizedVersion}](/versions/${normalizedVersion}/) - Snapshot of the ${normalizedVersion} docs`
+  const insertPosition = sortedVersions.indexOf(normalizedVersion)
 
-  return content.slice(0, sectionStart) + `${entries}\n` + content.slice(sectionEnd)
+  let versionCount = 0
+  const updatedSectionLines = []
+  let inserted = false
+
+  for (const line of sectionLines) {
+    const match = line.match(versionLinePattern)
+    if (match) {
+      if (!inserted && versionCount === insertPosition) {
+        updatedSectionLines.push(newVersionLine)
+        inserted = true
+      }
+      versionCount++
+    }
+    updatedSectionLines.push(line)
+  }
+
+  if (!inserted) {
+    updatedSectionLines.push(newVersionLine)
+  }
+
+  const result = updatedSectionLines.join('\n')
+  const needsTrailingNewline = section.endsWith('\n') && !result.endsWith('\n')
+  return content.slice(0, sectionStart) + result + (needsTrailingNewline ? '\n' : '') + content.slice(sectionEnd)
 }
 
 export function updateVersionSelectorContent(content, versionValue) {
@@ -224,23 +251,26 @@ export function updateVersionSelectorContent(content, versionValue) {
     return content
   }
 
-  const endIndex = lines.findIndex((line, index) => index > startIndex && line.trim() === ']')
+  const endIndex = lines.findIndex((line, index) => index > startIndex && /^\],?$/.test(line.trim()))
   if (endIndex === -1) {
     return content
   }
 
   const entryPattern = /^(\s*)\{ name: '([^']+)', url: '([^']+)', current: (true|false) }[,]?$/
-  const entries = lines
+  const parsedLines = lines
     .slice(startIndex + 1, endIndex)
-    .map(line => {
-      const match = line.match(entryPattern)
+    .map(rawLine => {
+      const match = rawLine.match(entryPattern)
       if (!match) {
-        return null
+        return {rawLine, parsedEntry: null}
       }
       const [, indent, name, url, current] = match
-      return {indent, name, url, current: current === 'true'}
+      return {rawLine, parsedEntry: {indent, name, url, current: current === 'true'}}
     })
-    .filter(Boolean)
+
+  const entries = parsedLines
+    .filter(item => item.parsedEntry !== null)
+    .map(item => item.parsedEntry)
 
   if (entries.some(entry => entry.name === normalizedVersion && entry.url === `/versions/${normalizedVersion}/`)) {
     return content
@@ -260,14 +290,46 @@ export function updateVersionSelectorContent(content, versionValue) {
     new Map(snapshotEntries.map(entry => [entry.url, entry])).values()
   ).sort((left, right) => compareVersionsDesc(left.name, right.name))
 
-  const rebuiltEntries = [...currentEntries, ...dedupedSnapshots].map((entry, index, allEntries) => {
-    const suffix = index === allEntries.length - 1 ? '' : ','
-    return `${indent}{ name: '${entry.name}', url: '${entry.url}', current: ${entry.current} }${suffix}`
-  })
+  const sortedEntries = [...currentEntries, ...dedupedSnapshots]
+
+  const rebuiltLines = []
+  let entryIndex = 0
+  let inserted = false
+
+  for (const item of parsedLines) {
+    if (item.parsedEntry === null) {
+      rebuiltLines.push(item.rawLine)
+      continue
+    }
+
+    const expectedEntry = sortedEntries[entryIndex]
+    const insertPosition = sortedEntries.indexOf(expectedEntry)
+    const shouldInsertBefore = !inserted && expectedEntry.name !== item.parsedEntry.name
+
+    if (shouldInsertBefore) {
+      const nextEntry = sortedEntries[entryIndex + 1]
+      const hasMore = entryIndex + 1 < sortedEntries.length
+      const suffix = hasMore ? ',' : ''
+      rebuiltLines.push(`${expectedEntry.indent}{ name: '${expectedEntry.name}', url: '${expectedEntry.url}', current: ${expectedEntry.current} }${suffix}`)
+      inserted = true
+      entryIndex++
+    }
+
+    const currentEntry = sortedEntries[entryIndex]
+    const hasMore = entryIndex + 1 < sortedEntries.length
+    const suffix = hasMore ? ',' : ''
+    rebuiltLines.push(`${currentEntry.indent}{ name: '${currentEntry.name}', url: '${currentEntry.url}', current: ${currentEntry.current} }${suffix}`)
+    entryIndex++
+  }
+
+  if (!inserted && entryIndex < sortedEntries.length) {
+    const lastEntry = sortedEntries[entryIndex]
+    rebuiltLines.push(`${lastEntry.indent}{ name: '${lastEntry.name}', url: '${lastEntry.url}', current: ${lastEntry.current} }`)
+  }
 
   const updatedLines = [
     ...lines.slice(0, startIndex + 1),
-    ...rebuiltEntries,
+    ...rebuiltLines,
     ...lines.slice(endIndex)
   ]
   return updatedLines.join('\n')

--- a/docs/scripts/snapshot-docs.js
+++ b/docs/scripts/snapshot-docs.js
@@ -6,19 +6,64 @@
 import {promises as fs} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
+import {fileURLToPath} from 'node:url'
 
-const args = process.argv.slice(2)
-const versionFlagIndex = args.findIndex(arg => arg === '--version' || arg === '-v')
-const version = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : null
+const VERSION_PATTERN = /^v?(\d+)\.(\d+)(?:\.(\d+))?$/
 
-if (!version) {
-  console.error('Usage: npm run snapshot -- --version vX.Y.Z')
-  process.exit(1)
+export function parseVersion(versionValue) {
+  if (!versionValue) {
+    throw new Error('Missing version. Use --version vX.Y or --version vX.Y.Z')
+  }
+
+  const match = versionValue.match(VERSION_PATTERN)
+  if (!match) {
+    throw new Error(`Invalid version "${versionValue}". Expected vX.Y or vX.Y.Z`)
+  }
+
+  const [, major, minor, patch] = match
+  return {
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: patch === undefined ? null : Number.parseInt(patch, 10)
+  }
+}
+
+export function normalizeVersion(versionValue) {
+  const parsed = parseVersion(versionValue)
+  return parsed.patch === null
+    ? `v${parsed.major}.${parsed.minor}`
+    : `v${parsed.major}.${parsed.minor}.${parsed.patch}`
+}
+
+export function compareVersionsDesc(left, right) {
+  const a = parseVersion(left)
+  const b = parseVersion(right)
+  return (
+    b.major - a.major ||
+    b.minor - a.minor ||
+    (b.patch ?? -1) - (a.patch ?? -1)
+  )
 }
 
 const root = process.cwd()
 const sourceDirs = ['guide']
-const destRoot = path.join(root, 'versions', version)
+const isDirectExecution =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+const args = process.argv.slice(2)
+const versionFlagIndex = args.findIndex(arg => arg === '--version' || arg === '-v')
+const versionArg = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : null
+let version = null
+let versionParseError = null
+
+if (versionArg) {
+  try {
+    version = normalizeVersion(versionArg)
+  } catch (error) {
+    versionParseError = error
+  }
+}
+
+const destRoot = version ? path.join(root, 'versions', version) : null
 
 async function exists(p) {
   try {
@@ -122,14 +167,10 @@ async function updateVersionsPage() {
     return
   }
   const content = await fs.readFile(versionsPath, 'utf8')
-  const entry = `- [${version}](/versions/${version}/) - Snapshot of the ${version} docs`
-  if (content.includes(entry)) {
+  const updated = updateVersionsPageContent(content, version)
+  if (updated === content) {
     return
   }
-  const updated = content.replace(
-    /## Previous Versions\\n\\n/,
-    `## Previous Versions\\n\\n${entry}\\n`
-  )
   await fs.writeFile(versionsPath, updated)
 }
 
@@ -139,15 +180,97 @@ async function updateVersionSelector() {
     return
   }
   const content = await fs.readFile(selectorPath, 'utf8')
-  const entry = `        { name: '${version}', url: '/versions/${version}/', current: false }`
-  if (content.includes(entry)) {
+  const updated = updateVersionSelectorContent(content, version)
+  if (updated === content) {
     return
   }
-  const updated = content.replace(
-    'versions: [\n',
-    `versions: [\n${entry},\n`
-  )
   await fs.writeFile(selectorPath, updated)
+}
+
+export function updateVersionsPageContent(content, versionValue) {
+  const normalizedVersion = normalizeVersion(versionValue)
+  const heading = '## Previous Versions\n\n'
+  const startIndex = content.indexOf(heading)
+  if (startIndex === -1) {
+    return content
+  }
+
+  const sectionStart = startIndex + heading.length
+  const nextHeadingIndex = content.indexOf('\n## ', sectionStart)
+  const sectionEnd = nextHeadingIndex === -1 ? content.length : nextHeadingIndex
+  const section = content.slice(sectionStart, sectionEnd)
+  const versions = Array.from(
+    section.matchAll(/^- \[([^\]]+)\]\(\/versions\/[^)]+\/\) - Snapshot of the .+ docs$/gm),
+    match => match[1]
+  )
+
+  if (versions.includes(normalizedVersion)) {
+    return content
+  }
+
+  const sortedVersions = [...versions, normalizedVersion].sort(compareVersionsDesc)
+  const entries = sortedVersions
+    .map(name => `- [${name}](/versions/${name}/) - Snapshot of the ${name} docs`)
+    .join('\n')
+
+  return content.slice(0, sectionStart) + `${entries}\n` + content.slice(sectionEnd)
+}
+
+export function updateVersionSelectorContent(content, versionValue) {
+  const normalizedVersion = normalizeVersion(versionValue)
+  const lines = content.split('\n')
+  const startIndex = lines.findIndex(line => line.includes('versions: ['))
+  if (startIndex === -1) {
+    return content
+  }
+
+  const endIndex = lines.findIndex((line, index) => index > startIndex && line.trim() === ']')
+  if (endIndex === -1) {
+    return content
+  }
+
+  const entryPattern = /^(\s*)\{ name: '([^']+)', url: '([^']+)', current: (true|false) }[,]?$/
+  const entries = lines
+    .slice(startIndex + 1, endIndex)
+    .map(line => {
+      const match = line.match(entryPattern)
+      if (!match) {
+        return null
+      }
+      const [, indent, name, url, current] = match
+      return {indent, name, url, current: current === 'true'}
+    })
+    .filter(Boolean)
+
+  if (entries.some(entry => entry.name === normalizedVersion && entry.url === `/versions/${normalizedVersion}/`)) {
+    return content
+  }
+
+  const indent = entries[0]?.indent ?? '        '
+  const currentEntries = entries.filter(entry => entry.current)
+  const snapshotEntries = entries.filter(entry => !entry.current)
+  snapshotEntries.push({
+    indent,
+    name: normalizedVersion,
+    url: `/versions/${normalizedVersion}/`,
+    current: false
+  })
+
+  const dedupedSnapshots = Array.from(
+    new Map(snapshotEntries.map(entry => [entry.url, entry])).values()
+  ).sort((left, right) => compareVersionsDesc(left.name, right.name))
+
+  const rebuiltEntries = [...currentEntries, ...dedupedSnapshots].map((entry, index, allEntries) => {
+    const suffix = index === allEntries.length - 1 ? '' : ','
+    return `${indent}{ name: '${entry.name}', url: '${entry.url}', current: ${entry.current} }${suffix}`
+  })
+
+  const updatedLines = [
+    ...lines.slice(0, startIndex + 1),
+    ...rebuiltEntries,
+    ...lines.slice(endIndex)
+  ]
+  return updatedLines.join('\n')
 }
 
 async function main() {
@@ -159,7 +282,17 @@ async function main() {
   console.log(`Docs snapshot created at docs/versions/${version}`)
 }
 
-main().catch(err => {
-  console.error(err.message)
-  process.exit(1)
-})
+if (isDirectExecution) {
+  if (!version || versionParseError) {
+    if (versionParseError) {
+      console.error(versionParseError.message)
+    }
+    console.error('Usage: npm run snapshot -- --version vX.Y[.Z]')
+    process.exit(1)
+  }
+
+  main().catch(err => {
+    console.error(err.message)
+    process.exit(1)
+  })
+}

--- a/docs/scripts/snapshot-docs.test.js
+++ b/docs/scripts/snapshot-docs.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  compareVersionsDesc,
+  normalizeVersion,
+  updateVersionSelectorContent,
+  updateVersionsPageContent
+} from './snapshot-docs.js'
+
+test('normalizeVersion accepts minor and patch releases', () => {
+  assert.equal(normalizeVersion('26.4'), 'v26.4')
+  assert.equal(normalizeVersion('26.4.2'), 'v26.4.2')
+  assert.equal(normalizeVersion('v2.6.4'), 'v2.6.4')
+})
+
+test('compareVersionsDesc distinguishes full semantic versions numerically', () => {
+  const versions = ['v2.6.4', 'v26.4.3', 'v26.4.2', 'v26.4', 'v10.9.8']
+  assert.deepEqual(
+    versions.sort(compareVersionsDesc),
+    ['v26.4.3', 'v26.4.2', 'v26.4', 'v10.9.8', 'v2.6.4']
+  )
+})
+
+test('updateVersionsPageContent inserts patch versions in descending order', () => {
+  const content = `# Versions
+
+## Previous Versions
+
+- [v26.4.1](/versions/v26.4.1/) - Snapshot of the v26.4.1 docs
+- [v2.6.4](/versions/v2.6.4/) - Snapshot of the v2.6.4 docs
+
+## About Versioning
+`
+
+  const updated = updateVersionsPageContent(content, '26.4.2')
+
+  assert.match(
+    updated,
+    /- \[v26\.4\.2]\(\/versions\/v26\.4\.2\/\) - Snapshot of the v26\.4\.2 docs\n- \[v26\.4\.1]\(\/versions\/v26\.4\.1\/\) - Snapshot of the v26\.4\.1 docs\n- \[v2\.6\.4]\(\/versions\/v2\.6\.4\/\) - Snapshot of the v2\.6\.4 docs/
+  )
+})
+
+test('updateVersionSelectorContent inserts snapshots using semantic version order', () => {
+  const content = `export default {
+  data() {
+    return {
+      versions: [
+        { name: 'v26.4', url: '/', current: true },
+        { name: 'v26.4.1', url: '/versions/v26.4.1/', current: false },
+        { name: 'v2.6.4', url: '/versions/v2.6.4/', current: false }
+      ]
+    }
+  }
+}
+`
+
+  const updated = updateVersionSelectorContent(content, '26.4.2')
+
+  assert.match(
+    updated,
+    /\{ name: 'v26\.4', url: '\/', current: true },\n        \{ name: 'v26\.4\.2', url: '\/versions\/v26\.4\.2\/', current: false },\n        \{ name: 'v26\.4\.1', url: '\/versions\/v26\.4\.1\/', current: false },\n        \{ name: 'v2\.6\.4', url: '\/versions\/v2\.6\.4\/', current: false }/
+  )
+})

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -20,10 +20,10 @@ The Pipeline Framework follows semantic versioning:
 
 ## Documentation Snapshot Policy
 
-This site keeps snapshots for major/minor releases and points the latest docs to the root.
+This site keeps snapshots for released docs versions and points the latest docs to the root.
 When cutting a new release, create a docs snapshot and update the version list:
 
 ```bash
 cd docs
-npm run snapshot -- --version vX.Y
+npm run snapshot -- --version vX.Y[.Z]
 ```


### PR DESCRIPTION
Updated docs/scripts/snapshot-docs.js so the snapshot version is parsed numerically as vX.Y or vX.Y.Z, normalized consistently, and inserted in semantic descending order when updating versions.md and the version selector. That means 26.4.2 and 2.6.4 are now treated as distinct versions, and v26.4.3 will sort ahead of v2.6.4 for the right reason instead of by string shape.

I also added a focused test file at docs/scripts/snapshot-docs.test.js, wired docs tests in docs/package.json, and updated the wording in docs/versions.md and docs/guide/evolve/publishing.md to reflect vX.Y[.Z] snapshots.

Verified with npm test in docs/, and the CLI now rejects invalid versions with a clear usage message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Snapshot policy clarified: snapshots are kept for released documentation versions; version argument now supports patch versions (e.g. v1.2.3).

* **Tests**
  * Added tests covering version parsing and snapshot utilities.

* **Bug Fixes**
  * Test command now discovers and runs tests instead of exiting with an error.

* **New Features**
  * Snapshot tooling now validates version input and avoids unnecessary file updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->