### PR TITLE
Add DEV.to feed widget to docs homepage

### DIFF
--- a/docs/.vitepress/theme/components/FeaturedArticles.vue
+++ b/docs/.vitepress/theme/components/FeaturedArticles.vue
@@ -55,11 +55,13 @@ const cacheKey = `tpf:articles:${articlesApiUrl}`
 
 const formatDate = (isoDate) => {
   if (!isoDate) return ''
+  const date = new Date(isoDate)
+  if (Number.isNaN(date.getTime())) return ''
   return new Intl.DateTimeFormat('en-GB', {
     day: '2-digit',
     month: 'short',
     year: 'numeric'
-  }).format(new Date(isoDate))
+  }).format(date)
 }
 
 onMounted(async () => {

--- a/docs/.vitepress/theme/components/FeaturedArticles.vue
+++ b/docs/.vitepress/theme/components/FeaturedArticles.vue
@@ -1,0 +1,193 @@
+<template>
+  <section class="articles-panel" aria-labelledby="latest-articles-title">
+    <div class="articles-head">
+      <h2 id="latest-articles-title">Latest Articles</h2>
+      <a class="all-articles" :href="feedUrl" target="_blank" rel="noopener noreferrer">
+        View feed
+      </a>
+    </div>
+
+    <p class="articles-subtitle">
+      Recent DEV Community posts tagged <code>tpf</code>.
+    </p>
+
+    <div v-if="loading" class="article-loading" aria-live="polite">
+      Loading articles...
+    </div>
+
+    <div v-else-if="error" class="article-error" aria-live="polite">
+      Could not load articles right now.
+      <a :href="feedUrl" target="_blank" rel="noopener noreferrer">Open feed</a>.
+    </div>
+
+    <div v-else-if="articles.length === 0" class="article-empty" aria-live="polite">
+      No tagged articles are available right now.
+      <a :href="feedUrl" target="_blank" rel="noopener noreferrer">Open feed</a>.
+    </div>
+
+    <ul v-else class="article-list">
+      <li v-for="article in articles" :key="article.id" class="article-item">
+        <a :href="article.url" target="_blank" rel="noopener noreferrer" class="article-link">
+          <span class="article-title">{{ article.title }}</span>
+          <span class="article-meta">
+            <span v-if="article.author">{{ article.author }}</span>
+            <time v-if="article.published_at" :datetime="article.published_at">
+              {{ formatDate(article.published_at) }}
+            </time>
+          </span>
+        </a>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup>
+import {onMounted, ref} from 'vue'
+
+const articles = ref([])
+const loading = ref(true)
+const error = ref(false)
+
+const feedUrl = 'https://dev.to/feed/tag/tpf'
+const articlesApiUrl = '/api/devto-feed?limit=10'
+const cacheTtlMs = 15 * 60 * 1000
+const cacheKey = `tpf:articles:${articlesApiUrl}`
+
+const formatDate = (isoDate) => {
+  if (!isoDate) return ''
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  }).format(new Date(isoDate))
+}
+
+onMounted(async () => {
+  try {
+    try {
+      const cached = sessionStorage.getItem(cacheKey)
+      if (cached) {
+        const parsed = JSON.parse(cached)
+        if (parsed?.timestamp && Array.isArray(parsed?.data) && parsed.data.length > 0 && Date.now() - parsed.timestamp < cacheTtlMs) {
+          articles.value = parsed.data
+          return
+        }
+      }
+    } catch (_) {
+      sessionStorage.removeItem(cacheKey)
+    }
+
+    const response = await fetch(articlesApiUrl)
+    if (!response.ok) {
+      throw new Error(`Feed API returned ${response.status}`)
+    }
+
+    const data = await response.json()
+    articles.value = Array.isArray(data) ? data.slice(0, 3) : []
+    sessionStorage.setItem(cacheKey, JSON.stringify({
+      timestamp: Date.now(),
+      data: articles.value
+    }))
+  } catch (_) {
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.articles-panel {
+  margin: 1.4rem 0 2rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 14px;
+  background:
+    radial-gradient(circle at top left, var(--vp-c-brand-subtle), transparent 52%),
+    var(--vp-c-bg);
+}
+
+.articles-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.articles-head h2 {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 1.2rem;
+  color: var(--vp-c-text-1);
+}
+
+.all-articles {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.articles-subtitle {
+  margin: 0.45rem 0 0.9rem;
+  color: var(--vp-c-text-2);
+}
+
+.articles-subtitle code {
+  font-size: 0.88em;
+}
+
+.article-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.article-item {
+  border: 1px solid var(--vp-c-border);
+  border-radius: 10px;
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+
+.article-item:hover {
+  border-color: var(--vp-c-brand-light);
+  transform: translateY(-1px);
+}
+
+.article-link {
+  display: grid;
+  gap: 0.35rem;
+  text-decoration: none;
+  padding: 0.75rem;
+}
+
+.article-title {
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+}
+
+.article-meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.84rem;
+}
+
+.article-loading,
+.article-empty,
+.article-error {
+  color: var(--vp-c-text-2);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .article-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2rem;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -19,6 +19,7 @@ import DefaultTheme from 'vitepress/theme'
 import {h} from 'vue'
 import './custom.css'
 import Callout from './components/Callout.vue'
+import FeaturedArticles from './components/FeaturedArticles.vue'
 import HeroSection from './components/HeroSection.vue'
 import VersionBadge from './components/VersionBadge.vue'
 import LatestReleases from './components/LatestReleases.vue'
@@ -33,6 +34,7 @@ export default {
   enhanceApp({ app }) {
     // Register custom components
     app.component('Callout', Callout)
+    app.component('FeaturedArticles', FeaturedArticles)
     app.component('HeroSection', HeroSection)
     app.component('LatestReleases', LatestReleases)
   }

--- a/docs/functions/api/devto-feed.js
+++ b/docs/functions/api/devto-feed.js
@@ -23,10 +23,10 @@ const XML_ENTITY_MAP = {
   mdash: '—',
   ndash: '–',
   hellip: '…',
-  rsquo: ''',
-  lsquo: ''',
-  rdquo: '"',
-  ldquo: '"'
+  rsquo: '’',
+  lsquo: '‘',
+  rdquo: '”',
+  ldquo: '“'
 }
 
 const parseLimit = (value) => {

--- a/docs/functions/api/devto-feed.js
+++ b/docs/functions/api/devto-feed.js
@@ -19,7 +19,14 @@ const XML_ENTITY_MAP = {
   gt: '>',
   lt: '<',
   quot: '"',
-  nbsp: ' '
+  nbsp: ' ',
+  mdash: '—',
+  ndash: '–',
+  hellip: '…',
+  rsquo: ''',
+  lsquo: ''',
+  rdquo: '"',
+  ldquo: '"'
 }
 
 const parseLimit = (value) => {

--- a/docs/functions/api/devto-feed.js
+++ b/docs/functions/api/devto-feed.js
@@ -1,0 +1,186 @@
+const DEVTO_FEED_URL = 'https://dev.to/feed/tag/tpf'
+const DEFAULT_LIMIT = 10
+const MIN_LIMIT = 1
+const MAX_LIMIT = 30
+const EDGE_CACHE_TTL_SECONDS = 300
+const SUCCESS_MAX_AGE_SECONDS = 300
+const SUCCESS_S_MAX_AGE_SECONDS = 600
+const ERROR_MAX_AGE_SECONDS = 60
+const ERROR_S_MAX_AGE_SECONDS = 120
+const RATE_LIMIT_MAX_AGE_SECONDS = 30
+const RATE_LIMIT_S_MAX_AGE_SECONDS = 180
+const PRE_FLIGHT_MAX_AGE_SECONDS = 86400
+const PRE_FLIGHT_S_MAX_AGE_SECONDS = 86400
+const EXCERPT_MAX_LENGTH = 180
+
+const XML_ENTITY_MAP = {
+  amp: '&',
+  apos: '\'',
+  gt: '>',
+  lt: '<',
+  quot: '"',
+  nbsp: ' '
+}
+
+const parseLimit = (value) => {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (Number.isNaN(parsed)) {
+    return DEFAULT_LIMIT
+  }
+  return Math.min(Math.max(parsed, MIN_LIMIT), MAX_LIMIT)
+}
+
+const responseHeaders = (cacheControl, corsMaxAgeSeconds) => ({
+  'content-type': 'application/json; charset=utf-8',
+  'cache-control': cacheControl,
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, OPTIONS',
+  'access-control-allow-headers': 'Content-Type',
+  ...(corsMaxAgeSeconds ? {'access-control-max-age': String(corsMaxAgeSeconds)} : {})
+})
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const stripCdata = (value) => value
+  .replace(/^<!\[CDATA\[/, '')
+  .replace(/\]\]>$/, '')
+
+export const decodeHtmlEntities = (value) => value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (entity, token) => {
+  if (token[0] === '#') {
+    const isHex = token[1]?.toLowerCase() === 'x'
+    const rawCode = isHex ? token.slice(2) : token.slice(1)
+    const codePoint = Number.parseInt(rawCode, isHex ? 16 : 10)
+    return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+  }
+
+  const normalized = token.toLowerCase()
+  return XML_ENTITY_MAP[normalized] ?? entity
+})
+
+export const stripHtml = (value) => value
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim()
+
+export const truncateText = (value, maxLength = EXCERPT_MAX_LENGTH) => {
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  const truncated = value.slice(0, maxLength).trimEnd()
+  const lastSpace = truncated.lastIndexOf(' ')
+  return `${(lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated).trimEnd()}...`
+}
+
+const readTag = (xml, tagName) => {
+  const pattern = new RegExp(`<${escapeRegex(tagName)}(?:\\s[^>]*)?>([\\s\\S]*?)</${escapeRegex(tagName)}>`, 'i')
+  const match = xml.match(pattern)
+  return match ? stripCdata(match[1].trim()) : ''
+}
+
+const normalizeDate = (value) => {
+  if (!value) {
+    return ''
+  }
+
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? '' : parsed.toISOString()
+}
+
+export const normalizeDevToFeed = (xml, limit = DEFAULT_LIMIT) => {
+  if (typeof xml !== 'string' || !xml.includes('<rss')) {
+    return []
+  }
+
+  const normalizedLimit = parseLimit(limit)
+  const items = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)]
+
+  return items
+    .map((match) => {
+      const itemXml = match[1]
+      const title = decodeHtmlEntities(readTag(itemXml, 'title'))
+      const url = decodeHtmlEntities(readTag(itemXml, 'link'))
+      const guid = decodeHtmlEntities(readTag(itemXml, 'guid'))
+      const author = decodeHtmlEntities(readTag(itemXml, 'dc:creator'))
+      const publishedAt = normalizeDate(readTag(itemXml, 'pubDate'))
+      const description = decodeHtmlEntities(readTag(itemXml, 'description'))
+      const excerpt = truncateText(stripHtml(description))
+
+      if (!title || !(url || guid)) {
+        return null
+      }
+
+      return {
+        id: guid || url,
+        title,
+        url: url || guid,
+        published_at: publishedAt,
+        author,
+        excerpt
+      }
+    })
+    .filter(Boolean)
+    .slice(0, normalizedLimit)
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: responseHeaders(
+      `public, max-age=${PRE_FLIGHT_MAX_AGE_SECONDS}, s-maxage=${PRE_FLIGHT_S_MAX_AGE_SECONDS}`,
+      PRE_FLIGHT_MAX_AGE_SECONDS
+    )
+  })
+}
+
+export async function onRequestGet(context) {
+  const {request} = context
+  const url = new URL(request.url)
+  const limit = parseLimit(url.searchParams.get('limit'))
+
+  let upstream
+  try {
+    upstream = await fetch(DEVTO_FEED_URL, {
+      headers: {
+        Accept: 'application/rss+xml, application/xml;q=0.9, text/xml;q=0.8'
+      },
+      cf: {
+        cacheEverything: true,
+        cacheTtl: EDGE_CACHE_TTL_SECONDS
+      }
+    })
+  } catch (_) {
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: responseHeaders(`public, max-age=${RATE_LIMIT_MAX_AGE_SECONDS}, s-maxage=${RATE_LIMIT_S_MAX_AGE_SECONDS}, stale-while-revalidate=120`)
+    })
+  }
+
+  if (upstream.status === 403 || upstream.status === 429) {
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: {
+        ...responseHeaders(`public, max-age=${RATE_LIMIT_MAX_AGE_SECONDS}, s-maxage=${RATE_LIMIT_S_MAX_AGE_SECONDS}, stale-while-revalidate=120`),
+        'x-rate-limited': 'true'
+      }
+    })
+  }
+
+  if (!upstream.ok) {
+    return new Response(
+      JSON.stringify({error: `DEV.to feed returned ${upstream.status}`}),
+      {
+        status: upstream.status,
+        headers: responseHeaders(`public, max-age=${ERROR_MAX_AGE_SECONDS}, s-maxage=${ERROR_S_MAX_AGE_SECONDS}`)
+      }
+    )
+  }
+
+  const rawXml = await upstream.text()
+  const normalized = normalizeDevToFeed(rawXml, limit)
+
+  return new Response(JSON.stringify(normalized), {
+    status: 200,
+    headers: responseHeaders(`public, max-age=${SUCCESS_MAX_AGE_SECONDS}, s-maxage=${SUCCESS_S_MAX_AGE_SECONDS}, stale-while-revalidate=120`)
+  })
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ features:
 The Pipeline Framework includes a visual canvas designer at <a href="https://app.pipelineframework.org" target="_blank">https://app.pipelineframework.org</a> that allows you to create and configure your pipelines using an intuitive drag-and-drop interface. Simply design your pipeline visually, click "Download Application", and you'll get a complete ZIP file with all the generated source code - no command-line tools needed!
 </Callout>
 
+<FeaturedArticles />
 <LatestReleases />
 
 ## Key Features

--- a/docs/scripts/devto-feed.test.js
+++ b/docs/scripts/devto-feed.test.js
@@ -67,6 +67,7 @@ test('normalizeDevToFeed strips HTML and truncates excerpts cleanly', () => {
 
   assert.match(article.excerpt, /^First paragraph with markup\./)
   assert.ok(article.excerpt.endsWith('...'))
+  // EXCERPT_MAX_LENGTH (180) + ellipsis (3)
   assert.ok(article.excerpt.length <= 183)
 })
 

--- a/docs/scripts/devto-feed.test.js
+++ b/docs/scripts/devto-feed.test.js
@@ -1,0 +1,97 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {normalizeDevToFeed} from '../functions/api/devto-feed.js'
+
+test('normalizeDevToFeed returns normalized feed items', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <item>
+      <title>Architectural mobility &amp; stronger software</title>
+      <dc:creator>Mariano Barcia</dc:creator>
+      <pubDate>Tue, 07 Apr 2026 19:37:36 +0000</pubDate>
+      <link>https://dev.to/mbarcia/architectural-mobility-for-stronger-software-2nh4</link>
+      <guid>https://dev.to/mbarcia/architectural-mobility-for-stronger-software-2nh4</guid>
+      <description>&lt;p&gt;Mobility matters.&lt;/p&gt;</description>
+    </item>
+    <item>
+      <title>Second item</title>
+      <dc:creator>TPF</dc:creator>
+      <pubDate>Wed, 08 Apr 2026 20:00:00 +0000</pubDate>
+      <link>https://dev.to/mbarcia/second</link>
+      <guid>https://dev.to/mbarcia/second</guid>
+      <description>&lt;p&gt;Second excerpt.&lt;/p&gt;</description>
+    </item>
+  </channel>
+</rss>`
+
+  const result = normalizeDevToFeed(xml, 10)
+
+  assert.deepEqual(result, [
+    {
+      id: 'https://dev.to/mbarcia/architectural-mobility-for-stronger-software-2nh4',
+      title: 'Architectural mobility & stronger software',
+      url: 'https://dev.to/mbarcia/architectural-mobility-for-stronger-software-2nh4',
+      published_at: '2026-04-07T19:37:36.000Z',
+      author: 'Mariano Barcia',
+      excerpt: 'Mobility matters.'
+    },
+    {
+      id: 'https://dev.to/mbarcia/second',
+      title: 'Second item',
+      url: 'https://dev.to/mbarcia/second',
+      published_at: '2026-04-08T20:00:00.000Z',
+      author: 'TPF',
+      excerpt: 'Second excerpt.'
+    }
+  ])
+})
+
+test('normalizeDevToFeed strips HTML and truncates excerpts cleanly', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <item>
+      <title>HTML excerpt</title>
+      <dc:creator>TPF</dc:creator>
+      <pubDate>Wed, 08 Apr 2026 20:00:00 +0000</pubDate>
+      <link>https://dev.to/mbarcia/html-excerpt</link>
+      <guid>https://dev.to/mbarcia/html-excerpt</guid>
+      <description>&lt;p&gt;First &lt;strong&gt;paragraph&lt;/strong&gt; with markup.&lt;/p&gt;&lt;p&gt;${'word '.repeat(60)}&lt;/p&gt;</description>
+    </item>
+  </channel>
+</rss>`
+
+  const [article] = normalizeDevToFeed(xml, 10)
+
+  assert.match(article.excerpt, /^First paragraph with markup\./)
+  assert.ok(article.excerpt.endsWith('...'))
+  assert.ok(article.excerpt.length <= 183)
+})
+
+test('normalizeDevToFeed tolerates missing author and invalid dates', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Missing author</title>
+      <pubDate>not-a-date</pubDate>
+      <link>https://dev.to/mbarcia/missing-author</link>
+      <guid>https://dev.to/mbarcia/missing-author</guid>
+      <description>&lt;p&gt;Excerpt&lt;/p&gt;</description>
+    </item>
+  </channel>
+</rss>`
+
+  const [article] = normalizeDevToFeed(xml, 10)
+
+  assert.equal(article.author, '')
+  assert.equal(article.published_at, '')
+  assert.equal(article.title, 'Missing author')
+})
+
+test('normalizeDevToFeed returns an empty array for malformed XML', () => {
+  assert.deepEqual(normalizeDevToFeed('<rss><channel><item>', 10), [])
+  assert.deepEqual(normalizeDevToFeed('not xml', 10), [])
+})


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages feed endpoint that normalizes the DEV.to `tpf` RSS feed
- add a homepage widget that renders the latest tagged articles above Latest Releases
- cover feed parsing and fallback behavior with docs node tests

## Validation
- npm --prefix docs test
- npm --prefix docs run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a featured articles section on the home page showcasing the latest Dev.to publications. Each article displays the title, author name, and publication date in user-friendly formatting. Results are cached to optimise page loading performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->