### PR TITLE
Clarify front-door TPF terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-The Pipeline Framework (TPF) is a Java framework for reactive pipeline systems on Quarkus 3.31.3+.
+The Pipeline Framework (TPF) is a Java framework for reactive pipeline systems on Quarkus 3.33.1+.
 It generates transport adapters at build time from pipeline metadata:
 
 - gRPC server/client artifacts

--- a/README.md
+++ b/README.md
@@ -4,156 +4,221 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Java 21+](https://img.shields.io/badge/Java-21+-brightgreen.svg)](https://adoptium.net/)
 [![Quarkus](https://img.shields.io/badge/Quarkus-3.33.1-orange)](https://quarkus.io)
-[![CodeRabbit](https://img.shields.io/coderabbit/prs/github/The-Pipeline-Framework/pipelineframework?label=CodeRabbit&color=purple
-)](https://coderabbit.ai)
+[![CodeRabbit](https://img.shields.io/coderabbit/prs/github/The-Pipeline-Framework/pipelineframework?label=CodeRabbit&color=purple)](https://coderabbit.ai)
 
-The Pipeline Framework is a powerful framework for building reactive pipeline processing systems. It simplifies the development of distributed systems by providing a consistent way to create, configure, and deploy pipeline steps with automatic gRPC and REST adapter generation.
+The Pipeline Framework (TPF) is a Java framework on Quarkus for building reliable applications from fast, forward-only chains of business functions. You write focused Java code such as "validate this payment", "enrich this record", "parse this document", or "call this existing operator"; TPF turns that code into a runnable Quarkus application with generated REST, gRPC, local, and function-style entry points.
 
-## 🚀 Quick Start
+TPF is for teams that want clean function-style business logic without hand-building the same transport, retry, failure, observability, and deployment glue in every service. The business flow stays portable Java and YAML; TPF generates the repeated Quarkus code, checks the flow at build time, and runs the generated pipeline runtime reliably.
 
-### Visual Designer
-The fastest way to get started is using our visual canvas designer:
-- Visit [https://app.pipelineframework.org](https://app.pipelineframework.org)
-- Design your pipeline visually
-- Download the complete source code for your pipeline application
+## What TPF Means by Pipeline
 
-## 📋 Featuring capabilities
+In TPF, a pipeline is not a CI/CD or batch pipeline made of coarse, long-running jobs. It is a low-latency, high-throughput flow of small Java functions.
 
-### Product Owners
-- **Microservices Architecture**: Each pipeline step can be deployed and scaled independently
-- **Data Integrity**: Immutability ensures that all transformations are preserved, providing robust data integrity
-- **Audit Trail**: Every input transformation is permanently recorded, enabling complete auditability
-- **Reliability**: Built-in dead letter queue for error handling ensures resilient processing
+- A **step** is one function in that flow.
+- A **typed** step has explicit Java input and output types.
+- A **reactive** flow can keep many items moving without blocking one thread per item.
+- The flow moves forward through declared functions with explicit boundaries.
+- The shape is simpler than an arbitrary graph because order, progress, and handoff points stay visible.
+- TPF generates, validates, and runs the Quarkus code around that flow.
 
-### Architects
-- **Immutability by Design**: No database updates during pipeline execution - only appends/preserves
-- **Kubernetes & Serverless Ready**: Native builds enable quick start-up times for Kubernetes and serverless platforms (AWS Lambda, Google Cloud Functions, Azure Functions)
-- **Cost Efficiency**: Reduced resource consumption with native builds and reactive processing
-- **Scalability**: Each pipeline step can be scaled independently based on demand
-- **gRPC & REST Flexibility**: High-performance gRPC for throughput-intensive tasks, REST for ease of integration
-- **Multiple Persistence Options**: Choose from reactive (Panache) or traditional/blocking persistence drivers, for multiple database vendors
-- **Rich Step Types**: Support for OneToOne, OneToMany, ManyToOne, ManyToMany, and SideEffect processing patterns
+## Key Terms in Plain English
 
-### Developers
-- **Monorepo Support**: Complete pipeline can be debugged step-by-step in a single repository
-- **Compile-Time Safety**: All entities in common package provide type safety across steps
-- **Reactive Processing**: Mutiny's event/worker thread model for efficient concurrency
-- **Build-Time Generation**: Automatic gRPC and REST adapter generation at build time
-- **gRPC & REST Flexibility**: Fast gRPC for high-throughput scenarios, REST for ease of development and integration
-- **TLS Ready**: Reference implementation includes TLS configuration out of the box
-- **Multiple Processing Patterns**: OneToOne, OneToMany, ManyToOne, ManyToMany, and SideEffect
-- **Health Monitoring**: Built-in health check capabilities for infrastructure monitoring
+- **Generated adapter**: TPF-created REST, gRPC, local, or function-style code that calls your business function.
+- **Operator**: an existing Java method or remote endpoint reused as a pipeline step.
+- **Mapper**: code that translates between your domain types and transport or external-system types.
+- **Durable execution**: accepted work is recorded outside the current JVM or process, so it can survive crashes and restarts.
+- **`QUEUE_ASYNC`**: the config value for background execution where TPF stores execution state, dispatches work, retries failed work, recovers after worker crashes, and sends terminal failures to a dead-letter channel.
+- **DLQ**: a dead-letter queue or channel for failed executions that need investigation or replay.
+- **Idempotency**: stable keys that let retries avoid duplicating business effects.
+- **Lineage**: enough tracking information to know where an item came from and which step produced it.
+- **Runtime layout**: where TPF logically places the orchestrator, steps, and plugin side effects.
+- **Build topology**: the Maven modules, JARs, and containers that physically create deployables.
+- **Transport mode**: how generated components call each other: gRPC, REST, or local in-process calls.
+- **Platform mode**: whether the app runs as a normal Quarkus service or through function-style entry points.
 
-### QA Engineers
-- **Unit Testing Excellence**: Each step deliberately kept small, making unit tests easy to write and fast to run
-- **Deterministic Behavior**: Immutability ensures consistent test results across runs
-- **AI-Assisted Development**: Modular structure is ideal for AI coding assistants
-- **Focused Testing**: Each step's limited scope enables comprehensive testing
-- **Multiple Execution Modes**: Test with different processing patterns (OneToOne, OneToMany, etc.) to validate behavior
-- **Health Check Testing**: Built-in health monitoring provides additional testable endpoints
+## How TPF Splits Responsibilities
 
-### CTOs
-- **Cost Reduction**: Native builds and reactive processing reduce infrastructure costs
-- **Developer Productivity**: Rapid development with visual designer and auto-generation
-- **Operational Excellence**: Built-in observability, health checks, and error handling
-- **Technology Modernization**: Reactive, cloud-native architecture with industry standards
-- **Risk Mitigation**: Dead letter queue and multiple processing patterns provide resilience
+TPF splits responsibility between your application code and the framework runtime.
 
-## ✨ Capabilities summary
+- **You define the business flow**: typed functions, input/output contracts, operators, mappers, and domain decisions such as "validate this payment", "reject this bad record", "index this document", or "handoff this checkout checkpoint".
+- **TPF generates the repeated code**: REST endpoints, gRPC services, local clients, function-style handlers, client calls, and runtime descriptions that would otherwise become hand-written service glue.
+- **TPF runs the generated runtime**: it starts the flow, calls each step, records progress when configured, retries failed work, recovers leased work after crashes, and sends terminal failures to the configured failure channel.
+- **You choose the runtime shape**: `modular`, `pipeline-runtime`, or `monolith`, plus the Maven and container topology that physically builds the deployables.
+- **TPF validates the flow before startup**: function shape, mapper compatibility, operator references, transport requirements, and generated runtime files are checked during the build.
+- **You own production policy**: provider selection, idempotency choices, retry budgets, DLQ handling, observability thresholds, and deployment rollout.
 
-- Reactive, immutable architecture with strong compile-time safety  
-- Automatic adapter generation for REST & gRPC  
-- Modular monorepo with clear separation of runtime vs. deployment  
-- Native-ready builds for ultra‑fast startup and cloud efficiency  
-- Built-in health monitoring, observability, metrics, and tracing  
-- Visual pipeline designer for rapid development  
-- Multiple execution patterns (OneToOne, OneToMany, ManyToOne, ManyToMany, SideEffect)  
-- Comprehensive error handling with dead-letter queue support  
-- Multiple persistence models (reactive or traditional drivers)  
-- Strong testing support: deterministic, focused, and easy to automate  
+The result is that application code stays focused on business behaviour while the framework handles the repeatable work of moving items through the pipeline reliably.
 
-## 📚 Documentation
+## Why TPF
 
-- **[Full Documentation](https://pipelineframework.org)** - Complete documentation site
-- **[Quick Start Guide](https://pipelineframework.org/guide/getting-started/quick-start)** - Step-by-step tutorial
-- **[Canvas Designer Guide](https://pipelineframework.org/guide/getting-started/canvas-guide)** - Visual design tool
-- **[API Reference](https://pipelineframework.org/guide/development/pipeline-step)** - Annotation documentation
+- **One flow, multiple ways to call it**: Generate gRPC, REST, local, and function-style entry points from the same ordered function chain.
+- **Build-time safety**: Catch mismatched operators, mappers, input/output types, and generated call paths before the application starts.
+- **Operator reuse**: Reuse a local Java `Class::method` operator or remote IDL v2 operator without hiding it behind ad-hoc service glue.
+- **Layout flexibility**: Run the same pipeline in `modular`, `pipeline-runtime`, or `monolith` layouts as your team and deployment model evolve.
+- **Platform flexibility**: Run as a normal Quarkus service or through function-style entry points without changing the business functions.
+- **Operational readiness**: Built-in health checks, tracing/metrics/logging hooks, crash-surviving background execution, retries, and dead-letter handling.
+- **Plugin extensibility**: Add persistence, caching, telemetry, and other cross-cutting work declaratively instead of repeating side-effect code in every function.
 
-## 🏗️ Architecture
+## Core Capabilities
 
-The framework follows a modular architecture:
+### Model-driven pipeline generation
 
-```text
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│   Orchestrator  │───▶│ Backend Service  │───▶│ Backend Service │
-│   (Coordinates) │    │     (Step 1)     │    │     (Step 2)    │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
-         │                        │                       │
-         ▼                        ▼                       ▼
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│    Input Data   │    │   Processing     │    │   Output Data   │
-│                 │    │   Pipeline       │    │                 │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
+TPF is YAML-driven first. You declare the function chain and write the business functions; TPF generates the Quarkus code that exposes, calls, validates, and runs them.
+
+- Pipeline order is written at build time to `META-INF/pipeline/order.json`.
+- Telemetry descriptions are written at build time to `META-INF/pipeline/telemetry.json`.
+- Build-time generation makes the generated call paths visible instead of spreading them through hand-written glue code.
+- In a payments flow, this means the framework can connect validation, enrichment, status creation, and rejection handling without each function owning its own transport layer.
+
+### Operators and external delegation
+
+Operators let a pipeline step call reusable code while the pipeline still makes the boundary explicit.
+
+- Local Java operators use `operator: fully.qualified.Class::method` and are resolved at build time.
+- Remote IDL v2 operators use generated adapters and explicit runtime targets for code that lives outside the Java build.
+- Mapper and transport checks keep delegated operator boundaries explicit instead of relying on implicit conversion.
+- For AI enrichment, an existing embedding, vector search, or LLM helper library can become part of the pipeline without rewriting it as a full service first.
+
+### Reducing hidden coupling
+
+Coupling is where function chains often decay: one function starts depending on another function's internal class, HTTP shape, deployment unit, side effect, retry assumption, or failure channel. TPF does not pretend coupling disappears; it makes the important coupling explicit and moves repeatable coupling into generated code or framework runtime behaviour.
+
+- **Data coupling**: explicit input/output types and mappers keep each function from importing another function's private classes.
+- **Transport coupling**: generated REST, gRPC, local, and function-style adapters keep business functions independent from how they are called.
+- **Deployment coupling**: runtime layout and build topology are separate decisions, so the business flow is not locked to one deployable shape.
+- **Cross-cutting coupling**: plugins/aspects keep persistence, cache, telemetry, and logging out of business functions.
+- **Lineage and idempotency coupling**: TPF tracks item identity, previous-item references, payload version, and idempotency keys so retries and investigation have stable context.
+- **Application state coupling**: examples such as CSV Payments carry prior context forward explicitly using a "Russian dolls" style domain model, instead of reaching sideways into earlier functions or shared mutable state.
+- **Failure coupling**: Item Reject Sink handles per-item business rejection, while an execution DLQ handles full-run failures that need operator attention.
+
+### Runtime layouts and deployment evolution
+
+TPF separates where the flow logically runs from how the deployable files are built.
+
+- **Runtime layout** decides the logical placement of orchestrators, business functions, and plugin side effects.
+- **Build topology** decides which Maven modules, JARs, and containers are actually produced.
+- **Transport mode** (`GRPC`, `REST`, `LOCAL`) decides how generated clients call pipeline functions.
+- **Platform mode** (`COMPUTE`, `FUNCTION`) decides whether the generated runtime targets a standard service or a function-style entry point model.
+
+That separation lets teams start with a monolith or grouped runtime, then move toward more distributed layouts when ownership, throughput, or deployment constraints justify it.
+
+### Plugins, aspects, and side effects
+
+Cross-cutting capabilities are configured declaratively through aspects and implemented by plugins.
+
+- You declare concerns such as persistence, cache, telemetry, or logging around the pipeline.
+- TPF generates and runs the transport-aware side-effect integration for gRPC, REST, and local execution paths.
+- Business functions stay focused on domain transformations instead of repeating infrastructure code.
+
+### Background execution and checkpoint-driven flows
+
+TPF supports normal request/response execution and background execution where callers submit work, receive an execution ID, and let TPF continue the flow after the request returns.
+
+- Background execution can store accepted work outside the current JVM so crashes and restarts do not lose that work.
+- Checkpoint-style handoff patterns for cross-pipeline orchestration, as demonstrated by the TPFGo example.
+- Lineage and replay-safe state handling across split/merge flows.
+- In a checkout flow, one pipeline can publish a stable checkpoint and the next pipeline can accept it through framework-owned handoff endpoints.
+
+### High availability and crash-surviving execution
+
+TPF's crash-surviving execution path is configured with `pipeline.orchestrator.mode=QUEUE_ASYNC`.
+
+- TPF stores execution progress, dispatches work, retries failed transitions, recovers work after worker crashes, and publishes terminal failures.
+- Execution state can be backed by providers outside the current process instead of process-local memory.
+- Work dispatch can use queue-backed providers for recovery and worker takeover.
+- Terminal execution failures can be routed to an execution DLQ, while item-level failures can use Item Reject Sink.
+- Your team still chooses the production policy: providers, idempotency rules, retry budgets, observability thresholds, and rollout strategy.
+
+### Function and cloud deployment
+
+TPF supports function-style deployment paths in addition to standard Quarkus service runtimes.
+
+- `FUNCTION` and `COMPUTE` are first-class platform modes.
+- Function-oriented flows use the same business functions and generated runtime rules rather than becoming a separate programming model.
+- Multi-cloud function support is part of the current platform story, including AWS Lambda, Azure Functions, and Google Cloud Functions guidance.
+
+## Architecture Model
+
+At a high level, TPF works like this:
+
+1. Define the pipeline, types, and business logic.
+2. Configure runtime mapping, transport, platform, and optional aspects/plugins.
+3. Compile the application so TPF validates the model and generates endpoints, clients, handlers, and runtime files.
+4. Run the application so TPF calls the generated code, records progress when configured, retries failures, and routes failed work.
+5. Operate the deployables with the production policies and topology your environment requires.
+
+This keeps the domain flow stable while generated endpoints, clients, handlers, and deployable shapes can change around it.
+
+## Getting Started
+
+### Design flow
+
+The fastest way to start is the Canvas designer:
+
+1. Open [app.pipelineframework.org](https://app.pipelineframework.org).
+2. Design the pipeline visually.
+3. Download the generated application scaffold.
+4. Build and run it with Quarkus and Maven.
+
+Canvas is the preferred onboarding path, but TPF also supports template- and YAML-driven flows for automation, CI, and deeper framework usage.
+
+### Core docs
+
+- [Documentation home](https://pipelineframework.org)
+- [Getting started](https://pipelineframework.org/guide/getting-started/)
+- [Runtime layouts and build topologies](https://pipelineframework.org/guide/build/runtime-layouts/)
+- [Using plugins](https://pipelineframework.org/guide/development/using-plugins)
+- [Orchestrator runtime](https://pipelineframework.org/guide/development/orchestrator-runtime)
+- [Testing](https://pipelineframework.org/guide/development/testing)
+- [Observability](https://pipelineframework.org/guide/operations/observability/)
+- [Operators](https://pipelineframework.org/guide/development/operators)
+- [Operator operations](https://pipelineframework.org/guide/operations/operators)
+- [Error handling and DLQ](https://pipelineframework.org/guide/operations/error-handling)
+- [TPFGo example](https://pipelineframework.org/guide/development/tpfgo-example)
+
+## Reference Examples
+
+- [`examples/csv-payments`](examples/csv-payments/) shows the topology and runtime-layout story across modular, pipeline-runtime, and monolith builds.
+- [`examples/search`](examples/search/) is the richer reference application for crawl/parse/tokenize/index flows, cache/persistence interplay, function-platform verification, and integration hardening.
+- [`examples/checkout`](examples/checkout/) contains the TPFGo reference flow for checkpoint-boundary handoff and multi-pipeline orchestration.
+
+## Project Surfaces
+
+- [`framework/runtime`](framework/runtime/) contains runtime APIs, execution, telemetry, and config loading.
+- [`framework/deployment`](framework/deployment/) contains annotation processing, validation, and code generation phases.
+- [`plugins`](plugins/) contains foundational cross-cutting capabilities such as persistence and cache.
+- [`docs`](docs/) contains the VitePress documentation site.
+- [`web-ui`](web-ui/) contains the Canvas/web UI.
+- [`template-generator-node`](template-generator-node/) contains template-generation and schema support.
+- [`ai-sdk`](ai-sdk/) contains the standalone Java SDK used for AI/delegation and transport exercises.
+
+## Build and Validation
+
+Framework verification:
+
+```bash
+./mvnw -f framework/pom.xml verify
 ```
 
-Each pipeline step is implemented as an independent service that can be scaled and deployed separately.
+Full repository verification:
 
-## 🛠️ Example Implementation
-
-Here's a simple pipeline step implementation:
-
-```java
-@PipelineStep(
-    inputType = PaymentRecord.class,
-    outputType = PaymentStatus.class,
-    stepType = StepOneToOne.class,
-    inboundMapper = PaymentRecordMapper.class,
-    outboundMapper = PaymentStatusMapper.class
-)
-@ApplicationScoped
-public class ProcessPaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
-
-    @Override
-    public Uni<PaymentStatus> process(PaymentRecord input) {
-        // Business logic here
-        PaymentStatus status = new PaymentStatus();
-        // Process the payment record
-        return Uni.createFrom().item(status);
-    }
-}
+```bash
+./mvnw verify
 ```
 
-## 🔌 Plugin System
+Docs build:
 
-The framework now includes a powerful plugin system that enables external components to participate in pipelines as side effect steps with typed gRPC endpoints. Plugins are implemented using simple interfaces without dependencies on DTOs, mappers, or protos.
-
-```java
-@ApplicationScoped
-public class LoggingPlugin implements ReactiveSideEffectService<String> {
-    private static final Logger LOG = Logger.getLogger(LoggingPlugin.class);
-
-    @Override
-    public Uni<String> process(String message) {
-        LOG.info("Processing message: " + message);
-        return Uni.createFrom().voidItem();
-    }
-}
+```bash
+npm --prefix docs run build
 ```
 
-For more information about the plugin system, see the [plugins' documentation](docs/plugins/index.md).
+## Security
 
-## Continuous Integration
-See our [CI documentation](CI.md)
+If you discover a security vulnerability, see our [security policy](SECURITY.md) for responsible disclosure details.
 
-## 🧪 Testing
-See our [Testing documentation](TESTING.md)
+## Contributing
 
-## 🛡️ Security
+Contributions are welcome across framework code, examples, docs, tooling, and design discussion.
 
-If you discover a security vulnerability, please see our [security policy](SECURITY.md) for details on how to report it responsibly.
-
-## 🤝 Contributing
-
-Contributions of all kinds are welcome — code, documentation, ideas, translations and questions.
-
-Please read our [contribution guidelines](CONTRIBUTING.md) for details on how to get started.
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+- Use [AGENTS.md](AGENTS.md) for repo-specific engineering guidance when working inside this repository.

--- a/docs/guide/build/configuration/index.md
+++ b/docs/guide/build/configuration/index.md
@@ -8,7 +8,7 @@ This page lists every supported configuration option, grouped by build-time and 
 
 ## Build-Time Configuration
 
-These settings are read during build/compile and affect generated code or CLI wiring.
+These settings are read during build/compile and affect generated code or CLI generation.
 
 ### Pipeline YAML
 
@@ -100,7 +100,7 @@ Prefix: `pipeline`
 
 ### Orchestrator Client Wiring (Generated)
 
-The annotation processor generates default client wiring for orchestrators at build time.
+The annotation processor generates default orchestrator client configuration at build time.
 Generated values have lower priority than explicit `application.properties` settings or environment variables.
 
 To override routing or ports, set the following in `application.properties`:
@@ -181,13 +181,15 @@ Prefix: `pipeline`
 | `pipeline.parallelism`     | string  | `AUTO`  | Parallelism policy: `SEQUENTIAL`, `AUTO`, or `PARALLEL`.    |
 | `pipeline.max-concurrency` | integer | `128`   | Per-step maximum in-flight items when parallel execution is enabled. |
 
-### Orchestrator Queue-Async
+### Orchestrator Background Execution
+
+Use these settings when the orchestrator should accept work, store execution state, dispatch work in the background, retry failures, and publish terminal failures. The config value for that execution path is `QUEUE_ASYNC`.
 
 Prefix: `pipeline.orchestrator`
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `pipeline.orchestrator.mode` | enum | `SYNC` | Orchestrator mode (`SYNC`, `QUEUE_ASYNC`). |
+| `pipeline.orchestrator.mode` | enum | `SYNC` | `SYNC` waits for the result in the request; `QUEUE_ASYNC` stores execution state and continues work in the background. |
 | `pipeline.orchestrator.default-tenant` | string | `default` | Fallback tenant when caller omits tenant id. |
 | `pipeline.orchestrator.execution-ttl-days` | int | `7` | Execution state retention in days. |
 | `pipeline.orchestrator.lease-ms` | long | `30000` | Lease duration for claimed executions. |
@@ -199,8 +201,8 @@ Prefix: `pipeline.orchestrator`
 | `pipeline.orchestrator.idempotency-policy` | enum | `OPTIONAL_CLIENT_KEY` | `OPTIONAL_CLIENT_KEY`, `CLIENT_KEY_REQUIRED`, `SERVER_KEY_ONLY`. |
 | `pipeline.orchestrator.state-provider` | string | `memory` | `ExecutionStateStore` provider selector. |
 | `pipeline.orchestrator.dispatcher-provider` | string | `event` | `WorkDispatcher` provider selector. |
-| `pipeline.orchestrator.dlq-provider` | string | `log` | `DeadLetterPublisher` provider selector. |
-| `pipeline.orchestrator.dlq-url` | string | none | Durable DLQ queue URL when `dlq-provider=sqs`. |
+| `pipeline.orchestrator.dlq-provider` | string | `log` | Dead-letter publisher provider for terminal execution failures. |
+| `pipeline.orchestrator.dlq-url` | string | none | Dead-letter queue URL when `dlq-provider=sqs`. |
 | `pipeline.orchestrator.queue-url` | string | none | Queue URL for external dispatcher providers. |
 | `pipeline.orchestrator.dynamo.execution-table` | string | `tpf_execution` | DynamoDB table used for execution state rows. |
 | `pipeline.orchestrator.dynamo.execution-key-table` | string | `tpf_execution_key` | DynamoDB table used for submit dedupe keys. |
@@ -211,15 +213,15 @@ Prefix: `pipeline.orchestrator`
 | `pipeline.orchestrator.sqs.local-loopback` | boolean | `true` | Also fire in-process work event after SQS enqueue (dev convenience). |
 | `pipeline.orchestrator.strict-startup` | boolean | `true` | Fail startup if queue mode prerequisites are invalid. |
 
-Queue mode notes:
+Background execution notes:
 
 1. `QUEUE_ASYNC` rejects async streaming output for this milestone.
-2. Keep `strict-startup=true` in production, so invalid provider wiring fails fast.
+2. Keep `strict-startup=true` in production, so invalid provider configuration fails fast.
 3. In queue mode, strict startup also requires `pipeline.orchestrator.idempotency-policy` to be explicitly set to a non-default value.
-4. In-memory providers are for local/dev only; use durable providers for HA.
-5. For durable dead-letter handling, set both `pipeline.orchestrator.dlq-provider=sqs` and `pipeline.orchestrator.dlq-url`.
+4. In-memory providers are for local/dev only; use providers backed by external storage/queues for crash recovery.
+5. For dead-letter handling that survives restarts, set both `pipeline.orchestrator.dlq-provider=sqs` and `pipeline.orchestrator.dlq-url`.
 
-Example durable provider wiring:
+Example crash-recovery provider configuration:
 
 ```properties
 pipeline.orchestrator.mode=QUEUE_ASYNC
@@ -238,10 +240,10 @@ Prefix: `pipeline.item-reject`
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `pipeline.item-reject.provider` | string | `log` | Step-level reject sink provider selector (`log`, `memory`, `sqs`). |
-| `pipeline.item-reject.strict-startup` | boolean | `true` | Fail startup when selected sink provider wiring is invalid. |
+| `pipeline.item-reject.strict-startup` | boolean | `true` | Fail startup when selected sink provider configuration is invalid. |
 | `pipeline.item-reject.include-payload` | boolean | `false` | Include rejected payload in sink envelope. |
 | `pipeline.item-reject.memory-capacity` | int | `512` | Bounded ring size for the `memory` provider. |
-| `pipeline.item-reject.publish-failure-policy` | enum | `CONTINUE` | Sink publish failure behavior (`CONTINUE`, `FAIL_PIPELINE`). |
+| `pipeline.item-reject.publish-failure-policy` | enum | `CONTINUE` | Sink publish failure behaviour (`CONTINUE`, `FAIL_PIPELINE`). |
 | `pipeline.item-reject.sqs.queue-url` | string | none | SQS queue URL when `provider=sqs`. |
 | `pipeline.item-reject.sqs.region` | string | none | Optional SQS region override. |
 | `pipeline.item-reject.sqs.endpoint-override` | string | none | Optional SQS endpoint override (local/dev). |
@@ -284,7 +286,7 @@ Prefix: `pipeline.kill-switch`
 | `pipeline.kill-switch.retry-amplification.enabled`                    | boolean  | `false`     | Enable retry amplification guard.             |
 | `pipeline.kill-switch.retry-amplification.window`                     | duration | `PT30S`     | Evaluation window for sustained inflight growth. |
 | `pipeline.kill-switch.retry-amplification.inflight-slope-threshold`   | double   | `10`        | Inflight slope threshold (items/sec).         |
-| `pipeline.kill-switch.retry-amplification.mode`                       | string   | `fail-fast` | Guard behavior (`fail-fast` or `log-only`).   |
+| `pipeline.kill-switch.retry-amplification.mode`                       | string   | `fail-fast` | Guard behaviour (`fail-fast` or `log-only`).   |
 | `pipeline.kill-switch.retry-amplification.sustain-samples`            | integer  | `3`         | Consecutive samples above the threshold required to trigger. |
 
 ### Global Defaults
@@ -295,7 +297,7 @@ Prefix: `pipeline.defaults`
 |--------------------------------------------------|---------|----------|---------------------------------------------|
 | `pipeline.defaults.retry-limit`                  | integer | `3`      | Max retry attempts for steps.               |
 | `pipeline.defaults.retry-wait-ms`                | long    | `2000`   | Base delay between retries (ms).            |
-| `pipeline.defaults.recover-on-failure`           | boolean | `false`  | Enables recovery behavior on failure.       |
+| `pipeline.defaults.recover-on-failure`           | boolean | `false`  | Enables recovery behaviour on failure.       |
 | `pipeline.defaults.max-backoff`                  | long    | `30000`  | Maximum backoff delay (ms).                 |
 | `pipeline.defaults.jitter`                       | boolean | `false`  | Adds jitter to retry delays.                |
 | `pipeline.defaults.backpressure-buffer-capacity` | integer | `128`   | Per-step backpressure buffer capacity (in items). |

--- a/docs/guide/build/runtime-layouts/index.md
+++ b/docs/guide/build/runtime-layouts/index.md
@@ -25,7 +25,7 @@ Defined in `pipeline.runtime.yaml`.
 Defined by Maven modules and POM structure.
 
 - Decides what artefacts are produced (how many JARs/containers).
-- Decides what is actually deployable in CI/prod.
+- Decides what is actually deployable in CI and production.
 - Is not rewritten automatically by runtime mapping.
 
 ### Transport mode (call mechanism)

--- a/docs/guide/build/runtime-layouts/index.md
+++ b/docs/guide/build/runtime-layouts/index.md
@@ -6,19 +6,25 @@ then choose how many deployables you actually want to run.
 
 ## Three terms you must separate
 
+These terms sound similar, but they answer different questions:
+
+1. Runtime layout: where TPF logically places the generated runtime pieces.
+2. Build topology: what Maven and CI actually build.
+3. Transport/platform: how generated pieces call each other and what kind of runtime they target.
+
 ### Runtime layout (logical)
 
 Defined in `pipeline.runtime.yaml`.
 
-- Decides where orchestrator, regular steps, and synthetic and plugin side effects are placed.
+- Decides where the orchestrator, regular steps, and plugin side effects logically run.
 - Values include `modular`, `pipeline-runtime`, and `monolith`.
-- Drives generated wiring and validation.
+- Drives generated calls and validation.
 
 ### Build topology (physical)
 
-Defined by Maven modules and POM wiring.
+Defined by Maven modules and POM structure.
 
-- Decides what artifacts are produced (how many JARs/containers).
+- Decides what artefacts are produced (how many JARs/containers).
 - Decides what is actually deployable in CI/prod.
 - Is not rewritten automatically by runtime mapping.
 
@@ -26,14 +32,14 @@ Defined by Maven modules and POM wiring.
 
 Values include `GRPC`, `REST`, and `LOCAL`.
 
-- Decides how steps are invoked.
+- Decides how generated components call steps.
 - Orthogonal to layout/topology.
 
 ### Platform mode (deployment target)
 
 Values include `COMPUTE` and `FUNCTION` (legacy aliases: `STANDARD`, `LAMBDA`).
 
-- Decides whether generation targets standard Quarkus runtimes or AWS Lambda packaging/runtime semantics.
+- Decides whether generation targets standard Quarkus services or function-style entry points.
 - Constrained by transport and step-shape compatibility (Function mode requires REST; unary and streaming shapes are supported via generated function bridges).
 - Orthogonal to runtime layout/topology.
 
@@ -47,7 +53,7 @@ Application developers using the normal onboarding path:
 
 ## Why people get confused
 
-You can set `layout: monolith` and still not have a real monolith artifact if the
+You can set `layout: monolith` and still not have a real monolith artefact if the
 Maven topology is still modular.
 
 - Runtime mapping changed the logical placement.
@@ -58,13 +64,13 @@ Both layers must be aligned to achieve your intended runtime shape.
 ## What runtime mapping changes automatically
 
 - Placement rules for regular and synthetic steps.
-- Validation behavior ([`auto` = best-effort fallback placement, `strict` = fail on unmapped/mismatched placement](/guide/evolve/runtime-mapping/schema#validation)).
-- Generated client/server wiring aligned to placement + transport.
+- Validation behaviour ([`auto` = best-effort fallback placement, `strict` = fail on unmapped/mismatched placement](/guide/evolve/runtime-mapping/schema#validation)).
+- Generated client/server calls aligned to placement + transport.
 
 ## What runtime mapping does not change automatically
 
 - Parent/module structure in Maven.
-- Number of runtime artifacts produced.
+- Number of runtime artefacts produced.
 - CI lanes needed to build/test a new topology.
 
 ::: note

--- a/docs/guide/development/orchestrator-runtime.md
+++ b/docs/guide/development/orchestrator-runtime.md
@@ -1,13 +1,25 @@
 # Orchestrator Runtime
 
-The orchestrator runtime coordinates step execution for a pipeline and exposes generated transport endpoints.
+The orchestrator runtime is the generated part of a TPF application that starts the pipeline, calls each step in order, tracks execution state when configured, and exposes generated REST, gRPC, or function-style entry points.
+
+## What durable execution means
+
+Durable execution means accepted work is recorded outside the current JVM or process before the runtime depends on it. If a worker crashes or the application restarts, another worker can recover the recorded state and continue from the last committed transition.
+
+Durability protects TPF execution state and dispatch/retry flow. External systems called by your business code still need idempotency, because a retry can call the same operator or downstream system again.
+
+## What background async execution means
+
+Background async execution means the caller submits work and receives an execution id instead of waiting for the whole pipeline result. TPF stores the execution, dispatches work through the configured dispatcher, retries failed transitions, and exposes status/result endpoints for follow-up.
+
+`QUEUE_ASYNC` is the config value for this execution path. It can use in-process providers for local development or durable providers such as DynamoDB/SQS-backed implementations for production-style recovery.
 
 ## Runtime Modes
 
 TPF supports two orchestrator runtime modes:
 
 1. `SYNC` (default): in-process request/response execution.
-2. `QUEUE_ASYNC`: queue-driven async job execution with durable execution state providers.
+2. `QUEUE_ASYNC`: background async execution with stored execution state, dispatch, retry, recovery, and dead-letter handling.
 
 Set mode with:
 
@@ -17,9 +29,9 @@ pipeline.orchestrator.mode=SYNC
 pipeline.orchestrator.mode=QUEUE_ASYNC
 ```
 
-## Transport Surfaces
+## Generated Transport Entry Points
 
-Generated orchestrator endpoints are transport-native:
+Generated orchestrator entry points use the selected transport:
 
 1. REST:
    - `POST /pipeline/run`
@@ -48,9 +60,9 @@ Reliable cross-pipeline handoff is orchestrator-owned and checkpoint-based.
 Supported in this release:
 
 1. source: final pipeline checkpoint publication from a `QUEUE_ASYNC` orchestrator,
-2. target: downstream orchestrator async admission bound by a named logical publication,
-3. idempotency: preserve incoming dispatch metadata when present, otherwise derive a deterministic handoff key from configured checkpoint fields,
-4. ownership: downstream retry/DLQ remains orchestrator-owned after async admission.
+2. target: downstream orchestrator background admission bound by a named logical publication,
+3. idempotency: preserve incoming dispatch identifiers when present, otherwise derive a repeat-safe handoff key from configured checkpoint fields,
+4. ownership: downstream retry/DLQ remains orchestrator-owned after background admission.
 
 Declare reliable handoff in `pipeline.yaml`:
 
@@ -66,7 +78,7 @@ output:
     idempotencyKeyFields: ["orderId", "customerId", "readyAt"]
 ```
 
-Runtime behavior:
+Runtime behaviour:
 
 1. build-time validation checks checkpoint boundary declarations and mapper compatibility,
 2. runtime endpoint bindings come from `pipeline.handoff.bindings.<publication>.targets.*`,
@@ -74,16 +86,16 @@ Runtime behavior:
 4. subscriber admission is handled by framework-owned HTTP and gRPC checkpoint publication endpoints instead of runtime subscription discovery,
 5. protobuf-over-HTTP and gRPC use the same framework-owned checkpoint protobuf envelope for transport-native admission,
 6. reliable handoff is supported only for `QUEUE_ASYNC` orchestrators and is rejected for `FUNCTION` pipelines,
-7. live `Subscribe` remains a weaker observer/tap surface and is not the reliable checkpoint handoff path.
+7. live `Subscribe` remains a weaker observer/tap API and is not the reliable checkpoint handoff path.
 
 Not yet supported:
 
 1. generic broker-message re-drive,
-2. a separate checkpoint-publication durable plane or publication-specific DLQ,
+2. a separate durable checkpoint-publication service or publication-specific DLQ,
 3. dynamic runtime publication discovery or runtime subscription registration,
 4. broker-backed publication targets such as `SQS` or `KAFKA`.
 
-## Queue-Async Semantics
+## Queue-Async Guarantees
 
 In `QUEUE_ASYNC` mode:
 
@@ -91,9 +103,9 @@ In `QUEUE_ASYNC` mode:
 2. dispatch and operator invocation are at-least-once,
 3. duplicate invocation can occur and must be handled with idempotency keys,
 4. streaming outputs are rejected for async execution in the current 26.4.x release line,
-5. persisted protobuf payload metadata stores `_tpf_message` as the protobuf schema full name.
+5. persisted protobuf payload descriptors store `_tpf_message` as the protobuf schema full name.
 
-## Queue-Async Control Plane
+## Queue-Async Runtime Components
 
 Runtime provider choices:
 
@@ -128,7 +140,7 @@ These guarantees are deterministic for orchestrator state, not for external side
 
 ## Queue-Async HA Baseline
 
-Use this as a minimum production baseline for queue-driven HA:
+Use this as a minimum production baseline for crash-surviving background execution:
 
 ```properties
 pipeline.orchestrator.mode=QUEUE_ASYNC
@@ -145,18 +157,18 @@ Operational expectations for this baseline:
 
 1. state transitions remain OCC-guarded and lease-claimed,
 2. queue delivery and operator invocation remain at-least-once,
-3. terminal dead-letter events are durable, not process-local log-only.
+3. terminal dead-letter events are stored outside the current process, not process-local log-only.
 
 CI confidence for this baseline:
 
 1. `SYNC` remains the default runtime mode and the fast baseline configuration.
-2. `QUEUE_ASYNC` remains opt-in and requires explicit durable provider configuration.
-3. the durable HA gate exercises the checkout `deliver-order` recovery path against `dynamo` + `sqs` semantics with `DynamoDB Local` + `ElasticMQ`.
+2. `QUEUE_ASYNC` remains opt-in and requires explicit provider configuration for crash recovery.
+3. the HA gate exercises the checkout `deliver-order` recovery path against `dynamo` + `sqs` behaviour with `DynamoDB Local` + `ElasticMQ`.
 4. this gate covers:
    - worker kill takeover,
    - sweeper redispatch,
    - duplicate submit determinism,
-   - durable DLQ publication.
+   - DLQ publication that survives process restarts.
 
 ## Generated Structure
 

--- a/docs/guide/development/using-plugins.md
+++ b/docs/guide/development/using-plugins.md
@@ -1,15 +1,15 @@
 # Using plugins
 
 Plugins let you add cross-cutting capabilities (like persistence, metrics, or logging) without pushing that code into every business step.
-You configure behavior through aspects; the framework wires and generates the integration pieces.
+You configure when the plugin should run through aspects; the framework generates the integration code and calls it at the right point.
 
-## Mental model
+## How plugins fit the flow
 
-- **Steps**: your business transformations.
-- **Aspects**: where and when a plugin should run.
-- **Plugins**: implementation modules that provide the side effect.
+- **Steps**: your business functions.
+- **Aspects**: declarations that say where and when a plugin should run, such as before or after a step.
+- **Plugins**: implementation modules that do the cross-cutting work, such as persistence, cache, telemetry, or logging.
 
-This keeps business logic focused while infrastructure concerns stay declarative.
+This keeps business logic focused while infrastructure concerns stay declared in configuration.
 
 ## What you configure
 
@@ -26,8 +26,8 @@ At build time and runtime, TPF handles:
 
 - Adapter and client/server code generation.
 - Transport-specific integration (gRPC/REST/LOCAL).
-- Type-aware side-effect wiring.
-- Runtime injection for generated plugin surfaces.
+- Type-aware side-effect calls.
+- Runtime injection for generated plugin code.
 
 ## Aspect naming and module mapping
 

--- a/docs/guide/development/using-plugins.md
+++ b/docs/guide/development/using-plugins.md
@@ -6,7 +6,7 @@ You configure when the plugin should run through aspects; the framework generate
 ## How plugins fit the flow
 
 - **Steps**: your business functions.
-- **Aspects**: declarations that say where and when a plugin should run, such as before or after a step.
+- **Aspects**: declarations that say where and when a plugin should run, such as before or after a step; see the [aspect semantics reference](/guide/evolve/aspects/semantics) for the formal rules.
 - **Plugins**: implementation modules that do the cross-cutting work, such as persistence, cache, telemetry, or logging.
 
 This keeps business logic focused while infrastructure concerns stay declared in configuration.

--- a/docs/guide/operations/error-handling.md
+++ b/docs/guide/operations/error-handling.md
@@ -28,6 +28,8 @@ pipeline.orchestrator.dlq-provider=sqs
 pipeline.orchestrator.dlq-url=https://sqs.eu-west-1.amazonaws.com/123456789012/tpf-dlq
 ```
 
+`QUEUE_ASYNC` is the mode name used by `pipeline.orchestrator.mode` for background execution.
+
 Execution DLQ applies to terminal execution failures only. A DLQ is a dead-letter channel for failed executions that need investigation or replay.
 It does not replace item-level rejection flows.
 

--- a/docs/guide/operations/error-handling.md
+++ b/docs/guide/operations/error-handling.md
@@ -1,7 +1,7 @@
 # Error Handling and Recovery
 
 This guide is for operations triage and recovery.
-It focuses on runtime failure channels and queue-async crash behavior.
+It focuses on runtime failure channels and background execution recovery behaviour.
 
 Step-level Item Reject Sink is intentionally a business processing path, not an execution failure.
 Developer implementation guidance lives in [Item Reject Sink](/guide/development/item-reject-sink).
@@ -20,7 +20,7 @@ Triage rule:
 2. A growing execution DLQ indicates control-plane, dependency, or systemic execution failure.
 3. When checkpoint publication backlog rises, it indicates throughput or admission pressure before downstream execution has started.
 
-## Execution DLQ Configuration (Queue-Async)
+## Execution DLQ Configuration (Background Execution)
 
 ```properties
 pipeline.orchestrator.mode=QUEUE_ASYNC
@@ -28,12 +28,12 @@ pipeline.orchestrator.dlq-provider=sqs
 pipeline.orchestrator.dlq-url=https://sqs.eu-west-1.amazonaws.com/123456789012/tpf-dlq
 ```
 
-Execution DLQ applies to terminal execution failures only.
+Execution DLQ applies to terminal execution failures only. A DLQ is a dead-letter channel for failed executions that need investigation or replay.
 It does not replace item-level rejection flows.
 
-## Execution DLQ Envelope (Terminal Metadata)
+## Execution DLQ Envelope (Terminal Details)
 
-Execution DLQ entries include standardized metadata for cross-transport triage:
+Execution DLQ entries include standard fields for triage across REST, gRPC, local, and function-style execution:
 
 - execution fields: `tenantId`, `executionId`, `executionKey`, `transitionKey`
 - correlation/resource fields: `correlationId`, `resourceType`, `resourceName`
@@ -47,13 +47,13 @@ Terminal reason mapping:
 | `retry_exhausted` | retryable failure class reached terminal state after exhausting retry budget (includes zero-retry configurations (`maxRetries = 0`)) | Stabilise dependency/path, then re-drive bounded batches |
 | `non_retryable` | non-retryable failure class (for example `NonRetryableException`) | Correct payload/contract issue before replay |
 
-## Queue-Async Crash Matrix
+## Background Execution Crash Matrix
 
 | Crash point | Behaviour after restart/recovery | Duplicate risk | Required safeguard |
 |---|---|---|---|
-| Before transition state commit | Work is redelivered and re-executed from last durable version | High | Idempotent operator boundary (`executionId:stepIndex:attempt`) |
-| After state commit, before next enqueue | Transition is durable, but next dispatch can stall until due sweeper re-dispatches | Low | Due-execution sweeper + durable state |
-| During retry scheduling | Retry can replay from last durable version if scheduling metadata was not committed | Medium | Persist retry intent (`attempt`, `nextDue`) before enqueue |
+| Before transition state commit | Work is redelivered and re-executed from the last stored version | High | Idempotent operator boundary (`executionId:stepIndex:attempt`) |
+| After state commit, before next enqueue | Transition is stored, but next dispatch can stall until due sweeper re-dispatches | Low | Due-execution sweeper + stored state |
+| During retry scheduling | Retry can replay from the last stored version if scheduling details were not committed | Medium | Persist retry intent (`attempt`, `nextDue`) before enqueue |
 | After external side effect, before commit | Side effect may repeat on replay because effect and commit are not one transaction | High | Downstream dedupe keyed by transition identity |
 | Worker dies while lease held | Lease expires and another worker can claim execution | Low | Short lease window + conditional lease claim (OCC) |
 
@@ -74,7 +74,7 @@ pipeline.defaults.jitter=true
 
 Use `NonRetryableException` to fail fast for non-transient failures.
 
-For at-least-once boundaries (queue delivery, operator invocation, re-drive), enforce idempotency with stable transition identity (`executionId:stepIndex:attempt`).
+For at-least-once boundaries (queue delivery, operator invocation, re-drive), enforce idempotency with stable transition identity (`executionId:stepIndex:attempt`). Idempotency means retries can happen without duplicating the business effect.
 
 ## Operations Runbook
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: The Pipeline Framework
-  text: Reactive Pipeline Processing
-  tagline: Build pipeline-style applications on Quarkus, with generated adapters and a shared type-safe core
+  text: Fast Typed Function Chains on Quarkus
+  tagline: Write focused Java business functions; TPF generates, validates, and runs the Quarkus code around them
   image:
     src: /logo.png
     alt: The Pipeline Framework
@@ -18,7 +18,7 @@ hero:
 
 features:
   - title: Developer Joy
-    details: Start quickly, keep types in one place, and spend less time wiring things together
+    details: Start quickly, keep function inputs and outputs explicit, and spend less time writing glue code
     link: /value/developer-experience
   - title: Performance
     details: Handle more work with less runtime overhead, using generated code paths and non-blocking execution
@@ -30,15 +30,15 @@ features:
     details: Start as a monolith, then split into layouts that fit your team boundaries when you are ready
     link: /value/deployment-evolution
   - title: Kube-Native
-    details: Container-first delivery and cloud-friendly runtime foundations, with operational patterns that scale
+    details: Container-first delivery with health, observability, retries, and failure handling that stay understandable
     link: /value/operational-confidence
   - title: Plugins, Not Glue
-    details: Add cross-cutting capabilities via plugins, while keeping domain code focused on behavior
+    details: Add persistence, cache, telemetry, and logging without pushing that code into every business function
     link: /value/extensibility-and-platform
 ---
 
 <Callout type="tip" title="Visual Pipeline Designer Available">
-The Pipeline Framework includes a visual canvas designer at <a href="https://app.pipelineframework.org" target="_blank" rel="noopener noreferrer">https://app.pipelineframework.org</a> that allows you to create and configure your pipelines using an intuitive drag-and-drop interface. Simply design your pipeline visually, click "Download Application", and you'll get a complete ZIP file with all the generated source code - no command-line tools needed!
+The Pipeline Framework includes a visual canvas designer at <a href="https://app.pipelineframework.org" target="_blank" rel="noopener noreferrer">https://app.pipelineframework.org</a>. Design the flow visually, click "Download Application", and you get a runnable Quarkus scaffold with generated code for the pipeline shape you designed.
 </Callout>
 
 <FeaturedArticles />
@@ -46,34 +46,34 @@ The Pipeline Framework includes a visual canvas designer at <a href="https://app
 
 ## Key Features
 
-The Pipeline Framework is a powerful tool for building reactive pipeline processing systems. It simplifies the development of distributed systems by providing a consistent way to create, configure, and deploy pipeline steps.
+The Pipeline Framework helps you build fast, forward-only flows of Java functions. A step is one function in the flow: it receives a typed input, produces a typed output, and lets TPF generate the REST, gRPC, local, or function-style code around it.
 
 ### Runtime and Processing Model
 
-- **Reactive by default**: Built on Mutiny for non-blocking throughput and backpressure-aware execution.
+- **Reactive by default**: Built on Mutiny so many items can move through the flow without blocking one thread per item.
 - **Why it matters**: Better CPU utilization and higher compute density typically mean lower runtime cost for the same workload.
-- **Quarkus runtime foundation**: Aligns with Quarkus runtime and build-time patterns for fast, production-grade services.
-- **Immutable event flow**: No in-place updates during execution; append/preserve semantics improve traceability and safety.
-- **Rich step semantics**: Supports OneToOne, OneToMany, ManyToOne, ManyToMany, and SideEffect patterns.
+- **Quarkus foundation**: Uses Quarkus build-time generation and runtime patterns for production-grade services.
+- **Traceable flow**: Preserve enough context to understand what produced each item and where it came from.
+- **Clear step shapes**: Supports one-to-one, one-to-many, many-to-one, many-to-many, and side-effect steps.
 
 ### Extensibility with Plugins
 
-- **Plugin-friendly model**: Pipeline plugins add cross-cutting capabilities without coupling business logic to infrastructure code.
-- **Why it matters**: You can deliver platform concerns (cache, telemetry, orchestration behaviors) with less code churn in core services.
-- **Clear extension points**: Use [Using Plugins](/guide/development/using-plugins) and [Aspect Semantics](/guide/evolve/aspects/semantics) as primary references.
+- **Plugin-friendly model**: Pipeline plugins add cross-cutting work without coupling business logic to infrastructure code.
+- **Why it matters**: You can add cache, telemetry, persistence, and logging with less code churn in core services.
+- **Clear extension points**: Use [Using Plugins](/guide/development/using-plugins) and the [Aspect guide](/guide/evolve/aspects/semantics) as primary references.
 
 ### Integration and Deployment Flexibility
 
-- **Transport coverage**: Automatic generation for gRPC, REST, and local/in-process clients.
+- **Transport coverage**: Automatic generation for gRPC, REST, and local in-process calls.
 - **Quarkus Dev Services workflow**: Smooth local development with managed service dependencies (for example, PostgreSQL) in dev/test flows.
 - **Why it matters**: Teams can adapt interfaces to consumers and platform constraints without rewriting core processing logic.
-- **Deployment layouts**: Works across modular, pipeline-runtime, and monolith build layouts.
+- **Deployment layouts**: Works across modular, grouped pipeline-runtime, and monolith layouts.
 - **Evolution path**: Start with a monolith for speed, then break into services as scale and ownership boundaries grow.
 
 ### Operations
 
-- **Built-in observability**: Metrics, tracing, and structured logging are first-class.
-- **Resilience features**: Health checks, robust error handling, and dead-letter queue support.
+- **Built-in observability**: Metrics, tracing, and structured logging are generated into the runtime shape.
+- **Resilience features**: Health checks, retries, crash-surviving background execution, and dead-letter handling.
 - **Container-first packaging**: Current delivery flow supports image builds with Jib for predictable CI/CD integration.
 - **Native compilation path**: Quarkus native builds support low cold-start and efficient resource usage where needed.
 - **Why it matters**: Teams get faster incident diagnosis, more predictable deployments, and lower operational overhead at scale.
@@ -81,7 +81,7 @@ The Pipeline Framework is a powerful tool for building reactive pipeline process
 ### Developer Experience
 
 - **Shared `common` module**: Central place for entity and DTO definitions used across pipeline components.
-- **Type safety across the pipeline**: Compile-time checks catch contract drift early as steps and transports evolve.
-- **Why it matters**: Teams get safer refactors, fewer runtime mapping errors, and faster confidence when changing domain models.
-- **Testability gains**: Functional boundaries and generated transport layers make behavior easier to isolate and test.
-- **Fast onboarding and testing**: Design visually with Canvas and validate behavior via [Testing with Testcontainers](/guide/development/testing).
+- **Type safety across the pipeline**: Compile-time checks catch mismatched step input/output types early.
+- **Why it matters**: Teams get safer refactors, fewer mapping mistakes, and faster confidence when changing domain models.
+- **Testability gains**: Functional boundaries and generated transport layers make behaviour easier to isolate and test.
+- **Fast onboarding and testing**: Design visually with Canvas and validate behaviour via [Testing with Testcontainers](/guide/development/testing).

--- a/docs/value/business-value.md
+++ b/docs/value/business-value.md
@@ -1,19 +1,19 @@
 # Business Value
 
-<p class="value-lead">The Pipeline Framework (TPF) is built to reduce delivery overhead while keeping you on portable, mainstream runtime foundations.</p>
+<p class="value-lead">The Pipeline Framework (TPF) helps teams ship Java business flows faster while staying on portable Quarkus foundations.</p>
 
 ## At a Glance
 
 <div class="value-glance">
-  <div class="value-glance-item"><strong>Faster Delivery</strong> &middot; Generate adapters and keep steps focused on one `process()` contract.</div>
-  <div class="value-glance-item"><strong>Lower Change Cost</strong> &middot; Consistency reduces integration drift and refactor fear.</div>
-  <div class="value-glance-item"><strong>Less Lock-in</strong> &middot; Plain Java + Quarkus + standard transports keep escape hatches real.</div>
+  <div class="value-glance-item"><strong>Faster Delivery</strong> &middot; Write business functions while TPF generates the calling code around them.</div>
+  <div class="value-glance-item"><strong>Lower Change Cost</strong> &middot; Explicit input/output types reduce surprises when flows change.</div>
+  <div class="value-glance-item"><strong>Less Lock-in</strong> &middot; Plain Java, Quarkus, REST, gRPC, and local calls keep escape hatches real.</div>
 </div>
 
 ## Use This When
 
-- Teams spend significant time on glue code, wiring, and “keeping things consistent”.
-- Changes ripple across multiple services just to update a contract or endpoint shape.
+- Teams spend significant time on glue code and keeping service boundaries consistent.
+- Changes ripple across multiple services just to update a Java type or API shape.
 - You want an architecture path from “works as a monolith” to “split into deployable units/services” without rewriting everything.
 
 ## Observed Impact (CSV Payments)
@@ -27,20 +27,20 @@ This is not a controlled study and results vary by team and process. The signal 
 
 Teams typically aim for:
 
-1. Faster delivery for comparable scope (often by eliminating hand-built adapters and conventions).
-2. Lower cost of change as contracts and transport surfaces stay consistent.
-3. Higher operational readiness because generated artifacts and metadata make deployments more legible.
+1. Faster delivery for comparable scope, often by eliminating hand-built adapters and conventions.
+2. Lower cost of change because Java types, mappers, and generated call paths stay consistent.
+3. Higher operational readiness because generated runtime files make it clearer what is running.
 
 ## What It Enables
 
-1. Faster iteration: change steps independently without reworking the entire pipeline.
-2. Predictable scaling: each step scales on its own workload characteristics.
+1. Faster iteration: change one function without reworking the entire flow.
+2. Predictable scaling: each function can be tuned around its own workload characteristics.
 3. Better ROI: less boilerplate, shorter lead times, and fewer bespoke integration layers.
 
 ## Reuse Existing Compute Logic
 
-Operators let teams wire proven Java logic into `pipeline.yaml` without rewriting step/service code.
-That reduces migration risk and preserves prior engineering investment while still benefiting from TPF build-time validation and generated invocation layers.
+Operators let teams plug proven Java methods into `pipeline.yaml` without rewriting them as new services first.
+That reduces migration risk and preserves prior engineering investment while still benefiting from TPF build-time validation and generated call paths.
 
 Typical reuse targets include domain rule engines, validators/enrichers, and transformation libraries already used in production.
 

--- a/docs/value/deployment-evolution.md
+++ b/docs/value/deployment-evolution.md
@@ -2,6 +2,8 @@
 
 <p class="value-lead">The Pipeline Framework (TPF) supports a practical architecture path: start with one deployable, then split when team ownership or scale makes it worth it.</p>
 
+See the [Runtime Layouts guide](/guide/build/runtime-layouts/) for the packaging details: choosing a monolith-style runtime does not automatically remove per-step service modules, because build topology and runtime layout are separate decisions.
+
 ## At a Glance
 
 <div class="value-glance">

--- a/docs/value/deployment-evolution.md
+++ b/docs/value/deployment-evolution.md
@@ -1,13 +1,13 @@
 # Start Monolith, Split Later
 
-<p class="value-lead">The Pipeline Framework (TPF) supports a practical architecture path: start with one deployable unit, then split when team and scale pressure make it worth it.</p>
+<p class="value-lead">The Pipeline Framework (TPF) supports a practical architecture path: start with one deployable, then split when team ownership or scale makes it worth it.</p>
 
 ## At a Glance
 
 <div class="value-glance">
-  <div class="value-glance-item"><strong>Fast First Release</strong> &middot; Monolith layout helps teams move quickly at the start.</div>
-  <div class="value-glance-item"><strong>Clear Migration Path</strong> &middot; Shift to pipeline-runtime or modular layouts as boundaries mature.</div>
-  <div class="value-glance-item"><strong>No Core Rewrite</strong> &middot; Change topology without rebuilding pipeline behavior.</div>
+  <div class="value-glance-item"><strong>Fast First Release</strong> &middot; Start with one application when that is the fastest path.</div>
+  <div class="value-glance-item"><strong>Clear Migration Path</strong> &middot; Move to grouped or modular layouts as boundaries mature.</div>
+  <div class="value-glance-item"><strong>No Core Rewrite</strong> &middot; Change deployable shape without rewriting the business functions.</div>
 </div>
 
 ## Use This When
@@ -15,6 +15,8 @@
 - You need speed now but know service boundaries will evolve.
 - Team ownership is outgrowing a single deployable unit.
 - Architecture discussions are stalling delivery.
+
+TPF separates **runtime layout** from **build topology**. Runtime layout is where the orchestrator, functions, and side effects logically run. Build topology is the Maven/container structure that physically creates deployables.
 
 ## Jump to Guides
 

--- a/docs/value/developer-experience.md
+++ b/docs/value/developer-experience.md
@@ -1,30 +1,30 @@
 # Developer Joy
 
-<p class="value-lead">TPF removes the repetitive parts of delivery so teams can focus on business behavior instead of plumbing.</p>
+<p class="value-lead">TPF removes repetitive delivery work so teams can focus on business behaviour instead of plumbing.</p>
 
 ## At a Glance
 
 <div class="value-glance">
   <div class="value-glance-item"><strong>Start Fast</strong> &middot; Design in Canvas and generate a runnable baseline.</div>
-  <div class="value-glance-item"><strong>Type Safety</strong> &middot; Shared `common` contracts catch drift at build time.</div>
-  <div class="value-glance-item"><strong>Less Boilerplate</strong> &middot; Adapters and client layers are generated for you.</div>
+  <div class="value-glance-item"><strong>Type Safety</strong> &middot; Explicit input/output types catch mismatches at build time.</div>
+  <div class="value-glance-item"><strong>Less Boilerplate</strong> &middot; REST, gRPC, local, and function callers are generated for you.</div>
 </div>
 
 ## Use This When
 
 - You want new developers productive quickly.
-- Refactors are becoming risky because contracts drift across modules.
-- Teams are spending too much time on integration wiring.
+- Refactors are becoming risky because Java types and API shapes drift across modules.
+- Teams are spending too much time on repeated integration glue.
 
 ## Operator Reuse
 
-When teams already have stable Java compute libraries, operators let them plug those methods directly into pipeline flow from `pipeline.yaml`.
+When teams already have stable Java compute libraries, operators let them plug those methods directly into the pipeline flow from `pipeline.yaml`.
 This shortens delivery time and avoids duplicate implementations.
 
 ## Business Rejections Without Workflow Collapse
 
 Not every failed item is a platform error. TPF lets step authors model per-item rejection as an expected business path using Item Reject Sink.
-Teams can reject specific records, continue processing the rest of the workload, and keep a durable audit/re-drive trail.
+Teams can reject specific records, continue processing the rest of the workload, and keep an audit/re-drive trail that can survive process restarts when backed by a persistent provider.
 This avoids custom side channels and keeps recovery logic explicit in step code.
 
 ## Jump to Guides

--- a/docs/value/extensibility-and-platform.md
+++ b/docs/value/extensibility-and-platform.md
@@ -1,12 +1,12 @@
 # Plugins, Not Glue
 
-<p class="value-lead">TPF gives teams structured extension points so cross-cutting needs do not leak into business flow code.</p>
+<p class="value-lead">TPF gives teams structured extension points so infrastructure concerns do not leak into business functions.</p>
 
 ## At a Glance
 
 <div class="value-glance">
-  <div class="value-glance-item"><strong>Clean Extensions</strong> &middot; Implement persistence, caching, and other cross-cutting concerns as plugins.</div>
-  <div class="value-glance-item"><strong>Consistent Wiring</strong> &middot; Generated adapters keep behavior aligned across roles and transports.</div>
+  <div class="value-glance-item"><strong>Clean Extensions</strong> &middot; Add persistence, caching, telemetry, and logging as declared plugins.</div>
+  <div class="value-glance-item"><strong>Consistent Integration</strong> &middot; Generated callers keep plugin behaviour aligned across REST, gRPC, and local paths.</div>
   <div class="value-glance-item"><strong>Strong Platform Base</strong> &middot; Quarkus runtime and tooling stay available underneath TPF.</div>
 </div>
 
@@ -14,7 +14,9 @@
 
 - Platform features keep duplicating across teams.
 - Core services are getting polluted with infrastructure logic.
-- You need shared extension patterns with predictable behavior.
+- You need shared extension patterns with predictable behaviour.
+
+In TPF, an **aspect** says where a plugin should run, such as before or after a step. A **plugin** provides the implementation, such as persistence or cache. Your business function remains focused on the domain work.
 
 ## Jump to Guides
 

--- a/docs/value/index.md
+++ b/docs/value/index.md
@@ -7,7 +7,7 @@
 <div class="value-glance">
   <div class="value-glance-item"><strong>Developer Joy</strong> &middot; Faster delivery with less glue code and safer refactors.</div>
   <div class="value-glance-item"><strong>Performance</strong> &middot; Keep many items moving without one thread per item.</div>
-  <div class="value-glance-item"><strong>Transport Choice</strong> &middot; One flow, generated REST, gRPC, local, and function entry points.</div>
+  <div class="value-glance-item"><strong>Transport Choice</strong> &middot; One Flow, Many Entry Points: generate gRPC, REST, local, and function-style callers from the same definition.</div>
   <div class="value-glance-item"><strong>Start Monolith, Split Later</strong> &middot; Change deployable shape when the team is ready.</div>
   <div class="value-glance-item"><strong>Kube-Native</strong> &middot; Container-first, cloud-friendly operation model.</div>
   <div class="value-glance-item"><strong>Plugins, Not Glue</strong> &middot; Add infrastructure concerns without polluting business functions.</div>

--- a/docs/value/index.md
+++ b/docs/value/index.md
@@ -1,16 +1,16 @@
 # Value Overview
 
-<p class="value-lead">The Pipeline Framework (TPF) helps teams move from idea to production pipelines without getting buried in repetitive integration and deployment work.</p>
+<p class="value-lead">The Pipeline Framework (TPF) helps teams move from Java business functions to production-ready flows without getting buried in repetitive integration and deployment work.</p>
 
 ## At a Glance
 
 <div class="value-glance">
   <div class="value-glance-item"><strong>Developer Joy</strong> &middot; Faster delivery with less glue code and safer refactors.</div>
-  <div class="value-glance-item"><strong>Performance</strong> &middot; Reactive-first runtime behavior with lower operational overhead.</div>
-  <div class="value-glance-item"><strong>Transport Choice</strong> &middot; One model, multiple client/server surfaces.</div>
-  <div class="value-glance-item"><strong>Start Monolith, Split Later</strong> &middot; A practical architecture evolution path.</div>
+  <div class="value-glance-item"><strong>Performance</strong> &middot; Keep many items moving without one thread per item.</div>
+  <div class="value-glance-item"><strong>Transport Choice</strong> &middot; One flow, generated REST, gRPC, local, and function entry points.</div>
+  <div class="value-glance-item"><strong>Start Monolith, Split Later</strong> &middot; Change deployable shape when the team is ready.</div>
   <div class="value-glance-item"><strong>Kube-Native</strong> &middot; Container-first, cloud-friendly operation model.</div>
-  <div class="value-glance-item"><strong>Plugins, Not Glue</strong> &middot; Cross-cutting capabilities without domain coupling.</div>
+  <div class="value-glance-item"><strong>Plugins, Not Glue</strong> &middot; Add infrastructure concerns without polluting business functions.</div>
 </div>
 
 ## Explore Tracks

--- a/docs/value/integration-flexibility.md
+++ b/docs/value/integration-flexibility.md
@@ -1,20 +1,22 @@
 # Transport Choice
 
-<p class="value-lead">TPF keeps pipeline behavior separate from transport wiring, so APIs can evolve without rewriting core flow logic.</p>
+<p class="value-lead">TPF keeps business functions separate from how they are called, so APIs can evolve without rewriting core flow logic.</p>
 
 ## At a Glance
 
 <div class="value-glance">
-  <div class="value-glance-item"><strong>One Model, Many Surfaces</strong> &middot; Generate gRPC, REST, and local clients from the same definition.</div>
-  <div class="value-glance-item"><strong>Domain First</strong> &middot; Transport details stay in generated adapters.</div>
-  <div class="value-glance-item"><strong>Function Ready</strong> &middot; Function-platform support where it adds value.</div>
+  <div class="value-glance-item"><strong>One Flow, Many Entry Points</strong> &middot; Generate gRPC, REST, local, and function-style callers from the same definition.</div>
+  <div class="value-glance-item"><strong>Domain First</strong> &middot; Protocol details stay in generated code, not business functions.</div>
+  <div class="value-glance-item"><strong>Function Ready</strong> &middot; Run through function-style entry points where that deployment model fits.</div>
 </div>
 
 ## Use This When
 
 - Different clients need different protocols.
 - You are migrating interfaces and need to avoid big-bang rewrites.
-- You need to keep contracts consistent across transports without manual reconciliation.
+- You need Java types and API shapes to stay consistent without manual reconciliation.
+
+In TPF, **transport mode** means how generated components call each other: gRPC, REST, or local in-process calls. It is separate from where the application is deployed.
 
 ## Jump to Guides
 

--- a/docs/value/operational-confidence.md
+++ b/docs/value/operational-confidence.md
@@ -16,7 +16,7 @@
 - Teams need a consistent operational baseline across services.
 - Container/Kubernetes rollout has outpaced ops maturity.
 
-For background execution, TPF can record accepted work outside the current process so crashes and restarts do not lose it. Terminal execution failures can go to a DLQ, a dead-letter channel for investigation or replay.
+For background execution, TPF can record accepted work outside the current process, so crashes and restarts do not lose it. Terminal execution failures can go to a DLQ, a dead-letter channel for investigation or replay.
 
 ## Jump to Guides
 

--- a/docs/value/operational-confidence.md
+++ b/docs/value/operational-confidence.md
@@ -1,13 +1,13 @@
 # Kube-Native
 
-<p class="value-lead">The Pipeline Framework (TPF) is designed for containerized environments with operational patterns that stay workable as complexity grows.</p>
+<p class="value-lead">The Pipeline Framework (TPF) is designed for containerized environments where teams need failures, retries, and runtime health to stay understandable.</p>
 
 ## At a Glance
 
 <div class="value-glance">
   <div class="value-glance-item"><strong>Container First</strong> &middot; Works naturally with Kubernetes-style deployment models.</div>
-  <div class="value-glance-item"><strong>Operational Metadata</strong> &middot; Generated metadata clarifies what is running and how.</div>
-  <div class="value-glance-item"><strong>Resilience Patterns</strong> &middot; Consistent DLQ, error handling, health, and observability practices.</div>
+  <div class="value-glance-item"><strong>Runtime Visibility</strong> &middot; Generated runtime files and telemetry show what is running and how calls move.</div>
+  <div class="value-glance-item"><strong>Failure Handling</strong> &middot; Consistent retries, dead-letter handling, health, and observability practices.</div>
 </div>
 
 ## Use This When
@@ -15,6 +15,8 @@
 - Production incidents take too long to diagnose.
 - Teams need a consistent operational baseline across services.
 - Container/Kubernetes rollout has outpaced ops maturity.
+
+For background execution, TPF can record accepted work outside the current process so crashes and restarts do not lose it. Terminal execution failures can go to a DLQ, a dead-letter channel for investigation or replay.
 
 ## Jump to Guides
 

--- a/docs/value/runtime-efficiency.md
+++ b/docs/value/runtime-efficiency.md
@@ -1,12 +1,12 @@
 # Runtime Efficiency
 
-<p class="value-lead">TPF is tuned for high-volume step processing where throughput and stability matter day to day.</p>
+<p class="value-lead">TPF is tuned for high-volume function chains where throughput and stability matter day to day.</p>
 
 ## At a Glance
 
 <div class="value-glance">
-  <div class="value-glance-item"><strong>High Throughput</strong> &middot; Reactive flow handles concurrency without thread-per-request bottlenecks.</div>
-  <div class="value-glance-item"><strong>Predictable Runtime</strong> &middot; Generated paths reduce hidden runtime wiring.</div>
+  <div class="value-glance-item"><strong>High Throughput</strong> &middot; Reactive flow keeps many items moving without one thread per item.</div>
+  <div class="value-glance-item"><strong>Predictable Runtime</strong> &middot; Generated call paths reduce hidden glue code.</div>
   <div class="value-glance-item"><strong>Quarkus Foundation</strong> &middot; Keep Quarkus startup, container, and runtime strengths.</div>
 </div>
 
@@ -14,7 +14,9 @@
 
 - Infrastructure cost is rising as traffic grows.
 - You need faster startup and tighter runtime footprint.
-- Performance tuning is blocked by opaque framework behavior.
+- Performance tuning is blocked by opaque framework behaviour.
+
+Reactive execution means the runtime can keep work moving while waiting for I/O, instead of tying up a thread for each item from start to finish.
 
 ## Jump to Guides
 

--- a/docs/value/runtime-efficiency.md
+++ b/docs/value/runtime-efficiency.md
@@ -17,6 +17,7 @@
 - Performance tuning is blocked by opaque framework behaviour.
 
 Reactive execution means the runtime can keep work moving while waiting for I/O, instead of tying up a thread for each item from start to finish.
+If a step must do blocking work, offload it explicitly to a worker thread pool, executor, or blocking dispatcher so it does not occupy request/event-loop threads.
 
 ## Jump to Guides
 


### PR DESCRIPTION
## Summary
- Reworks the README around plain-language definitions before TPF-specific terms.
- Aligns docs homepage and value pages with the same front-door terminology.
- Adds local explanations for durable/background execution, runtime layout vs build topology, and plugin/aspect concepts.
- Keeps `QUEUE_ASYNC` as the exact config value but explains it as crash-surviving background execution before using the name.

## Scope
- README and docs wording/IA only.
- No code, API, schema, or Maven behaviour changes.
- Includes the existing factual AGENTS.md Quarkus baseline alignment to 3.33.1+.

## Validation
- `npm --prefix docs run build` passed. Vite emitted the existing chunk-size warning only.
- `git diff --check` passed.
- Terminology scan passed for targeted cryptic phrases: `shared type-safe`, `pipeline-style`, `wiring`, `surface`, `runtime semantics`, `async admission`, `retry boundaries`, `transport surfaces`, `generated invocation`, `runtime wiring`, `QUEUE_ASYNC orchestration`, `durable async`, `entrypoints`, `Mental model`.
- Local link check passed for README, docs homepage, and docs value pages.

## CodeRabbit
- Attempted local prompt-only review with `cr review --prompt-only --base main --config ./AGENTS.md`.
- CodeRabbit returned: `Rate limit exceeded, please try after 57 minutes and 56 seconds`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quarkus compatibility documentation (3.33.1+).
  * Substantially expanded guides covering background execution, crash-surviving execution, runtime layouts, and deployment evolution.
  * Clarified messaging around pipeline semantics, Java type safety, generated code, and operational resilience (retries, dead-letter handling, observability).
  * Enhanced sections on plugin/aspect model and deployment flexibility across REST, gRPC, local, and function-style entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->