### PR TITLE
Fix CSV reject-and-continue stream completion

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/service/throwStatusRuntimeExceptionFunction.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/throwStatusRuntimeExceptionFunction.java
@@ -55,6 +55,10 @@ public class throwStatusRuntimeExceptionFunction implements Function<Throwable, 
     if (message == null || message.isBlank()) {
       return throwable == null ? "Unknown error" : throwable.getClass().getSimpleName();
     }
-    return message.replaceAll("[^\\x20-\\x7E]+", " ").trim();
+    String sanitized = message.replaceAll("[^\\x20-\\x7E]+", " ").trim();
+    if (sanitized == null || sanitized.isBlank()) {
+      return throwable == null ? "Unknown error" : throwable.getClass().getSimpleName();
+    }
+    return sanitized;
   }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/service/throwStatusRuntimeExceptionFunction.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/throwStatusRuntimeExceptionFunction.java
@@ -55,6 +55,6 @@ public class throwStatusRuntimeExceptionFunction implements Function<Throwable, 
     if (message == null || message.isBlank()) {
       return throwable == null ? "Unknown error" : throwable.getClass().getSimpleName();
     }
-    return message.replaceAll("[\\r\\n\\t]+", " ").trim();
+    return message.replaceAll("[^\\x20-\\x7E]+", " ").trim();
   }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/service/throwStatusRuntimeExceptionFunction.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/throwStatusRuntimeExceptionFunction.java
@@ -40,12 +40,21 @@ public class throwStatusRuntimeExceptionFunction implements Function<Throwable, 
     Metadata metadata = new Metadata();
     Metadata.Key<String> errorKey =
         Metadata.Key.of("error-details", Metadata.ASCII_STRING_MARSHALLER);
-    metadata.put(errorKey, throwable.getMessage());
+    String description = sanitizeForGrpcHeader(throwable);
+    metadata.put(errorKey, description);
 
-    Status status = Status.INTERNAL.withDescription(throwable.getMessage()).withCause(throwable);
+    Status status = Status.INTERNAL.withDescription(description).withCause(throwable);
 
     LOG.debug("Runtime exception thrown: ", throwable);
 
     return new StatusRuntimeException(status, metadata);
+  }
+
+  private static String sanitizeForGrpcHeader(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "Unknown error" : throwable.getClass().getSimpleName();
+    }
+    return message.replaceAll("[\\r\\n\\t]+", " ").trim();
   }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
@@ -199,7 +199,17 @@ class PipelineStepExecutorTest {
             if ("bad".equals(in)) {
                 return Multi.createFrom().failure(new RuntimeException("stream boom"));
             }
-            return Multi.createFrom().item(in + "-ok");
+            return Multi.createFrom().emitter(emitter -> {
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(10);
+                        emitter.emit(in + "-ok");
+                        emitter.complete();
+                    } catch (InterruptedException e) {
+                        emitter.fail(e);
+                    }
+                }).start();
+            });
         }
 
         @Override
@@ -232,7 +242,17 @@ class PipelineStepExecutorTest {
             if ("bad".equals(in)) {
                 return Multi.createFrom().failure(new RuntimeException("stream boom"));
             }
-            return Multi.createFrom().item(in + "-ok");
+            return Multi.createFrom().emitter(emitter -> {
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(10);
+                        emitter.emit(in + "-ok");
+                        emitter.complete();
+                    } catch (InterruptedException e) {
+                        emitter.fail(e);
+                    }
+                }).start();
+            });
         }
 
         @Override

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -94,6 +95,46 @@ class PipelineStepExecutorTest {
     }
 
     @Test
+    void oneToManyParallelRecoveryCompletesAfterRejectedInnerStream() {
+        RecoveringOneToManyStep step = new RecoveringOneToManyStep();
+
+        Object result = PipelineStepExecutor.applyOneToManyUnchecked(
+            step,
+            Multi.createFrom().items("first", "bad", "second"),
+            true,
+            16,
+            null,
+            null,
+            null);
+
+        List<String> values = ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5));
+
+        assertEquals(Set.of("first-ok", "second-ok"), Set.copyOf(values));
+        assertEquals(2, values.size());
+        assertTrue(step.rejectCalled());
+    }
+
+    @Test
+    void oneToManyParallelFailureStillFailsWhenRecoveryDisabled() {
+        NonRecoveringOneToManyStep step = new NonRecoveringOneToManyStep();
+
+        Object result = PipelineStepExecutor.applyOneToManyUnchecked(
+            step,
+            Multi.createFrom().items("first", "bad", "second"),
+            true,
+            16,
+            null,
+            null,
+            null);
+
+        io.smallrye.mutiny.helpers.test.AssertSubscriber<String> subscriber =
+            ((Multi<String>) result).subscribe().withSubscriber(
+                io.smallrye.mutiny.helpers.test.AssertSubscriber.create(2));
+        subscriber.awaitFailure(Duration.ofSeconds(5));
+        assertTrue(subscriber.getFailure() instanceof RuntimeException);
+    }
+
+    @Test
     void manyToOneFromMultiReducesItems() {
         Object result = PipelineStepExecutor.applyManyToOneUnchecked(
             (ManyToOne<String, String>) input -> input.collect().asList().map(items -> String.join(",", items)),
@@ -147,6 +188,59 @@ class PipelineStepExecutorTest {
         @Override
         public Multi<String> applyOneToMany(String in) {
             return Multi.createFrom().items(in + "-1", in + "-2");
+        }
+    }
+
+    static final class RecoveringOneToManyStep extends ConfigurableStep implements StepOneToMany<String, String> {
+        private final AtomicBoolean rejectCalled = new AtomicBoolean(false);
+
+        @Override
+        public Multi<String> applyOneToMany(String in) {
+            if ("bad".equals(in)) {
+                return Multi.createFrom().failure(new RuntimeException("stream boom"));
+            }
+            return Multi.createFrom().item(in + "-ok");
+        }
+
+        @Override
+        public org.pipelineframework.config.StepConfig effectiveConfig() {
+            return new org.pipelineframework.config.StepConfig()
+                .recoverOnFailure(true)
+                .retryLimit(1)
+                .retryWait(Duration.ofMillis(1));
+        }
+
+        @Override
+        public Uni<String> rejectStream(
+            List<String> sampleItems,
+            long totalItemCount,
+            Throwable cause,
+            Integer retriesObserved,
+            Integer retryLimit) {
+            rejectCalled.set(true);
+            return Uni.createFrom().nullItem();
+        }
+
+        boolean rejectCalled() {
+            return rejectCalled.get();
+        }
+    }
+
+    static final class NonRecoveringOneToManyStep extends ConfigurableStep implements StepOneToMany<String, String> {
+        @Override
+        public Multi<String> applyOneToMany(String in) {
+            if ("bad".equals(in)) {
+                return Multi.createFrom().failure(new RuntimeException("stream boom"));
+            }
+            return Multi.createFrom().item(in + "-ok");
+        }
+
+        @Override
+        public org.pipelineframework.config.StepConfig effectiveConfig() {
+            return new org.pipelineframework.config.StepConfig()
+                .recoverOnFailure(false)
+                .retryLimit(0)
+                .retryWait(Duration.ofMillis(1));
         }
     }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/service/ThrowStatusRuntimeExceptionFunctionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/service/ThrowStatusRuntimeExceptionFunctionTest.java
@@ -51,4 +51,29 @@ class ThrowStatusRuntimeExceptionFunctionTest {
                 originalThrowable.getMessage(),
                 metadata.get(Metadata.Key.of("error-details", Metadata.ASCII_STRING_MARSHALLER)));
     }
+
+    @Test
+    void apply_ShouldSanitizeMultilineThrowableMessagesForGrpcHeaders() {
+        // Given
+        throwStatusRuntimeExceptionFunction function = new throwStatusRuntimeExceptionFunction();
+        Throwable originalThrowable =
+                new RuntimeException("CSV processing error:\nUnterminated quoted field\r\nBROKEN,USD");
+
+        // When
+        Throwable result = function.apply(originalThrowable);
+
+        // Then
+        assertInstanceOf(StatusRuntimeException.class, result);
+        StatusRuntimeException statusRuntimeException = (StatusRuntimeException) result;
+        String expected = "CSV processing error: Unterminated quoted field BROKEN,USD";
+
+        assertEquals(expected, statusRuntimeException.getStatus().getDescription());
+        assertSame(originalThrowable, statusRuntimeException.getStatus().getCause());
+
+        Metadata metadata = statusRuntimeException.getTrailers();
+        assertNotNull(metadata);
+        assertEquals(
+                expected,
+                metadata.get(Metadata.Key.of("error-details", Metadata.ASCII_STRING_MARSHALLER)));
+    }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/service/ThrowStatusRuntimeExceptionFunctionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/service/ThrowStatusRuntimeExceptionFunctionTest.java
@@ -76,4 +76,34 @@ class ThrowStatusRuntimeExceptionFunctionTest {
                 expected,
                 metadata.get(Metadata.Key.of("error-details", Metadata.ASCII_STRING_MARSHALLER)));
     }
+
+    @Test
+    void apply_ShouldUseClassSimpleNameWhenMessageIsNull() {
+        // Given
+        throwStatusRuntimeExceptionFunction function = new throwStatusRuntimeExceptionFunction();
+        Throwable originalThrowable = new RuntimeException();
+
+        // When
+        Throwable result = function.apply(originalThrowable);
+
+        // Then
+        assertInstanceOf(StatusRuntimeException.class, result);
+        StatusRuntimeException statusRuntimeException = (StatusRuntimeException) result;
+        assertEquals("RuntimeException", statusRuntimeException.getStatus().getDescription());
+        assertSame(originalThrowable, statusRuntimeException.getStatus().getCause());
+    }
+
+    @Test
+    void apply_ShouldReturnUnknownErrorWhenThrowableIsNull() {
+        // Given
+        throwStatusRuntimeExceptionFunction function = new throwStatusRuntimeExceptionFunction();
+
+        // When
+        Throwable result = function.apply(null);
+
+        // Then
+        assertInstanceOf(StatusRuntimeException.class, result);
+        StatusRuntimeException statusRuntimeException = (StatusRuntimeException) result;
+        assertEquals("Unknown error", statusRuntimeException.getStatus().getDescription());
+    }
 }

--- a/scripts/ci/bootstrap-local-repo-prereqs.sh
+++ b/scripts/ci/bootstrap-local-repo-prereqs.sh
@@ -32,6 +32,7 @@ install_framework_and_plugins() {
 
 install_csv_prereqs() {
   mvn -f "$ROOT_DIR/examples/csv-payments/pom.xml" -N install
+  mvn -f "$ROOT_DIR/examples/csv-payments/pom.xml" -pl common -DskipTests install
   mvn -f "$ROOT_DIR/plugins/foundational/persistence/pom.xml" -DskipTests install
 }
 


### PR DESCRIPTION
## Summary

Fixes the malformed CSV reject-and-continue release blocker without changing the `BROKEN` fixture.

The root cause was not the fixture itself: multiline CSV parser errors were copied directly into gRPC status descriptions/trailers. gRPC metadata cannot contain raw CR/LF characters, so the remote one-to-many stream could fail while attempting to report the original parse failure, preventing the orchestrator path from completing cleanly.

## Changes

- Sanitise gRPC status descriptions and `error-details` trailers before returning `StatusRuntimeException`, while keeping the original throwable as the status cause.
- Add regression coverage for multiline throwable messages in gRPC error metadata.
- Add one-to-many regression coverage proving `recoverOnFailure=true` rejects a failed inner stream and completes cleanly, while `recoverOnFailure=false` still fails.
- Install `examples/csv-payments/common` in the CSV prereq bootstrap so the targeted pipeline-runtime gate starts from a valid local Maven state.

## Validation

- `./mvnw -f framework/pom.xml test`
- `./scripts/ci/bootstrap-local-repo-prereqs.sh csv`
- Removed stale CSV image tags before rebuilding.
- `./examples/csv-payments/build-pipeline-runtime.sh -DskipTests -Dquarkus.container-image.build=true`
- `./examples/csv-payments/build-pipeline-runtime.sh -pl orchestrator-svc -Dcsv.runtime.layout=pipeline-runtime -Dtest=PipelineRuntimeTopologyTest -Dit.test=CsvPaymentsPipelineRuntimeEndToEndIT verify`

## Release note

The existing local `v26.5.1` tag from the interrupted release prep was not pushed. After this merges, refresh `main`, delete/recreate the local release tag by rerunning `release:prepare`, then continue the guarded `26.5.1` release flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages are now sanitised before gRPC transmission: non-printable chars replaced, multiline reduced to single line, and sensible fallbacks for missing messages.

* **Tests**
  * Enhanced tests for parallel/one-to-many stream recovery and failure scenarios, including verification of rejection hook invocation.
  * Added validation for error message sanitisation in gRPC communications.

* **Chores**
  * Refined build script to install a specific Maven module for prerequisites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->