### PR TITLE
Clarify FUNCTION platform docs and provider navigation

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -30,7 +30,7 @@ const mainSidebar = [
             {text: 'Business Value', link: '/value/business-value'},
             {text: 'Developer Joy', link: '/value/developer-experience'},
             {text: 'Performance', link: '/value/runtime-efficiency'},
-            {text: 'Transport Choice', link: '/value/integration-flexibility'},
+            {text: 'Portable Serverless Functions', link: '/value/integration-flexibility'},
             {text: 'State, Replay, and Queryable Data', link: '/value/state-replay-and-queryable-data'},
             {text: 'Start Monolith, Split Later', link: '/value/deployment-evolution'},
             {text: 'Operational Confidence', link: '/value/operational-confidence'},
@@ -102,6 +102,8 @@ const mainSidebar = [
             {text: 'Orchestrator Runtime', link: '/guide/development/orchestrator-runtime'},
             {text: 'TPFGo Example', link: '/guide/development/tpfgo-example'},
             {text: 'AWS Lambda Platform', link: '/guide/development/aws-lambda'},
+            {text: 'Azure Functions Platform', link: '/guide/development/azure-functions'},
+            {text: 'Google Cloud Run Functions Platform', link: '/guide/development/google-cloud-run-functions'},
             {text: 'Performance', link: '/guide/development/performance'},
             {text: 'Customization Points', link: '/guide/development/customization-points'}
         ]

--- a/docs/guide/build/runtime-layouts/function-providers.md
+++ b/docs/guide/build/runtime-layouts/function-providers.md
@@ -1,16 +1,21 @@
 # Multi-Cloud Function Providers Guide
 
-This guide covers deploying TPF (The Pipeline Framework) pipelines to multiple cloud function providers: AWS Lambda, Azure Functions, and Google Cloud Functions.
+This guide is the multi-cloud entry point for TPF function deployments. It shows how the same `FUNCTION` platform mode can target AWS Lambda, Azure Functions, and Google Cloud Run functions while keeping the typed business flow unchanged.
 
 ## Overview
 
-TPF supports three major serverless function platforms:
+TPF supports three major cloud function platforms:
 
 | Provider | Extension | Handler Interface | Local Testing |
 |----------|-----------|-------------------|---------------|
 | **AWS Lambda** | `quarkus-amazon-lambda` | `RequestHandler<I, O>` | Mock event server |
 | **Azure Functions** | `quarkus-azure-functions` | HTTP trigger + REST | Core Tools v4.x |
-| **Google Cloud Functions** | `quarkus-google-cloud-functions` | `HttpFunction` | Functions Framework |
+| **Google Cloud Run functions** | `quarkus-google-cloud-functions` | `HttpFunction` | Functions Framework |
+
+Important runtime constraint:
+
+- `FUNCTION` currently requires `REST` transport. `gRPC` is not a supported `FUNCTION` transport in the current implementation.
+- Google's current product name is Cloud Run functions, while the current Quarkus extension name remains `quarkus-google-cloud-functions`.
 
 ## Architecture
 
@@ -28,9 +33,25 @@ The orchestrator handler (`PipelineRunFunctionHandler`) generates **provider-spe
 
 - **AWS Lambda**: Implements `RequestHandler<I, O>` with Lambda `Context`
 - **Azure Functions**: POJO with `ExecutionContext` parameter
-- **GCP Cloud Functions**: Implements `HttpFunction` with `HttpRequest`/`HttpResponse`
+- **Google Cloud Run functions**: Implements `HttpFunction` with `HttpRequest`/`HttpResponse`
 
-All providers preserve FUNCTION platform semantics (cardinality, failure handling) and support async handlers (run-async, status, result). Azure and GCP deployments can also use the REST transport approach if desired, where HTTP triggers route requests to Quarkus REST endpoints while preserving FUNCTION semantics.
+All providers preserve FUNCTION platform semantics (cardinality, failure handling) and support async handlers (run-async, status, result). Azure and GCP FUNCTION deployments use the required REST transport approach, where HTTP triggers route requests to Quarkus REST endpoints while preserving FUNCTION semantics.
+
+## What this guide covers and does not cover
+
+This guide covers the current repo-supported `FUNCTION` targets:
+
+1. AWS Lambda
+2. Azure Functions
+3. Google Cloud Run functions
+
+It does not currently document or implement:
+
+1. Google Cloud Run services as a generic container/service target,
+2. Azure Durable Functions as a separate TPF runtime model,
+3. `gRPC` as a `FUNCTION` transport.
+
+If you need queue-backed recovery, checkpoint handoff, or orchestrator-managed HA, use the `COMPUTE` + `QUEUE_ASYNC` path instead of treating function providers as a replacement for that runtime model.
 
 ## Quick Start
 
@@ -72,7 +93,7 @@ See [AWS Lambda Platform Guide](/guide/development/aws-lambda) for detailed depl
 
 See [Azure Functions Testing Guide](/guide/build/runtime-layouts/search-azure-functions) for detailed deployment instructions.
 
-### Google Cloud Functions
+### Google Cloud Run functions
 
 ```bash
 # Build
@@ -138,7 +159,7 @@ The framework selects the provider using this precedence:
 - Cold starts on Consumption plan
 - Storage account dependency
 
-### Google Cloud Functions
+### Google Cloud Run functions
 
 **Strengths:**
 - Simple deployment model
@@ -169,7 +190,7 @@ This is **cloud-agnostic** and works identically across all providers.
 |----------|-----------|--------------|
 | AWS Lambda | `LambdaMockEventServerSmokeTest` | None |
 | Azure Functions | `AzureFunctionsBootstrapSmokeTest` | None |
-| GCP Cloud Functions | `GcpFunctionsBootstrapSmokeTest` | None |
+| Google Cloud Run functions | `GcpFunctionsBootstrapSmokeTest` | None |
 
 ### Integration Testing
 
@@ -177,7 +198,7 @@ This is **cloud-agnostic** and works identically across all providers.
 |----------|-----------|--------------|
 | AWS Lambda | `*-EndToEndIT` | AWS credentials, SAM/CloudFormation |
 | Azure Functions | `AzureFunctionsEndToEndIT` | Azure subscription, Terraform |
-| GCP Cloud Functions | `GcpFunctionsBootstrapSmokeTest` | GCP project, Functions Framework bootstrap/smoke coverage |
+| Google Cloud Run functions | `GcpFunctionsBootstrapSmokeTest` | Build with the `gcp-functions` profile; validates Quarkus Functions extension bootstrap and `HttpFunction` loading only |
 
 ## Troubleshooting
 

--- a/docs/guide/build/runtime-layouts/index.md
+++ b/docs/guide/build/runtime-layouts/index.md
@@ -40,6 +40,7 @@ Values include `GRPC`, `REST`, and `LOCAL`.
 Values include `COMPUTE` and `FUNCTION` (legacy aliases: `STANDARD`, `LAMBDA`).
 
 - Decides whether generation targets standard Quarkus services or function-style entry points.
+- This page provides the canonical deeper reference for choosing between `COMPUTE` and `FUNCTION`.
 - Constrained by transport and step-shape compatibility (Function mode requires REST; unary and streaming shapes are supported via generated function bridges).
 - Orthogonal to runtime layout/topology.
 

--- a/docs/guide/development/aws-lambda.md
+++ b/docs/guide/development/aws-lambda.md
@@ -1,12 +1,14 @@
 # AWS Lambda Platform (Development)
 
-This page is the canonical TPF guide for building pipeline applications for AWS Lambda.
+This page is the canonical TPF guide for `FUNCTION` platform builds that target AWS Lambda. For the broader multi-cloud function story, pair it with the [Multi-Cloud Function Providers Guide](/guide/build/runtime-layouts/function-providers).
 
 ## What TPF Supports Today
 
 - Platform mode: `FUNCTION` (default platform remains `COMPUTE`)
 - Transport mode: `REST` (required in Function mode)
 - Step shapes: unary and streaming shapes are supported in FUNCTION mode through generated adapter/bridge wiring
+
+`FUNCTION` does not currently support `gRPC` transport. If you select `FUNCTION`, the generated runtime must use `REST`.
 
 Supported FUNCTION step shapes today:
 
@@ -29,6 +31,29 @@ Set platform mode during build:
 ```
 
 TPF uses build switches for this mode. It does not require a dedicated Maven profile.
+
+## Other Function Targets
+
+AWS Lambda is the most complete provider-specific development guide in the current docs, but it is not the only `FUNCTION` target in the repo.
+
+Current repo-supported function targets are:
+
+1. AWS Lambda
+2. Azure Functions
+3. Google Cloud Run functions
+
+Use these guides for the broader function-platform story:
+
+- [Multi-Cloud Function Providers Guide](/guide/build/runtime-layouts/function-providers)
+- [Azure Functions Platform](/guide/development/azure-functions)
+- [Google Cloud Run Functions Platform](/guide/development/google-cloud-run-functions)
+- [Search Azure Functions Testing Guide](/guide/build/runtime-layouts/search-azure-functions)
+
+Current scope notes:
+
+1. The Google function path is best described today as Cloud Run functions; the current repo implementation still uses the Quarkus Google Cloud Functions extension.
+2. Azure Durable Functions are not a separate TPF platform mode and do not change TPF runtime semantics.
+3. Queue-backed HA and checkpoint handoff remain part of the `COMPUTE` + `QUEUE_ASYNC` orchestrator path rather than the `FUNCTION` path.
 
 ::: warning Checkpoint Handoff Is Not Available In FUNCTION Mode
 Checkpoint publication and subscription are not available in `FUNCTION` mode.

--- a/docs/guide/development/azure-functions.md
+++ b/docs/guide/development/azure-functions.md
@@ -1,0 +1,64 @@
+# Azure Functions Platform (Development)
+
+This page is the canonical The Pipeline Framework (TPF) guide for `FUNCTION` platform builds that target Azure Functions. For the broader provider matrix, pair it with the [Multi-Cloud Function Providers Guide](/guide/build/runtime-layouts/function-providers).
+
+## What TPF Supports Today
+
+- Platform mode: `FUNCTION` (default platform remains `COMPUTE`)
+- Transport mode: `REST` (required in Function mode)
+- Azure-specific handlers: generated HTTP-trigger handlers using Azure Functions bindings
+- Local verification: Azure Functions Core Tools and the Search example in `examples/search`
+
+`FUNCTION` does not currently support `gRPC` transport. If you select `FUNCTION`, the generated runtime must use `REST`.
+
+## What this path covers
+
+TPF keeps the typed Java business flow unchanged while generating Azure-specific entry points around it.
+
+This path is for:
+
+1. generated Azure Functions handlers,
+2. local/provider verification of the function runtime,
+3. deploying the same flow through Azure’s function platform.
+
+This path is not:
+
+1. a replacement for `COMPUTE` + `QUEUE_ASYNC`,
+2. a checkpoint-handoff runtime,
+3. a separate TPF runtime model just because Azure also offers Durable Functions.
+
+Azure Durable Functions do not change TPF runtime semantics. If you need queue-backed HA, checkpoint handoff, or orchestrator-managed crash recovery, use the `COMPUTE` + `QUEUE_ASYNC` path.
+
+## Example verification surface
+
+The current repo verification surface for Azure is located in `examples/search`.
+
+Build:
+
+```bash
+./examples/search/build-azure.sh -DskipTests
+```
+
+Bootstrap smoke:
+
+```bash
+./scripts/ci/bootstrap-local-repo-prereqs.sh framework
+
+./mvnw -f examples/search/orchestrator-svc/pom.xml \
+  -Dtpf.build.platform=FUNCTION \
+  -Dtpf.build.transport=REST \
+  -Dtpf.build.rest.naming.strategy=RESOURCEFUL \
+  -Dtpf.build.azure.scope=compile \
+  -Dquarkus.profile=azure-functions \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=AzureFunctionsBootstrapSmokeTest \
+  test
+```
+
+For deeper Azure-specific setup and local runtime testing with Core Tools, use the dedicated Search guide.
+
+## Next Steps
+
+- [Search Azure Functions Testing Guide](/guide/build/runtime-layouts/search-azure-functions)
+- [Multi-Cloud Function Providers Guide](/guide/build/runtime-layouts/function-providers)
+- [Runtime Layouts](/guide/build/runtime-layouts/)

--- a/docs/guide/development/google-cloud-run-functions.md
+++ b/docs/guide/development/google-cloud-run-functions.md
@@ -1,0 +1,58 @@
+# Google Cloud Run Functions Platform (Development)
+
+This page is the canonical TPF guide for `FUNCTION` platform builds that target Google Cloud Run functions. For the broader provider matrix, pair it with the [Multi-Cloud Function Providers Guide](/guide/build/runtime-layouts/function-providers).
+
+## What TPF Supports Today
+
+- Platform mode: `FUNCTION` (default platform remains `COMPUTE`)
+- Transport mode: `REST` (required in Function mode)
+- Google-specific handlers: generated `HttpFunction` handlers via the Quarkus Google Cloud Functions extension
+- Local verification: bootstrap/smoke coverage through the Search example
+
+`FUNCTION` does not currently support `gRPC` transport. If you select `FUNCTION`, the generated runtime must use `REST`.
+
+## Cloud Run functions vs Cloud Run services
+
+This page covers **Cloud Run functions**, the serverless function product path.
+
+It does not cover generic **Cloud Run services**. A container-style Cloud Run deployment is closer to the normal `COMPUTE` path for a Quarkus service, not the current TPF `FUNCTION` provider path.
+
+## Durable-workflow note
+
+Provider-level durable or workflow products do not change TPF runtime semantics.
+
+That means:
+
+1. they are not a separate TPF platform mode,
+2. they do not replace `COMPUTE` + `QUEUE_ASYNC`,
+3. checkpoint handoff and queue-backed HA still belong to the orchestrator runtime path rather than the function-provider path.
+
+## Example verification surface
+
+The current repo verification surface for Google Cloud Run functions is located in `examples/search`.
+
+Build:
+
+```bash
+./examples/search/build-gcp.sh -DskipTests
+```
+
+Bootstrap smoke:
+
+```bash
+./mvnw -f examples/search/pom.xml \
+  -pl orchestrator-svc \
+  -Dtpf.build.platform=FUNCTION \
+  -Dtpf.build.transport=REST \
+  -Dtpf.build.rest.naming.strategy=RESOURCEFUL \
+  -Dtpf.build.gcp.scope=compile \
+  -Dquarkus.profile=gcp-functions \
+  -Dtest=GcpFunctionsBootstrapSmokeTest \
+  test
+```
+
+## Next Steps
+
+- [Multi-Cloud Function Providers Guide](/guide/build/runtime-layouts/function-providers)
+- [Runtime Layouts](/guide/build/runtime-layouts/)
+- [AWS Lambda Platform](/guide/development/aws-lambda)

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,8 @@ features:
   - title: Runtime Efficiency
     details: Keep many items moving through reactive function chains without one thread per item
     link: /value/runtime-efficiency
-  - title: REST, gRPC, Local, or Functions
-    details: Expose the same business flow through the calling style and deployment model that fits your environment
+  - title: Portable Serverless Functions
+    details: Generate serverless function entry points and handlers for AWS Lambda, Azure Functions, and Google Cloud Run functions from the same typed Java flow
     link: /value/integration-flexibility
   - title: Start Monolith, Split Later
     details: Choose a runtime layout without pretending it automatically rewrites your Maven or container topology
@@ -45,6 +45,10 @@ features:
 
 <Callout type="tip" title="Fastest path: design with Canvas">
 Use <a href="https://app.pipelineframework.org" target="_blank" rel="noopener noreferrer">Canvas</a> when you want to sketch the flow visually and download a runnable Quarkus scaffold. The same model can then be refined through YAML, Java functions, existing-method operators, type mappers, and runtime configuration.
+</Callout>
+
+<Callout type="info" title="Platform mode and transport mode are different decisions">
+`COMPUTE` and `FUNCTION` are platform modes: they decide whether TPF generates a standard Quarkus service runtime or a function-style runtime. REST, gRPC, and local are transport modes: they decide how generated components call each other.
 </Callout>
 
 <FeaturedArticles />
@@ -83,7 +87,7 @@ Start with [pipeline compilation](/guide/build/pipeline-compilation) when you wa
 
 TPF creates the REST resources, gRPC services, local clients, function-style handlers, and runtime files that would otherwise become handwritten service glue. An **adapter** is the generated code around your business function: it lets another component call the function through the selected transport.
 
-Generated code keeps business logic independent of whether a caller uses REST, gRPC, local in-process calls, or a function-style entry point. See [Transport Choice](/value/integration-flexibility) and [runtime layouts](/guide/build/runtime-layouts/) when you want the details behind calling style, logical placement, and Maven/container packaging.
+Generated code keeps business logic independent of whether a caller uses REST, gRPC, local in-process calls, or a serverless function entry point. See [Portable Serverless Functions](/value/integration-flexibility) and [runtime layouts](/guide/build/runtime-layouts/) when you want the details behind platform mode, transport mode, logical placement, and Maven/container packaging.
 
 ### Run the flow reliably
 
@@ -128,6 +132,10 @@ If you already have proven Java libraries or remote endpoints, operators let you
     <h3>AI enrichment</h3>
     <p>Reuse embedding, vector-search, or LLM helper libraries as operators inside a typed Java flow.</p>
   </div>
+  <div>
+    <h3>Serverless deployments</h3>
+    <p>Run the same typed flow behind AWS Lambda, Azure Functions, or Google Cloud Run functions without rewriting the business code.</p>
+  </div>
 </div>
 
 ## Start Here
@@ -136,6 +144,10 @@ If you already have proven Java libraries or remote endpoints, operators let you
 - [Pipeline Compilation](/guide/build/pipeline-compilation) for YAML-first generation and build-time validation.
 - [Operators](/guide/development/operators) for reusing existing Java methods or remote endpoints.
 - [Runtime Layouts](/guide/build/runtime-layouts/) for logical placement versus Maven/container build topology.
+- [AWS Lambda Platform](/guide/development/aws-lambda) for the canonical `FUNCTION` platform guide.
+- [Azure Functions Platform](/guide/development/azure-functions) for Azure development-time guidance.
+- [Google Cloud Run Functions Platform](/guide/development/google-cloud-run-functions) for the Google function-platform path.
+- [Multi-Cloud Function Providers](/guide/build/runtime-layouts/function-providers) for provider-specific function deployment targets.
 - [Orchestrator Runtime](/guide/development/orchestrator-runtime) for synchronous execution, background execution, crash recovery, and DLQ behaviour.
 - [Using Plugins](/guide/development/using-plugins) for persistence, cache, telemetry, and logging extensions.
 - [TPFGo Example](/guide/development/tpfgo-example) for checkpoint handoff between pipelines.

--- a/docs/value/index.md
+++ b/docs/value/index.md
@@ -7,7 +7,7 @@
 <div class="value-glance">
   <div class="value-glance-item"><strong>Developer Joy</strong> &middot; Write focused Java functions while TPF generates repeated Quarkus code.</div>
   <div class="value-glance-item"><strong>Define the Flow Once</strong> &middot; Describe the flow in YAML and catch function, mapper, and operator mismatches at build time.</div>
-  <div class="value-glance-item"><strong>Transport Choice</strong> &middot; Generate gRPC, REST, local, and cloud-function entry points from the same definition.</div>
+  <div class="value-glance-item"><strong>Portable Serverless Functions</strong> &middot; Generate serverless function runtimes for AWS Lambda, Azure Functions, and Google's Cloud Run functions from the same typed flow.</div>
   <div class="value-glance-item"><strong>Reliable Background Work</strong> &middot; Store accepted work, retry failures, recover after crashes, and route terminal failures.</div>
   <div class="value-glance-item"><strong>Start Monolith, Split Later</strong> &middot; Change runtime layout when the team is ready while keeping build topology explicit.</div>
   <div class="value-glance-item"><strong>State and Replay</strong> &middot; Persist business data, reuse expensive outputs, and replay safely without bespoke state plumbing.</div>
@@ -18,7 +18,7 @@
 - [Business Value](/value/business-value)
 - [Developer Joy](/value/developer-experience)
 - [Performance](/value/runtime-efficiency)
-- [Transport Choice](/value/integration-flexibility)
+- [Portable Serverless Functions](/value/integration-flexibility)
 - [State, Replay, and Queryable Data](/value/state-replay-and-queryable-data)
 - [Start Monolith, Split Later](/value/deployment-evolution)
 - [Operational Confidence](/value/operational-confidence)

--- a/docs/value/integration-flexibility.md
+++ b/docs/value/integration-flexibility.md
@@ -1,30 +1,66 @@
-# Transport Choice
+# Portable Serverless Functions
 
-<p class="value-lead">TPF keeps business functions separate from how they are called, so REST, gRPC, local, and cloud-function entry points can evolve without rewriting core flow logic.</p>
+<p class="value-lead">The Pipeline Framework (TPF) lets teams keep the same typed Java functions while targeting either a standard Quarkus service runtime (`COMPUTE`) or a portable serverless function runtime (`FUNCTION`).</p>
 
 ## At a Glance
 
 <div class="value-glance">
-  <div class="value-glance-item"><strong>One Flow, Many Entry Points</strong> &middot; Generate gRPC, REST, local, and cloud-function callers from the same YAML definition.</div>
-  <div class="value-glance-item"><strong>Domain First</strong> &middot; Protocol details stay in generated caller code, not business functions.</div>
-  <div class="value-glance-item"><strong>Function Ready</strong> &middot; Run the same business code through cloud-function entry points when that deployment model fits.</div>
+  <div class="value-glance-item"><strong>Same Functions, Different Runtime</strong> &middot; Keep the same typed Java flow while choosing between `COMPUTE` and `FUNCTION` platform modes.</div>
+  <div class="value-glance-item"><strong>Portable Serverless Targets</strong> &middot; Target AWS Lambda, Azure Functions, and Google's Cloud Run functions without rewriting the business functions.</div>
+  <div class="value-glance-item"><strong>Transport Still Separate</strong> &middot; REST, gRPC, and local calls remain a separate transport decision from the platform mode.</div>
 </div>
 
 ## Use This When
 
-- Different clients need different protocols.
-- You are migrating interfaces and need to avoid big-bang rewrites.
-- You need Java types and API shapes to stay consistent without manual reconciliation.
+- You want a serverless deployment target without rewriting the business flow.
+- You need the same pipeline logic to stay portable across cloud function providers.
+- You need platform choices and call mechanisms to stay explicit instead of getting mixed together.
 
-In TPF, an **adapter** is generated code that lets another component call your business function. **Transport mode** means how generated components call each other: gRPC, REST, or local in-process calls. It is separate from the deployment style, which decides whether the runtime behaves like a normal Quarkus service or a cloud function.
+TPF keeps the business functions stable while changing the generated runtime around them. That means you can keep one typed Java flow and choose whether TPF generates a standard service runtime or serverless function entry points.
+
+## Platform mode vs transport mode
+
+These are different decisions:
+
+1. **Platform mode** chooses the generated runtime shape.
+   - `COMPUTE`: standard Quarkus service/runtime
+   - `FUNCTION`: serverless function entry points and handlers
+2. **Transport mode** chooses how generated components call each other.
+   - REST
+   - gRPC
+   - local in-process calls
+
+In TPF, an **adapter** is generated code that lets another component call your business function. Platform mode decides what kind of runtime TPF generates around that function. Transport mode decides how the generated components talk.
+
+## What FUNCTION mode gives you
+
+With `FUNCTION` mode, TPF can generate serverless function entry points while preserving the same typed Java functions and build-time validation rules.
+
+This is the current portable function-platform story:
+
+1. AWS Lambda
+2. Azure Functions
+3. Google's Cloud Run functions
+
+The provider-specific handler shape changes, but the flow logic, operator reuse, and generated validation model stay aligned.
+
+## Current constraints
+
+Keep the current platform limits explicit:
+
+1. `FUNCTION` currently requires `REST` transport; `gRPC` is not a supported `FUNCTION` transport today.
+2. Checkpoint handoff is not available in `FUNCTION` mode.
+3. Queue-backed HA and crash recovery belong to the orchestrator `COMPUTE` + `QUEUE_ASYNC` path. `FUNCTION` mode is limited to generated serverless entry points and provider portability; it does not implement the queue-async recovery model.
 
 ## Jump to Guides
 
 <div class="value-links">
 
-- [Customization points](/guide/development/customization-points)
 - [AWS Lambda Platform](/guide/development/aws-lambda)
+- [Azure Functions Platform](/guide/development/azure-functions)
+- [Google Cloud Run Functions Platform](/guide/development/google-cloud-run-functions)
 - [Runtime Layouts](/guide/build/runtime-layouts/)
 - [Multi-Cloud Function Providers](/guide/build/runtime-layouts/function-providers)
+- [Orchestrator Runtime](/guide/development/orchestrator-runtime)
 
 </div>


### PR DESCRIPTION
## Summary
- expose AWS Lambda, Azure Functions, and Google Cloud Run functions at the same level under the Develop navigation
- make the current docs front door explicit about `COMPUTE` vs `FUNCTION` and the portable serverless function story
- clarify the current repo truth for provider support: `FUNCTION` currently requires `REST`, Cloud Run functions are the Google function target, and provider durable-function products do not redefine TPF runtime semantics

## What changed
- added current-docs development entry pages for Azure Functions and Google Cloud Run functions
- retitled the value pillar from transport-choice framing to portable serverless functions
- updated the homepage, value overview, and multi-cloud provider guide to expose serverless/function support clearly
- clarified that queue-backed HA belongs to the orchestrator `COMPUTE` + `QUEUE_ASYNC` path rather than the provider `FUNCTION` path
- aligned the multi-cloud provider guide wording with the actual `GcpFunctionsBootstrapSmokeTest` scope

## Validation
- `cr review --prompt-only --type uncommitted --base main --config ./AGENTS.md`
- `cr review --plain --type uncommitted --base main --config ./AGENTS.md`
- `npm --prefix docs run build`

## Scope notes
- current docs only; no `docs/versions/**` changes
- no runtime or API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added new guides for Azure Functions and Google Cloud Run Functions platform deployments
* Restructured documentation to highlight portable serverless functions across AWS Lambda, Azure and Google Cloud
* Enhanced guides clarifying platform versus transport mode selection and capabilities
* Added multi-cloud function providers reference documentation with deployment examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->