### PR TITLE
Restore container and Kubernetes docs framing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,8 +35,8 @@ features:
   - title: Portable Serverless Functions
     details: Generate serverless function entry points and handlers for AWS Lambda, Azure Functions, and Google Cloud Run functions from the same typed Java flow
     link: /value/integration-flexibility
-  - title: Start Monolith, Split Later
-    details: Choose a runtime layout without pretending it automatically rewrites your Maven or container topology
+  - title: Container and Kubernetes Ready
+    details: Generate standard Quarkus service runtimes for containers and Kubernetes, then evolve from monolith to split layouts when needed
     link: /value/deployment-evolution
   - title: State, Replay, and Queryable Data
     details: Use persistence for durable business state and caching for fast recomputation, replay, and query-ready outputs
@@ -48,7 +48,7 @@ Use <a href="https://app.pipelineframework.org" target="_blank" rel="noopener no
 </Callout>
 
 <Callout type="info" title="Platform mode and transport mode are different decisions">
-`COMPUTE` and `FUNCTION` are platform modes: they decide whether TPF generates a standard Quarkus service runtime or a function-style runtime. REST, gRPC, and local are transport modes: they decide how generated components call each other.
+`COMPUTE` and `FUNCTION` are platform modes: they decide whether TPF generates a standard Quarkus service runtime for containers and Kubernetes or a function-style runtime. REST, gRPC, and local are transport modes: they decide how generated components call each other.
 </Callout>
 
 <FeaturedArticles />
@@ -87,7 +87,7 @@ Start with [pipeline compilation](/guide/build/pipeline-compilation) when you wa
 
 TPF creates the REST resources, gRPC services, local clients, function-style handlers, and runtime files that would otherwise become handwritten service glue. An **adapter** is the generated code around your business function: it lets another component call the function through the selected transport.
 
-Generated code keeps business logic independent of whether a caller uses REST, gRPC, local in-process calls, or a serverless function entry point. See [Portable Serverless Functions](/value/integration-flexibility) and [runtime layouts](/guide/build/runtime-layouts/) when you want the details behind platform mode, transport mode, logical placement, and Maven/container packaging.
+Generated code keeps business logic independent of whether a caller uses REST, gRPC, local in-process calls, or a serverless function entry point. That same generated runtime can be packaged as a standard Quarkus service for containers and Kubernetes or as a `FUNCTION` deployment when that model fits better. See [Portable Serverless Functions](/value/integration-flexibility) and [runtime layouts](/guide/build/runtime-layouts/) when you want the details behind platform mode, transport mode, logical placement, and Maven/container packaging.
 
 ### Run the flow reliably
 
@@ -135,6 +135,10 @@ If you already have proven Java libraries or remote endpoints, operators let you
   <div>
     <h3>Serverless deployments</h3>
     <p>Run the same typed flow behind AWS Lambda, Azure Functions, or Google Cloud Run functions without rewriting the business code.</p>
+  </div>
+  <div>
+    <h3>Container platforms</h3>
+    <p>Run the same typed flow as a standard Quarkus service in containers or Kubernetes when you want service-style deployment and operations.</p>
   </div>
 </div>
 

--- a/docs/value/deployment-evolution.md
+++ b/docs/value/deployment-evolution.md
@@ -1,12 +1,13 @@
-# Start Monolith, Split Later
+# Container and Kubernetes Ready
 
-<p class="value-lead">The Pipeline Framework (TPF) supports a practical architecture path: start with one deployable, then split when team ownership or scale makes it worth it.</p>
+<p class="value-lead">The Pipeline Framework (TPF) generates standard Quarkus service runtimes that fit container and Kubernetes deployments, while still giving teams a practical path from one deployable to split layouts later.</p>
 
 See the [Runtime Layouts guide](/guide/build/runtime-layouts/) for the packaging details: choosing a monolith-style runtime does not automatically remove per-step service modules, because build topology and runtime layout are separate decisions.
 
 ## At a Glance
 
 <div class="value-glance">
+  <div class="value-glance-item"><strong>Container-Friendly Runtime</strong> &middot; Use standard Quarkus service runtimes that fit normal container and Kubernetes operations.</div>
   <div class="value-glance-item"><strong>Fast First Release</strong> &middot; Start with one application when that is the fastest path.</div>
   <div class="value-glance-item"><strong>Clear Migration Path</strong> &middot; Move to grouped or modular layouts as service splits become clearer.</div>
   <div class="value-glance-item"><strong>No Core Rewrite</strong> &middot; Keep the typed business functions stable while runtime layout and build topology evolve.</div>
@@ -16,6 +17,7 @@ See the [Runtime Layouts guide](/guide/build/runtime-layouts/) for the packaging
 
 - You need speed now but know service ownership and deployment splits will evolve.
 - Team ownership is outgrowing a single deployable unit.
+- You want normal container or Kubernetes operations without giving up a later path to split runtimes.
 - Architecture discussions are stalling delivery.
 
 TPF separates **runtime layout** from **build topology**. Runtime layout is the logical shape of the running system: where the orchestrator, functions, and side effects live. Build topology is the Maven and container structure that physically produces deployables. Changing the runtime layout changes generated placement and calls; it does not automatically rewrite Maven modules.

--- a/docs/value/deployment-evolution.md
+++ b/docs/value/deployment-evolution.md
@@ -2,7 +2,7 @@
 
 <p class="value-lead">The Pipeline Framework (TPF) generates standard Quarkus service runtimes that fit container and Kubernetes deployments, while still giving teams a practical path from one deployable to split layouts later.</p>
 
-See the [Runtime Layouts guide](/guide/build/runtime-layouts/) for the packaging details: choosing a monolith-style runtime does not automatically remove per-step service modules, because build topology and runtime layout are separate decisions.
+See the [Runtime Layouts guide](/guide/build/runtime-layouts/) for the packaging details: choosing a monolith-style runtime does not automatically remove per-step service modules because build topology and runtime layout are separate decisions.
 
 ## At a Glance
 

--- a/docs/value/index.md
+++ b/docs/value/index.md
@@ -9,7 +9,7 @@
   <div class="value-glance-item"><strong>Define the Flow Once</strong> &middot; Describe the flow in YAML and catch function, mapper, and operator mismatches at build time.</div>
   <div class="value-glance-item"><strong>Portable Serverless Functions</strong> &middot; Generate serverless function runtimes for AWS Lambda, Azure Functions, and Google's Cloud Run functions from the same typed flow.</div>
   <div class="value-glance-item"><strong>Reliable Background Work</strong> &middot; Store accepted work, retry failures, recover after crashes, and route terminal failures.</div>
-  <div class="value-glance-item"><strong>Start Monolith, Split Later</strong> &middot; Change runtime layout when the team is ready while keeping build topology explicit.</div>
+  <div class="value-glance-item"><strong>Container and Kubernetes Ready</strong> &middot; Generate standard Quarkus service runtimes for containers and Kubernetes while keeping runtime layout and build topology explicit.</div>
   <div class="value-glance-item"><strong>State and Replay</strong> &middot; Persist business data, reuse expensive outputs, and replay safely without bespoke state plumbing.</div>
 </div>
 
@@ -20,6 +20,6 @@
 - [Performance](/value/runtime-efficiency)
 - [Portable Serverless Functions](/value/integration-flexibility)
 - [State, Replay, and Queryable Data](/value/state-replay-and-queryable-data)
-- [Start Monolith, Split Later](/value/deployment-evolution)
+- [Container and Kubernetes Ready](/value/deployment-evolution)
 - [Operational Confidence](/value/operational-confidence)
 - [Plugins, Not Glue](/value/extensibility-and-platform)


### PR DESCRIPTION
## Summary
- restore the container and Kubernetes story on the docs homepage
- rebalance the front door so `COMPUTE` is visible alongside the newer serverless/function messaging
- align the deployment value surface with the same container-first framing

## What changed
- replaced the homepage layout-only card with `Container and Kubernetes Ready`
- updated the platform-mode callout to say `COMPUTE` means a standard Quarkus service runtime for containers and Kubernetes
- added explicit container-platform wording to the homepage body and practice examples
- retitled the deployment value track to `Container and Kubernetes Ready`
- updated the deployment value page lead and glance items to foreground standard Quarkus service runtimes for containers and Kubernetes

## Validation
- `npm --prefix docs run build`

## Scope notes
- current docs only
- no `docs/versions/**` changes
- no runtime or API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated messaging to emphasise "Container and Kubernetes Ready" deployment capabilities
  * Clarified how generated Quarkus services integrate with standard container and Kubernetes operations
  * Added container platform deployment examples alongside serverless options
  * Enhanced explanations of platform modes, transport modes, and packaging choices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->