### PR TITLE
chore: align Quarkus example and template versions

### DIFF
--- a/examples/csv-payments/pom.xml
+++ b/examples/csv-payments/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <enablePreview>true</enablePreview>
-        <quarkus.platform.version>3.31.3</quarkus.platform.version>
+        <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <protobuf.version>4.33.2</protobuf.version>

--- a/examples/search/pom.xml
+++ b/examples/search/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <enablePreview>true</enablePreview>
-        <quarkus.platform.version>3.31.3</quarkus.platform.version>
+        <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <protobuf.version>4.33.2</protobuf.version>
@@ -107,6 +107,27 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>reset-generated-pipeline-sources</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <delete dir="${project.build.directory}/generated-sources/pipeline"/>
+                                <delete dir="${project.build.directory}/generated-sources/role-compile"/>
+                                <delete dir="${project.build.directory}/classes-pipeline"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/template-generator-node/__tests__/pipeline-generator-v2.test.js
+++ b/template-generator-node/__tests__/pipeline-generator-v2.test.js
@@ -45,6 +45,40 @@ describe('PipelineGenerator v2', () => {
     expect(config.steps[0].outputTypeName).toBe('CustomerOutput');
   });
 
+  test('generateFromConfig emits parent pom aligned to root quarkus platform version', async () => {
+    const generator = new PipelineGenerator();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-generator-'));
+    const configPath = path.join(tempDir, 'config.yaml');
+    const outputPath = path.join(tempDir, 'generated-app');
+    fs.writeFileSync(configPath, `version: 2
+appName: Generated App
+basePackage: com.example.generated
+transport: GRPC
+runtimeLayout: MODULAR
+messages:
+  Request:
+    fields:
+      - number: 1
+        name: id
+        type: uuid
+  Response:
+    fields:
+      - number: 1
+        name: status
+        type: string
+steps:
+  - name: Process Request
+    cardinality: ONE_TO_ONE
+    inputTypeName: Request
+    outputTypeName: Response
+`);
+
+    await generator.generateFromConfig(configPath, outputPath);
+
+    const parentPom = fs.readFileSync(path.join(outputPath, 'pom.xml'), 'utf8');
+    expect(parentPom).toContain('<quarkus.platform.version>3.33.1</quarkus.platform.version>');
+  });
+
   test('toScaffoldConfig derives legacy field bindings from v2 messages', () => {
     const generator = new PipelineGenerator();
     const config = {

--- a/template-generator-node/templates/parent-pom.hbs
+++ b/template-generator-node/templates/parent-pom.hbs
@@ -53,7 +53,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <enablePreview>true</enablePreview>
-        <quarkus.platform.version>3.31.3</quarkus.platform.version>
+        <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <protobuf.version>4.28.2</protobuf.version>


### PR DESCRIPTION
## Summary
- align `quarkus.platform.version` to `3.33.1` in `examples/csv-payments`, `examples/search`, and the template-generator parent POM template
- add a template-generator regression test that asserts generated parent POMs emit the aligned Quarkus version
- reset stale generated pipeline sources in `examples/search` during `initialize` so plain `compile` no longer reuses old generated mapper/resource code

## Scope
This PR is intentionally limited to issue #282 plus the compile-hygiene fix needed to keep `examples/search` stable after generator/mapping evolution.

Out of scope:
- broader mapper warning cleanup
- runtime semantics
- docs restructuring

Deferred follow-up:
- #289

## Validation
- `./mvnw -f examples/csv-payments/pom.xml -DskipTests compile`
- `./mvnw -f examples/search/pom.xml -DskipTests compile`
- `./mvnw -f examples/search/pom.xml -DskipTests clean compile`
- `npm --prefix template-generator-node test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Quarkus platform dependency version from 3.31.3 to 3.33.1 across all example projects and build templates to maintain consistency across the codebase.
  * Enhanced project build configuration with improved initialisation logic for resetting and cleaning generated build artefacts prior to compilation.

* **Tests**
  * Added test coverage to validate that dynamically generated project configurations correctly align with and reference the updated Quarkus platform version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/290)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->