### PR TITLE
docs: harden replay viewer shell navigation

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -128,7 +128,7 @@ const mainSidebar = [
                     {text: 'Metrics', link: '/guide/operations/observability/metrics'},
                     {text: 'Tracing', link: '/guide/operations/observability/tracing'},
                     {text: 'Replay & Live Topology', link: '/guide/operations/observability/replay'},
-                    {text: 'Replay Viewer', link: '/replay-viewer/index.html'},
+                    {text: 'Replay Viewer', link: '/replay-viewer/'},
                     {text: 'Logging', link: '/guide/operations/observability/logging'},
                     {text: 'Health Checks', link: '/guide/operations/observability/health-checks'},
                     {text: 'Alerting', link: '/guide/operations/observability/alerting'},

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -24,6 +24,36 @@ import HeroSection from './components/HeroSection.vue'
 import VersionBadge from './components/VersionBadge.vue'
 import LatestReleases from './components/LatestReleases.vue'
 
+function installReplayViewerHardNavigation() {
+  if (typeof window === 'undefined' || window.__tpfReplayViewerHardNavInstalled) {
+    return
+  }
+  window.__tpfReplayViewerHardNavInstalled = true
+  const replayViewerPaths = new Set(['/replay-viewer/', '/replay-viewer/index.html'])
+  window.addEventListener('click', (event) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return
+    }
+    const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null
+    if (!anchor) {
+      return
+    }
+    const href = anchor.getAttribute('href')
+    if (!replayViewerPaths.has(href)) {
+      return
+    }
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    window.location.assign('/replay-viewer/')
+  }, true)
+
+  window.addEventListener('popstate', () => {
+    if (window.location.pathname.startsWith('/replay-viewer/')) {
+      window.location.replace('/replay-viewer/')
+    }
+  })
+}
+
 export default {
   ...DefaultTheme,
   Layout() {
@@ -37,5 +67,6 @@ export default {
     app.component('FeaturedArticles', FeaturedArticles)
     app.component('HeroSection', HeroSection)
     app.component('LatestReleases', LatestReleases)
+    installReplayViewerHardNavigation()
   }
 }

--- a/docs/guide/operations/observability/replay.md
+++ b/docs/guide/operations/observability/replay.md
@@ -118,7 +118,9 @@ The viewer uses a video-first layout:
 - bottom-right utility icons for replay source, replay info, and player fullscreen
 - modal panes for source selection/import and `Run parameters` plus `Legend`
 
-`Custom replay` is only exposed inside the replay-source modal. Selecting a source there stages the choice; the viewer only switches when `Load dataset` is pressed. Closing the modal or re-entering the page from browser history resets staged source state back to the active replay. Older replay files without `runParameters` remain loadable and show `Run parameters unavailable`.
+`Custom replay` is only exposed inside the replay-source modal. Selecting a source there stages the choice, and the viewer only switches when `Load dataset` is pressed.
+
+Closing the modal or re-entering the page from browser history resets staged source state back to the active replay. Older replay files without `runParameters` remain loadable and show `Run parameters unavailable`.
 
 The canonical viewer source lives in:
 

--- a/docs/guide/operations/observability/replay.md
+++ b/docs/guide/operations/observability/replay.md
@@ -94,6 +94,10 @@ If any prerequisite is missing, replay export stays off and the runtime logs one
 
 The supported replay viewer is published from the docs site at:
 
+- `/replay-viewer/`
+
+Compatibility entrypoint:
+
 - `/replay-viewer/index.html`
 
 It ships with built-in datasets and also accepts imported replay JSON files generated from your own runs.
@@ -108,12 +112,13 @@ The viewer exposes:
 The viewer uses a video-first layout:
 
 - the replay canvas as the main player surface
+- a persistent shell link back to `/guide/operations/observability/replay`
 - a metadata strip below the player for dataset, pipeline, duration, topology, and event summary
 - hover or tap-revealed player chrome over the canvas for transport controls, the scrubber, and inline speed radios
 - bottom-right utility icons for replay source, replay info, and player fullscreen
 - modal panes for source selection/import and `Run parameters` plus `Legend`
 
-`Custom replay` is only exposed inside the replay-source modal. Selecting a source there stages the choice; the viewer only switches when `Load dataset` is pressed. Older replay files without `runParameters` remain loadable and show `Run parameters unavailable`.
+`Custom replay` is only exposed inside the replay-source modal. Selecting a source there stages the choice; the viewer only switches when `Load dataset` is pressed. Closing the modal or re-entering the page from browser history resets staged source state back to the active replay. Older replay files without `runParameters` remain loadable and show `Run parameters unavailable`.
 
 The canonical viewer source lives in:
 

--- a/docs/public/replay-viewer/README.md
+++ b/docs/public/replay-viewer/README.md
@@ -2,7 +2,7 @@
 
 Standalone Three.js viewer for framework replay JSON.
 
-The canonical replay viewer source lives in `tools/replay-viewer/`. The docs site publishes the app at `/replay-viewer/index.html` by copying these files into `docs/public/replay-viewer/` during the docs build.
+The canonical replay viewer source lives in `tools/replay-viewer/`. The docs site publishes the app at `/replay-viewer/` by copying these files into `docs/public/replay-viewer/` during the docs build. `/replay-viewer/index.html` stays valid as a compatibility entrypoint.
 
 ## Supported input
 
@@ -23,6 +23,7 @@ So the viewer only needs one file at import time.
 - transition edges
 - replay metadata in a strip below the player
 - player chrome over the viewport for transport, scrubber, inline speed radios, and utility icons
+- a persistent shell link back to the replay docs page outside the player chrome
 - modal source and info surfaces opened from the bottom-right utility icons
 - semantic effects for:
   - `start`
@@ -52,6 +53,8 @@ You can either:
 The local replay file picker is shown only while `Custom replay` is selected.
 
 If an imported replay predates `runParameters`, the viewer keeps working and shows `Run parameters unavailable`.
+
+When the viewer is hosted from the docs site, the shell exposes a persistent `Back to docs` link to `/guide/operations/observability/replay`. It stays visible even when the player chrome is hidden.
 
 ## Built-in datasets
 

--- a/docs/public/replay-viewer/app.js
+++ b/docs/public/replay-viewer/app.js
@@ -2042,6 +2042,16 @@ renderRunParameters(replayDocument.runParameters);
 if (backToDocsLink) {
   backToDocsLink.href = resolveReplayDocsHref();
   backToDocsLink.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
     event.preventDefault();
     window.location.assign(backToDocsLink.href);
   });

--- a/docs/public/replay-viewer/app.js
+++ b/docs/public/replay-viewer/app.js
@@ -4,6 +4,7 @@ const mount = document.getElementById("threeMount");
 const viewport = document.querySelector(".viewport");
 const playerSurface = document.getElementById("playerSurface");
 const playerChrome = document.getElementById("playerChrome");
+const backToDocsLink = document.getElementById("backToDocsLink");
 const playPauseButton = document.getElementById("playPauseButton");
 const stopButton = document.getElementById("stopButton");
 const restartButton = document.getElementById("restartButton");
@@ -152,6 +153,37 @@ let chromeHideTimeout = null;
 let openModal = null;
 let isScrubbingTimeline = false;
 let prefersTapChrome = window.matchMedia("(hover: none), (pointer: coarse)").matches;
+
+function resolveReplayDocsHref() {
+  const replayDocsPath = "/guide/operations/observability/replay";
+  const currentPath = window.location.pathname;
+  if (currentPath.includes("/replay-viewer/")) {
+    return `${window.location.origin}${replayDocsPath}`;
+  }
+  return `https://pipelineframework.org${replayDocsPath}`;
+}
+
+function reloadIfViewerShellRouteChanged() {
+  if (!window.location.pathname.includes("/replay-viewer/")) {
+    window.location.replace(window.location.href);
+    return true;
+  }
+  return false;
+}
+
+function clearReplayFileSelection() {
+  if (replayFileInput) {
+    replayFileInput.value = "";
+  }
+}
+
+function syncStagedReplaySourceToActive() {
+  stagedReplaySourceKey = activeReplaySourceKey;
+  datasetSelect.value = stagedReplaySourceKey;
+  setCustomReplayVisibility(stagedReplaySourceKey === "custom");
+  clearReplayFileSelection();
+  updateSourceApplyButton();
+}
 
 function setCustomReplayVisibility(visible) {
   customReplayInputWrap.hidden = !visible;
@@ -490,6 +522,9 @@ function revealPlayerChrome(sticky = false) {
 }
 
 function openModalElement(name, element) {
+  if (name === "source") {
+    syncStagedReplaySourceToActive();
+  }
   openModal = name;
   element.hidden = false;
   element.setAttribute("aria-hidden", "false");
@@ -499,6 +534,9 @@ function openModalElement(name, element) {
 function closeModalElement(name, element) {
   if (openModal !== name) {
     return;
+  }
+  if (name === "source") {
+    syncStagedReplaySourceToActive();
   }
   openModal = null;
   element.hidden = true;
@@ -1832,10 +1870,6 @@ replayFileInput.addEventListener("change", async (event) => {
 });
 
 sourceButton.addEventListener("click", () => {
-  stagedReplaySourceKey = activeReplaySourceKey;
-  datasetSelect.value = stagedReplaySourceKey;
-  setCustomReplayVisibility(stagedReplaySourceKey === "custom");
-  updateSourceApplyButton();
   openModalElement("source", sourceModal);
 });
 
@@ -1981,9 +2015,37 @@ document.addEventListener("keydown", (event) => {
   }
 });
 
+window.addEventListener("popstate", () => {
+  reloadIfViewerShellRouteChanged();
+});
+
+window.addEventListener("pageshow", () => {
+  if (reloadIfViewerShellRouteChanged()) {
+    return;
+  }
+  if (!sourceModal.hidden) {
+    sourceModal.hidden = true;
+    sourceModal.setAttribute("aria-hidden", "true");
+  }
+  if (!infoModal.hidden) {
+    infoModal.hidden = true;
+    infoModal.setAttribute("aria-hidden", "true");
+  }
+  openModal = null;
+  syncStagedReplaySourceToActive();
+  revealPlayerChrome(prefersTapChrome || isLoadingReplay);
+});
+
 setCustomReplayVisibility(false);
 updateSourceApplyButton();
 renderRunParameters(replayDocument.runParameters);
+if (backToDocsLink) {
+  backToDocsLink.href = resolveReplayDocsHref();
+  backToDocsLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    window.location.assign(backToDocsLink.href);
+  });
+}
 setPlayerChromeVisible(true);
 updateUi();
 requestAnimationFrame(tick);

--- a/docs/public/replay-viewer/index.html
+++ b/docs/public/replay-viewer/index.html
@@ -9,6 +9,9 @@
   <body>
     <div class="app-shell">
       <main class="viewer-page">
+        <header class="viewer-shell-bar" aria-label="Replay viewer navigation">
+          <a id="backToDocsLink" class="shell-link" href="/guide/operations/observability/replay">Back to docs</a>
+        </header>
         <section class="player-panel">
           <section class="viewport" id="playerSurface">
             <div id="threeMount" class="three-mount"></div>

--- a/docs/public/replay-viewer/style.css
+++ b/docs/public/replay-viewer/style.css
@@ -47,6 +47,30 @@ button:disabled {
   padding: 16px;
 }
 
+.viewer-shell-bar {
+  display: flex;
+  align-items: center;
+}
+
+.shell-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 14px;
+  border: 1px solid rgb(148 163 184 / 20%);
+  border-radius: 999px;
+  background: rgb(12 20 35 / 78%);
+  color: #f8fbff;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+}
+
+.shell-link:hover {
+  background: rgb(24 35 59 / 96%);
+}
+
 .player-panel {
   display: grid;
   gap: 12px;
@@ -501,6 +525,10 @@ button:disabled {
 @media (max-width: 820px) {
   .viewer-page {
     padding: 12px;
+  }
+
+  .viewer-shell-bar {
+    justify-content: flex-start;
   }
 
   .three-mount {

--- a/tools/replay-viewer/README.md
+++ b/tools/replay-viewer/README.md
@@ -2,7 +2,7 @@
 
 Standalone Three.js viewer for framework replay JSON.
 
-The canonical replay viewer source lives in `tools/replay-viewer/`. The docs site publishes the app at `/replay-viewer/index.html` by copying these files into `docs/public/replay-viewer/` during the docs build.
+The canonical replay viewer source lives in `tools/replay-viewer/`. The docs site publishes the app at `/replay-viewer/` by copying these files into `docs/public/replay-viewer/` during the docs build. `/replay-viewer/index.html` stays valid as a compatibility entrypoint.
 
 ## Supported input
 
@@ -23,6 +23,7 @@ So the viewer only needs one file at import time.
 - transition edges
 - replay metadata in a strip below the player
 - player chrome over the viewport for transport, scrubber, inline speed radios, and utility icons
+- a persistent shell link back to the replay docs page outside the player chrome
 - modal source and info surfaces opened from the bottom-right utility icons
 - semantic effects for:
   - `start`
@@ -52,6 +53,8 @@ You can either:
 The local replay file picker is shown only while `Custom replay` is selected.
 
 If an imported replay predates `runParameters`, the viewer keeps working and shows `Run parameters unavailable`.
+
+When the viewer is hosted from the docs site, the shell exposes a persistent `Back to docs` link to `/guide/operations/observability/replay`. It stays visible even when the player chrome is hidden.
 
 ## Built-in datasets
 

--- a/tools/replay-viewer/app.js
+++ b/tools/replay-viewer/app.js
@@ -2042,6 +2042,16 @@ renderRunParameters(replayDocument.runParameters);
 if (backToDocsLink) {
   backToDocsLink.href = resolveReplayDocsHref();
   backToDocsLink.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
     event.preventDefault();
     window.location.assign(backToDocsLink.href);
   });

--- a/tools/replay-viewer/app.js
+++ b/tools/replay-viewer/app.js
@@ -4,6 +4,7 @@ const mount = document.getElementById("threeMount");
 const viewport = document.querySelector(".viewport");
 const playerSurface = document.getElementById("playerSurface");
 const playerChrome = document.getElementById("playerChrome");
+const backToDocsLink = document.getElementById("backToDocsLink");
 const playPauseButton = document.getElementById("playPauseButton");
 const stopButton = document.getElementById("stopButton");
 const restartButton = document.getElementById("restartButton");
@@ -152,6 +153,37 @@ let chromeHideTimeout = null;
 let openModal = null;
 let isScrubbingTimeline = false;
 let prefersTapChrome = window.matchMedia("(hover: none), (pointer: coarse)").matches;
+
+function resolveReplayDocsHref() {
+  const replayDocsPath = "/guide/operations/observability/replay";
+  const currentPath = window.location.pathname;
+  if (currentPath.includes("/replay-viewer/")) {
+    return `${window.location.origin}${replayDocsPath}`;
+  }
+  return `https://pipelineframework.org${replayDocsPath}`;
+}
+
+function reloadIfViewerShellRouteChanged() {
+  if (!window.location.pathname.includes("/replay-viewer/")) {
+    window.location.replace(window.location.href);
+    return true;
+  }
+  return false;
+}
+
+function clearReplayFileSelection() {
+  if (replayFileInput) {
+    replayFileInput.value = "";
+  }
+}
+
+function syncStagedReplaySourceToActive() {
+  stagedReplaySourceKey = activeReplaySourceKey;
+  datasetSelect.value = stagedReplaySourceKey;
+  setCustomReplayVisibility(stagedReplaySourceKey === "custom");
+  clearReplayFileSelection();
+  updateSourceApplyButton();
+}
 
 function setCustomReplayVisibility(visible) {
   customReplayInputWrap.hidden = !visible;
@@ -490,6 +522,9 @@ function revealPlayerChrome(sticky = false) {
 }
 
 function openModalElement(name, element) {
+  if (name === "source") {
+    syncStagedReplaySourceToActive();
+  }
   openModal = name;
   element.hidden = false;
   element.setAttribute("aria-hidden", "false");
@@ -499,6 +534,9 @@ function openModalElement(name, element) {
 function closeModalElement(name, element) {
   if (openModal !== name) {
     return;
+  }
+  if (name === "source") {
+    syncStagedReplaySourceToActive();
   }
   openModal = null;
   element.hidden = true;
@@ -1832,10 +1870,6 @@ replayFileInput.addEventListener("change", async (event) => {
 });
 
 sourceButton.addEventListener("click", () => {
-  stagedReplaySourceKey = activeReplaySourceKey;
-  datasetSelect.value = stagedReplaySourceKey;
-  setCustomReplayVisibility(stagedReplaySourceKey === "custom");
-  updateSourceApplyButton();
   openModalElement("source", sourceModal);
 });
 
@@ -1981,9 +2015,37 @@ document.addEventListener("keydown", (event) => {
   }
 });
 
+window.addEventListener("popstate", () => {
+  reloadIfViewerShellRouteChanged();
+});
+
+window.addEventListener("pageshow", () => {
+  if (reloadIfViewerShellRouteChanged()) {
+    return;
+  }
+  if (!sourceModal.hidden) {
+    sourceModal.hidden = true;
+    sourceModal.setAttribute("aria-hidden", "true");
+  }
+  if (!infoModal.hidden) {
+    infoModal.hidden = true;
+    infoModal.setAttribute("aria-hidden", "true");
+  }
+  openModal = null;
+  syncStagedReplaySourceToActive();
+  revealPlayerChrome(prefersTapChrome || isLoadingReplay);
+});
+
 setCustomReplayVisibility(false);
 updateSourceApplyButton();
 renderRunParameters(replayDocument.runParameters);
+if (backToDocsLink) {
+  backToDocsLink.href = resolveReplayDocsHref();
+  backToDocsLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    window.location.assign(backToDocsLink.href);
+  });
+}
 setPlayerChromeVisible(true);
 updateUi();
 requestAnimationFrame(tick);

--- a/tools/replay-viewer/index.html
+++ b/tools/replay-viewer/index.html
@@ -9,6 +9,9 @@
   <body>
     <div class="app-shell">
       <main class="viewer-page">
+        <header class="viewer-shell-bar" aria-label="Replay viewer navigation">
+          <a id="backToDocsLink" class="shell-link" href="/guide/operations/observability/replay">Back to docs</a>
+        </header>
         <section class="player-panel">
           <section class="viewport" id="playerSurface">
             <div id="threeMount" class="three-mount"></div>

--- a/tools/replay-viewer/style.css
+++ b/tools/replay-viewer/style.css
@@ -47,6 +47,30 @@ button:disabled {
   padding: 16px;
 }
 
+.viewer-shell-bar {
+  display: flex;
+  align-items: center;
+}
+
+.shell-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 14px;
+  border: 1px solid rgb(148 163 184 / 20%);
+  border-radius: 999px;
+  background: rgb(12 20 35 / 78%);
+  color: #f8fbff;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+}
+
+.shell-link:hover {
+  background: rgb(24 35 59 / 96%);
+}
+
 .player-panel {
   display: grid;
   gap: 12px;
@@ -501,6 +525,10 @@ button:disabled {
 @media (max-width: 820px) {
   .viewer-page {
     padding: 12px;
+  }
+
+  .viewer-shell-bar {
+    justify-content: flex-start;
   }
 
   .three-mount {


### PR DESCRIPTION
## Summary
- harden replay viewer entry/exit behavior for the docs shell
- add a persistent back-to-docs affordance outside player chrome
- reset staged source/custom replay modal state on close and history re-entry

## Scope
Implements issue #288 only. No replay/runtime semantic changes.

## Validation
- npm --prefix docs run build
- Chromium docs-shell navigation and custom replay modal reset checks
- WebKit docs-shell navigation, browser back/forward, and custom replay modal reset checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent "Back to Replay Docs" link within the replay viewer for easier navigation back to documentation.
  * Improved browser navigation handling to ensure back/forward buttons work reliably within the replay viewer context.

* **Documentation**
  * Updated replay viewer documentation to clarify supported URL routes and document the new persistent navigation link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->