### PR TITLE
Reintroduce blocking step authoring

### DIFF
--- a/docs/guide/development/code-a-step.md
+++ b/docs/guide/development/code-a-step.md
@@ -45,7 +45,7 @@ steps:
 
 The `input` and `output` fields specify the service domain types and must match the generic parameters of your service interface (`ReactiveService<I, O>`). The `inboundMapper` and `outboundMapper` fields reference mappers that translate between Domain ↔ External (e.g., `Mapper<Domain, External>`). Mappers should be provided as paired `Mapper<Domain, External>` implementations to validate boundaries and avoid build-time type mismatches.
 
-When a step can produce several closed business outcomes, keep the single-output shape and declare the output as a typed union. See [Typed Union Outputs](/guide/development/typed-union-outputs).
+When a step can produce several closed business outcomes, keep the single-output shape and declare the output as a typed union.
 
 ## 3) Implement the Service
 

--- a/docs/guide/development/code-a-step.md
+++ b/docs/guide/development/code-a-step.md
@@ -15,7 +15,7 @@ Choose the interface family that matches your data flow:
 - `ReactiveStreamingClientService<I, O>`: stream of inputs → one output
 - `ReactiveBidirectionalStreamingService<I, O>`: stream of inputs → stream of outputs
 - `BlockingService<I, O>`: one input → one output, synchronous user code
-- `BlockingStreamingService<I, O>`: one input → many outputs, returns `List<O>` and materializes the full output
+- `BlockingStreamingService<I, O>`: one input → many outputs, returns `List<O>` and materialises the full output
 - `BlockingIteratorService<I, O>`: one input → many outputs, returns `CloseableIterator<O>` for incremental blocking streaming
 - `BlockingStreamingClientService<I, O>`: many inputs → one output, consumes `List<I>`
 - `BlockingBidirectionalStreamingService<I, O>`: many inputs → many outputs, transforms `List<I>` to `List<O>`
@@ -82,7 +82,7 @@ public class ProcessCsvService implements BlockingIteratorService<CsvFile, Payme
 
 The framework keeps transport adapters reactive in both cases. Blocking service interfaces expose synchronous methods such as `processBlocking(...)`, and the framework supplies the reactive `process(...)` adapter. Blocking services are wrapped in a generated reactive bridge and offloaded to worker threads by default, or to virtual threads when `runOnVirtualThreads = true`.
 
-`BlockingStreamingService`, `BlockingStreamingClientService`, and `BlockingBidirectionalStreamingService` are materializing contracts. They trade away automatic backpressure and also increase heap usage, GC pressure, first-item latency, and whole-batch retry cost. `BlockingIteratorService` reduces those materialization costs, but it is still blocking work and should be used only when synchronous authoring is worth the throughput tradeoff.
+`BlockingStreamingService`, `BlockingStreamingClientService`, and `BlockingBidirectionalStreamingService` are materialising contracts. They trade away automatic backpressure and also increase heap usage, GC pressure, first-item latency, and whole-batch retry cost. `BlockingIteratorService` reduces those materialisation costs, but it is still blocking work and should be used only when synchronous authoring is worth the throughput trade-off.
 
 ## 4) Add Mappers
 

--- a/docs/guide/development/code-a-step.md
+++ b/docs/guide/development/code-a-step.md
@@ -43,7 +43,7 @@ steps:
     outboundMapper: com.app.payment.PaymentStatusMapper
 ```
 
-The `input` and `output` fields specify the service domain types and must match the generic parameters of your service interface (`ReactiveService<I, O>`). The `inboundMapper` and `outboundMapper` fields reference mappers that translate between Domain ↔ External (e.g., `Mapper<Domain, External>`). Mappers should be provided as paired `Mapper<Domain, External>` implementations to validate boundaries and avoid build-time type mismatches.
+The `input` and `output` fields specify the service domain types and must match the generic parameters of the service interface you implement, whether reactive or blocking. The `inboundMapper` and `outboundMapper` fields reference mappers that translate between Domain ↔ External (e.g., `Mapper<Domain, External>`). Mappers should be provided as paired `Mapper<Domain, External>` implementations to validate boundaries and avoid build-time type mismatches.
 
 When a step can produce several closed business outcomes, keep the single-output shape and declare the output as a typed union.
 

--- a/docs/guide/development/code-a-step.md
+++ b/docs/guide/development/code-a-step.md
@@ -8,11 +8,25 @@ Use the Canvas designer at <a href="https://app.pipelineframework.org" target="_
 
 ## 1) Pick the Service Interface
 
-Choose the reactive interface that matches your data flow:
+Choose the interface family that matches your data flow:
 
 - `ReactiveService<I, O>`: one input → one output
 - `ReactiveStreamingService<I, O>`: one input → stream of outputs
 - `ReactiveStreamingClientService<I, O>`: stream of inputs → one output
+- `ReactiveBidirectionalStreamingService<I, O>`: stream of inputs → stream of outputs
+- `BlockingService<I, O>`: one input → one output, synchronous user code
+- `BlockingStreamingService<I, O>`: one input → many outputs, returns `List<O>` and materializes the full output
+- `BlockingIteratorService<I, O>`: one input → many outputs, returns `CloseableIterator<O>` for incremental blocking streaming
+- `BlockingStreamingClientService<I, O>`: many inputs → one output, consumes `List<I>`
+- `BlockingBidirectionalStreamingService<I, O>`: many inputs → many outputs, transforms `List<I>` to `List<O>`
+
+Use the blocking family in two explicit modes:
+
+| Need | Recommended contract |
+| --- | --- |
+| Bounded batch or batch-oriented SDKs | `BlockingStreamingService`, `BlockingStreamingClientService`, `BlockingBidirectionalStreamingService` |
+| Blocking library with a cursor, iterator, reader, or JDBC-style incremental API | `BlockingIteratorService` |
+| Async or naturally non-blocking library | Reactive service interfaces |
 
 ## 2) Define the Step Contract in YAML
 
@@ -31,10 +45,14 @@ steps:
 
 The `input` and `output` fields specify the service domain types and must match the generic parameters of your service interface (`ReactiveService<I, O>`). The `inboundMapper` and `outboundMapper` fields reference mappers that translate between Domain ↔ External (e.g., `Mapper<Domain, External>`). Mappers should be provided as paired `Mapper<Domain, External>` implementations to validate boundaries and avoid build-time type mismatches.
 
+When a step can produce several closed business outcomes, keep the single-output shape and declare the output as a typed union. See [Typed Union Outputs](/guide/development/typed-union-outputs).
+
 ## 3) Implement the Service
 
 Annotate the class with `@PipelineStep` so build-time generation can discover it.
 Keep Java-local concerns such as ordering, thread safety, cache keys, and side effects on the annotation.
+
+Reactive authoring:
 
 ```java
 @PipelineStep
@@ -47,6 +65,24 @@ public class ProcessPaymentService implements ReactiveService<PaymentRecord, Pay
     }
 }
 ```
+
+Blocking authoring:
+
+```java
+@PipelineStep(runOnVirtualThreads = true)
+@ApplicationScoped
+public class ProcessCsvService implements BlockingIteratorService<CsvFile, PaymentRecord> {
+
+    @Override
+    public CloseableIterator<PaymentRecord> iterateBlocking(CsvFile input) {
+        return openCsvIterator(input);
+    }
+}
+```
+
+The framework keeps transport adapters reactive in both cases. Blocking service interfaces expose synchronous methods such as `processBlocking(...)`, and the framework supplies the reactive `process(...)` adapter. Blocking services are wrapped in a generated reactive bridge and offloaded to worker threads by default, or to virtual threads when `runOnVirtualThreads = true`.
+
+`BlockingStreamingService`, `BlockingStreamingClientService`, and `BlockingBidirectionalStreamingService` are materializing contracts. They trade away automatic backpressure and also increase heap usage, GC pressure, first-item latency, and whole-batch retry cost. `BlockingIteratorService` reduces those materialization costs, but it is still blocking work and should be used only when synchronous authoring is worth the throughput tradeoff.
 
 ## 4) Add Mappers
 
@@ -94,6 +130,8 @@ return processBatch(batchItem)
 that must be tracked and re-driven without failing the full execution.
 See [Item Reject Sink](/guide/development/item-reject-sink) for the canonical model and wiring.
 
+Blocking services can throw normally. The generated bridge feeds those failures into the same retry, reject, DLQ, and telemetry paths that the reactive step APIs use.
+
 ## 6) Test in Isolation
 
 ```java
@@ -117,6 +155,7 @@ class ProcessPaymentServiceTest {
 ## Best Practices
 
 1. Keep step logic focused on a single responsibility.
-2. Prefer non-blocking I/O and reactive composition.
-3. Choose failure handling by intent: use domain responses for expected business outcomes (for example validation/state conflicts), use Item Reject Sink (`rejectItem` / `rejectStream`) for per-item recoverable processing failures that must be tracked for downstream handling, and use execution DLQ for systemic or unrecoverable pipeline/execution failures.
-4. Validate input early and consistently.
+2. Prefer non-blocking I/O and reactive composition when you need streaming efficiency or backpressure.
+3. Use blocking services for straightforward synchronous code, but keep them isolated and explicit.
+4. Choose failure handling by intent: use domain responses for expected business outcomes (for example validation/state conflicts), use Item Reject Sink (`rejectItem` / `rejectStream`) for per-item recoverable processing failures that must be tracked for downstream handling, and use execution DLQ for systemic or unrecoverable pipeline/execution failures.
+5. Validate input early and consistently.

--- a/docs/guide/development/performance.md
+++ b/docs/guide/development/performance.md
@@ -36,4 +36,29 @@ For step shapes and how to reason about expansion vs. reduction, see
 
 ## Server Execution Strategy
 
-Service-side execution context (event loop vs. worker threads) affects throughput for I/O-heavy steps. Prefer non-blocking I/O and offload truly blocking work using the framework or runtime facilities (for example, Vert.x `executeBlocking`) to avoid starving the event loop.
+Service-side execution context (event loop vs. worker threads) affects throughput for I/O-heavy steps. Prefer non-blocking I/O and offload truly blocking work using the framework or runtime facilities to avoid starving the event loop.
+
+## Blocking Steps
+
+TPF now supports a first-class blocking authoring path for internal `service:` steps.
+
+- Blocking services are executed on worker threads by default.
+- `@PipelineStep(runOnVirtualThreads = true)` switches the generated blocking bridge and service entrypoints to virtual threads.
+- Blocking authoring is split into two modes:
+  - materialized blocking: `BlockingStreamingService`, `BlockingStreamingClientService`, `BlockingBidirectionalStreamingService`
+  - incremental blocking: `BlockingIteratorService`
+
+Materialized blocking does not just lose reactive backpressure. It also:
+
+- increases heap usage because full input or output collections live in memory at once
+- increases GC pressure and whole-batch retry cost
+- delays first output until the full blocking callback finishes
+- wastes more CPU work when downstream later fails or cancels
+
+Iterator blocking reduces those materialization costs, but it is still blocking I/O or CPU work running on an offload executor rather than on the event loop.
+
+Use blocking steps when synchronous business code is the practical choice. Refactor to reactive services when you need:
+
+- sustained high throughput under streaming load
+- partial consumption without full list materialization and your blocking library cannot express it through an iterator
+- native non-blocking I/O instead of worker or virtual-thread offload

--- a/docs/guide/development/pipeline-step.md
+++ b/docs/guide/development/pipeline-step.md
@@ -92,7 +92,7 @@ These operator-specific fields must use fully-qualified class::method references
      - `BlockingIteratorService<I, O>`
      - `BlockingStreamingClientService<I, O>`
      - `BlockingBidirectionalStreamingService<I, O>`
-4. Keep YAML cardinality aligned with the implemented reactive interface.
+4. Keep YAML cardinality aligned with the implemented interface, reactive or blocking.
 
 Parallelism is configured at the pipeline level (`pipeline.parallelism` and `pipeline.max-concurrency`).
 The `ordering` and `threadSafety` values on `@PipelineStep` are propagated to the generated client step,

--- a/docs/guide/development/pipeline-step.md
+++ b/docs/guide/development/pipeline-step.md
@@ -50,6 +50,7 @@ Use `@PipelineStep` for Java-local execution concerns:
 - `cacheKeyGenerator`
 - `ordering`
 - `threadSafety`
+- `runOnVirtualThreads`
 - `sideEffect`
 - `delegate` (for operator steps only)
 
@@ -85,10 +86,36 @@ These operator-specific fields must use fully-qualified class::method references
    - `ReactiveStreamingService<I, O>`
    - `ReactiveStreamingClientService<I, O>`
    - `ReactiveBidirectionalStreamingService<I, O>`
+   - or the matching blocking interface when the step is intentionally synchronous:
+     - `BlockingService<I, O>`
+     - `BlockingStreamingService<I, O>`
+     - `BlockingIteratorService<I, O>`
+     - `BlockingStreamingClientService<I, O>`
+     - `BlockingBidirectionalStreamingService<I, O>`
 4. Keep YAML cardinality aligned with the implemented reactive interface.
 
 Parallelism is configured at the pipeline level (`pipeline.parallelism` and `pipeline.max-concurrency`).
 The `ordering` and `threadSafety` values on `@PipelineStep` are propagated to the generated client step,
 which the runtime uses to decide parallelism under `AUTO`.
 
+Blocking services are offloaded by default onto worker threads so the framework does not execute them on event-loop threads.
+Set `runOnVirtualThreads = true` when you want the generated blocking bridge and server entrypoints to use virtual threads instead of the default worker pool.
+
 Transport selection (gRPC vs REST) is configured in `pipeline.yaml`, not on the annotation.
+
+## Blocking vs Reactive
+
+Use the blocking path when the business code is naturally synchronous and the team is not going to maintain Mutiny-based implementations.
+
+- The framework still generates reactive transport adapters.
+- Internal blocking services are wrapped in a generated reactive bridge.
+- `BlockingStreamingService`, `BlockingStreamingClientService`, and `BlockingBidirectionalStreamingService` use materialized `List` semantics.
+- `BlockingIteratorService` keeps `ONE_TO_MANY` incremental without forcing Mutiny into user method signatures.
+
+Decision guide:
+
+| Need | Contract |
+| --- | --- |
+| Bounded batch, blocking SDKs, or simple synchronous code | Materializing blocking interfaces |
+| Incremental blocking streaming from an iterator/reader/cursor API | `BlockingIteratorService` |
+| End-to-end backpressure, async I/O, or highest streaming throughput | Reactive interfaces |

--- a/docs/guide/evolve/annotation-processor/index.md
+++ b/docs/guide/evolve/annotation-processor/index.md
@@ -45,7 +45,7 @@ Internal `service:` steps can now be authored against reactive service interface
 - Transport renderers still target reactive service contracts. They inject the generated bridge instead of the authored blocking service directly.
 - The generated bridge adapts `List`-based blocking contracts with materializing helpers and adapts `BlockingIteratorService` with iterator-to-`Multi` offload helpers.
 
-This keeps gRPC, REST, local, and function generation on one transport contract family while still allowing synchronous user code in internal services.
+This keeps REST, gRPC, and LOCAL generation on one transport contract family while still allowing synchronous user code in internal services, and preserves FUNCTION as a platform-generation path.
 
 ## Scope
 

--- a/docs/guide/evolve/annotation-processor/index.md
+++ b/docs/guide/evolve/annotation-processor/index.md
@@ -37,13 +37,13 @@ flowchart LR
 
 ## Current Internal-Service Handling
 
-Internal `service:` steps can now be authored against reactive service interfaces, materializing blocking service interfaces, or the incremental blocking iterator service interface.
+Internal `service:` steps can now be authored against reactive service interfaces, materialising blocking service interfaces, or the incremental blocking iterator service interface.
 
 - Model extraction classifies the authored service contract family and validates YAML cardinality against it.
-- Model extraction emits build-time warnings for materializing blocking streaming contracts and points users toward `BlockingIteratorService` for incremental `1 -> N` cases.
+- Model extraction emits build-time warnings for materialising blocking streaming contracts and points users toward `BlockingIteratorService` for incremental `1 -> N` cases.
 - Target resolution adds a generated reactive bridge target for blocking-authored internal services.
 - Transport renderers still target reactive service contracts. They inject the generated bridge instead of the authored blocking service directly.
-- The generated bridge adapts `List`-based blocking contracts with materializing helpers and adapts `BlockingIteratorService` with iterator-to-`Multi` offload helpers.
+- The generated bridge adapts `List`-based blocking contracts with materialising helpers and adapts `BlockingIteratorService` with iterator-to-`Multi` offload helpers.
 
 This keeps REST, gRPC, and LOCAL generation on one transport contract family while still allowing synchronous user code in internal services, and preserves FUNCTION as a platform-generation path.
 

--- a/docs/guide/evolve/annotation-processor/index.md
+++ b/docs/guide/evolve/annotation-processor/index.md
@@ -35,6 +35,18 @@ flowchart LR
 - `PipelineCompiler`: phase orchestrator.
 - `PipelineCompilationContext`: mutable phase handoff contract.
 
+## Current Internal-Service Handling
+
+Internal `service:` steps can now be authored against reactive service interfaces, materializing blocking service interfaces, or the incremental blocking iterator service interface.
+
+- Model extraction classifies the authored service contract family and validates YAML cardinality against it.
+- Model extraction emits build-time warnings for materializing blocking streaming contracts and points users toward `BlockingIteratorService` for incremental `1 -> N` cases.
+- Target resolution adds a generated reactive bridge target for blocking-authored internal services.
+- Transport renderers still target reactive service contracts. They inject the generated bridge instead of the authored blocking service directly.
+- The generated bridge adapts `List`-based blocking contracts with materializing helpers and adapts `BlockingIteratorService` with iterator-to-`Multi` offload helpers.
+
+This keeps gRPC, REST, local, and function generation on one transport contract family while still allowing synchronous user code in internal services.
+
 ## Scope
 
 This guide is canonical documentation for the current framework implementation.

--- a/examples/csv-payments/README.md
+++ b/examples/csv-payments/README.md
@@ -103,6 +103,28 @@ cd <repo-root>
 
 That lane starts a dedicated LGTM stack, points the modular services and packaged orchestrator at its OTLP collector, and then queries Tempo directly to prove traces arrived and are queryable.
 
+### Blocking CSV Input Demand Pacing
+
+The input CSV step is authored as a blocking iterator service. It still reads rows incrementally from OpenCSV, and it also applies demand pacing before each row is pulled from the iterator.
+
+This pacing is a blocking-thread throttle, not end-to-end reactive backpressure. The framework offloads the iterator to worker or virtual threads, and the example pacer deliberately blocks that offloaded thread when the configured row budget is exhausted.
+
+Configure the default row budget in the input service:
+
+```properties
+csv-payments.reader-demand-pacer.rows-per-period=10
+csv-payments.reader-demand-pacer.millis-period=100
+```
+
+The E2E harness can override those settings for large-input observability runs:
+
+```bash
+-Dcsv.e2e.reader-demand-pacer.rows-per-period=20
+-Dcsv.e2e.reader-demand-pacer.millis-period=1000
+```
+
+Use lower rates when you need the demo to expose pipeline timing, retry, and tracing behaviour clearly. Use higher rates when you want throughput-oriented local validation.
+
 For local manual inspection before teardown:
 
 ```bash

--- a/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputService.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputService.java
@@ -126,8 +126,14 @@ public class ProcessCsvPaymentsInputService
         emitted++;
         String serviceId = ProcessCsvPaymentsInputService.class.toString();
         MDC.put("serviceId", serviceId);
-        LOG.infof("Executed blocking CSV iteration on %s --> %s", input.getSourceName(), record);
-        MDC.remove("serviceId");
+        try {
+            LOG.debugf(
+                "Executed blocking CSV iteration on %s (csvId=%s)",
+                input.getSourceName(),
+                record.getCsvId());
+        } finally {
+            MDC.remove("serviceId");
+        }
         return record;
     }
 

--- a/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputService.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputService.java
@@ -16,31 +16,27 @@
 
 package org.pipelineframework.csv.service;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.util.List;
+import java.io.Reader;
+import java.util.Iterator;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import com.opencsv.bean.CsvToBeanBuilder;
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.subscription.FixedDemandPacer;
-import io.smallrye.mutiny.unchecked.Unchecked;
 import lombok.Getter;
 import org.jboss.logging.Logger;
 import org.jboss.logging.MDC;
 import org.pipelineframework.annotation.PipelineStep;
+import org.pipelineframework.blocking.CloseableIterator;
 import org.pipelineframework.csv.common.domain.CsvPaymentsInputFile;
 import org.pipelineframework.csv.common.domain.PaymentRecord;
 import org.pipelineframework.csv.util.DemandPacerConfig;
-import org.pipelineframework.service.ReactiveStreamingService;
+import org.pipelineframework.service.blocking.BlockingIteratorService;
 
 @PipelineStep
 @ApplicationScoped
 @Getter
 public class ProcessCsvPaymentsInputService
-    implements ReactiveStreamingService<CsvPaymentsInputFile, PaymentRecord> {
+    implements BlockingIteratorService<CsvPaymentsInputFile, PaymentRecord> {
 
   private static final Logger LOG = Logger.getLogger(ProcessCsvPaymentsInputService.class);
   private final long rowsPerPeriod;
@@ -49,7 +45,7 @@ public class ProcessCsvPaymentsInputService
     /**
      * Create a service instance configured with demand-pacing parameters.
      *
-     * Initialises the instance fields used for pacing from the supplied configuration and logs the configured values.
+     * Initialises the instance fields retained for example-level diagnostics and logs the configured values.
      *
      * @param config configuration supplying the number of rows per pacing period and the period duration in milliseconds
      */
@@ -65,57 +61,85 @@ public class ProcessCsvPaymentsInputService
     }
 
   /**
-   * Stream parsed PaymentRecord objects from the provided CSV input file with demand pacing.
-   *
-   * <p>Each subscription opens a fresh reader, validates the CSV eagerly (before emitting any
-   * records), and then streams parsed records with demand pacing. The reader is closed when the
-   * stream terminates or if an error occurs during setup or parsing.
-   *
-   * @param input the CSV input file wrapper providing the reader, source name and mapping strategy
-   * @return a {@code Multi<PaymentRecord>} that emits parsed payment records paced by the service's
-   *     configured rows-per-period and period duration
+   * Open a blocking iterator over the CSV records without materializing the full file in memory.
    */
   @Override
-  public Multi<PaymentRecord> process(CsvPaymentsInputFile input) {
-    return Multi.createFrom().deferred(
-        Unchecked.supplier(
-            () -> {
-              try {
-                List<PaymentRecord> records;
-                try (var reader = input.openReader()) {
-                    var csvReader =
-                        new CsvToBeanBuilder<PaymentRecord>(reader)
-                        .withType(PaymentRecord.class)
-                        .withMappingStrategy(input.veryOwnStrategy())
-                        .withSeparator(',')
-                        .withIgnoreLeadingWhiteSpace(true)
-                        .withIgnoreEmptyLine(true)
-                        .build();
-                    records = csvReader.parse();
-                    LOG.infof("Closed CSV reader for: %s", input.getSourceName());
-                }
+  public CloseableIterator<PaymentRecord> iterateBlocking(CsvPaymentsInputFile input) {
+    try {
+        Reader reader = input.openReader();
+        try {
+            Iterator<PaymentRecord> delegate =
+                new CsvToBeanBuilder<PaymentRecord>(reader)
+                    .withType(PaymentRecord.class)
+                    .withMappingStrategy(input.veryOwnStrategy())
+                    .withSeparator(',')
+                    .withIgnoreLeadingWhiteSpace(true)
+                    .withIgnoreEmptyLine(true)
+                    .build()
+                    .iterator();
+            return new OpenCsvPaymentRecordIterator(reader, delegate, input, rowsPerPeriod, millisPeriod);
+        } catch (Exception e) {
+            reader.close();
+            throw e;
+        }
+    } catch (Exception e) {
+        LOG.errorf(e, "CSV processing failed for file: %s", input.getSourceName());
+        throw new RuntimeException("CSV processing error: " + e.getMessage(), e);
+    }
+  }
 
-                String serviceId = this.getClass().toString();
-                FixedDemandPacer pacer =
-                    new FixedDemandPacer(rowsPerPeriod, Duration.ofMillis(millisPeriod));
+  private static final class OpenCsvPaymentRecordIterator implements CloseableIterator<PaymentRecord> {
+    private final Reader reader;
+    private final Iterator<PaymentRecord> delegate;
+    private final CsvPaymentsInputFile input;
+    private final long rowsPerPeriod;
+    private final long millisPeriod;
+    private long emitted;
+    private boolean closed;
 
-                return Multi.createFrom()
-                    .iterable(records)
-                    .paceDemand()
-                    .on(Infrastructure.getDefaultWorkerPool())
-                    .using(pacer)
-                    .onItem()
-                    .invoke(
-                        rec -> {
-                          MDC.put("serviceId", serviceId);
-                          LOG.infof(
-                              "Executed command on %s --> %s", input.getSourceName(), rec);
-                          MDC.remove("serviceId");
-                        });
-              } catch (Exception e) {
-                LOG.errorf(e, "CSV processing failed for file: %s", input.getSourceName());
-                return Multi.createFrom().failure(new RuntimeException("CSV processing error: " + e.getMessage(), e));
-              }
-            }));
+    private OpenCsvPaymentRecordIterator(
+        Reader reader,
+        Iterator<PaymentRecord> delegate,
+        CsvPaymentsInputFile input,
+        long rowsPerPeriod,
+        long millisPeriod
+    ) {
+        this.reader = reader;
+        this.delegate = delegate;
+        this.input = input;
+        this.rowsPerPeriod = rowsPerPeriod;
+        this.millisPeriod = millisPeriod;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public PaymentRecord next() {
+        PaymentRecord record = delegate.next();
+        emitted++;
+        String serviceId = ProcessCsvPaymentsInputService.class.toString();
+        MDC.put("serviceId", serviceId);
+        LOG.infof("Executed blocking CSV iteration on %s --> %s", input.getSourceName(), record);
+        MDC.remove("serviceId");
+        return record;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        reader.close();
+        LOG.infof(
+            "Closed CSV reader for: %s (iterated %d records, rowsPerPeriod=%d, periodMillis=%d)",
+            input.getSourceName(),
+            emitted,
+            rowsPerPeriod,
+            millisPeriod);
+    }
   }
 }

--- a/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputService.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputService.java
@@ -29,6 +29,7 @@ import org.pipelineframework.annotation.PipelineStep;
 import org.pipelineframework.blocking.CloseableIterator;
 import org.pipelineframework.csv.common.domain.CsvPaymentsInputFile;
 import org.pipelineframework.csv.common.domain.PaymentRecord;
+import org.pipelineframework.csv.util.BlockingIteratorPacer;
 import org.pipelineframework.csv.util.DemandPacerConfig;
 import org.pipelineframework.service.blocking.BlockingIteratorService;
 
@@ -77,7 +78,10 @@ public class ProcessCsvPaymentsInputService
                     .withIgnoreEmptyLine(true)
                     .build()
                     .iterator();
-            return new OpenCsvPaymentRecordIterator(reader, delegate, input, rowsPerPeriod, millisPeriod);
+            return new BlockingIteratorPacer<>(
+                new OpenCsvPaymentRecordIterator(reader, delegate, input, rowsPerPeriod, millisPeriod),
+                rowsPerPeriod,
+                millisPeriod);
         } catch (Exception e) {
             reader.close();
             throw e;

--- a/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/util/BlockingIteratorPacer.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/util/BlockingIteratorPacer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.csv.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.pipelineframework.blocking.CloseableIterator;
+
+/**
+ * Example-local pacing decorator for blocking CSV iterators.
+ *
+ * <p>This limits how quickly a blocking iterator is consumed. It is not reactive
+ * backpressure; it deliberately blocks the worker or virtual thread that is
+ * executing the iterator bridge.
+ *
+ * @param <T> item type
+ */
+public final class BlockingIteratorPacer<T> implements CloseableIterator<T> {
+
+    @FunctionalInterface
+    interface NanoClock {
+        long nanoTime();
+    }
+
+    @FunctionalInterface
+    interface NanoSleeper {
+        void sleepNanos(long nanos) throws InterruptedException;
+    }
+
+    private final CloseableIterator<T> delegate;
+    private final long rowsPerPeriod;
+    private final long periodNanos;
+    private final NanoClock clock;
+    private final NanoSleeper sleeper;
+    private boolean windowInitialised;
+    private long windowStartNanos;
+    private long emittedInWindow;
+
+    public BlockingIteratorPacer(
+            CloseableIterator<T> delegate,
+            long rowsPerPeriod,
+            long millisPeriod) {
+        this(delegate, rowsPerPeriod, millisPeriod, System::nanoTime, TimeUnit.NANOSECONDS::sleep);
+    }
+
+    BlockingIteratorPacer(
+            CloseableIterator<T> delegate,
+            long rowsPerPeriod,
+            long millisPeriod,
+            NanoClock clock,
+            NanoSleeper sleeper) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
+        if (rowsPerPeriod <= 0) {
+            throw new IllegalArgumentException("rowsPerPeriod must be positive");
+        }
+        if (millisPeriod <= 0) {
+            throw new IllegalArgumentException("millisPeriod must be positive");
+        }
+        this.delegate = delegate;
+        this.rowsPerPeriod = rowsPerPeriod;
+        this.periodNanos = TimeUnit.MILLISECONDS.toNanos(millisPeriod);
+        this.clock = clock;
+        this.sleeper = sleeper;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public T next() {
+        awaitPermit();
+        return delegate.next();
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+
+    private void awaitPermit() {
+        long now = clock.nanoTime();
+        if (!windowInitialised) {
+            windowInitialised = true;
+            windowStartNanos = now;
+        }
+
+        if (now - windowStartNanos >= periodNanos) {
+            resetWindow(now);
+        }
+
+        if (emittedInWindow >= rowsPerPeriod) {
+            long waitNanos = periodNanos - (now - windowStartNanos);
+            if (waitNanos > 0) {
+                sleep(waitNanos);
+                now = clock.nanoTime();
+            }
+            resetWindow(now);
+        }
+
+        emittedInWindow++;
+    }
+
+    private void resetWindow(long now) {
+        windowStartNanos = now;
+        emittedInWindow = 0;
+    }
+
+    private void sleep(long waitNanos) {
+        try {
+            sleeper.sleepNanos(waitNanos);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while pacing blocking iterator", e);
+        }
+    }
+}

--- a/examples/csv-payments/input-csv-file-processing-svc/src/test/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputServiceTest.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/test/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputServiceTest.java
@@ -33,9 +33,11 @@ import org.mockito.MockitoAnnotations;
 import org.pipelineframework.blocking.CloseableIterator;
 import org.pipelineframework.csv.common.domain.CsvPaymentsInputFile;
 import org.pipelineframework.csv.common.domain.PaymentRecord;
+import org.pipelineframework.csv.util.BlockingIteratorPacer;
 import org.pipelineframework.csv.util.DemandPacerConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -63,7 +65,7 @@ class ProcessCsvPaymentsInputServiceTest {
                         new DemandPacerConfig() {
                             @Override
                             public long rowsPerPeriod() {
-                                return 1;
+                                return 10;
                             }
 
                             @Override
@@ -108,6 +110,15 @@ class ProcessCsvPaymentsInputServiceTest {
         assertEquals(new BigDecimal("200.50"), record2.getAmount());
         assertEquals(Currency.getInstance("EUR"), record2.getCurrency());
         assertEquals(csvFile.getFilepath(), record2.getCsvPaymentsInputFilePath());
+    }
+
+    @Test
+    void iterateBlockingReturnsPacedIterator() throws Exception {
+        CsvPaymentsInputFile csvFile = new CsvPaymentsInputFile(tempCsvFile.toFile());
+
+        try (CloseableIterator<PaymentRecord> iterator = service.iterateBlocking(csvFile)) {
+            assertInstanceOf(BlockingIteratorPacer.class, iterator);
+        }
     }
 
     @Test

--- a/examples/csv-payments/input-csv-file-processing-svc/src/test/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputServiceTest.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/test/java/org/pipelineframework/csv/service/ProcessCsvPaymentsInputServiceTest.java
@@ -24,20 +24,20 @@ import java.util.Currency;
 import java.util.List;
 import java.util.UUID;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockitoAnnotations;
+import org.pipelineframework.blocking.CloseableIterator;
 import org.pipelineframework.csv.common.domain.CsvPaymentsInputFile;
 import org.pipelineframework.csv.common.domain.PaymentRecord;
 import org.pipelineframework.csv.util.DemandPacerConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ProcessCsvPaymentsInputServiceTest {
 
@@ -79,19 +79,20 @@ class ProcessCsvPaymentsInputServiceTest {
     }
 
     @Test
-    void process() {
+    void iterateBlocking() throws Exception {
         // Given
         CsvPaymentsInputFile csvFile = new CsvPaymentsInputFile(tempCsvFile.toFile());
 
         // When
-        Multi<PaymentRecord> resultMulti = service.process(csvFile);
+        List<PaymentRecord> records;
+        try (CloseableIterator<PaymentRecord> iterator = service.iterateBlocking(csvFile)) {
+            records = new java.util.ArrayList<>();
+            while (iterator.hasNext()) {
+                records.add(iterator.next());
+            }
+        }
 
         // Then
-        AssertSubscriber<PaymentRecord> subscriber =
-                resultMulti.subscribe().withSubscriber(AssertSubscriber.create(2));
-        subscriber.awaitCompletion();
-
-        List<PaymentRecord> records = subscriber.getItems();
         assertEquals(2, records.size());
 
         PaymentRecord record1 = records.getFirst();
@@ -114,14 +115,7 @@ class ProcessCsvPaymentsInputServiceTest {
     void process_fileNotFound() {
         try (CsvPaymentsInputFile csvFile =
                 new CsvPaymentsInputFile(tempDir.resolve("nonexistent.csv").toFile())) {
-            Multi<PaymentRecord> result = service.process(csvFile);
-
-            // Subscribe to trigger the lazy processing
-            AssertSubscriber<PaymentRecord> subscriber =
-                    result.subscribe().withSubscriber(AssertSubscriber.create(1));
-
-            subscriber.awaitFailure();
-            subscriber.assertFailedWith(RuntimeException.class);
+            assertThrows(RuntimeException.class, () -> service.iterateBlocking(csvFile));
         }
     }
 
@@ -136,12 +130,25 @@ class ProcessCsvPaymentsInputServiceTest {
         CsvPaymentsInputFile csvFile = new CsvPaymentsInputFile(tempCsvFile.toFile());
 
         // When
-        Multi<PaymentRecord> resultMulti = service.process(csvFile);
+        assertThrows(RuntimeException.class, () -> {
+            try (CloseableIterator<PaymentRecord> iterator = service.iterateBlocking(csvFile)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+    }
 
-        // Then
-        AssertSubscriber<PaymentRecord> subscriber =
-                resultMulti.subscribe().withSubscriber(AssertSubscriber.create(1));
-        subscriber.awaitFailure();
-        subscriber.assertFailedWith(RuntimeException.class);
+    @Test
+    void processReactiveAdapterStreamsRecords() {
+        CsvPaymentsInputFile csvFile = new CsvPaymentsInputFile(tempCsvFile.toFile());
+
+        List<PaymentRecord> records = service.process(csvFile)
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+        assertEquals(2, records.size());
     }
 }

--- a/examples/csv-payments/input-csv-file-processing-svc/src/test/java/org/pipelineframework/csv/util/BlockingIteratorPacerTest.java
+++ b/examples/csv-payments/input-csv-file-processing-svc/src/test/java/org/pipelineframework/csv/util/BlockingIteratorPacerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.csv.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.blocking.CloseableIterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockingIteratorPacerTest {
+
+    @AfterEach
+    void clearInterruptFlag() {
+        Thread.interrupted();
+    }
+
+    @Test
+    void emitsFirstRowsPerPeriodWithoutDelay() {
+        FakeClock clock = new FakeClock();
+        RecordingSleeper sleeper = new RecordingSleeper(clock);
+        BlockingIteratorPacer<String> pacer =
+                new BlockingIteratorPacer<>(iteratorOf("a", "b", "c"), 2, 100, clock::nanoTime, sleeper::sleepNanos);
+
+        assertEquals("a", pacer.next());
+        assertEquals("b", pacer.next());
+
+        assertTrue(sleeper.sleeps().isEmpty());
+    }
+
+    @Test
+    void blocksBeforeFirstRecordBeyondConfiguredPeriod() {
+        FakeClock clock = new FakeClock();
+        RecordingSleeper sleeper = new RecordingSleeper(clock);
+        BlockingIteratorPacer<String> pacer =
+                new BlockingIteratorPacer<>(iteratorOf("a", "b", "c"), 2, 100, clock::nanoTime, sleeper::sleepNanos);
+
+        assertEquals("a", pacer.next());
+        assertEquals("b", pacer.next());
+        assertEquals("c", pacer.next());
+
+        assertEquals(List.of(TimeUnit.MILLISECONDS.toNanos(100)), sleeper.sleeps());
+    }
+
+    @Test
+    void resetsPermitsAfterPeriod() {
+        FakeClock clock = new FakeClock();
+        RecordingSleeper sleeper = new RecordingSleeper(clock);
+        BlockingIteratorPacer<String> pacer =
+                new BlockingIteratorPacer<>(iteratorOf("a", "b"), 1, 100, clock::nanoTime, sleeper::sleepNanos);
+
+        assertEquals("a", pacer.next());
+        clock.advanceNanos(TimeUnit.MILLISECONDS.toNanos(100));
+        assertEquals("b", pacer.next());
+
+        assertTrue(sleeper.sleeps().isEmpty());
+    }
+
+    @Test
+    void closesDelegate() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        CloseableIterator<String> delegate = new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public String next() {
+                throw new IllegalStateException("no items");
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+
+        new BlockingIteratorPacer<>(delegate, 1, 100).close();
+
+        assertTrue(closed.get());
+    }
+
+    @Test
+    void rejectsInvalidConfiguration() {
+        CloseableIterator<String> delegate = iteratorOf("a");
+
+        assertThrows(IllegalArgumentException.class, () -> new BlockingIteratorPacer<>(delegate, 0, 100));
+        assertThrows(IllegalArgumentException.class, () -> new BlockingIteratorPacer<>(delegate, 1, 0));
+        assertThrows(IllegalArgumentException.class, () -> new BlockingIteratorPacer<>(null, 1, 100));
+    }
+
+    @Test
+    void interruptionRestoresInterruptStatusAndFailsIteration() {
+        FakeClock clock = new FakeClock();
+        BlockingIteratorPacer.NanoSleeper sleeper = ignored -> {
+            throw new InterruptedException("stop");
+        };
+        BlockingIteratorPacer<String> pacer =
+                new BlockingIteratorPacer<>(iteratorOf("a", "b"), 1, 100, clock::nanoTime, sleeper);
+
+        assertEquals("a", pacer.next());
+        RuntimeException failure = assertThrows(RuntimeException.class, pacer::next);
+
+        assertTrue(Thread.currentThread().isInterrupted());
+        assertEquals("Interrupted while pacing blocking iterator", failure.getMessage());
+        assertInstanceOf(InterruptedException.class, failure.getCause());
+    }
+
+    @SafeVarargs
+    private static <T> CloseableIterator<T> iteratorOf(T... items) {
+        Iterator<T> iterator = List.of(items).iterator();
+        return new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return iterator.next();
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+    private static final class FakeClock {
+        private long now;
+
+        private long nanoTime() {
+            return now;
+        }
+
+        private void advanceNanos(long nanos) {
+            now += nanos;
+        }
+    }
+
+    private static final class RecordingSleeper {
+        private final FakeClock clock;
+        private final List<Long> sleeps = new ArrayList<>();
+
+        private RecordingSleeper(FakeClock clock) {
+            this.clock = clock;
+        }
+
+        private void sleepNanos(long nanos) {
+            assertFalse(Thread.currentThread().isInterrupted());
+            sleeps.add(nanos);
+            clock.advanceNanos(nanos);
+        }
+
+        private List<Long> sleeps() {
+            return sleeps;
+        }
+    }
+}

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -126,6 +126,11 @@ abstract class AbstractCsvPaymentsEndToEnd {
     }
 
     private static String resolvePipelineRuntimeImage() {
+        String propertyImage = System.getProperty("csv.e2e.pipeline.runtime.image");
+        if (propertyImage != null && !propertyImage.isBlank()) {
+            return propertyImage;
+        }
+
         String explicitImage = System.getenv("PIPELINE_RUNTIME_IMAGE");
         if (explicitImage != null && !explicitImage.isBlank()) {
             return explicitImage;

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -1814,7 +1814,7 @@ abstract class AbstractCsvPaymentsEndToEnd {
         if (!CUSTOM_INPUT_FILE) {
             return 5L;
         }
-        try (Stream<String> lines = Files.lines(Paths.get(CSV_E2E_INPUT_FILE))) {
+        try (Stream<String> lines = Files.lines(resolveCustomInputCsvFile())) {
             return Math.max(0L, lines.count() - 1L);
         }
     }

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -1571,7 +1571,7 @@ abstract class AbstractCsvPaymentsEndToEnd {
         if (!CUSTOM_INPUT_FILE) {
             return 0L;
         }
-        try (Stream<String> lines = Files.lines(Paths.get(CSV_E2E_INPUT_FILE))) {
+        try (Stream<String> lines = Files.lines(resolveCustomInputCsvFile())) {
             return lines.skip(1)
                     .map(String::trim)
                     .filter(line -> !line.isBlank())

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -202,17 +202,18 @@ abstract class AbstractCsvPaymentsEndToEnd {
         }
 
         if (PIPELINE_RUNTIME_LAYOUT) {
-            Startables.deepStart(
-                    Stream.of(getPostgresContainer(), getPersistenceService(), getPipelineRuntimeService()))
-                .join();
+            Startables.deepStart(Stream.of(getPostgresContainer())).join();
+            Startables.deepStart(Stream.of(getPersistenceService(), getPipelineRuntimeService())).join();
             return;
         }
 
-        Stream.Builder<GenericContainer<?>> services = Stream.builder();
-        services.add(getPostgresContainer());
         if (TEMPO_VERIFICATION_ACTIVE) {
-            services.add(getLgtmStackContainer());
+            Startables.deepStart(Stream.of(getPostgresContainer(), getLgtmStackContainer())).join();
+        } else {
+            Startables.deepStart(Stream.of(getPostgresContainer())).join();
         }
+
+        Stream.Builder<GenericContainer<?>> services = Stream.builder();
         services.add(getPersistenceService());
         services.add(getInputCsvService());
         services.add(getPaymentsProcessingService());

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -1411,7 +1411,7 @@ abstract class AbstractCsvPaymentsEndToEnd {
     }
 
     private void createCustomInputCsvFile() throws IOException {
-        Path source = Paths.get(CSV_E2E_INPUT_FILE).toAbsolutePath().normalize();
+        Path source = resolveCustomInputCsvFile();
         assertTrue(Files.isRegularFile(source), "Expected custom CSV input file at " + source);
 
         String fileName = source.getFileName().toString();
@@ -1431,6 +1431,23 @@ abstract class AbstractCsvPaymentsEndToEnd {
                 target,
                 source,
                 expectedPaymentRecordCount());
+    }
+
+    private Path resolveCustomInputCsvFile() {
+        Path configured = Paths.get(CSV_E2E_INPUT_FILE);
+        if (configured.isAbsolute()) {
+            return configured.normalize();
+        }
+
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(configured).normalize();
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        return configured.toAbsolutePath().normalize();
     }
 
     private void createValidAndMalformedCsvFiles() throws IOException {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/extractor/PipelineStepIRExtractor.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/extractor/PipelineStepIRExtractor.java
@@ -61,18 +61,20 @@ public class PipelineStepIRExtractor {
             return null;
         }
 
-        ReactiveSignature reactiveSignature = resolveReactiveSignature(serviceClass);
+        ServiceContract serviceContract = resolveServiceContract(serviceClass);
 
         // Determine semantic configuration
         StreamingShape streamingShape = determineStreamingShape(
             AnnotationProcessingUtils.getAnnotationValue(annotationMirror, "stepType"),
-            reactiveSignature);
+            serviceContract);
 
         Set<GenerationTarget> targets = EnumSet.noneOf(GenerationTarget.class);
         targets.add(GenerationTarget.GRPC_SERVICE);
         targets.add(GenerationTarget.CLIENT_STEP);
 
-        ExecutionMode executionMode = ExecutionMode.DEFAULT;
+        boolean runOnVirtualThreads = AnnotationProcessingUtils.getAnnotationValueAsBoolean(
+            annotationMirror, "runOnVirtualThreads", false);
+        ExecutionMode executionMode = runOnVirtualThreads ? ExecutionMode.VIRTUAL_THREADS : ExecutionMode.DEFAULT;
         OrderingRequirement orderingRequirement = AnnotationProcessingUtils.getAnnotationValueAsEnum(
             annotationMirror, "ordering", OrderingRequirement.class, OrderingRequirement.RELAXED);
         ThreadSafety threadSafety = AnnotationProcessingUtils.getAnnotationValueAsEnum(
@@ -83,12 +85,12 @@ public class PipelineStepIRExtractor {
         TypeMapping inputMapping = extractTypeMapping(
             AnnotationProcessingUtils.getAnnotationValue(annotationMirror, "inputType"),
             AnnotationProcessingUtils.getAnnotationValue(annotationMirror, "inboundMapper"),
-            reactiveSignature == null ? null : reactiveSignature.inputType());
+            serviceContract == null ? null : serviceContract.inputType());
 
         TypeMapping outputMapping = extractTypeMapping(
             AnnotationProcessingUtils.getAnnotationValue(annotationMirror, "outputType"),
             AnnotationProcessingUtils.getAnnotationValue(annotationMirror, "outboundMapper"),
-            reactiveSignature == null ? null : reactiveSignature.outputType());
+            serviceContract == null ? null : serviceContract.outputType());
 
         ClassName cacheKeyGenerator = resolveCacheKeyGenerator(annotationMirror);
         
@@ -132,6 +134,7 @@ public class PipelineStepIRExtractor {
             .cacheKeyGenerator(cacheKeyGenerator)
             .delegateService(delegateService)
             .externalMapper(externalMapper)
+            .serviceApiKind(serviceContract == null ? ServiceApiKind.REACTIVE : serviceContract.apiKind())
             .build();
 
         return new ExtractResult(model);
@@ -181,7 +184,7 @@ public class PipelineStepIRExtractor {
      *         - `org.pipelineframework.step.StepManyToMany` → `STREAMING_STREAMING`
      *         - `org.pipelineframework.step.StepOneToOne` → `UNARY_UNARY`
      */
-    private StreamingShape determineStreamingShape(TypeMirror stepType, ReactiveSignature reactiveSignature) {
+    private StreamingShape determineStreamingShape(TypeMirror stepType, ServiceContract serviceContract) {
         if (stepType != null) {
             String stepTypeStr = stepType.toString();
             switch (stepTypeStr) {
@@ -197,9 +200,24 @@ public class PipelineStepIRExtractor {
                 case "org.pipelineframework.step.StepOneToOne" -> {
                     return StreamingShape.UNARY_UNARY;
                 }
+                case "org.pipelineframework.step.blocking.StepOneToManyBlocking" -> {
+                    return StreamingShape.UNARY_STREAMING;
+                }
+                case "org.pipelineframework.step.blocking.StepOneToManyBlockingIterator" -> {
+                    return StreamingShape.UNARY_STREAMING;
+                }
+                case "org.pipelineframework.step.blocking.StepManyToOneBlocking" -> {
+                    return StreamingShape.STREAMING_UNARY;
+                }
+                case "org.pipelineframework.step.blocking.StepManyToManyBlocking" -> {
+                    return StreamingShape.STREAMING_STREAMING;
+                }
+                case "org.pipelineframework.step.blocking.StepOneToOneBlocking" -> {
+                    return StreamingShape.UNARY_UNARY;
+                }
             }
         }
-        return reactiveSignature != null ? reactiveSignature.shape() : StreamingShape.UNARY_UNARY;
+        return serviceContract != null ? serviceContract.shape() : StreamingShape.UNARY_UNARY;
     }
 
     /**
@@ -269,14 +287,21 @@ public class PipelineStepIRExtractor {
             || typeMirror.toString().equals("java.lang.Void");
     }
 
-    private ReactiveSignature resolveReactiveSignature(TypeElement serviceClass) {
+    private ServiceContract resolveServiceContract(TypeElement serviceClass) {
         Types typeUtils = processingEnv.getTypeUtils();
-        for (ReactiveContract contract : ReactiveContract.values()) {
+        for (SupportedContract contract : SupportedContract.values()) {
             DeclaredType declared = findReactiveSupertype(typeUtils, serviceClass.asType(), contract.interfaceName);
             if (declared == null || declared.getTypeArguments().size() < 2) {
                 continue;
             }
-            return new ReactiveSignature(
+            if (contract.materializingWarning != null) {
+                processingEnv.getMessager().printMessage(
+                    javax.tools.Diagnostic.Kind.WARNING,
+                    contract.materializingWarning,
+                    serviceClass);
+            }
+            return new ServiceContract(
+                contract.apiKind,
                 contract.shape,
                 TypeName.get(declared.getTypeArguments().get(0)),
                 TypeName.get(declared.getTypeArguments().get(1)));
@@ -371,21 +396,61 @@ public class PipelineStepIRExtractor {
         return operatorMapper != null ? operatorMapper : externalMapper;
     }
 
-    private record ReactiveSignature(StreamingShape shape, TypeName inputType, TypeName outputType) {
+    private record ServiceContract(ServiceApiKind apiKind, StreamingShape shape, TypeName inputType, TypeName outputType) {
     }
 
-    private enum ReactiveContract {
-        UNARY("org.pipelineframework.service.ReactiveService", StreamingShape.UNARY_UNARY),
-        SERVER_STREAMING("org.pipelineframework.service.ReactiveStreamingService", StreamingShape.UNARY_STREAMING),
-        CLIENT_STREAMING("org.pipelineframework.service.ReactiveStreamingClientService", StreamingShape.STREAMING_UNARY),
-        BIDI_STREAMING("org.pipelineframework.service.ReactiveBidirectionalStreamingService", StreamingShape.STREAMING_STREAMING);
+    private enum SupportedContract {
+        UNARY_BLOCKING("org.pipelineframework.service.blocking.BlockingService", ServiceApiKind.BLOCKING, StreamingShape.UNARY_UNARY, null),
+        SERVER_STREAMING_BLOCKING(
+            "org.pipelineframework.service.blocking.BlockingStreamingService",
+            ServiceApiKind.BLOCKING,
+            StreamingShape.UNARY_STREAMING,
+            "BlockingStreamingService materializes the full output list before downstream emission. "
+                + "Use BlockingIteratorService for incremental non-Mutiny 1->N streaming."),
+        SERVER_STREAMING_BLOCKING_ITERATOR(
+            "org.pipelineframework.service.blocking.BlockingIteratorService",
+            ServiceApiKind.BLOCKING_ITERATOR,
+            StreamingShape.UNARY_STREAMING,
+            null),
+        CLIENT_STREAMING_BLOCKING(
+            "org.pipelineframework.service.blocking.BlockingStreamingClientService",
+            ServiceApiKind.BLOCKING,
+            StreamingShape.STREAMING_UNARY,
+            "BlockingStreamingClientService materializes the full input list before invocation. "
+                + "Batch retries rerun the full callback."),
+        BIDI_STREAMING_BLOCKING(
+            "org.pipelineframework.service.blocking.BlockingBidirectionalStreamingService",
+            ServiceApiKind.BLOCKING,
+            StreamingShape.STREAMING_STREAMING,
+            "BlockingBidirectionalStreamingService materializes the full input list and full output list. "
+                + "Batch retries rerun the full callback."),
+        UNARY_REACTIVE("org.pipelineframework.service.ReactiveService", ServiceApiKind.REACTIVE, StreamingShape.UNARY_UNARY, null),
+        SERVER_STREAMING_REACTIVE(
+            "org.pipelineframework.service.ReactiveStreamingService",
+            ServiceApiKind.REACTIVE,
+            StreamingShape.UNARY_STREAMING,
+            null),
+        CLIENT_STREAMING_REACTIVE(
+            "org.pipelineframework.service.ReactiveStreamingClientService",
+            ServiceApiKind.REACTIVE,
+            StreamingShape.STREAMING_UNARY,
+            null),
+        BIDI_STREAMING_REACTIVE(
+            "org.pipelineframework.service.ReactiveBidirectionalStreamingService",
+            ServiceApiKind.REACTIVE,
+            StreamingShape.STREAMING_STREAMING,
+            null);
 
         private final String interfaceName;
+        private final ServiceApiKind apiKind;
         private final StreamingShape shape;
+        private final String materializingWarning;
 
-        ReactiveContract(String interfaceName, StreamingShape shape) {
+        SupportedContract(String interfaceName, ServiceApiKind apiKind, StreamingShape shape, String materializingWarning) {
             this.interfaceName = interfaceName;
+            this.apiKind = apiKind;
             this.shape = shape;
+            this.materializingWarning = materializingWarning;
         }
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/extractor/PipelineStepIRExtractor.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/extractor/PipelineStepIRExtractor.java
@@ -1,6 +1,8 @@
 package org.pipelineframework.processor.extractor;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -289,24 +291,88 @@ public class PipelineStepIRExtractor {
 
     private ServiceContract resolveServiceContract(TypeElement serviceClass) {
         Types typeUtils = processingEnv.getTypeUtils();
+        List<ServiceContract> matches = new ArrayList<>();
+        List<String> matchNames = new ArrayList<>();
+        List<SupportedContract> matchedContracts = new ArrayList<>();
+        List<String> directSupportedInterfaces = directSupportedInterfaceNames(typeUtils, serviceClass);
+        if (directSupportedInterfaces.size() > 1) {
+            processingEnv.getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Pipeline step '" + serviceClass.getQualifiedName()
+                    + "' implements multiple supported service interfaces: " + String.join(", ", directSupportedInterfaces)
+                    + ". Please implement exactly one reactive or blocking service contract.",
+                serviceClass);
+            return null;
+        }
         for (SupportedContract contract : SupportedContract.values()) {
             DeclaredType declared = findReactiveSupertype(typeUtils, serviceClass.asType(), contract.interfaceName);
             if (declared == null || declared.getTypeArguments().size() < 2) {
                 continue;
             }
-            if (contract.materializingWarning != null) {
-                processingEnv.getMessager().printMessage(
-                    javax.tools.Diagnostic.Kind.WARNING,
-                    contract.materializingWarning,
-                    serviceClass);
-            }
-            return new ServiceContract(
+            matches.add(new ServiceContract(
                 contract.apiKind,
                 contract.shape,
                 TypeName.get(declared.getTypeArguments().get(0)),
-                TypeName.get(declared.getTypeArguments().get(1)));
+                TypeName.get(declared.getTypeArguments().get(1))));
+            matchNames.add(contract.interfaceName);
+            matchedContracts.add(contract);
         }
-        return null;
+        List<ServiceContract> effectiveMatches = new ArrayList<>();
+        List<String> effectiveMatchNames = new ArrayList<>();
+        List<SupportedContract> effectiveMatchedContracts = new ArrayList<>();
+        for (int i = 0; i < matches.size(); i++) {
+            ServiceContract match = matches.get(i);
+            boolean impliedByBlocking = match.apiKind() == ServiceApiKind.REACTIVE
+                && matches.stream()
+                    .anyMatch(other -> other.apiKind() != ServiceApiKind.REACTIVE
+                        && other.shape() == match.shape());
+            if (!impliedByBlocking) {
+                effectiveMatches.add(match);
+                effectiveMatchNames.add(matchNames.get(i));
+                effectiveMatchedContracts.add(matchedContracts.get(i));
+            }
+        }
+        if (effectiveMatches.size() > 1) {
+            processingEnv.getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Pipeline step '" + serviceClass.getQualifiedName()
+                    + "' implements multiple supported service interfaces: " + String.join(", ", effectiveMatchNames)
+                    + ". Please implement exactly one reactive or blocking service contract.",
+                serviceClass);
+            return null;
+        }
+        if (effectiveMatches.isEmpty()) {
+            return null;
+        }
+        SupportedContract contract = effectiveMatchedContracts.get(0);
+        if (contract.materializingWarning != null) {
+            processingEnv.getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.WARNING,
+                contract.materializingWarning,
+                serviceClass);
+        }
+        return effectiveMatches.get(0);
+    }
+
+    private List<String> directSupportedInterfaceNames(Types typeUtils, TypeElement serviceClass) {
+        List<String> directNames = new ArrayList<>();
+        for (TypeMirror iface : serviceClass.getInterfaces()) {
+            Element element = typeUtils.asElement(iface);
+            if (element instanceof TypeElement typeElement && isSupportedServiceInterface(typeElement)) {
+                directNames.add(typeElement.getQualifiedName().toString());
+            }
+        }
+        return directNames;
+    }
+
+    private boolean isSupportedServiceInterface(TypeElement typeElement) {
+        String qualifiedName = typeElement.getQualifiedName().toString();
+        for (SupportedContract contract : SupportedContract.values()) {
+            if (contract.interfaceName.equals(qualifiedName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private DeclaredType findReactiveSupertype(Types typeUtils, TypeMirror type, String erasureName) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/GenerationTarget.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/GenerationTarget.java
@@ -23,4 +23,6 @@ public enum GenerationTarget {
     EXTERNAL_ADAPTER,
     /** Generated service implementation that dispatches to a remote operator endpoint */
     REMOTE_OPERATOR_ADAPTER,
+    /** Generated reactive bridge for blocking-authored internal services */
+    BLOCKING_REACTIVE_BRIDGE,
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
@@ -31,6 +31,7 @@ import org.pipelineframework.parallelism.ThreadSafety;
  * @param externalMapper Gets the operator mapper class if operator mapping is used, otherwise null.
  * @param mapperFallbackMode Gets mapper fallback mode used when no explicit/inferred mapper matches.
  * @param remoteExecution Gets remote operator execution metadata when the step is remote, otherwise null.
+ * @param serviceApiKind Distinguishes reactive-authored from blocking-authored internal services.
  */
 public record PipelineStepModel(
         String serviceName,
@@ -50,7 +51,8 @@ public record PipelineStepModel(
         ClassName delegateService,
         ClassName externalMapper,
         MapperFallbackMode mapperFallbackMode,
-        PipelineTemplateStepExecution remoteExecution
+        PipelineTemplateStepExecution remoteExecution,
+        ServiceApiKind serviceApiKind
 ) {
     /**
          * Creates a new PipelineStepModel with the supplied service identity, type mappings and generation configuration.
@@ -92,7 +94,8 @@ public record PipelineStepModel(
             ClassName delegateService,
             ClassName externalMapper,
             MapperFallbackMode mapperFallbackMode,
-            PipelineTemplateStepExecution remoteExecution) {
+            PipelineTemplateStepExecution remoteExecution,
+            ServiceApiKind serviceApiKind) {
         // Validate non-null invariants
         if (serviceName == null)
             throw new IllegalArgumentException("serviceName cannot be null");
@@ -129,6 +132,7 @@ public record PipelineStepModel(
         this.externalMapper = externalMapper;
         this.mapperFallbackMode = mapperFallbackMode == null ? MapperFallbackMode.NONE : mapperFallbackMode;
         this.remoteExecution = remoteExecution;
+        this.serviceApiKind = serviceApiKind == null ? ServiceApiKind.REACTIVE : serviceApiKind;
     }
 
     /**
@@ -168,7 +172,8 @@ public record PipelineStepModel(
             delegateService,
             externalMapper,
             MapperFallbackMode.NONE,
-            null);
+            null,
+            ServiceApiKind.REACTIVE);
     }
 
     /**
@@ -209,7 +214,8 @@ public record PipelineStepModel(
             delegateService,
             externalMapper,
             mapperFallbackMode,
-            null);
+            null,
+            ServiceApiKind.REACTIVE);
     }
 
     /**
@@ -261,7 +267,8 @@ public record PipelineStepModel(
             null,
             null,
             MapperFallbackMode.NONE,
-            null);
+            null,
+            ServiceApiKind.REACTIVE);
     }
 
     /**
@@ -311,6 +318,7 @@ public record PipelineStepModel(
         private ClassName externalMapper;
         private MapperFallbackMode mapperFallbackMode = MapperFallbackMode.NONE;
         private PipelineTemplateStepExecution remoteExecution;
+        private ServiceApiKind serviceApiKind = ServiceApiKind.REACTIVE;
 
         /**
          * Sets the service name.
@@ -522,6 +530,17 @@ public record PipelineStepModel(
         }
 
         /**
+         * Sets the authored service API kind for this step model.
+         *
+         * @param serviceApiKind distinguishes reactive-authored from blocking-authored services
+         * @return this {@link PipelineStepModel.Builder} for chaining
+         */
+        public Builder serviceApiKind(ServiceApiKind serviceApiKind) {
+            this.serviceApiKind = serviceApiKind;
+            return this;
+        }
+
+        /**
          * Create a PipelineStepModel populated from the builder's current state.
          *
          * @return a PipelineStepModel populated with the builder's state
@@ -564,7 +583,8 @@ public record PipelineStepModel(
                 delegateService,
                 externalMapper,
                 mapperFallbackMode,
-                remoteExecution);
+                remoteExecution,
+                serviceApiKind);
         }
     }
     
@@ -593,7 +613,8 @@ public record PipelineStepModel(
             delegateService,
             externalMapper,
             mapperFallbackMode,
-            remoteExecution
+            remoteExecution,
+            serviceApiKind
         );
     }
 
@@ -628,6 +649,7 @@ public record PipelineStepModel(
             .delegateService(delegateService)
             .externalMapper(externalMapper)
             .mapperFallbackMode(mapperFallbackMode)
-            .remoteExecution(remoteExecution);
+            .remoteExecution(remoteExecution)
+            .serviceApiKind(serviceApiKind);
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/ServiceApiKind.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/ServiceApiKind.java
@@ -1,0 +1,10 @@
+package org.pipelineframework.processor.ir;
+
+/**
+ * Distinguishes the authored service contract family for an internal step.
+ */
+public enum ServiceApiKind {
+    REACTIVE,
+    BLOCKING,
+    BLOCKING_ITERATOR
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -987,24 +987,6 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             "BlockingBidirectionalStreamingService materializes the full input list and full output list. "
                 + "Batch retries rerun the full callback.");
 
-        if (blockingMatches.size() > 1) {
-            messager.printMessage(
-                javax.tools.Diagnostic.Kind.ERROR,
-                "Internal service '" + serviceElement.getQualifiedName()
-                    + "' implements multiple supported service interfaces: " + String.join(", ", blockingMatchNames)
-                    + ". Please implement exactly one.");
-            return null;
-        }
-        if (!blockingMatches.isEmpty()) {
-            if (blockingMatches.getFirst().materializingWarning() != null) {
-                messager.printMessage(
-                    javax.tools.Diagnostic.Kind.WARNING,
-                    blockingMatches.getFirst().materializingWarning(),
-                    serviceElement);
-            }
-            return blockingMatches.get(0);
-        }
-
         List<SupportedServiceSignature> matches = new ArrayList<>();
         List<String> matchNames = new ArrayList<>();
 
@@ -1020,15 +1002,72 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             "org.pipelineframework.service.ReactiveBidirectionalStreamingService", ServiceApiKind.REACTIVE,
             StreamingShape.STREAMING_STREAMING,
             null);
-        if (matches.size() > 1) {
+
+        List<String> directSupportedInterfaces = directSupportedInterfaceNames(typeUtils, serviceElement);
+        if (directSupportedInterfaces.size() > 1) {
             messager.printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal service '" + serviceElement.getQualifiedName()
-                    + "' implements multiple supported service interfaces: " + String.join(", ", matchNames)
+                    + "' implements multiple supported service interfaces: " + String.join(", ", directSupportedInterfaces)
                     + ". Please implement exactly one.");
             return null;
         }
-        return matches.isEmpty() ? null : matches.get(0);
+
+        List<SupportedServiceSignature> combinedMatches = new ArrayList<>(blockingMatches);
+        List<String> combinedMatchNames = new ArrayList<>(blockingMatchNames);
+        for (int i = 0; i < matches.size(); i++) {
+            SupportedServiceSignature reactiveMatch = matches.get(i);
+            boolean impliedByBlocking = blockingMatches.stream()
+                .anyMatch(blockingMatch -> blockingMatch.shape() == reactiveMatch.shape());
+            if (!impliedByBlocking) {
+                combinedMatches.add(reactiveMatch);
+                combinedMatchNames.add(matchNames.get(i));
+            }
+        }
+
+        if (combinedMatches.size() > 1) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Internal service '" + serviceElement.getQualifiedName()
+                    + "' implements multiple supported service interfaces: " + String.join(", ", combinedMatchNames)
+                    + ". Please implement exactly one.");
+            return null;
+        }
+        if (combinedMatches.isEmpty()) {
+            return null;
+        }
+        SupportedServiceSignature match = combinedMatches.get(0);
+        if (match.materializingWarning() != null) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.WARNING,
+                match.materializingWarning(),
+                serviceElement);
+        }
+        return match;
+    }
+
+    private List<String> directSupportedInterfaceNames(Types typeUtils, TypeElement serviceElement) {
+        List<String> directNames = new ArrayList<>();
+        for (TypeMirror iface : serviceElement.getInterfaces()) {
+            Element element = typeUtils.asElement(iface);
+            if (element instanceof TypeElement typeElement && isSupportedServiceInterface(typeElement)) {
+                directNames.add(typeElement.getQualifiedName().toString());
+            }
+        }
+        return directNames;
+    }
+
+    private boolean isSupportedServiceInterface(TypeElement typeElement) {
+        String qualifiedName = typeElement.getQualifiedName().toString();
+        return qualifiedName.equals("org.pipelineframework.service.blocking.BlockingService")
+            || qualifiedName.equals("org.pipelineframework.service.blocking.BlockingStreamingService")
+            || qualifiedName.equals("org.pipelineframework.service.blocking.BlockingIteratorService")
+            || qualifiedName.equals("org.pipelineframework.service.blocking.BlockingStreamingClientService")
+            || qualifiedName.equals("org.pipelineframework.service.blocking.BlockingBidirectionalStreamingService")
+            || qualifiedName.equals("org.pipelineframework.service.ReactiveService")
+            || qualifiedName.equals("org.pipelineframework.service.ReactiveStreamingService")
+            || qualifiedName.equals("org.pipelineframework.service.ReactiveStreamingClientService")
+            || qualifiedName.equals("org.pipelineframework.service.ReactiveBidirectionalStreamingService");
     }
 
     private void collectSupportedMatch(

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -31,6 +31,7 @@ import org.pipelineframework.processor.ir.ExecutionMode;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.MapperFallbackMode;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TypeMapping;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
@@ -297,25 +298,25 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         }
         PipelineStepModel extractedModel = extracted.model();
 
-        ReactiveSignature reactiveSignature = resolveReactiveSignature(
+        SupportedServiceSignature serviceSignature = resolveSupportedInternalSignature(
             serviceClass,
             ctx.getProcessingEnv().getTypeUtils(),
             ctx.getProcessingEnv().getMessager());
-        if (reactiveSignature == null) {
+        if (serviceSignature == null) {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal step service '" + stepDef.executionClass().canonicalName()
-                    + "' must implement exactly one supported reactive service interface for step '" + stepDef.name() + "'");
+                    + "' must implement exactly one supported service interface for step '" + stepDef.name() + "'");
             return null;
         }
 
         StreamingShape yamlShape = stepDef.streamingShapeHint();
-        if (yamlShape != null && yamlShape != reactiveSignature.shape()) {
+        if (yamlShape != null && yamlShape != serviceSignature.shape()) {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal step '" + stepDef.name() + "' declares cardinality "
                     + yamlShape + " in YAML, but service '" + stepDef.executionClass().canonicalName()
-                    + "' implements " + reactiveSignature.shape() + " semantics.");
+                    + "' implements " + serviceSignature.shape() + " semantics.");
             return null;
         }
 
@@ -325,7 +326,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             "input",
             stepDef.inputType(),
             extractedModel.inboundDomainType(),
-            reactiveSignature.inputType());
+            serviceSignature.inputType());
         if (inputType == null) {
             return null;
         }
@@ -335,7 +336,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             "output",
             stepDef.outputType(),
             extractedModel.outboundDomainType(),
-            reactiveSignature.outputType());
+            serviceSignature.outputType());
         if (outputType == null) {
             return null;
         }
@@ -367,7 +368,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .generatedName(serviceName)
             .inputMapping(new TypeMapping(inputType, inboundMapper, inboundMapper != null, inputType))
             .outputMapping(new TypeMapping(outputType, outboundMapper, outboundMapper != null, outputType))
-            .streamingShape(reactiveSignature.shape())
+            .streamingShape(serviceSignature.shape())
+            .serviceApiKind(serviceSignature.apiKind())
             .build();
     }
 
@@ -956,6 +958,101 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         return matches.isEmpty() ? null : matches.get(0);
     }
 
+    private SupportedServiceSignature resolveSupportedInternalSignature(
+            TypeElement serviceElement,
+            Types typeUtils,
+            javax.annotation.processing.Messager messager) {
+        List<SupportedServiceSignature> blockingMatches = new ArrayList<>();
+        List<String> blockingMatchNames = new ArrayList<>();
+
+        collectSupportedMatch(blockingMatches, blockingMatchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.blocking.BlockingService", ServiceApiKind.BLOCKING, StreamingShape.UNARY_UNARY, null);
+        collectSupportedMatch(blockingMatches, blockingMatchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.blocking.BlockingStreamingService", ServiceApiKind.BLOCKING,
+            StreamingShape.UNARY_STREAMING,
+            "BlockingStreamingService materializes the full output list before downstream emission. "
+                + "Use BlockingIteratorService for incremental non-Mutiny 1->N streaming.");
+        collectSupportedMatch(blockingMatches, blockingMatchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.blocking.BlockingIteratorService", ServiceApiKind.BLOCKING_ITERATOR,
+            StreamingShape.UNARY_STREAMING,
+            null);
+        collectSupportedMatch(blockingMatches, blockingMatchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.blocking.BlockingStreamingClientService", ServiceApiKind.BLOCKING,
+            StreamingShape.STREAMING_UNARY,
+            "BlockingStreamingClientService materializes the full input list before invocation. "
+                + "Batch retries rerun the full callback.");
+        collectSupportedMatch(blockingMatches, blockingMatchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.blocking.BlockingBidirectionalStreamingService", ServiceApiKind.BLOCKING,
+            StreamingShape.STREAMING_STREAMING,
+            "BlockingBidirectionalStreamingService materializes the full input list and full output list. "
+                + "Batch retries rerun the full callback.");
+
+        if (blockingMatches.size() > 1) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Internal service '" + serviceElement.getQualifiedName()
+                    + "' implements multiple supported service interfaces: " + String.join(", ", blockingMatchNames)
+                    + ". Please implement exactly one.");
+            return null;
+        }
+        if (!blockingMatches.isEmpty()) {
+            if (blockingMatches.getFirst().materializingWarning() != null) {
+                messager.printMessage(
+                    javax.tools.Diagnostic.Kind.WARNING,
+                    blockingMatches.getFirst().materializingWarning(),
+                    serviceElement);
+            }
+            return blockingMatches.get(0);
+        }
+
+        List<SupportedServiceSignature> matches = new ArrayList<>();
+        List<String> matchNames = new ArrayList<>();
+
+        collectSupportedMatch(matches, matchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.ReactiveService", ServiceApiKind.REACTIVE, StreamingShape.UNARY_UNARY, null);
+        collectSupportedMatch(matches, matchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.ReactiveStreamingService", ServiceApiKind.REACTIVE, StreamingShape.UNARY_STREAMING, null);
+        collectSupportedMatch(matches, matchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.ReactiveStreamingClientService", ServiceApiKind.REACTIVE,
+            StreamingShape.STREAMING_UNARY,
+            null);
+        collectSupportedMatch(matches, matchNames, typeUtils, serviceElement,
+            "org.pipelineframework.service.ReactiveBidirectionalStreamingService", ServiceApiKind.REACTIVE,
+            StreamingShape.STREAMING_STREAMING,
+            null);
+        if (matches.size() > 1) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Internal service '" + serviceElement.getQualifiedName()
+                    + "' implements multiple supported service interfaces: " + String.join(", ", matchNames)
+                    + ". Please implement exactly one.");
+            return null;
+        }
+        return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    private void collectSupportedMatch(
+            List<SupportedServiceSignature> matches,
+            List<String> matchNames,
+            Types typeUtils,
+            TypeElement serviceElement,
+            String interfaceName,
+            ServiceApiKind apiKind,
+            StreamingShape shape,
+            String materializingWarning) {
+        DeclaredType declared = findReactiveSupertype(typeUtils, serviceElement.asType(), interfaceName);
+        if (declared == null || declared.getTypeArguments().size() < 2) {
+            return;
+        }
+        matches.add(new SupportedServiceSignature(
+            apiKind,
+            shape,
+            TypeName.get(declared.getTypeArguments().get(0)),
+            TypeName.get(declared.getTypeArguments().get(1)),
+            materializingWarning));
+        matchNames.add(interfaceName);
+    }
+
     private static final ClassName INVALID_CLASS_NAME = ClassName.get("java.lang", "Void");
 
     private TypeName resolveInternalDomainType(
@@ -980,7 +1077,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                 ctx.getProcessingEnv().getMessager().printMessage(
                     javax.tools.Diagnostic.Kind.ERROR,
                     "Internal step '" + stepName + "' has deprecated @PipelineStep " + direction + "Type '"
-                        + annotationType + "' that does not match the reactive service interface " + direction + " type '"
+                        + annotationType + "' that does not match the implemented service interface " + direction + " type '"
                         + reactiveType + "'.");
                 return null;
             }
@@ -1142,6 +1239,15 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
     }
 
     private record ReactiveSignature(StreamingShape shape, TypeName inputType, TypeName outputType) {
+    }
+
+    private record SupportedServiceSignature(
+        ServiceApiKind apiKind,
+        StreamingShape shape,
+        TypeName inputType,
+        TypeName outputType,
+        String materializingWarning
+    ) {
     }
 
     private List<PipelineStepModel> deduplicateByServiceName(List<PipelineStepModel> stepModels) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -86,6 +86,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
         RestClientStepRenderer restClientRenderer = new RestClientStepRenderer();
         RestResourceRenderer restRenderer = new RestResourceRenderer();
         RestFunctionHandlerRenderer restFunctionHandlerRenderer = new RestFunctionHandlerRenderer();
+        BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer = new BlockingReactiveBridgeRenderer();
         RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer = new RemoteOperatorAdapterRenderer();
         OrchestratorGrpcRenderer orchestratorGrpcRenderer = new OrchestratorGrpcRenderer();
         OrchestratorRestResourceRenderer orchestratorRestRenderer = new OrchestratorRestResourceRenderer();
@@ -234,6 +235,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
                 restClientRenderer,
                 restRenderer,
                 restFunctionHandlerRenderer,
+                blockingReactiveBridgeRenderer,
                 remoteOperatorAdapterRenderer);
         }
 
@@ -469,6 +471,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             RestClientStepRenderer restClientRenderer,
             RestResourceRenderer restRenderer,
             RestFunctionHandlerRenderer restFunctionHandlerRenderer,
+            BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
             RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer) throws IOException {
         stepArtifactGenerationService.generateArtifactsForModel(
             ctx,
@@ -487,6 +490,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             restClientRenderer,
             restRenderer,
             restFunctionHandlerRenderer,
+            blockingReactiveBridgeRenderer,
             remoteOperatorAdapterRenderer);
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -14,6 +14,7 @@ import org.pipelineframework.processor.PipelineCompilationPhase;
 import org.pipelineframework.processor.ir.DeploymentRole;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.TransportMode;
 
 /**
@@ -128,6 +129,12 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             && model.deploymentRole() == DeploymentRole.PLUGIN_SERVER) {
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
-        return Collections.unmodifiableSet(new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode)));
+        LinkedHashSet<GenerationTarget> targets = new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode));
+        if (model.serviceApiKind() != ServiceApiKind.REACTIVE
+            && model.delegateService() == null
+            && (model.remoteExecution() == null || !model.remoteExecution().isRemote())) {
+            targets.add(GenerationTarget.BLOCKING_REACTIVE_BRIDGE);
+        }
+        return Collections.unmodifiableSet(targets);
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -15,6 +15,7 @@ import org.pipelineframework.processor.ir.LocalBinding;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.RestBinding;
 import org.pipelineframework.processor.renderer.ClientStepRenderer;
+import org.pipelineframework.processor.renderer.BlockingReactiveBridgeRenderer;
 import org.pipelineframework.processor.renderer.GenerationContext;
 import org.pipelineframework.processor.renderer.GrpcServiceAdapterRenderer;
 import org.pipelineframework.processor.renderer.LocalClientStepRenderer;
@@ -67,6 +68,7 @@ class StepArtifactGenerationService {
      * @param restClientRenderer renderer used to produce REST client-step artifacts
      * @param restRenderer renderer used to produce REST resource artifacts
      * @param restFunctionHandlerRenderer renderer used to produce REST function handlers when in function mode
+     * @param blockingReactiveBridgeRenderer renderer used to produce reactive bridge artifacts for blocking-authored services
      * @param remoteOperatorAdapterRenderer renderer used to produce remote operator adapter artifacts
      * @throws IOException if any renderer or file output operation fails
      */
@@ -87,6 +89,7 @@ class StepArtifactGenerationService {
             RestClientStepRenderer restClientRenderer,
             RestResourceRenderer restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
+            BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
             RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer) throws IOException {
         for (GenerationTarget target : model.enabledTargets()) {
             switch (target) {
@@ -265,6 +268,19 @@ class StepArtifactGenerationService {
                         cacheKeyGenerator,
                         descriptorSet));
                     roleMetadataGenerator.recordClassWithRole(restClientClassName, restClientRole.name());
+                }
+                case BLOCKING_REACTIVE_BRIDGE -> {
+                    String bridgeClassName = model.servicePackage() + PIPELINE_DOT
+                        + model.generatedName() + "BlockingReactiveBridge";
+                    DeploymentRole bridgeRole = model.deploymentRole();
+                    blockingReactiveBridgeRenderer.render(model, new GenerationContext(
+                        ctx.getProcessingEnv(),
+                        pathResolver.resolveRoleOutputDir(ctx, bridgeRole),
+                        bridgeRole,
+                        enabledAspects,
+                        cacheKeyGenerator,
+                        descriptorSet));
+                    roleMetadataGenerator.recordClassWithRole(bridgeClassName, bridgeRole.name());
                 }
                 case REMOTE_OPERATOR_ADAPTER -> {
                     if (grpcBinding == null) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/BlockingReactiveBridgeRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/BlockingReactiveBridgeRenderer.java
@@ -1,0 +1,153 @@
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import javax.lang.model.element.Modifier;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import io.quarkus.arc.Unremovable;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.util.GeneratedServiceTypeResolver;
+
+/**
+ * Generates a reactive bridge bean for blocking-authored internal services.
+ */
+public class BlockingReactiveBridgeRenderer {
+
+    public GenerationTarget target() {
+        return GenerationTarget.BLOCKING_REACTIVE_BRIDGE;
+    }
+
+    public void render(PipelineStepModel model, GenerationContext ctx) throws IOException {
+        TypeSpec bridgeClass = buildBridgeClass(model, ctx.role());
+        JavaFile.builder(
+                model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
+                bridgeClass)
+            .build()
+            .writeTo(ctx.outputDir());
+    }
+
+    private TypeSpec buildBridgeClass(
+        PipelineStepModel model,
+        org.pipelineframework.processor.ir.DeploymentRole role
+    ) {
+        TypeName inputType = model.inboundDomainType() != null ? model.inboundDomainType() : ClassName.OBJECT;
+        TypeName outputType = model.outboundDomainType() != null ? model.outboundDomainType() : ClassName.OBJECT;
+
+        TypeSpec.Builder builder = TypeSpec.classBuilder(GeneratedServiceTypeResolver.blockingReactiveBridgeClassName(model).simpleName())
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("jakarta.enterprise.context", "ApplicationScoped")).build())
+            .addAnnotation(AnnotationSpec.builder(Unremovable.class).build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.pipelineframework.annotation", "GeneratedRole"))
+                .addMember("value", "$T.$L",
+                    ClassName.get("org.pipelineframework.annotation", "GeneratedRole", "Role"),
+                    role.name())
+                .build());
+
+        builder.addSuperinterface(resolveReactiveInterface(model, inputType, outputType));
+        builder.addField(FieldSpec.builder(model.serviceClassName(), "blockingService", Modifier.PRIVATE)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("jakarta.inject", "Inject")).build())
+            .build());
+        builder.addField(FieldSpec.builder(
+                ClassName.get("org.pipelineframework.blocking", "BlockingExecutionSupport"),
+                "blockingExecutionSupport",
+                Modifier.PRIVATE)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("jakarta.inject", "Inject")).build())
+            .build());
+
+        boolean useVirtualThreads = model.executionMode() == org.pipelineframework.processor.ir.ExecutionMode.VIRTUAL_THREADS;
+        builder.addMethod(buildProcessMethod(model, inputType, outputType, useVirtualThreads));
+        return builder.build();
+    }
+
+    private TypeName resolveReactiveInterface(PipelineStepModel model, TypeName inputType, TypeName outputType) {
+        return switch (model.streamingShape()) {
+            case UNARY_STREAMING -> ParameterizedTypeName.get(
+                ClassName.get("org.pipelineframework.service", "ReactiveStreamingService"),
+                inputType,
+                outputType);
+            case STREAMING_UNARY -> ParameterizedTypeName.get(
+                ClassName.get("org.pipelineframework.service", "ReactiveStreamingClientService"),
+                inputType,
+                outputType);
+            case STREAMING_STREAMING -> ParameterizedTypeName.get(
+                ClassName.get("org.pipelineframework.service", "ReactiveBidirectionalStreamingService"),
+                inputType,
+                outputType);
+            default -> ParameterizedTypeName.get(
+                ClassName.get("org.pipelineframework.service", "ReactiveService"),
+                inputType,
+                outputType);
+        };
+    }
+
+    private MethodSpec buildProcessMethod(
+        PipelineStepModel model,
+        TypeName inputType,
+        TypeName outputType,
+        boolean useVirtualThreads
+    ) {
+        if (model.serviceApiKind() == ServiceApiKind.BLOCKING_ITERATOR) {
+            return MethodSpec.methodBuilder("process")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Multi.class), outputType))
+                .addParameter(inputType, "processableObj")
+                .addStatement(
+                    "return blockingExecutionSupport.emitIterator($L, () -> blockingService.iterateBlocking(processableObj))",
+                    useVirtualThreads)
+                .build();
+        }
+        return switch (model.streamingShape()) {
+            case UNARY_STREAMING -> MethodSpec.methodBuilder("process")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Multi.class), outputType))
+                .addParameter(inputType, "processableObj")
+                .addStatement(
+                    "return blockingExecutionSupport.emitList($L, () -> blockingService.processBlocking(processableObj))",
+                    useVirtualThreads)
+                .build();
+            case STREAMING_UNARY -> MethodSpec.methodBuilder("process")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), outputType))
+                .addParameter(ParameterizedTypeName.get(ClassName.get(Multi.class), inputType), "processableObj")
+                .addStatement(
+                    "return processableObj.collect().asList()"
+                        + ".onItem().transformToUni(items -> blockingExecutionSupport.supply($L, () -> blockingService.processBlocking(items)))",
+                    useVirtualThreads)
+                .build();
+            case STREAMING_STREAMING -> MethodSpec.methodBuilder("process")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Multi.class), outputType))
+                .addParameter(ParameterizedTypeName.get(ClassName.get(Multi.class), inputType), "processableObj")
+                .addStatement(
+                    "return processableObj.collect().asList()"
+                        + ".onItem().transformToMulti(items -> blockingExecutionSupport.emitList($L, () -> blockingService.processBlocking(items)))",
+                    useVirtualThreads)
+                .build();
+            default -> MethodSpec.methodBuilder("process")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), outputType))
+                .addParameter(inputType, "processableObj")
+                .addStatement(
+                    "return blockingExecutionSupport.supply($L, () -> blockingService.processBlocking(processableObj))",
+                    useVirtualThreads)
+                .build();
+        };
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/GrpcServiceAdapterRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/GrpcServiceAdapterRenderer.java
@@ -13,6 +13,7 @@ import org.pipelineframework.processor.PipelineStepProcessor;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.GrpcBinding;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.util.GeneratedServiceTypeResolver;
 import org.pipelineframework.processor.util.GrpcJavaTypeResolver;
 
 /**
@@ -550,12 +551,7 @@ public record GrpcServiceAdapterRenderer(GenerationTarget target) implements Pip
      *         otherwise the generated pipeline service class located in the model's package plus the pipeline package suffix
      */
     private TypeName resolveServiceType(PipelineStepModel model) {
-        if (!model.sideEffect()) {
-            return model.serviceClassName();
-        }
-        return ClassName.get(
-            model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
-            model.serviceName());
+        return GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/LocalClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/LocalClientStepRenderer.java
@@ -21,6 +21,7 @@ import org.pipelineframework.processor.PipelineStepProcessor;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.LocalBinding;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.util.GeneratedServiceTypeResolver;
 import org.pipelineframework.step.StepManyToOne;
 import org.pipelineframework.step.StepOneToOne;
 
@@ -225,12 +226,7 @@ public class LocalClientStepRenderer implements PipelineRenderer<LocalBinding> {
      * @return `ClassName` for the service in the pipeline package when the step declares side effects; otherwise the service class name declared on the model
      */
     private TypeName resolveServiceType(PipelineStepModel model) {
-        if (model.sideEffect()) {
-            return ClassName.get(
-                model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
-                model.serviceName());
-        }
-        return model.serviceClassName();
+        return GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/RestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/RestResourceRenderer.java
@@ -11,6 +11,7 @@ import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.RestBinding;
 import org.pipelineframework.processor.util.DtoTypeUtils;
+import org.pipelineframework.processor.util.GeneratedServiceTypeResolver;
 import org.pipelineframework.processor.util.ResourceNameUtils;
 import org.pipelineframework.processor.util.RestPathResolver;
 
@@ -464,12 +465,7 @@ public class RestResourceRenderer implements PipelineRenderer<RestBinding> {
      * @return the service class to use: the model's declared service class when the step is not a side effect, otherwise the service class located in the pipeline package derived from the model's service package and service name
      */
     private TypeName resolveServiceType(PipelineStepModel model) {
-        if (!model.sideEffect()) {
-            return model.serviceClassName();
-        }
-        return ClassName.get(
-            model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
-            model.serviceName());
+        return GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/GeneratedServiceTypeResolver.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/GeneratedServiceTypeResolver.java
@@ -1,0 +1,51 @@
+package org.pipelineframework.processor.util;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.TypeName;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+
+/**
+ * Resolves generated service types used by transport adapters.
+ */
+public final class GeneratedServiceTypeResolver {
+
+    private GeneratedServiceTypeResolver() {
+    }
+
+    /**
+     * Resolves the service type that transport adapters should inject for a pipeline step model.
+     *
+     * @param model the pipeline step model to inspect; must not be {@code null}
+     * @return the authored service type, generated side-effect bean type, or generated blocking
+     *         reactive bridge type depending on {@code sideEffect()} and {@code serviceApiKind()}
+     * @throws IllegalArgumentException if {@code model} is {@code null}
+     * @throws IllegalStateException if the resolved default service path requires
+     *         {@code serviceClassName()} but it is {@code null}
+     */
+    public static TypeName resolveInjectedServiceType(PipelineStepModel model) {
+        if (model == null) {
+            throw new IllegalArgumentException("model cannot be null");
+        }
+        if (model.sideEffect()) {
+            return ClassName.get(
+                model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
+                model.serviceName());
+        }
+        if (model.serviceApiKind() == ServiceApiKind.BLOCKING
+            || model.serviceApiKind() == ServiceApiKind.BLOCKING_ITERATOR) {
+            return blockingReactiveBridgeClassName(model);
+        }
+        if (model.serviceClassName() == null) {
+            throw new IllegalStateException("serviceClassName cannot be null for reactive service injection");
+        }
+        return model.serviceClassName();
+    }
+
+    public static ClassName blockingReactiveBridgeClassName(PipelineStepModel model) {
+        return ClassName.get(
+            model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
+            model.generatedName() + "BlockingReactiveBridge");
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/GeneratedServiceTypeResolver.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/GeneratedServiceTypeResolver.java
@@ -33,12 +33,15 @@ public final class GeneratedServiceTypeResolver {
                 model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
                 model.serviceName());
         }
-        if (model.serviceApiKind() == ServiceApiKind.BLOCKING
-            || model.serviceApiKind() == ServiceApiKind.BLOCKING_ITERATOR) {
+        boolean useBlockingBridge = (model.serviceApiKind() == ServiceApiKind.BLOCKING
+            || model.serviceApiKind() == ServiceApiKind.BLOCKING_ITERATOR)
+            && model.delegateService() == null
+            && (model.remoteExecution() == null || !model.remoteExecution().isRemote());
+        if (useBlockingBridge) {
             return blockingReactiveBridgeClassName(model);
         }
         if (model.serviceClassName() == null) {
-            throw new IllegalStateException("serviceClassName cannot be null for reactive service injection");
+            throw new IllegalStateException("serviceClassName cannot be null for service injection");
         }
         return model.serviceClassName();
     }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/BlockingServiceProcessorWarningTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/BlockingServiceProcessorWarningTest.java
@@ -1,0 +1,112 @@
+package org.pipelineframework.processor;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class BlockingServiceProcessorWarningTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void materializingBlockingStreamingServiceEmitsWarning() throws Exception {
+        Path generatedSourcesDir = tempDir.resolve("generated-sources");
+        Files.createDirectories(generatedSourcesDir);
+        Path descriptorDir = prepareDescriptorDir("descriptor-materialized");
+
+        Compilation compilation = compiler(generatedSourcesDir, descriptorDir).compile(
+            JavaFileObjects.forSourceString("test.blocking.Input", "package test.blocking; public class Input {}"),
+            JavaFileObjects.forSourceString("test.blocking.Output", "package test.blocking; public class Output {}"),
+            JavaFileObjects.forSourceString("test.blocking.ProcessMaterializingService", """
+                package test.blocking;
+
+                import java.util.List;
+                import org.pipelineframework.annotation.PipelineStep;
+                import org.pipelineframework.service.blocking.BlockingStreamingService;
+
+                @PipelineStep
+                public class ProcessMaterializingService implements BlockingStreamingService<Input, Output> {
+                    @Override
+                    public List<Output> processBlocking(Input processableObj) {
+                        return List.of();
+                    }
+                }
+                """));
+
+        assertThat(compilation).failed();
+        assertThat(compilation).hadWarningContaining("BlockingStreamingService materializes the full output list");
+    }
+
+    @Test
+    void iteratorBlockingServiceDoesNotEmitMaterializationWarning() throws Exception {
+        Path generatedSourcesDir = tempDir.resolve("generated-sources-iterator");
+        Files.createDirectories(generatedSourcesDir);
+        Path descriptorDir = prepareDescriptorDir("descriptor-iterator");
+
+        Compilation compilation = compiler(generatedSourcesDir, descriptorDir).compile(
+            JavaFileObjects.forSourceString("test.blocking.Input", "package test.blocking; public class Input {}"),
+            JavaFileObjects.forSourceString("test.blocking.Output", "package test.blocking; public class Output {}"),
+            JavaFileObjects.forSourceString("test.blocking.ProcessIteratorService", """
+                package test.blocking;
+
+                import org.pipelineframework.annotation.PipelineStep;
+                import org.pipelineframework.blocking.CloseableIterator;
+                import org.pipelineframework.service.blocking.BlockingIteratorService;
+
+                @PipelineStep
+                public class ProcessIteratorService implements BlockingIteratorService<Input, Output> {
+                    @Override
+                    public CloseableIterator<Output> iterateBlocking(Input processableObj) {
+                        return new CloseableIterator<>() {
+                            @Override
+                            public boolean hasNext() {
+                                return false;
+                            }
+
+                            @Override
+                            public Output next() {
+                                throw new java.util.NoSuchElementException();
+                            }
+
+                            @Override
+                            public void close() {
+                            }
+                        };
+                    }
+                }
+                """));
+
+        assertThat(compilation).failed();
+        assertFalse(compilation.warnings().stream()
+            .map(diagnostic -> diagnostic.getMessage(Locale.ROOT))
+            .anyMatch(message -> message.contains("materializes the full output list")));
+    }
+
+    private Compiler compiler(Path generatedSourcesDir, Path descriptorDir) {
+        return Compiler.javac()
+            .withProcessors(new PipelineStepProcessor())
+            .withOptions(
+                "-Apipeline.generatedSourcesDir=" + generatedSourcesDir,
+                "-Aprotobuf.descriptor.path=" + descriptorDir);
+    }
+
+    private Path prepareDescriptorDir(String name) throws Exception {
+        Path descriptorDir = tempDir.resolve(name);
+        Files.createDirectories(descriptorDir);
+        Files.copy(
+            Paths.get(System.getProperty("user.dir")).resolve("src/test/resources/descriptor_set_search.dsc"),
+            descriptorDir.resolve("descriptor_set.dsc"));
+        return descriptorDir;
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/BlockingServiceProcessorWarningTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/BlockingServiceProcessorWarningTest.java
@@ -1,8 +1,8 @@
 package org.pipelineframework.processor;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Locale;
 
 import com.google.testing.compile.Compilation;
@@ -93,6 +93,41 @@ class BlockingServiceProcessorWarningTest {
             .anyMatch(message -> message.contains("materializes the full output list")));
     }
 
+    @Test
+    void serviceImplementingBlockingAndReactiveContractsFails() throws Exception {
+        Path generatedSourcesDir = tempDir.resolve("generated-sources-ambiguous");
+        Files.createDirectories(generatedSourcesDir);
+        Path descriptorDir = prepareDescriptorDir("descriptor-ambiguous");
+
+        Compilation compilation = compiler(generatedSourcesDir, descriptorDir).compile(
+            JavaFileObjects.forSourceString("test.blocking.Input", "package test.blocking; public class Input {}"),
+            JavaFileObjects.forSourceString("test.blocking.Output", "package test.blocking; public class Output {}"),
+            JavaFileObjects.forSourceString("test.blocking.AmbiguousService", """
+                package test.blocking;
+
+                import io.smallrye.mutiny.Uni;
+                import org.pipelineframework.annotation.PipelineStep;
+                import org.pipelineframework.service.ReactiveService;
+                import org.pipelineframework.service.blocking.BlockingService;
+
+                @PipelineStep
+                public class AmbiguousService implements BlockingService<Input, Output>, ReactiveService<Input, Output> {
+                    @Override
+                    public Output processBlocking(Input processableObj) {
+                        return new Output();
+                    }
+
+                    @Override
+                    public Uni<Output> process(Input processableObj) {
+                        return Uni.createFrom().item(new Output());
+                    }
+                }
+                """));
+
+        assertThat(compilation).failed();
+        assertThat(compilation).hadErrorContaining("implements multiple supported service interfaces");
+    }
+
     private Compiler compiler(Path generatedSourcesDir, Path descriptorDir) {
         return Compiler.javac()
             .withProcessors(new PipelineStepProcessor())
@@ -104,9 +139,12 @@ class BlockingServiceProcessorWarningTest {
     private Path prepareDescriptorDir(String name) throws Exception {
         Path descriptorDir = tempDir.resolve(name);
         Files.createDirectories(descriptorDir);
-        Files.copy(
-            Paths.get(System.getProperty("user.dir")).resolve("src/test/resources/descriptor_set_search.dsc"),
-            descriptorDir.resolve("descriptor_set.dsc"));
+        try (InputStream descriptor = getClass().getResourceAsStream("/descriptor_set_search.dsc")) {
+            if (descriptor == null) {
+                throw new IllegalStateException("Missing test resource: descriptor_set_search.dsc");
+            }
+            Files.copy(descriptor, descriptorDir.resolve("descriptor_set.dsc"));
+        }
         return descriptorDir;
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/ir/PipelineStepModelTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/ir/PipelineStepModelTest.java
@@ -262,4 +262,174 @@ class PipelineStepModelTest {
 
         assertEquals(MapperFallbackMode.NONE, model.mapperFallbackMode());
     }
+
+    // --- serviceApiKind tests (added in blocking service support PR) ---
+
+    @Test
+    void builderDefaultsServiceApiKindToReactive() {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_UNARY)
+                .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .build();
+
+        assertEquals(ServiceApiKind.REACTIVE, model.serviceApiKind());
+    }
+
+    @Test
+    void builderCanSetBlockingServiceApiKind() {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_UNARY)
+                .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .serviceApiKind(ServiceApiKind.BLOCKING)
+                .build();
+
+        assertEquals(ServiceApiKind.BLOCKING, model.serviceApiKind());
+    }
+
+    @Test
+    void builderCanSetBlockingIteratorServiceApiKind() {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_STREAMING)
+                .enabledTargets(Set.of(GenerationTarget.GRPC_SERVICE))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+                .build();
+
+        assertEquals(ServiceApiKind.BLOCKING_ITERATOR, model.serviceApiKind());
+    }
+
+    @Test
+    void toBuilderPreservesServiceApiKind() {
+        PipelineStepModel original = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_UNARY)
+                .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .serviceApiKind(ServiceApiKind.BLOCKING)
+                .build();
+
+        PipelineStepModel rebuilt = original.toBuilder().build();
+
+        assertEquals(ServiceApiKind.BLOCKING, rebuilt.serviceApiKind());
+    }
+
+    @Test
+    void toBuilderAllowsChangingServiceApiKind() {
+        PipelineStepModel original = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_UNARY)
+                .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .serviceApiKind(ServiceApiKind.REACTIVE)
+                .build();
+
+        PipelineStepModel modified = original.toBuilder()
+                .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+                .build();
+
+        assertEquals(ServiceApiKind.REACTIVE, original.serviceApiKind());
+        assertEquals(ServiceApiKind.BLOCKING_ITERATOR, modified.serviceApiKind());
+    }
+
+    @Test
+    void constructorNullServiceApiKindDefaultsToReactive() {
+        PipelineStepModel model = new PipelineStepModel(
+                "TestService",
+                "TestService",
+                "com.example",
+                ClassName.get("com.example", "TestService"),
+                new TypeMapping(TypeName.INT, TypeName.INT, false),
+                new TypeMapping(TypeName.INT, TypeName.INT, false),
+                StreamingShape.UNARY_UNARY,
+                Set.of(GenerationTarget.CLIENT_STEP),
+                ExecutionMode.DEFAULT,
+                DeploymentRole.PIPELINE_SERVER,
+                false,
+                null,
+                OrderingRequirement.RELAXED,
+                ThreadSafety.SAFE,
+                null,
+                null,
+                null,
+                null,
+                null /* serviceApiKind */);
+
+        assertEquals(ServiceApiKind.REACTIVE, model.serviceApiKind());
+    }
+
+    @Test
+    void withDeploymentRolePreservesServiceApiKind() {
+        PipelineStepModel original = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_UNARY)
+                .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+                .build();
+
+        PipelineStepModel modified = original.withDeploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT);
+
+        assertEquals(ServiceApiKind.BLOCKING_ITERATOR, modified.serviceApiKind());
+        assertEquals(DeploymentRole.ORCHESTRATOR_CLIENT, modified.deploymentRole());
+    }
+
+    @Test
+    void twelveParamConstructorDefaultsServiceApiKindToReactive() {
+        PipelineStepModel model = new PipelineStepModel(
+                "TestService",
+                "TestService",
+                "com.example",
+                ClassName.get("com.example", "TestService"),
+                new TypeMapping(TypeName.INT, TypeName.INT, false),
+                new TypeMapping(TypeName.INT, TypeName.INT, false),
+                StreamingShape.UNARY_UNARY,
+                Set.of(GenerationTarget.CLIENT_STEP),
+                ExecutionMode.DEFAULT,
+                DeploymentRole.PIPELINE_SERVER,
+                false,
+                null);
+
+        assertEquals(ServiceApiKind.REACTIVE, model.serviceApiKind());
+    }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -12,6 +12,7 @@ import org.pipelineframework.processor.ir.DeploymentRole;
 import org.pipelineframework.processor.ir.ExecutionMode;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TransportMode;
 import org.pipelineframework.processor.ir.TypeMapping;
@@ -216,6 +217,44 @@ class PipelineTargetResolutionPhaseTest {
         assertEquals(
             Set.of(GenerationTarget.GRPC_SERVICE, GenerationTarget.REMOTE_OPERATOR_ADAPTER),
             context.getResolvedTargets());
+    }
+
+    @Test
+    void blockingInternalStepsAddReactiveBridgeTarget() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        PipelineStepModel blocking = step("BlockingCsvStep", DeploymentRole.PIPELINE_SERVER)
+            .toBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .build();
+        context.setStepModels(List.of(blocking));
+        context.setTransportMode(TransportMode.REST);
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertEquals(
+            Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
+            updated.enabledTargets());
+    }
+
+    @Test
+    void blockingIteratorInternalStepsAddReactiveBridgeTarget() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        PipelineStepModel blocking = step("BlockingIteratorCsvStep", DeploymentRole.PIPELINE_SERVER)
+            .toBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+            .build();
+        context.setStepModels(List.of(blocking));
+        context.setTransportMode(TransportMode.REST);
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertEquals(
+            Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
+            updated.enabledTargets());
     }
 
     private void assertResolvedTargets(

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -17,6 +17,8 @@ import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TransportMode;
 import org.pipelineframework.processor.ir.TypeMapping;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -255,6 +257,83 @@ class PipelineTargetResolutionPhaseTest {
         assertEquals(
             Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
             updated.enabledTargets());
+    }
+
+    @Test
+    void blockingInternalStepWithDelegateDoesNotAddReactiveBridgeTarget() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        PipelineStepModel blocking = step("BlockingDelegatedStep", DeploymentRole.PIPELINE_SERVER)
+            .toBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .delegateService(ClassName.get("com.external.lib", "ExternalService"))
+            .build();
+        context.setStepModels(List.of(blocking));
+        context.setTransportMode(TransportMode.REST);
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertFalse(updated.enabledTargets().contains(GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
+            "Delegated steps should not get a blocking reactive bridge target");
+    }
+
+    @Test
+    void blockingInternalStepWithRemoteExecutionDoesNotAddReactiveBridgeTarget() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        PipelineStepModel blocking = step("BlockingRemoteStep", DeploymentRole.PIPELINE_SERVER)
+            .toBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .remoteExecution(new PipelineTemplateStepExecution(
+                "REMOTE", "remote-operator", "PROTOBUF_HTTP_V1", 3000,
+                new PipelineTemplateRemoteTarget("https://operator.example/process", null)))
+            .build();
+        context.setStepModels(List.of(blocking));
+        context.setTransportMode(TransportMode.REST);
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertFalse(updated.enabledTargets().contains(GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
+            "Remote steps should not get a blocking reactive bridge target");
+    }
+
+    @Test
+    void reactiveServerStepDoesNotAddReactiveBridgeTarget() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        PipelineStepModel reactive = step("ReactiveStep", DeploymentRole.PIPELINE_SERVER)
+            .toBuilder()
+            .serviceApiKind(ServiceApiKind.REACTIVE)
+            .build();
+        context.setStepModels(List.of(reactive));
+        context.setTransportMode(TransportMode.REST);
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertFalse(updated.enabledTargets().contains(GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
+            "Reactive steps must never get a blocking reactive bridge target");
+    }
+
+    @Test
+    void blockingIteratorStepWithDelegateDoesNotAddReactiveBridgeTarget() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        PipelineStepModel blocking = step("BlockingIteratorDelegatedStep", DeploymentRole.PIPELINE_SERVER)
+            .toBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+            .delegateService(ClassName.get("com.external.lib", "ExternalIteratorService"))
+            .build();
+        context.setStepModels(List.of(blocking));
+        context.setTransportMode(TransportMode.GRPC);
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertFalse(updated.enabledTargets().contains(GenerationTarget.BLOCKING_REACTIVE_BRIDGE),
+            "Delegated blocking iterator steps should not get a reactive bridge target");
     }
 
     private void assertResolvedTargets(

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepArtifactGenerationServiceTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepArtifactGenerationServiceTest.java
@@ -25,6 +25,7 @@ import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TypeMapping;
 import org.pipelineframework.processor.renderer.ClientStepRenderer;
+import org.pipelineframework.processor.renderer.BlockingReactiveBridgeRenderer;
 import org.pipelineframework.processor.renderer.GenerationContext;
 import org.pipelineframework.processor.renderer.GrpcServiceAdapterRenderer;
 import org.pipelineframework.processor.renderer.LocalClientStepRenderer;
@@ -135,6 +136,7 @@ class StepArtifactGenerationServiceTest {
             mock(RestClientStepRenderer.class),
             mock(RestResourceRenderer.class),
             mock(RestFunctionHandlerRenderer.class),
+            mock(BlockingReactiveBridgeRenderer.class),
             renderer
         );
 
@@ -166,6 +168,7 @@ class StepArtifactGenerationServiceTest {
             mock(RestClientStepRenderer.class),
             mock(RestResourceRenderer.class),
             mock(RestFunctionHandlerRenderer.class),
+            mock(BlockingReactiveBridgeRenderer.class),
             mock(RemoteOperatorAdapterRenderer.class)
         );
     }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/BlockingReactiveBridgeRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/BlockingReactiveBridgeRendererTest.java
@@ -1,0 +1,62 @@
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import javax.annotation.processing.ProcessingEnvironment;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class BlockingReactiveBridgeRendererTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rendersIteratorBridgeUsingEmitIterator() throws IOException {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+            .serviceName("ProcessCsvPaymentsInputService")
+            .generatedName("ProcessCsvPaymentsInput")
+            .servicePackage("org.pipelineframework.csv.service")
+            .serviceClassName(ClassName.get("org.pipelineframework.csv.service", "ProcessCsvPaymentsInputService"))
+            .streamingShape(StreamingShape.UNARY_STREAMING)
+            .executionMode(ExecutionMode.DEFAULT)
+            .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+            .inputMapping(new TypeMapping(
+                ClassName.get("org.pipelineframework.csv.common.domain", "CsvPaymentsInputFile"),
+                null,
+                false))
+            .outputMapping(new TypeMapping(
+                ClassName.get("org.pipelineframework.csv.common.domain", "PaymentRecord"),
+                null,
+                false))
+            .enabledTargets(Set.of())
+            .build();
+
+        new BlockingReactiveBridgeRenderer().render(model, new GenerationContext(
+            mock(ProcessingEnvironment.class),
+            tempDir,
+            DeploymentRole.PIPELINE_SERVER,
+            Set.of(),
+            null,
+            null));
+
+        String source = Files.readString(tempDir.resolve(
+            "org/pipelineframework/csv/service/pipeline/ProcessCsvPaymentsInputBlockingReactiveBridge.java"));
+
+        assertTrue(source.contains("implements ReactiveStreamingService<CsvPaymentsInputFile, PaymentRecord>"));
+        assertTrue(source.contains("emitIterator(false, () -> blockingService.iterateBlocking(processableObj))"));
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/BlockingReactiveBridgeRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/BlockingReactiveBridgeRendererTest.java
@@ -11,11 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.pipelineframework.processor.ir.DeploymentRole;
 import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TypeMapping;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -23,6 +25,11 @@ class BlockingReactiveBridgeRendererTest {
 
     @TempDir
     Path tempDir;
+
+    @Test
+    void targetReturnsBlockingReactiveBridgeTarget() {
+        assertEquals(GenerationTarget.BLOCKING_REACTIVE_BRIDGE, new BlockingReactiveBridgeRenderer().target());
+    }
 
     @Test
     void rendersIteratorBridgeUsingEmitIterator() throws IOException {
@@ -58,5 +65,152 @@ class BlockingReactiveBridgeRendererTest {
 
         assertTrue(source.contains("implements ReactiveStreamingService<CsvPaymentsInputFile, PaymentRecord>"));
         assertTrue(source.contains("emitIterator(false, () -> blockingService.iterateBlocking(processableObj))"));
+    }
+
+    @Test
+    void rendersUnaryBlockingBridgeUsingSupply() throws IOException {
+        PipelineStepModel model = buildModel("UnaryBlockingService", "UnaryBlocking",
+            StreamingShape.UNARY_UNARY, ServiceApiKind.BLOCKING, ExecutionMode.DEFAULT);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("UnaryBlockingBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("implements ReactiveService<"), "should implement ReactiveService");
+        assertTrue(source.contains("blockingExecutionSupport.supply(false,"), "should delegate to supply()");
+    }
+
+    @Test
+    void rendersServerStreamingBlockingBridgeUsingEmitList() throws IOException {
+        PipelineStepModel model = buildModel("StreamingBlockingService", "StreamingBlocking",
+            StreamingShape.UNARY_STREAMING, ServiceApiKind.BLOCKING, ExecutionMode.DEFAULT);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("StreamingBlockingBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("implements ReactiveStreamingService<"), "should implement ReactiveStreamingService");
+        assertTrue(source.contains("blockingExecutionSupport.emitList(false,"), "should delegate to emitList()");
+    }
+
+    @Test
+    void rendersClientStreamingBlockingBridgeUsingTransformToUni() throws IOException {
+        PipelineStepModel model = buildModel("ClientStreamingService", "ClientStreaming",
+            StreamingShape.STREAMING_UNARY, ServiceApiKind.BLOCKING, ExecutionMode.DEFAULT);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("ClientStreamingBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("implements ReactiveStreamingClientService<"), "should implement ReactiveStreamingClientService");
+        assertTrue(source.contains("transformToUni"), "should use transformToUni for client streaming");
+        assertTrue(source.contains("blockingExecutionSupport.supply(false,"), "should delegate to supply()");
+    }
+
+    @Test
+    void rendersBidirectionalStreamingBlockingBridgeUsingTransformToMulti() throws IOException {
+        PipelineStepModel model = buildModel("BidiStreamingService", "BidiStreaming",
+            StreamingShape.STREAMING_STREAMING, ServiceApiKind.BLOCKING, ExecutionMode.DEFAULT);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("BidiStreamingBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("implements ReactiveBidirectionalStreamingService<"),
+            "should implement ReactiveBidirectionalStreamingService");
+        assertTrue(source.contains("transformToMulti"), "should use transformToMulti for bidi streaming");
+        assertTrue(source.contains("blockingExecutionSupport.emitList(false,"), "should delegate to emitList()");
+    }
+
+    @Test
+    void rendersVirtualThreadsBridgeWithTrueFlag() throws IOException {
+        PipelineStepModel model = buildModel("VirtualBlockingService", "VirtualBlocking",
+            StreamingShape.UNARY_UNARY, ServiceApiKind.BLOCKING, ExecutionMode.VIRTUAL_THREADS);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("VirtualBlockingBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("blockingExecutionSupport.supply(true,"),
+            "virtual threads mode should pass true to supply()");
+    }
+
+    @Test
+    void rendersIteratorBridgeWithVirtualThreadsFlag() throws IOException {
+        PipelineStepModel model = buildModel("VirtualIteratorService", "VirtualIterator",
+            StreamingShape.UNARY_STREAMING, ServiceApiKind.BLOCKING_ITERATOR, ExecutionMode.VIRTUAL_THREADS);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("VirtualIteratorBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("emitIterator(true,"),
+            "virtual threads mode should pass true to emitIterator()");
+    }
+
+    @Test
+    void renderedBridgeHasApplicationScopedAnnotation() throws IOException {
+        PipelineStepModel model = buildModel("ScopedBlockingService", "ScopedBlocking",
+            StreamingShape.UNARY_UNARY, ServiceApiKind.BLOCKING, ExecutionMode.DEFAULT);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("ScopedBlockingBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("@ApplicationScoped"), "bridge should be application-scoped CDI bean");
+    }
+
+    @Test
+    void renderedBridgeInjectsBlockingService() throws IOException {
+        PipelineStepModel model = buildModel("InjectTestService", "InjectTest",
+            StreamingShape.UNARY_UNARY, ServiceApiKind.BLOCKING, ExecutionMode.DEFAULT);
+
+        new BlockingReactiveBridgeRenderer().render(model, generationContext());
+
+        String source = readGeneratedSource("InjectTestBlockingReactiveBridge.java");
+
+        assertTrue(source.contains("blockingService"), "bridge should inject the blocking service");
+        assertTrue(source.contains("blockingExecutionSupport"), "bridge should inject blocking execution support");
+    }
+
+    private PipelineStepModel buildModel(
+            String serviceName,
+            String generatedName,
+            StreamingShape shape,
+            ServiceApiKind apiKind,
+            ExecutionMode executionMode) {
+        return new PipelineStepModel.Builder()
+            .serviceName(serviceName)
+            .generatedName(generatedName)
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", serviceName))
+            .streamingShape(shape)
+            .executionMode(executionMode)
+            .serviceApiKind(apiKind)
+            .inputMapping(new TypeMapping(
+                ClassName.get("com.example.domain", "Input"),
+                null,
+                false))
+            .outputMapping(new TypeMapping(
+                ClassName.get("com.example.domain", "Output"),
+                null,
+                false))
+            .enabledTargets(Set.of())
+            .build();
+    }
+
+    private GenerationContext generationContext() {
+        return new GenerationContext(
+            mock(ProcessingEnvironment.class),
+            tempDir,
+            DeploymentRole.PIPELINE_SERVER,
+            Set.of(),
+            null,
+            null);
+    }
+
+    private String readGeneratedSource(String simpleFileName) throws IOException {
+        return Files.readString(
+            tempDir.resolve("com/example/service/pipeline/" + simpleFileName));
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/RestResourceRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/RestResourceRendererTest.java
@@ -397,4 +397,58 @@ class RestResourceRendererTest {
 
         assertTrue(source.contains("@RestStreamElementType(\"application/json\")"));
     }
+
+    @Test
+    void blockingServicesInjectGeneratedReactiveBridge() throws IOException {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+            .serviceName("ProcessCsvPaymentsInputService")
+            .servicePackage("org.pipelineframework.csv.service")
+            .serviceClassName(ClassName.get("org.pipelineframework.csv.service", "ProcessCsvPaymentsInputService"))
+            .streamingShape(StreamingShape.UNARY_STREAMING)
+            .executionMode(ExecutionMode.DEFAULT)
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .inputMapping(new TypeMapping(
+                ClassName.get("org.pipelineframework.csv.common.domain", "CsvPaymentsInputFile"),
+                null,
+                false))
+            .outputMapping(new TypeMapping(
+                ClassName.get("org.pipelineframework.csv.common.domain", "PaymentRecord"),
+                null,
+                false))
+            .enabledTargets(Set.of(GenerationTarget.REST_RESOURCE))
+            .build();
+
+        String source = renderAndReadSource(
+            new RestBinding(model, null),
+            "org/pipelineframework/csv/service/pipeline/ProcessCsvPaymentsInputResource.java");
+
+        assertTrue(source.contains("ProcessCsvPaymentsInputServiceBlockingReactiveBridge domainService;"));
+    }
+
+    @Test
+    void blockingIteratorServicesInjectGeneratedReactiveBridge() throws IOException {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+            .serviceName("ProcessCsvPaymentsInputService")
+            .servicePackage("org.pipelineframework.csv.service")
+            .serviceClassName(ClassName.get("org.pipelineframework.csv.service", "ProcessCsvPaymentsInputService"))
+            .streamingShape(StreamingShape.UNARY_STREAMING)
+            .executionMode(ExecutionMode.DEFAULT)
+            .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+            .inputMapping(new TypeMapping(
+                ClassName.get("org.pipelineframework.csv.common.domain", "CsvPaymentsInputFile"),
+                null,
+                false))
+            .outputMapping(new TypeMapping(
+                ClassName.get("org.pipelineframework.csv.common.domain", "PaymentRecord"),
+                null,
+                false))
+            .enabledTargets(Set.of(GenerationTarget.REST_RESOURCE))
+            .build();
+
+        String source = renderAndReadSource(
+            new RestBinding(model, null),
+            "org/pipelineframework/csv/service/pipeline/ProcessCsvPaymentsInputResource.java");
+
+        assertTrue(source.contains("ProcessCsvPaymentsInputServiceBlockingReactiveBridge domainService;"));
+    }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/GeneratedServiceTypeResolverTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/GeneratedServiceTypeResolverTest.java
@@ -1,0 +1,218 @@
+package org.pipelineframework.processor.util;
+
+import java.util.Set;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.TypeName;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.template.PipelineTemplateRemoteTarget;
+import org.pipelineframework.config.template.PipelineTemplateStepExecution;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link GeneratedServiceTypeResolver}.
+ */
+class GeneratedServiceTypeResolverTest {
+
+    private static final String SERVICE_PACKAGE = "com.example.service";
+    private static final String SERVICE_NAME = "MyService";
+    private static final String GENERATED_NAME = "MyServiceGenerated";
+    private static final ClassName SERVICE_CLASS_NAME = ClassName.get(SERVICE_PACKAGE, SERVICE_NAME);
+
+    @Test
+    void resolveInjectedServiceType_throwsWhenModelIsNull() {
+        assertThrows(IllegalArgumentException.class,
+            () -> GeneratedServiceTypeResolver.resolveInjectedServiceType(null));
+    }
+
+    @Test
+    void resolveInjectedServiceType_sideEffectReturnsGeneratedBeanInPipelinePackage() {
+        PipelineStepModel model = baseBuilder()
+            .sideEffect(true)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        ClassName expected = ClassName.get(
+            SERVICE_PACKAGE + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
+            SERVICE_NAME);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_blockingWithNoDelegateAndNoRemoteReturnsReactiveBridgeType() {
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        assertEquals(GeneratedServiceTypeResolver.blockingReactiveBridgeClassName(model), result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_blockingIteratorWithNoDelegateAndNoRemoteReturnsReactiveBridgeType() {
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        assertEquals(GeneratedServiceTypeResolver.blockingReactiveBridgeClassName(model), result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_reactiveReturnsServiceClassName() {
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.REACTIVE)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        assertEquals(SERVICE_CLASS_NAME, result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_blockingWithDelegateReturnsServiceClassName() {
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .delegateService(ClassName.get("com.external.lib", "ExternalService"))
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        assertEquals(SERVICE_CLASS_NAME, result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_blockingWithRemoteExecutionReturnsServiceClassName() {
+        PipelineTemplateStepExecution remoteExecution = new PipelineTemplateStepExecution(
+            "REMOTE", "my-operator", "PROTOBUF_HTTP_V1", 3000,
+            new PipelineTemplateRemoteTarget("https://operator.example/process", null));
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .remoteExecution(remoteExecution)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        assertEquals(SERVICE_CLASS_NAME, result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_blockingWithLocalExecutionReturnsReactiveBridgeType() {
+        PipelineTemplateStepExecution localExecution = new PipelineTemplateStepExecution(
+            "LOCAL", null, null, null, null);
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .remoteExecution(localExecution)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        assertEquals(GeneratedServiceTypeResolver.blockingReactiveBridgeClassName(model), result);
+    }
+
+    @Test
+    void resolveInjectedServiceType_serviceClassNameIsCheckedByConstructor() {
+        // PipelineStepModel enforces non-null serviceClassName at construction time.
+        // Verify that the constructor guard prevents a null serviceClassName model
+        // from even being created, ensuring the resolver never encounters it.
+        assertThrows(IllegalArgumentException.class, () ->
+            new PipelineStepModel(
+                SERVICE_NAME,
+                GENERATED_NAME,
+                SERVICE_PACKAGE,
+                null, // serviceClassName is null — constructor rejects this
+                new TypeMapping(TypeName.INT, null, false),
+                new TypeMapping(TypeName.INT, null, false),
+                StreamingShape.UNARY_UNARY,
+                Set.of(GenerationTarget.GRPC_SERVICE),
+                ExecutionMode.DEFAULT,
+                DeploymentRole.PIPELINE_SERVER,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                ServiceApiKind.REACTIVE));
+    }
+
+    @Test
+    void blockingReactiveBridgeClassName_returnsCorrectNameInPipelinePackage() {
+        PipelineStepModel model = baseBuilder()
+            .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+            .build();
+
+        ClassName result = GeneratedServiceTypeResolver.blockingReactiveBridgeClassName(model);
+
+        assertEquals(
+            SERVICE_PACKAGE + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
+            result.packageName());
+        assertEquals(GENERATED_NAME + "BlockingReactiveBridge", result.simpleName());
+    }
+
+    @Test
+    void blockingReactiveBridgeClassName_usesGeneratedNameNotServiceName() {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+            .serviceName("ActualServiceName")
+            .generatedName("GeneratedBridgeName")
+            .servicePackage(SERVICE_PACKAGE)
+            .serviceClassName(ClassName.get(SERVICE_PACKAGE, "ActualServiceName"))
+            .inputMapping(new TypeMapping(TypeName.INT, null, false))
+            .outputMapping(new TypeMapping(TypeName.INT, null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of())
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .build();
+
+        ClassName result = GeneratedServiceTypeResolver.blockingReactiveBridgeClassName(model);
+
+        assertEquals("GeneratedBridgeName" + "BlockingReactiveBridge", result.simpleName());
+    }
+
+    @Test
+    void resolveInjectedServiceType_sideEffectTakesPrecedenceOverBlocking() {
+        // sideEffect=true + BLOCKING → should return side-effect bean, not bridge
+        PipelineStepModel model = baseBuilder()
+            .sideEffect(true)
+            .serviceApiKind(ServiceApiKind.BLOCKING)
+            .build();
+
+        TypeName result = GeneratedServiceTypeResolver.resolveInjectedServiceType(model);
+
+        ClassName expected = ClassName.get(
+            SERVICE_PACKAGE + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX,
+            SERVICE_NAME);
+        assertEquals(expected, result);
+    }
+
+    private PipelineStepModel.Builder baseBuilder() {
+        return new PipelineStepModel.Builder()
+            .serviceName(SERVICE_NAME)
+            .generatedName(GENERATED_NAME)
+            .servicePackage(SERVICE_PACKAGE)
+            .serviceClassName(SERVICE_CLASS_NAME)
+            .inputMapping(new TypeMapping(ClassName.get("com.example.domain", "Input"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.domain", "Output"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.GRPC_SERVICE))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/annotation/PipelineStep.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/annotation/PipelineStep.java
@@ -132,6 +132,17 @@ public @interface PipelineStep {
     ThreadSafety threadSafety() default ThreadSafety.SAFE;
 
     /**
+     * Opts generated adapters and blocking bridges into virtual-thread execution.
+     *
+     * Blocking work is still offloaded explicitly; this flag selects the virtual-thread executor
+     * instead of the default worker pool and enables {@code @RunOnVirtualThread} on generated
+     * REST/gRPC entrypoints.
+     *
+     * @return whether blocking execution should use virtual threads
+     */
+    boolean runOnVirtualThreads() default false;
+
+    /**
      * Specifies the operator service class that provides the actual execution implementation.
      * When present, the annotated class becomes a client-only step that delegates to the specified service.
      * When absent (defaults to Void.class), the annotated class is treated as a traditional internal step.

--- a/framework/runtime/src/main/java/org/pipelineframework/blocking/BlockingExecutionSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/blocking/BlockingExecutionSupport.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.blocking;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.pipelineframework.context.PipelineContext;
+import org.pipelineframework.context.PipelineContextHolder;
+import org.pipelineframework.context.TransportDispatchMetadata;
+import org.pipelineframework.context.TransportDispatchMetadataHolder;
+
+/**
+ * Offloads blocking callbacks to a worker executor by default, with an opt-in virtual-thread path.
+ */
+@ApplicationScoped
+@Unremovable
+public class BlockingExecutionSupport {
+
+    private final ExecutorService virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
+
+    public <T> Uni<T> supply(boolean useVirtualThreads, Supplier<T> supplier) {
+        PipelineContext context = PipelineContextHolder.get();
+        TransportDispatchMetadata transport = TransportDispatchMetadataHolder.get();
+        return Uni.createFrom()
+            .item(() -> withCapturedContext(context, transport, supplier))
+            .runSubscriptionOn(selectExecutor(useVirtualThreads));
+    }
+
+    public <T> Multi<T> emitList(boolean useVirtualThreads, Supplier<List<T>> supplier) {
+        return supply(useVirtualThreads, supplier)
+            .onItem()
+            .transformToMulti(items -> items == null
+                ? Multi.createFrom().empty()
+                : Multi.createFrom().iterable(items));
+    }
+
+    public <T> Multi<T> emitIterator(boolean useVirtualThreads, Supplier<? extends CloseableIterator<T>> supplier) {
+        return supply(useVirtualThreads, supplier::get)
+            .onItem()
+            .transformToMulti(iterator -> iterator == null
+                ? Multi.createFrom().empty()
+                : emitIteratorItems(useVirtualThreads, iterator));
+    }
+
+    private <T> Multi<T> emitIteratorItems(boolean useVirtualThreads, CloseableIterator<T> iterator) {
+        IteratorEmissionState<T> state = new IteratorEmissionState<>(iterator);
+        return Multi.createBy()
+            .repeating()
+            .uni(() -> state, current -> supply(useVirtualThreads, current::nextResult))
+            .until(IteratorResult::done)
+            .onItem()
+            .transform(result -> result.item())
+            .onTermination()
+            .call(() -> supply(useVirtualThreads, () -> {
+                state.close();
+                return Boolean.TRUE;
+            }));
+    }
+
+    private Executor selectExecutor(boolean useVirtualThreads) {
+        return useVirtualThreads ? virtualThreadExecutor : Infrastructure.getDefaultWorkerPool();
+    }
+
+    private static <T> T withCapturedContext(
+        PipelineContext context,
+        TransportDispatchMetadata transport,
+        Supplier<T> supplier
+    ) {
+        PipelineContext previousContext = PipelineContextHolder.get();
+        TransportDispatchMetadata previousTransport = TransportDispatchMetadataHolder.get();
+        if (context != null) {
+            PipelineContextHolder.set(context);
+        } else {
+            PipelineContextHolder.clear();
+        }
+        if (transport != null) {
+            TransportDispatchMetadataHolder.set(transport);
+        } else {
+            TransportDispatchMetadataHolder.clear();
+        }
+        try {
+            return supplier.get();
+        } finally {
+            if (previousContext != null) {
+                PipelineContextHolder.set(previousContext);
+            } else {
+                PipelineContextHolder.clear();
+            }
+            if (previousTransport != null) {
+                TransportDispatchMetadataHolder.set(previousTransport);
+            } else {
+                TransportDispatchMetadataHolder.clear();
+            }
+        }
+    }
+
+    @PreDestroy
+    void close() {
+        virtualThreadExecutor.shutdown();
+    }
+
+    private static final class IteratorEmissionState<T> {
+        private final CloseableIterator<T> iterator;
+        private boolean completed;
+        private boolean closed;
+
+        private IteratorEmissionState(CloseableIterator<T> iterator) {
+            this.iterator = iterator;
+        }
+
+        private synchronized IteratorResult<T> nextResult() {
+            if (closed) {
+                return IteratorResult.completedResult();
+            }
+            if (completed) {
+                return IteratorResult.completedResult();
+            }
+            if (!iterator.hasNext()) {
+                completed = true;
+                return IteratorResult.completedResult();
+            }
+            return IteratorResult.nextItem(iterator.next());
+        }
+
+        private synchronized void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            try {
+                iterator.close();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to close blocking iterator", e);
+            }
+        }
+    }
+
+    private record IteratorResult<T>(boolean done, T item) {
+        private static <T> IteratorResult<T> completedResult() {
+            return new IteratorResult<>(true, null);
+        }
+
+        private static <T> IteratorResult<T> nextItem(T item) {
+            return new IteratorResult<>(false, item);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/blocking/BlockingExecutions.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/blocking/BlockingExecutions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.blocking;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import org.pipelineframework.annotation.PipelineStep;
+
+/**
+ * Runtime access helpers for blocking step default adapters.
+ */
+public final class BlockingExecutions {
+
+    private static final BlockingExecutionSupport FALLBACK_SUPPORT = new BlockingExecutionSupport();
+
+    private BlockingExecutions() {
+    }
+
+    public static <T> Uni<T> supply(Object owner, Supplier<T> supplier) {
+        return support().supply(useVirtualThreads(owner), supplier);
+    }
+
+    public static <T> Multi<T> emitList(Object owner, Supplier<List<T>> supplier) {
+        return support().emitList(useVirtualThreads(owner), supplier);
+    }
+
+    public static <T> Multi<T> emitIterator(Object owner, Supplier<? extends CloseableIterator<T>> supplier) {
+        return support().emitIterator(useVirtualThreads(owner), supplier);
+    }
+
+    public static boolean useVirtualThreads(Object owner) {
+        if (owner == null) {
+            return false;
+        }
+        PipelineStep annotation = owner.getClass().getAnnotation(PipelineStep.class);
+        return annotation != null && annotation.runOnVirtualThreads();
+    }
+
+    private static BlockingExecutionSupport support() {
+        try {
+            CDI<Object> cdi = CDI.current();
+            Instance<BlockingExecutionSupport> instance = cdi.select(BlockingExecutionSupport.class);
+            if (!instance.isUnsatisfied()) {
+                return instance.get();
+            }
+        } catch (RuntimeException ignored) {
+            // Tests and non-CDI callers fall back to the local support instance.
+        }
+        return FALLBACK_SUPPORT;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/blocking/CloseableIterator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/blocking/CloseableIterator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.blocking;
+
+import java.util.Iterator;
+
+/**
+ * A framework-managed iterator boundary for incremental blocking streaming.
+ *
+ * <p>Implementations are expected to hold any underlying blocking resource needed to iterate.
+ * The framework closes the iterator on normal completion, failure, or cancellation when the
+ * iterator is consumed through the blocking adapters.
+ *
+ * @param <T> the item type
+ */
+public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
+
+    @Override
+    void close() throws Exception;
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineOrderExpander.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineOrderExpander.java
@@ -266,6 +266,11 @@ public final class PipelineOrderExpander {
             || name.endsWith("StepOneToMany")
             || name.endsWith("StepManyToOne")
             || name.endsWith("StepManyToMany")
+            || name.endsWith("StepOneToOneBlocking")
+            || name.endsWith("StepOneToManyBlocking")
+            || name.endsWith("StepOneToManyBlockingIterator")
+            || name.endsWith("StepManyToOneBlocking")
+            || name.endsWith("StepManyToManyBlocking")
             || name.endsWith("StepOneToOneCompletableFuture"));
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingBidirectionalStreamingService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingBidirectionalStreamingService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.service.blocking;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Multi;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.service.ReactiveBidirectionalStreamingService;
+
+@FunctionalInterface
+public interface BlockingBidirectionalStreamingService<T, S> extends ReactiveBidirectionalStreamingService<T, S> {
+
+    /**
+     * Materializes the full input list and the full output list.
+     *
+     * <p>This contract is intended for bounded batch-style transformations. It does not preserve
+     * incremental stream semantics, and batch retries rerun the full callback.
+     */
+    List<S> processBlocking(List<T> processableObj);
+
+    @Override
+    default Multi<S> process(Multi<T> processableObj) {
+        return processableObj.collect()
+            .asList()
+            .onItem()
+            .transformToMulti(items -> BlockingExecutions.emitList(this, () -> processBlocking(items)));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingIteratorService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingIteratorService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.service.blocking;
+
+import io.smallrye.mutiny.Multi;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.blocking.CloseableIterator;
+import org.pipelineframework.service.ReactiveStreamingService;
+
+/**
+ * Incremental blocking 1 -> N service contract.
+ *
+ * <p>Use this contract when a synchronous library can iterate results incrementally and you want
+ * non-Mutiny authored code without forcing full in-memory materialization.
+ *
+ * <p>The returned iterator is still blocking. The framework offloads iterator acquisition and item
+ * iteration to worker threads by default, or virtual threads when
+ * {@code @PipelineStep(runOnVirtualThreads = true)} is enabled.
+ */
+@FunctionalInterface
+public interface BlockingIteratorService<T, S> extends ReactiveStreamingService<T, S> {
+
+    CloseableIterator<S> iterateBlocking(T processableObj);
+
+    @Override
+    default Multi<S> process(T processableObj) {
+        return BlockingExecutions.emitIterator(this, () -> iterateBlocking(processableObj));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.service.blocking;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.service.ReactiveService;
+
+@FunctionalInterface
+public interface BlockingService<T, S> extends ReactiveService<T, S> {
+
+    S processBlocking(T processableObj);
+
+    @Override
+    default Uni<S> process(T processableObj) {
+        return BlockingExecutions.supply(this, () -> processBlocking(processableObj));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingStreamingClientService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingStreamingClientService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.service.blocking;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.service.ReactiveStreamingClientService;
+
+@FunctionalInterface
+public interface BlockingStreamingClientService<T, S> extends ReactiveStreamingClientService<T, S> {
+
+    /**
+     * Materializes the full input list before invoking the blocking callback.
+     *
+     * <p>This contract is intended for bounded batch-style aggregation. Batch retries rerun the full
+     * callback with the collected list.
+     */
+    S processBlocking(List<T> processableObj);
+
+    @Override
+    default Uni<S> process(Multi<T> processableObj) {
+        return processableObj.collect()
+            .asList()
+            .onItem()
+            .transformToUni(items -> BlockingExecutions.supply(this, () -> processBlocking(items)));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingStreamingService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/service/blocking/BlockingStreamingService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.service.blocking;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Multi;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.service.ReactiveStreamingService;
+
+@FunctionalInterface
+public interface BlockingStreamingService<T, S> extends ReactiveStreamingService<T, S> {
+
+    /**
+     * Materializes the full output list before any downstream item is emitted.
+     *
+     * <p>This contract is intended for bounded batch-style work. It does not preserve incremental
+     * streaming or automatic reactive backpressure. Prefer {@link BlockingIteratorService} when a
+     * blocking library can iterate results incrementally.
+     */
+    List<S> processBlocking(T processableObj);
+
+    @Override
+    default Multi<S> process(T processableObj) {
+        return BlockingExecutions.emitList(this, () -> processBlocking(processableObj));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepManyToManyBlocking.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepManyToManyBlocking.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.step.blocking;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Multi;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.step.StepManyToMany;
+
+public interface StepManyToManyBlocking<I, O> extends StepManyToMany<I, O> {
+
+    /**
+     * Materializes the full input list and the full output list.
+     *
+     * <p>This is a bounded batch contract. It does not preserve incremental stream semantics.
+     * Inputs and outputs are fully resident in memory during execution, so large batches can
+     * increase heap pressure and GC cost. Prefer explicit chunking, reactive backpressure, or an
+     * incremental streaming contract when batch size is large or unbounded.
+     */
+    List<O> applyBatchBlocking(List<I> inputs);
+
+    @Override
+    default Multi<O> applyTransform(Multi<I> input) {
+        return input.collect().asList()
+            .onItem().transformToMulti(items -> BlockingExecutions.emitList(this, () -> applyBatchBlocking(items)));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepManyToOneBlocking.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepManyToOneBlocking.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.step.blocking;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.step.StepManyToOne;
+
+public interface StepManyToOneBlocking<I, O> extends StepManyToOne<I, O> {
+
+    /**
+     * Materializes the full input list before invoking the blocking callback.
+     *
+     * <p>This is a bounded batch contract. Batch retries rerun the full callback with the collected
+     * list.
+     */
+    O applyBatchBlocking(List<I> inputs);
+
+    @Override
+    default Uni<O> applyReduce(Multi<I> input) {
+        return input.collect().asList()
+            .onItem().transformToUni(items -> BlockingExecutions.supply(this, () -> applyBatchBlocking(items)));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepOneToManyBlocking.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepOneToManyBlocking.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.step.blocking;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Multi;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.step.StepOneToMany;
+
+public interface StepOneToManyBlocking<I, O> extends StepOneToMany<I, O> {
+
+    /**
+     * Materializes the full output list before any downstream item is emitted.
+     *
+     * <p>Prefer {@link StepOneToManyBlockingIterator} when a blocking library can iterate results
+     * incrementally and you want to avoid full in-memory materialization.
+     */
+    List<O> applyBlocking(I in);
+
+    @Override
+    default Multi<O> applyOneToMany(I in) {
+        return BlockingExecutions.emitList(this, () -> applyBlocking(in));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepOneToManyBlockingIterator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepOneToManyBlockingIterator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.step.blocking;
+
+import io.smallrye.mutiny.Multi;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.blocking.CloseableIterator;
+import org.pipelineframework.step.StepOneToMany;
+
+/**
+ * Incremental blocking 1 -> N step contract.
+ *
+ * <p>Use this contract when authored code should stay synchronous but can produce results
+ * incrementally via a cursor or iterator. The framework owns iterator closure when the step is
+ * consumed through the pipeline runtime.
+ */
+public interface StepOneToManyBlockingIterator<I, O> extends StepOneToMany<I, O> {
+
+    CloseableIterator<O> iterateBlocking(I in);
+
+    @Override
+    default Multi<O> applyOneToMany(I in) {
+        return BlockingExecutions.emitIterator(this, () -> iterateBlocking(in));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepOneToOneBlocking.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/blocking/StepOneToOneBlocking.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.step.blocking;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.blocking.BlockingExecutions;
+import org.pipelineframework.step.StepOneToOne;
+
+public interface StepOneToOneBlocking<I, O> extends StepOneToOne<I, O> {
+
+    O applyBlocking(I in);
+
+    @Override
+    default Uni<O> applyOneToOne(I in) {
+        return BlockingExecutions.supply(this, () -> applyBlocking(in));
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
@@ -25,12 +25,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.junit.jupiter.api.Test;
+import org.pipelineframework.blocking.CloseableIterator;
 import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
 import org.pipelineframework.step.ConfigurableStep;
 import org.pipelineframework.step.StepManyToMany;
 import org.pipelineframework.step.StepOneToMany;
 import org.pipelineframework.step.StepOneToOne;
+import org.pipelineframework.step.blocking.StepManyToManyBlocking;
+import org.pipelineframework.step.blocking.StepManyToOneBlocking;
+import org.pipelineframework.step.blocking.StepOneToManyBlocking;
+import org.pipelineframework.step.blocking.StepOneToManyBlockingIterator;
+import org.pipelineframework.step.blocking.StepOneToOneBlocking;
 import org.pipelineframework.step.functional.ManyToOne;
 import org.pipelineframework.step.future.StepOneToOneCompletableFuture;
 
@@ -158,6 +164,67 @@ class PipelineStepExecutorTest {
         assertEquals(List.of("x-mapped"), ((Multi<String>) result).collect().asList().await().indefinitely());
     }
 
+    @Test
+    void blockingOneToOneOnUniProducesOutput() {
+        Object result = PipelineStepExecutor.applyOneToOneUnchecked(
+            new BlockingSuffixOneToOneStep("-blocking"),
+            Uni.createFrom().item("x"));
+
+        assertEquals("x-blocking", ((Uni<String>) result).await().indefinitely());
+    }
+
+    @Test
+    void blockingOneToManyProducesExpandedItems() {
+        Object result = PipelineStepExecutor.applyOneToManyUnchecked(
+            new BlockingExpandingOneToManyStep(),
+            Uni.createFrom().item("x"),
+            false,
+            16,
+            null,
+            null,
+            null);
+
+        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().indefinitely());
+    }
+
+    @Test
+    void blockingIteratorOneToManyProducesExpandedItems() {
+        Object result = PipelineStepExecutor.applyOneToManyUnchecked(
+            new BlockingIteratorOneToManyStep(),
+            Uni.createFrom().item("x"),
+            false,
+            16,
+            null,
+            null,
+            null);
+
+        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().indefinitely());
+    }
+
+    @Test
+    void blockingManyToOneReducesItems() {
+        Object result = PipelineStepExecutor.applyManyToOneUnchecked(
+            new BlockingReducingManyToOneStep(),
+            Multi.createFrom().items("a", "b"),
+            null,
+            null,
+            null);
+
+        assertEquals("a,b", ((Uni<String>) result).await().indefinitely());
+    }
+
+    @Test
+    void blockingManyToManyMapsItems() {
+        Object result = PipelineStepExecutor.applyManyToManyUnchecked(
+            new BlockingMappingManyToManyStep(),
+            Multi.createFrom().items("a", "b"),
+            null,
+            null,
+            null);
+
+        assertEquals(List.of("a-mapped", "b-mapped"), ((Multi<String>) result).collect().asList().await().indefinitely());
+    }
+
     static final class SuffixOneToOneStep extends ConfigurableStep implements StepOneToOne<String, String> {
         private final String suffix;
 
@@ -268,6 +335,64 @@ class PipelineStepExecutorTest {
         @Override
         public Multi<String> applyTransform(Multi<String> input) {
             return input.onItem().transform(item -> item + "-mapped");
+        }
+    }
+
+    static final class BlockingSuffixOneToOneStep extends ConfigurableStep implements StepOneToOneBlocking<String, String> {
+        private final String suffix;
+
+        BlockingSuffixOneToOneStep(String suffix) {
+            this.suffix = suffix;
+        }
+
+        @Override
+        public String applyBlocking(String in) {
+            return in + suffix;
+        }
+    }
+
+    static final class BlockingExpandingOneToManyStep extends ConfigurableStep implements StepOneToManyBlocking<String, String> {
+        @Override
+        public List<String> applyBlocking(String in) {
+            return List.of(in + "-1", in + "-2");
+        }
+    }
+
+    static final class BlockingIteratorOneToManyStep extends ConfigurableStep
+        implements StepOneToManyBlockingIterator<String, String> {
+        @Override
+        public CloseableIterator<String> iterateBlocking(String in) {
+            return new CloseableIterator<>() {
+                private int index;
+
+                @Override
+                public boolean hasNext() {
+                    return index < 2;
+                }
+
+                @Override
+                public String next() {
+                    return in + "-" + ++index;
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+        }
+    }
+
+    static final class BlockingReducingManyToOneStep extends ConfigurableStep implements StepManyToOneBlocking<String, String> {
+        @Override
+        public String applyBatchBlocking(List<String> inputs) {
+            return String.join(",", inputs);
+        }
+    }
+
+    static final class BlockingMappingManyToManyStep extends ConfigurableStep implements StepManyToManyBlocking<String, String> {
+        @Override
+        public List<String> applyBatchBlocking(List<String> inputs) {
+            return inputs.stream().map(item -> item + "-mapped").toList();
         }
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/blocking/BlockingExecutionSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/blocking/BlockingExecutionSupportTest.java
@@ -1,0 +1,253 @@
+package org.pipelineframework.blocking;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.mutiny.subscription.Cancellable;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.annotation.PipelineStep;
+import org.pipelineframework.service.blocking.BlockingService;
+import org.pipelineframework.service.blocking.BlockingIteratorService;
+import org.pipelineframework.service.blocking.BlockingStreamingService;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockingExecutionSupportTest {
+
+    private final BlockingExecutionSupport support = new BlockingExecutionSupport();
+
+    @Test
+    void workerExecutionRunsOffCallerThread() {
+        AtomicReference<Thread> executingThread = new AtomicReference<>();
+        Thread caller = Thread.currentThread();
+
+        String value = support.supply(false, () -> {
+            executingThread.set(Thread.currentThread());
+            return "ok";
+        }).await().atMost(Duration.ofSeconds(5));
+
+        assertNotEquals(caller, executingThread.get());
+        assertFalse(executingThread.get().isVirtual());
+        assertTrue("ok".equals(value));
+    }
+
+    @Test
+    void virtualThreadExecutionUsesVirtualThreads() {
+        AtomicBoolean isVirtual = new AtomicBoolean(false);
+
+        String value = support.supply(true, () -> {
+            isVirtual.set(Thread.currentThread().isVirtual());
+            return "ok";
+        }).await().atMost(Duration.ofSeconds(5));
+
+        assertTrue(isVirtual.get());
+        assertTrue("ok".equals(value));
+    }
+
+    @Test
+    void blockingUnaryServiceReactiveAdapterRunsOffCallerThread() {
+        AtomicReference<Thread> executingThread = new AtomicReference<>();
+        Thread caller = Thread.currentThread();
+
+        BlockingService<String, String> service = new BlockingService<>() {
+            @Override
+            public String processBlocking(String processableObj) {
+                executingThread.set(Thread.currentThread());
+                return processableObj + "-done";
+            }
+        };
+
+        String value = service.process("ok").await().atMost(Duration.ofSeconds(5));
+
+        assertNotEquals(caller, executingThread.get());
+        assertFalse(executingThread.get().isVirtual());
+        assertTrue("ok-done".equals(value));
+    }
+
+    @Test
+    void blockingStreamingServiceReactiveAdapterRunsOffCallerThread() {
+        AtomicReference<Thread> executingThread = new AtomicReference<>();
+        Thread caller = Thread.currentThread();
+
+        BlockingStreamingService<String, String> service = new BlockingStreamingService<>() {
+            @Override
+            public List<String> processBlocking(String processableObj) {
+                executingThread.set(Thread.currentThread());
+                return List.of(processableObj + "-1", processableObj + "-2");
+            }
+        };
+
+        List<String> values = service.process("ok")
+            .collect()
+            .asList()
+            .await()
+            .atMost(Duration.ofSeconds(5));
+
+        assertNotEquals(caller, executingThread.get());
+        assertFalse(executingThread.get().isVirtual());
+        assertTrue(values.equals(List.of("ok-1", "ok-2")));
+    }
+
+    @Test
+    void emitIteratorRunsAcquisitionAndIterationOffCallerThreadAndClosesOnCompletion() throws Exception {
+        AtomicReference<Thread> openThread = new AtomicReference<>();
+        AtomicReference<Thread> iterationThread = new AtomicReference<>();
+        CountDownLatch closed = new CountDownLatch(1);
+        Thread caller = Thread.currentThread();
+
+        io.smallrye.mutiny.Multi<String> emitted = support.emitIterator(false, () -> {
+            openThread.set(Thread.currentThread());
+            return new CloseableIterator<String>() {
+                private int index;
+
+                @Override
+                public boolean hasNext() {
+                    iterationThread.compareAndSet(null, Thread.currentThread());
+                    return index < 2;
+                }
+
+                @Override
+                public String next() {
+                    iterationThread.compareAndSet(null, Thread.currentThread());
+                    return index++ == 0 ? "a" : "b";
+                }
+
+                @Override
+                public void close() {
+                    closed.countDown();
+                }
+            };
+        });
+        List<String> values = emitted.collect().asList().await().atMost(Duration.ofSeconds(5));
+
+        assertTrue(values.equals(List.of("a", "b")));
+        assertNotEquals(caller, openThread.get());
+        assertNotEquals(caller, iterationThread.get());
+        assertFalse(openThread.get().isVirtual());
+        assertFalse(iterationThread.get().isVirtual());
+        assertTrue(closed.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void emitIteratorClosesOnCancellation() throws Exception {
+        CountDownLatch closed = new CountDownLatch(1);
+        AtomicReference<Cancellable> cancellable = new AtomicReference<>();
+
+        Cancellable subscription = support.emitIterator(false, () -> new CloseableIterator<String>() {
+            private int index;
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public String next() {
+                if (index++ == 0) {
+                    return "first";
+                }
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return "later";
+            }
+
+            @Override
+            public void close() {
+                closed.countDown();
+            }
+        }).subscribe().with(item -> {
+            if ("first".equals(item)) {
+                cancellable.get().cancel();
+            }
+        });
+        cancellable.set(subscription);
+
+        assertTrue(closed.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void emitIteratorClosesOnFailure() throws Exception {
+        CountDownLatch closed = new CountDownLatch(1);
+
+        RuntimeException failure = assertThrows(RuntimeException.class, () -> support.emitIterator(false, () -> new CloseableIterator<String>() {
+            private boolean emitted;
+
+            @Override
+            public boolean hasNext() {
+                if (emitted) {
+                    throw new RuntimeException("boom");
+                }
+                return true;
+            }
+
+            @Override
+            public String next() {
+                emitted = true;
+                return "first";
+            }
+
+            @Override
+            public void close() {
+                closed.countDown();
+            }
+        }).collect().asList().await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(failure.getMessage().contains("boom"));
+        assertTrue(closed.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void blockingIteratorServiceReactiveAdapterUsesVirtualThreadsWhenAnnotated() {
+        AtomicBoolean openOnVirtualThread = new AtomicBoolean(false);
+
+        List<String> values = new VirtualIteratorService(openOnVirtualThread).process("ok")
+            .collect()
+            .asList()
+            .await()
+            .atMost(Duration.ofSeconds(5));
+
+        assertTrue(openOnVirtualThread.get());
+        assertTrue(values.equals(List.of("ok-1", "ok-2")));
+    }
+
+    @PipelineStep(runOnVirtualThreads = true)
+    static final class VirtualIteratorService implements BlockingIteratorService<String, String> {
+        private final AtomicBoolean openOnVirtualThread;
+
+        private VirtualIteratorService(AtomicBoolean openOnVirtualThread) {
+            this.openOnVirtualThread = openOnVirtualThread;
+        }
+
+        @Override
+        public CloseableIterator<String> iterateBlocking(String processableObj) {
+            openOnVirtualThread.set(Thread.currentThread().isVirtual());
+            return new CloseableIterator<String>() {
+                private int index;
+
+                @Override
+                public boolean hasNext() {
+                    return index < 2;
+                }
+
+                @Override
+                public String next() {
+                    return processableObj + "-" + ++index;
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+        }
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/blocking/BlockingExecutionSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/blocking/BlockingExecutionSupportTest.java
@@ -167,7 +167,10 @@ class BlockingExecutionSupportTest {
             }
         }).subscribe().with(item -> {
             if ("first".equals(item)) {
-                cancellable.get().cancel();
+                Cancellable current = cancellable.get();
+                if (current != null) {
+                    current.cancel();
+                }
             }
         });
         cancellable.set(subscription);

--- a/framework/runtime/src/test/java/org/pipelineframework/blocking/BlockingExecutionSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/blocking/BlockingExecutionSupportTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.annotation.PipelineStep;
 import org.pipelineframework.service.blocking.BlockingService;
@@ -138,9 +138,8 @@ class BlockingExecutionSupportTest {
     @Test
     void emitIteratorClosesOnCancellation() throws Exception {
         CountDownLatch closed = new CountDownLatch(1);
-        AtomicReference<Cancellable> cancellable = new AtomicReference<>();
 
-        Cancellable subscription = support.emitIterator(false, () -> new CloseableIterator<String>() {
+        AssertSubscriber<String> subscriber = support.emitIterator(false, () -> new CloseableIterator<String>() {
             private int index;
 
             @Override
@@ -165,16 +164,10 @@ class BlockingExecutionSupportTest {
             public void close() {
                 closed.countDown();
             }
-        }).subscribe().with(item -> {
-            if ("first".equals(item)) {
-                Cancellable current = cancellable.get();
-                if (current != null) {
-                    current.cancel();
-                }
-            }
-        });
-        cancellable.set(subscription);
+        }).subscribe().withSubscriber(AssertSubscriber.create(1));
 
+        subscriber.awaitItems(1);
+        subscriber.cancel();
         assertTrue(closed.await(5, TimeUnit.SECONDS));
     }
 


### PR DESCRIPTION
## Summary
- reintroduce first-class blocking step and service authoring without Mutiny in user signatures
- add an incremental blocking iterator path for `1 -> N` streaming while keeping list-based blocking as the bounded batch path
- bridge blocking-authored services back into the existing reactive transport/runtime generation path and update csv-payments/docs/tests accordingly

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=PipelineStepExecutorTest,org.pipelineframework.blocking.BlockingExecutionSupportTest test`
- `./mvnw -f framework/pom.xml -pl deployment -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.pipelineframework.processor.BlockingServiceProcessorWarningTest,org.pipelineframework.processor.renderer.BlockingReactiveBridgeRendererTest,PipelineTargetResolutionPhaseTest,RestResourceRendererTest,StepArtifactGenerationServiceTest test`
- `./mvnw -pl examples/csv-payments/input-csv-file-processing-svc -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ProcessCsvPaymentsInputServiceTest test`

## Notes
- full pipeline-runtime E2E/local-image validation is not included in this PR
- local CodeRabbit review produced one actionable batch which was fixed; a second follow-up run was blocked by CodeRabbit usage credits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class blocking step support: synchronous, materialised-batch and iterator-based streaming APIs; automatic reactive bridges and optional virtual-thread execution via a new step flag.
  * Runtime helpers to offload blocking work with context propagation, iterator lifecycle management and pacing support.

* **Documentation**
  * Expanded guidance on choosing blocking vs reactive, execution strategies, virtual-thread opt-in and failure-handling best practices.

* **Examples & Tests**
  * CSV example updated and extensive tests added for blocking paths, bridges and virtual-thread behaviour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->