### PR TITLE
Add await step foundation

### DIFF
--- a/docs/guide/build/configuration/index.md
+++ b/docs/guide/build/configuration/index.md
@@ -206,6 +206,8 @@ Prefix: `pipeline.orchestrator`
 | `pipeline.orchestrator.queue-url` | string | none | Queue URL for external dispatcher providers. |
 | `pipeline.orchestrator.dynamo.execution-table` | string | `tpf_execution` | DynamoDB table used for execution state rows. |
 | `pipeline.orchestrator.dynamo.execution-key-table` | string | `tpf_execution_key` | DynamoDB table used for submit dedupe keys. |
+| `pipeline.orchestrator.dynamo.await-interaction-table` | string | `tpf_await_interaction` | DynamoDB table used for durable await interaction rows. |
+| `pipeline.orchestrator.dynamo.await-interaction-key-table` | string | `tpf_await_interaction_key` | DynamoDB table used for await idempotency and correlation lookup keys. |
 | `pipeline.orchestrator.dynamo.region` | string | none | Optional DynamoDB region override. |
 | `pipeline.orchestrator.dynamo.endpoint-override` | string | none | Optional DynamoDB endpoint override (local/dev). |
 | `pipeline.orchestrator.sqs.region` | string | none | Optional SQS region override. |

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/GenerationTarget.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/GenerationTarget.java
@@ -25,4 +25,6 @@ public enum GenerationTarget {
     REMOTE_OPERATOR_ADAPTER,
     /** Generated reactive bridge for blocking-authored internal services */
     BLOCKING_REACTIVE_BRIDGE,
+    /** Generated await client step that suspends queue-async execution */
+    AWAIT_CLIENT_STEP,
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
@@ -70,7 +70,7 @@ public record StepDefinition(
     ) {
         this(
             name,
-            kind,
+            requireNonRemoteKind(kind),
             executionClass,
             null,
             Map.of(),
@@ -98,7 +98,7 @@ public record StepDefinition(
     ) {
         this(
             name,
-            kind,
+            requireNonRemoteKind(kind),
             executionClass,
             null,
             Map.of(),

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
@@ -16,6 +16,8 @@
 
 package org.pipelineframework.processor.ir;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import com.squareup.javapoet.ClassName;
@@ -29,6 +31,9 @@ import org.pipelineframework.config.template.PipelineTemplateStepExecution;
  * @param kind The kind of step (INTERNAL, DELEGATED, or REMOTE)
  * @param executionClass The class that provides the execution implementation
  * @param remoteExecution remote execution metadata for REMOTE steps
+ * @param awaitConfig raw await configuration for AWAIT steps
+ * @param timeout await timeout string for AWAIT steps
+ * @param idempotencyKeyFields fields used to derive await idempotency keys
  * @param inboundMapper The inbound mapper class for internal service steps (nullable)
  * @param outboundMapper The outbound mapper class for internal service steps (nullable)
  * @param externalMapper The operator mapper class for mapping between domain and operator types (nullable)
@@ -42,6 +47,9 @@ public record StepDefinition(
         StepKind kind,
         @Nullable ClassName executionClass,
         @Nullable PipelineTemplateStepExecution remoteExecution,
+        Map<String, Object> awaitConfig,
+        @Nullable String timeout,
+        List<String> idempotencyKeyFields,
         @Nullable ClassName inboundMapper,
         @Nullable ClassName outboundMapper,
         @Nullable ClassName externalMapper,
@@ -64,6 +72,10 @@ public record StepDefinition(
             name,
             kind,
             executionClass,
+            null,
+            Map.of(),
+            null,
+            List.of(),
             null,
             null,
             externalMapper,
@@ -88,6 +100,10 @@ public record StepDefinition(
             name,
             kind,
             executionClass,
+            null,
+            Map.of(),
+            null,
+            List.of(),
             inboundMapper,
             outboundMapper,
             null,
@@ -114,6 +130,9 @@ public record StepDefinition(
             requireNonRemoteKind(kind),
             executionClass,
             null,
+            Map.of(),
+            null,
+            List.of(),
             inboundMapper,
             outboundMapper,
             externalMapper,
@@ -134,15 +153,23 @@ public record StepDefinition(
         }
         if (kind == StepKind.REMOTE) {
             Objects.requireNonNull(remoteExecution, "Remote execution cannot be null for REMOTE steps");
+        } else if (kind == StepKind.AWAIT) {
+            if (executionClass != null || remoteExecution != null) {
+                throw new IllegalArgumentException("AWAIT steps cannot declare executionClass or remoteExecution");
+            }
+            Objects.requireNonNull(inputType, "Input type cannot be null for AWAIT steps");
+            Objects.requireNonNull(outputType, "Output type cannot be null for AWAIT steps");
         } else {
             Objects.requireNonNull(executionClass, "Execution class cannot be null");
         }
         mapperFallback = mapperFallback == null ? MapperFallbackMode.NONE : mapperFallback;
+        awaitConfig = awaitConfig == null ? Map.of() : Map.copyOf(awaitConfig);
+        idempotencyKeyFields = idempotencyKeyFields == null ? List.of() : List.copyOf(idempotencyKeyFields);
     }
 
     private static StepKind requireNonRemoteKind(StepKind kind) {
-        if (kind == StepKind.REMOTE) {
-            throw new IllegalArgumentException("Convenience constructor cannot be used for StepKind.REMOTE; provide remoteExecution");
+        if (kind == StepKind.REMOTE || kind == StepKind.AWAIT) {
+            throw new IllegalArgumentException("Convenience constructor cannot be used for " + kind);
         }
         return kind;
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepKind.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepKind.java
@@ -36,5 +36,11 @@ public enum StepKind {
      * A remote step whose execution is delegated to an external operator endpoint
      * resolved from v2 template execution metadata.
      */
-    REMOTE
+    REMOTE,
+
+    /**
+     * An await step that dispatches external work, stores durable interaction state,
+     * and resumes from a correlated completion.
+     */
+    AWAIT
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -501,6 +501,26 @@ public class StepDefinitionParser {
             report(Diagnostic.Kind.ERROR, message);
             return null;
         }
+        Object correlationObj = awaitMap.get("correlation");
+        if (correlationObj instanceof Map<?, ?> correlationMap) {
+            String strategy = stringValue(correlationMap.get("strategy"));
+            if (isBlank(strategy)) {
+                String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
+                LOG.warn(message);
+                report(Diagnostic.Kind.ERROR, message);
+                return null;
+            }
+        } else if (correlationObj != null) {
+            String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        } else {
+            String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
         return (Map<String, Object>) normalizeMap(awaitMap);
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -531,8 +531,9 @@ public class StepDefinitionParser {
         }
         List<String> result = new ArrayList<>();
         for (Object item : iterable) {
-            if (item != null && !item.toString().isBlank()) {
-                result.add(item.toString());
+            String text = item == null ? null : item.toString().trim();
+            if (!isBlank(text)) {
+                result.add(text);
             }
         }
         return List.copyOf(result);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -68,7 +68,11 @@ public class StepDefinitionParser {
         "inputFields",
         "outputTypeName",
         "outputFields",
-        "execution");
+        "execution",
+        "kind",
+        "await",
+        "timeout",
+        "idempotencyKeyFields");
     private final BiConsumer<Diagnostic.Kind, String> diagnosticReporter;
     private final String legacyInternalPackageSuffix;
 
@@ -181,6 +185,8 @@ public class StepDefinitionParser {
         String operatorClassName = getStringValue(stepData, "operator");
         String delegateClassName = getStringValue(stepData, "delegate");
         String serviceClassName = getStringValue(stepData, "service");
+        String rawKind = getStringValue(stepData, "kind");
+        boolean awaitStep = "await".equalsIgnoreCase(rawKind);
         String delegatedClassName = null;
 
         if (!isBlank(operatorClassName) && !isBlank(delegateClassName)) {
@@ -201,6 +207,25 @@ public class StepDefinitionParser {
             report(Diagnostic.Kind.ERROR, message);
             return null;
         }
+        if (awaitStep && (!isBlank(delegatedClassName) || !isBlank(serviceClassName) || remoteExecution != null)) {
+            String message = "Skipping step '" + name
+                + "': await steps cannot declare 'service', 'operator', 'delegate', or remote 'execution'";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
+        if (!isBlank(rawKind)
+            && !awaitStep
+            && !"internal".equalsIgnoreCase(rawKind)
+            && !"delegated".equalsIgnoreCase(rawKind)
+            && !"delegate".equalsIgnoreCase(rawKind)
+            && !"remote".equalsIgnoreCase(rawKind)) {
+            String message = "Skipping step '" + name + "': unsupported kind '" + rawKind
+                + "'. Allowed values: internal, delegated, remote, await";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
         if (remoteExecution != null && (!isBlank(delegatedClassName) || !isBlank(serviceClassName))) {
             String message = "Skipping step '" + name
                 + "': remote execution is mutually exclusive with 'service', 'operator', and 'delegate'";
@@ -208,12 +233,15 @@ public class StepDefinitionParser {
             report(Diagnostic.Kind.ERROR, message);
             return null;
         }
-        boolean inferredLegacyInternal = isBlank(delegatedClassName) && isBlank(serviceClassName);
+        boolean inferredLegacyInternal = !awaitStep && isBlank(delegatedClassName) && isBlank(serviceClassName);
 
         StepKind kind;
         String executionClassName;
 
-        if (remoteExecution != null) {
+        if (awaitStep) {
+            kind = StepKind.AWAIT;
+            executionClassName = null;
+        } else if (remoteExecution != null) {
             kind = StepKind.REMOTE;
             executionClassName = null;
         } else if (!isBlank(delegatedClassName)) {
@@ -372,6 +400,58 @@ public class StepDefinitionParser {
                 kind,
                 null,
                 remoteExecution,
+                Map.of(),
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                MapperFallbackMode.NONE,
+                inputType,
+                outputType,
+                StreamingShape.UNARY_UNARY);
+        }
+
+        if (kind == StepKind.AWAIT) {
+            if (inboundMapper != null || outboundMapper != null || externalMapper != null || mapperFallback != MapperFallbackMode.NONE) {
+                String message = "Skipping step '" + name
+                    + "': await steps cannot declare mapper fields in this slice; use typed input/output contracts";
+                LOG.warn(message);
+                report(Diagnostic.Kind.ERROR, message);
+                return null;
+            }
+            if (inputType == null || outputType == null) {
+                String message = "Skipping step '" + name + "': await steps must provide input and output types";
+                LOG.warn(message);
+                report(Diagnostic.Kind.ERROR, message);
+                return null;
+            }
+            StreamingShape shape = parseStreamingShapeHint(stepData, name);
+            if (shape != null && shape != StreamingShape.UNARY_UNARY) {
+                String message = "Skipping step '" + name + "': await steps support only ONE_TO_ONE cardinality in this slice";
+                LOG.warn(message);
+                report(Diagnostic.Kind.ERROR, message);
+                return null;
+            }
+            Map<String, Object> awaitConfig = parseAwaitConfig(stepData, name);
+            if (awaitConfig == null) {
+                return null;
+            }
+            String timeout = getStringValue(stepData, "timeout");
+            if (isBlank(timeout)) {
+                String message = "Skipping step '" + name + "': await steps must declare timeout";
+                LOG.warn(message);
+                report(Diagnostic.Kind.ERROR, message);
+                return null;
+            }
+            return new StepDefinition(
+                name,
+                StepKind.AWAIT,
+                null,
+                null,
+                awaitConfig,
+                timeout,
+                parseStringList(stepData.get("idempotencyKeyFields"), name, "idempotencyKeyFields"),
                 null,
                 null,
                 null,
@@ -399,6 +479,72 @@ public class StepDefinitionParser {
             inputType,
             outputType,
             parseStreamingShapeHint(stepData, name));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseAwaitConfig(Map<String, Object> stepData, String stepName) {
+        Object awaitObj = stepData.get("await");
+        if (!(awaitObj instanceof Map<?, ?> awaitMap)) {
+            String message = "Skipping step '" + stepName + "': await steps must declare an await map";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
+        Object transportObj = awaitMap.get("transport");
+        if (!(transportObj instanceof Map<?, ?> transportMap) || isBlank(stringValue(transportMap.get("type")))) {
+            String message = "Skipping step '" + stepName + "': await.transport.type must be declared";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
+        return (Map<String, Object>) normalizeMap(awaitMap);
+    }
+
+    private List<String> parseStringList(Object value, String stepName, String fieldName) {
+        if (value == null) {
+            return List.of();
+        }
+        if (!(value instanceof Iterable<?> iterable)) {
+            String message = "Skipping step '" + stepName + "': " + fieldName + " must be a list";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (Object item : iterable) {
+            if (item != null && !item.toString().isBlank()) {
+                result.add(item.toString());
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private Map<String, Object> normalizeMap(Map<?, ?> map) {
+        java.util.LinkedHashMap<String, Object> normalized = new java.util.LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getKey() != null) {
+                normalized.put(entry.getKey().toString(), normalizeValue(entry.getValue()));
+            }
+        }
+        return Map.copyOf(normalized);
+    }
+
+    private Object normalizeValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return normalizeMap(map);
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<Object> normalized = new ArrayList<>();
+            for (Object item : iterable) {
+                normalized.add(normalizeValue(item));
+            }
+            return List.copyOf(normalized);
+        }
+        return value;
+    }
+
+    private String stringValue(Object value) {
+        return value == null ? null : value.toString();
     }
 
     private ClassName parseOptionalStepMapper(String mapperName, String stepName, String fieldName) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -515,11 +515,6 @@ public class StepDefinitionParser {
             LOG.warn(message);
             report(Diagnostic.Kind.ERROR, message);
             return null;
-        } else {
-            String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
-            LOG.warn(message);
-            report(Diagnostic.Kind.ERROR, message);
-            return null;
         }
         return (Map<String, Object>) normalizeMap(awaitMap);
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -444,6 +444,10 @@ public class StepDefinitionParser {
                 report(Diagnostic.Kind.ERROR, message);
                 return null;
             }
+            List<String> idempotencyKeyFields = parseStringList(stepData.get("idempotencyKeyFields"), name, "idempotencyKeyFields");
+            if (idempotencyKeyFields == null) {
+                return null;
+            }
             return new StepDefinition(
                 name,
                 StepKind.AWAIT,
@@ -451,7 +455,7 @@ public class StepDefinitionParser {
                 null,
                 awaitConfig,
                 timeout,
-                parseStringList(stepData.get("idempotencyKeyFields"), name, "idempotencyKeyFields"),
+                idempotencyKeyFields,
                 null,
                 null,
                 null,
@@ -508,7 +512,7 @@ public class StepDefinitionParser {
             String message = "Skipping step '" + stepName + "': " + fieldName + " must be a list";
             LOG.warn(message);
             report(Diagnostic.Kind.ERROR, message);
-            return List.of();
+            return null;
         }
         List<String> result = new ArrayList<>();
         for (Object item : iterable) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -208,7 +208,50 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             case REMOTE -> {
                 yield createRemoteStepModel(ctx, stepDef, ctxWarningLogger);
             }
+            case AWAIT -> {
+                yield createAwaitStepModel(ctx, stepDef, ctxWarningLogger);
+            }
         };
+    }
+
+    private PipelineStepModel createAwaitStepModel(
+            PipelineCompilationContext ctx,
+            org.pipelineframework.processor.ir.StepDefinition stepDef,
+            Consumer<String> ctxWarningLogger) {
+        if (stepDef.inputType() == null || stepDef.outputType() == null) {
+            ctx.getProcessingEnv().getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Await step '" + stepDef.name() + "' must resolve both input and output domain types");
+            return null;
+        }
+        StreamingShape streamingShape = stepDef.streamingShapeHint() != null
+            ? stepDef.streamingShapeHint()
+            : StreamingShape.UNARY_UNARY;
+        if (streamingShape != StreamingShape.UNARY_UNARY) {
+            ctx.getProcessingEnv().getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Await step '" + stepDef.name() + "' currently supports only ONE_TO_ONE cardinality");
+            return null;
+        }
+
+        String serviceName = toYamlServiceName(stepDef.name());
+        String servicePackage = deriveYamlServicePackage(stepDef.inputType(), ctxWarningLogger);
+        return new PipelineStepModel.Builder()
+            .serviceName(serviceName)
+            .generatedName(serviceName)
+            .servicePackage(servicePackage)
+            .serviceClassName(ClassName.get("org.pipelineframework.awaitable", "AwaitStepDescriptor"))
+            .inputMapping(new TypeMapping(stepDef.inputType(), null, false, stepDef.inputType()))
+            .outputMapping(new TypeMapping(stepDef.outputType(), null, false, stepDef.outputType()))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(java.util.Set.of(GenerationTarget.AWAIT_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .sideEffect(false)
+            .cacheKeyGenerator(null)
+            .orderingRequirement(OrderingRequirement.RELAXED)
+            .threadSafety(ThreadSafety.SAFE)
+            .build();
     }
 
     private PipelineStepModel createRemoteStepModel(

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -88,6 +88,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
         RestFunctionHandlerRenderer restFunctionHandlerRenderer = new RestFunctionHandlerRenderer();
         BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer = new BlockingReactiveBridgeRenderer();
         RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer = new RemoteOperatorAdapterRenderer();
+        AwaitClientStepRenderer awaitClientStepRenderer = new AwaitClientStepRenderer();
         OrchestratorGrpcRenderer orchestratorGrpcRenderer = new OrchestratorGrpcRenderer();
         OrchestratorRestResourceRenderer orchestratorRestRenderer = new OrchestratorRestResourceRenderer();
         AbstractOrchestratorFunctionHandlerRenderer orchestratorFunctionHandlerRenderer =
@@ -236,7 +237,8 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
                 restRenderer,
                 restFunctionHandlerRenderer,
                 blockingReactiveBridgeRenderer,
-                remoteOperatorAdapterRenderer);
+                remoteOperatorAdapterRenderer,
+                awaitClientStepRenderer);
         }
 
         if (ctx.isTransportModeGrpc() && descriptorSet != null) {
@@ -472,7 +474,8 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             RestResourceRenderer restRenderer,
             RestFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
-            RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer) throws IOException {
+            RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer,
+            AwaitClientStepRenderer awaitClientStepRenderer) throws IOException {
         stepArtifactGenerationService.generateArtifactsForModel(
             ctx,
             model,
@@ -491,7 +494,8 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             restRenderer,
             restFunctionHandlerRenderer,
             blockingReactiveBridgeRenderer,
-            remoteOperatorAdapterRenderer);
+            remoteOperatorAdapterRenderer,
+            awaitClientStepRenderer);
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -113,6 +113,10 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      * @return a set of GenerationTarget values applicable to the given step model
      */
     private Set<GenerationTarget> resolveTargetsForModel(PipelineStepModel model, TransportMode transportMode) {
+        if (model.serviceClassName() != null
+            && "org.pipelineframework.awaitable.AwaitStepDescriptor".equals(model.serviceClassName().canonicalName())) {
+            return Set.of(GenerationTarget.AWAIT_CLIENT_STEP);
+        }
         var remoteExecution = model.remoteExecution();
         if (remoteExecution != null && remoteExecution.isRemote()) {
             Set<GenerationTarget> targets = new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode));

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -23,6 +23,7 @@ import org.pipelineframework.processor.ir.TransportMode;
  * and decides client/server roles for each step.
  */
 public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
+    public static final String AWAIT_STEP_DESCRIPTOR_CLASS = "org.pipelineframework.awaitable.AwaitStepDescriptor";
 
     private final EnumMap<DeploymentRole, TargetResolutionStrategy> strategiesByRole;
 
@@ -114,7 +115,7 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      */
     private Set<GenerationTarget> resolveTargetsForModel(PipelineStepModel model, TransportMode transportMode) {
         if (model.serviceClassName() != null
-            && "org.pipelineframework.awaitable.AwaitStepDescriptor".equals(model.serviceClassName().canonicalName())) {
+            && AWAIT_STEP_DESCRIPTOR_CLASS.equals(model.serviceClassName().canonicalName())) {
             return Set.of(GenerationTarget.AWAIT_CLIENT_STEP);
         }
         var remoteExecution = model.remoteExecution();

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -96,8 +96,11 @@ class StepArtifactGenerationService {
         for (GenerationTarget target : model.enabledTargets()) {
             switch (target) {
                 case AWAIT_CLIENT_STEP -> {
-                    String awaitClientClassName = model.servicePackage() + PIPELINE_DOT
-                        + ResourceNameUtils.normalizeBaseName(model.generatedName()).replace("Service", "") + "AwaitClientStep";
+                    String baseName = ResourceNameUtils.normalizeBaseName(model.generatedName());
+                    if (baseName.endsWith("Service")) {
+                        baseName = baseName.substring(0, baseName.length() - "Service".length());
+                    }
+                    String awaitClientClassName = model.servicePackage() + PIPELINE_DOT + baseName + "AwaitClientStep";
                     DeploymentRole clientRole = resolveClientRole(model.deploymentRole());
                     awaitClientStepRenderer.render(model, new GenerationContext(
                         ctx.getProcessingEnv(),

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -22,6 +22,7 @@ import org.pipelineframework.processor.renderer.LocalClientStepRenderer;
 import org.pipelineframework.processor.renderer.RemoteOperatorAdapterRenderer;
 import org.pipelineframework.processor.renderer.RestClientStepRenderer;
 import org.pipelineframework.processor.renderer.AbstractFunctionHandlerRenderer;
+import org.pipelineframework.processor.renderer.AwaitClientStepRenderer;
 import org.pipelineframework.processor.renderer.RestResourceRenderer;
 import org.pipelineframework.processor.util.ResourceNameUtils;
 import org.pipelineframework.processor.util.RoleMetadataGenerator;
@@ -90,9 +91,23 @@ class StepArtifactGenerationService {
             RestResourceRenderer restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
-            RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer) throws IOException {
+            RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer,
+            AwaitClientStepRenderer awaitClientStepRenderer) throws IOException {
         for (GenerationTarget target : model.enabledTargets()) {
             switch (target) {
+                case AWAIT_CLIENT_STEP -> {
+                    String awaitClientClassName = model.servicePackage() + PIPELINE_DOT
+                        + ResourceNameUtils.normalizeBaseName(model.generatedName()).replace("Service", "") + "AwaitClientStep";
+                    DeploymentRole clientRole = resolveClientRole(model.deploymentRole());
+                    awaitClientStepRenderer.render(model, new GenerationContext(
+                        ctx.getProcessingEnv(),
+                        pathResolver.resolveRoleOutputDir(ctx, clientRole),
+                        clientRole,
+                        enabledAspects,
+                        cacheKeyGenerator,
+                        descriptorSet));
+                    roleMetadataGenerator.recordClassWithRole(awaitClientClassName, clientRole.name());
+                }
                 case GRPC_SERVICE -> {
                     if (model.deploymentRole() == DeploymentRole.PLUGIN_SERVER
                         && !generationPolicy.allowPluginServerArtifacts(ctx)) {
@@ -310,6 +325,47 @@ class StepArtifactGenerationService {
                 }
             }
         }
+    }
+
+    void generateArtifactsForModel(
+            PipelineCompilationContext ctx,
+            PipelineStepModel model,
+            GrpcBinding grpcBinding,
+            RestBinding restBinding,
+            LocalBinding localBinding,
+            Set<String> generatedSideEffectBeans,
+            Set<String> enabledAspects,
+            DescriptorProtos.FileDescriptorSet descriptorSet,
+            ClassName cacheKeyGenerator,
+            RoleMetadataGenerator roleMetadataGenerator,
+            GrpcServiceAdapterRenderer grpcRenderer,
+            ClientStepRenderer clientRenderer,
+            LocalClientStepRenderer localClientRenderer,
+            RestClientStepRenderer restClientRenderer,
+            RestResourceRenderer restRenderer,
+            AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
+            BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
+            RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer) throws IOException {
+        generateArtifactsForModel(
+            ctx,
+            model,
+            grpcBinding,
+            restBinding,
+            localBinding,
+            generatedSideEffectBeans,
+            enabledAspects,
+            descriptorSet,
+            cacheKeyGenerator,
+            roleMetadataGenerator,
+            grpcRenderer,
+            clientRenderer,
+            localClientRenderer,
+            restClientRenderer,
+            restRenderer,
+            restFunctionHandlerRenderer,
+            blockingReactiveBridgeRenderer,
+            remoteOperatorAdapterRenderer,
+            new AwaitClientStepRenderer());
     }
 
     private DeploymentRole resolveClientRole(DeploymentRole serverRole) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -97,9 +97,6 @@ class StepArtifactGenerationService {
             switch (target) {
                 case AWAIT_CLIENT_STEP -> {
                     String baseName = ResourceNameUtils.normalizeBaseName(model.generatedName());
-                    if (baseName.endsWith("Service")) {
-                        baseName = baseName.substring(0, baseName.length() - "Service".length());
-                    }
                     String awaitClientClassName = model.servicePackage() + PIPELINE_DOT + baseName + "AwaitClientStep";
                     DeploymentRole clientRole = resolveClientRole(model.deploymentRole());
                     awaitClientStepRenderer.render(model, new GenerationContext(

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwaitClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwaitClientStepRenderer.java
@@ -51,7 +51,7 @@ public class AwaitClientStepRenderer {
             .addModifiers(Modifier.PUBLIC)
             .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), outputType))
             .addParameter(inputType, "input")
-            .addStatement("return support.awaitOneToOne(descriptorFactory.descriptor($S, $S, $S), input)",
+            .addStatement("return descriptorFactory.descriptor($S, $S, $S).onItem().transformToUni(descriptor -> support.awaitOneToOne(descriptor, input))",
                 model.serviceName(),
                 inputType.toString(),
                 outputType.toString())

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwaitClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwaitClientStepRenderer.java
@@ -1,0 +1,95 @@
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import javax.lang.model.element.Modifier;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import io.quarkus.arc.Unremovable;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.parallelism.OrderingRequirement;
+import org.pipelineframework.parallelism.ThreadSafety;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.step.StepOneToOne;
+
+/**
+ * Renders generated await client steps.
+ */
+public class AwaitClientStepRenderer {
+
+    public GenerationTarget target() {
+        return GenerationTarget.AWAIT_CLIENT_STEP;
+    }
+
+    public void render(PipelineStepModel model, GenerationContext ctx) throws IOException {
+        String baseName = model.generatedName().endsWith("Service")
+            ? model.generatedName().substring(0, model.generatedName().length() - "Service".length())
+            : model.generatedName();
+        String className = baseName + "AwaitClientStep";
+        TypeName inputType = model.inboundDomainType();
+        TypeName outputType = model.outboundDomainType();
+
+        FieldSpec support = FieldSpec.builder(ClassName.get("org.pipelineframework.awaitable", "AwaitStepSupport"), "support")
+            .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
+            .build();
+        FieldSpec descriptorFactory = FieldSpec.builder(
+                ClassName.get("org.pipelineframework.awaitable", "AwaitStepDescriptorFactory"),
+                "descriptorFactory")
+            .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
+            .build();
+
+        MethodSpec apply = MethodSpec.methodBuilder("applyOneToOne")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), outputType))
+            .addParameter(inputType, "input")
+            .addStatement("return support.awaitOneToOne(descriptorFactory.descriptor($S, $S, $S), input)",
+                model.serviceName(),
+                inputType.toString(),
+                outputType.toString())
+            .build();
+
+        MethodSpec cacheKeyTargetType = MethodSpec.methodBuilder("cacheKeyTargetType")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(ClassName.get(Class.class),
+                com.squareup.javapoet.WildcardTypeName.subtypeOf(Object.class)))
+            .addStatement("return $T.class", outputType)
+            .build();
+
+        TypeSpec type = TypeSpec.classBuilder(className)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("jakarta.enterprise.context", "Dependent")).build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get(Unremovable.class)).build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.pipelineframework.annotation", "GeneratedRole"))
+                .addMember("value", "$T.$L",
+                    ClassName.get("org.pipelineframework.annotation", "GeneratedRole", "Role"),
+                    ctx.role().name())
+                .build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.pipelineframework.annotation", "ParallelismHint"))
+                .addMember("ordering", "$T.$L", ClassName.get(OrderingRequirement.class), OrderingRequirement.RELAXED.name())
+                .addMember("threadSafety", "$T.$L", ClassName.get(ThreadSafety.class), ThreadSafety.SAFE.name())
+                .build())
+            .superclass(ClassName.get("org.pipelineframework.step", "ConfigurableStep"))
+            .addSuperinterface(ParameterizedTypeName.get(ClassName.get(StepOneToOne.class), inputType, outputType))
+            .addSuperinterface(ClassName.get("org.pipelineframework.cache", "CacheKeyTarget"))
+            .addField(support)
+            .addField(descriptorFactory)
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build())
+            .addMethod(cacheKeyTargetType)
+            .addMethod(apply)
+            .build();
+
+        JavaFile.builder(model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX, type)
+            .build()
+            .writeTo(ctx.outputDir());
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -31,6 +31,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         OrchestratorRpcConstants.GET_EXECUTION_STATUS_METHOD;
     private static final String ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD =
         OrchestratorRpcConstants.GET_EXECUTION_RESULT_METHOD;
+    private static final String ORCHESTRATOR_COMPLETE_AWAIT_METHOD =
+        OrchestratorRpcConstants.COMPLETE_AWAIT_METHOD;
+    private static final String ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD =
+        OrchestratorRpcConstants.LIST_PENDING_AWAIT_METHOD;
     private static final String ORCHESTRATOR_INGEST_METHOD = OrchestratorRpcConstants.INGEST_METHOD;
     private static final String ORCHESTRATOR_SUBSCRIBE_METHOD = OrchestratorRpcConstants.SUBSCRIBE_METHOD;
 
@@ -98,6 +102,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             binding, descriptorSet, ctx, ORCHESTRATOR_GET_EXECUTION_STATUS_METHOD, false, false);
         var resultBinding = safeResolveBinding(
             binding, descriptorSet, ctx, ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD, false, false);
+        var completeAwaitBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_COMPLETE_AWAIT_METHOD, false, false);
+        var listPendingAwaitBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD, false, false);
 
         FieldSpec executionField = FieldSpec.builder(executionService, "pipelineExecutionService", Modifier.PRIVATE)
             .addAnnotation(inject)
@@ -280,6 +288,8 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             resultBinding,
             outputType,
             uni);
+        MethodSpec completeAwaitMethod = buildCompleteAwaitMethod(typeResolver, ctx, completeAwaitBinding, uni);
+        MethodSpec listPendingAwaitMethod = buildListPendingAwaitMethod(typeResolver, ctx, listPendingAwaitBinding, uni);
 
         TypeSpec.Builder serviceBuilder = TypeSpec.classBuilder(GRPC_CLASS)
             .addModifiers(Modifier.PUBLIC)
@@ -298,6 +308,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         }
         if (executionResultMethod != null) {
             serviceBuilder.addMethod(executionResultMethod);
+        }
+        if (completeAwaitMethod != null) {
+            serviceBuilder.addMethod(completeAwaitMethod);
+        }
+        if (listPendingAwaitMethod != null) {
+            serviceBuilder.addMethod(listPendingAwaitMethod);
         }
 
         TypeSpec service = serviceBuilder.build();
@@ -616,5 +632,124 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 ClassName.get("io.grpc", "Status"));
         }
         return method.build();
+    }
+
+    private MethodSpec buildCompleteAwaitMethod(
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding completeAwaitBinding,
+        ClassName uni
+    ) {
+        if (completeAwaitBinding == null) {
+            return null;
+        }
+        var types = typeResolver.resolve(completeAwaitBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = types.grpcParameterType();
+        ClassName responseType = types.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+        ClassName command = ClassName.get("org.pipelineframework.awaitable", "AwaitCompletionCommand");
+        return MethodSpec.methodBuilder("completeAwait")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()")
+            .addCode("""
+                return pipelineExecutionService.completeAwaitInteraction(new $T(
+                        request.getTenantId(),
+                        request.getInteractionId(),
+                        request.getCorrelationId(),
+                        request.getIdempotencyKey(),
+                        request.getResponseJson(),
+                        request.getActor(),
+                        $T.currentTimeMillis()))
+                    .onItem().transform(result -> $T.newBuilder()
+                        .setInteractionId(result.record().interactionId())
+                        .setExecutionId(result.record().executionId())
+                        .setStepId(result.record().stepId())
+                        .setStatus(result.record().status().name())
+                        .setDuplicate(result.duplicate())
+                        .build())
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                command,
+                System.class,
+                responseType,
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_COMPLETE_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_COMPLETE_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"))
+            .build();
+    }
+
+    private MethodSpec buildListPendingAwaitMethod(
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding listPendingAwaitBinding,
+        ClassName uni
+    ) {
+        if (listPendingAwaitBinding == null) {
+            return null;
+        }
+        var types = typeResolver.resolve(listPendingAwaitBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = types.grpcParameterType();
+        ClassName responseType = types.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+        return MethodSpec.methodBuilder("listPendingAwait")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()")
+            .addCode("""
+                return pipelineExecutionService.queryPendingAwaitInteractions(
+                        request.getTenantId(),
+                        request.getAssignee(),
+                        request.getGroup(),
+                        request.getStepId(),
+                        request.getLimit())
+                    .onItem().transform(records -> {
+                        $T.Builder builder = $T.newBuilder();
+                        for (var record : records) {
+                            builder.addInteractionsBuilder()
+                                .setInteractionId(record.interactionId())
+                                .setCorrelationId(record.correlationId())
+                                .setExecutionId(record.executionId())
+                                .setStepId(record.stepId())
+                                .setStepIndex(record.stepIndex())
+                                .setOutputType(record.outputType())
+                                .setStatus(record.status().name())
+                                .setTransportType(record.transportType())
+                                .setDeadlineEpochMs(record.deadlineEpochMs())
+                                .setCreatedAtEpochMs(record.createdAtEpochMs())
+                                .setUpdatedAtEpochMs(record.updatedAtEpochMs());
+                        }
+                        return builder.build();
+                    })
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                responseType,
+                responseType,
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"))
+            .build();
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -2,7 +2,13 @@ package org.pipelineframework.processor.renderer;
 
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
+import javax.tools.Diagnostic;
 
 import com.google.protobuf.DescriptorProtos;
 import com.squareup.javapoet.*;
@@ -82,7 +88,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         }
 
         GrpcJavaTypeResolver typeResolver = new GrpcJavaTypeResolver();
-        var grpcTypes = typeResolver.resolve(grpcBinding, ctx.processingEnv().getMessager());
+        var grpcTypes = typeResolver.resolve(grpcBinding, messager(ctx));
         ClassName inputType = grpcTypes.grpcParameterType();
         ClassName outputType = grpcTypes.grpcReturnType();
         if (inputType == null || outputType == null) {
@@ -338,12 +344,45 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 methodName,
                 inputStreaming,
                 outputStreaming,
-                ctx.processingEnv().getMessager());
+                messager(ctx));
         } catch (IllegalStateException e) {
-            ctx.processingEnv().getMessager().printMessage(
-                javax.tools.Diagnostic.Kind.WARNING,
+            messager(ctx).printMessage(
+                Diagnostic.Kind.WARNING,
                 "Skipping orchestrator gRPC generation: " + e.getMessage());
             return null;
+        }
+    }
+
+    private Messager messager(GenerationContext ctx) {
+        ProcessingEnvironment processingEnv = ctx.processingEnv();
+        if (processingEnv == null || processingEnv.getMessager() == null) {
+            return NoopMessager.INSTANCE;
+        }
+        return processingEnv.getMessager();
+    }
+
+    private enum NoopMessager implements Messager {
+        INSTANCE;
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence msg) {
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e) {
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a) {
+        }
+
+        @Override
+        public void printMessage(
+            Diagnostic.Kind kind,
+            CharSequence msg,
+            Element e,
+            AnnotationMirror a,
+            AnnotationValue v) {
         }
     }
 
@@ -374,7 +413,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (runAsyncBinding == null) {
             return null;
         }
-        var asyncTypes = typeResolver.resolve(runAsyncBinding, ctx.processingEnv().getMessager());
+        var asyncTypes = typeResolver.resolve(runAsyncBinding, messager(ctx));
         ClassName requestType = asyncTypes.grpcParameterType();
         ClassName responseType = asyncTypes.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -485,7 +524,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (statusBinding == null) {
             return null;
         }
-        var statusTypes = typeResolver.resolve(statusBinding, ctx.processingEnv().getMessager());
+        var statusTypes = typeResolver.resolve(statusBinding, messager(ctx));
         ClassName requestType = statusTypes.grpcParameterType();
         ClassName responseType = statusTypes.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -562,7 +601,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (resultBinding == null) {
             return null;
         }
-        var resultTypes = typeResolver.resolve(resultBinding, ctx.processingEnv().getMessager());
+        var resultTypes = typeResolver.resolve(resultBinding, messager(ctx));
         ClassName requestType = resultTypes.grpcParameterType();
         ClassName responseType = resultTypes.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -643,7 +682,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (completeAwaitBinding == null) {
             return null;
         }
-        var types = typeResolver.resolve(completeAwaitBinding, ctx.processingEnv().getMessager());
+        var types = typeResolver.resolve(completeAwaitBinding, messager(ctx));
         ClassName requestType = types.grpcParameterType();
         ClassName responseType = types.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -699,7 +738,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (listPendingAwaitBinding == null) {
             return null;
         }
-        var types = typeResolver.resolve(listPendingAwaitBinding, ctx.processingEnv().getMessager());
+        var types = typeResolver.resolve(listPendingAwaitBinding, messager(ctx));
         ClassName requestType = types.grpcParameterType();
         ClassName responseType = types.grpcReturnType();
         if (requestType == null || responseType == null) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -356,12 +356,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
     private Messager messager(GenerationContext ctx) {
         ProcessingEnvironment processingEnv = ctx.processingEnv();
         if (processingEnv == null || processingEnv.getMessager() == null) {
-            return NoopMessager.INSTANCE;
+            return StderrMessager.INSTANCE;
         }
         return processingEnv.getMessager();
     }
 
-    private enum NoopMessager implements Messager {
+    private enum StderrMessager implements Messager {
         INSTANCE;
 
         @Override
@@ -717,6 +717,17 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .addParameter(requestType, "request")
             .addStatement("long startTime = System.nanoTime()")
             .addCode("""
+                if (request.getTenantId() == null || request.getTenantId().isBlank()) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("tenantId is required")
+                        .asRuntimeException());
+                }
+                if ((request.getInteractionId() == null || request.getInteractionId().isBlank())
+                        && (request.getCorrelationId() == null || request.getCorrelationId().isBlank())) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("interactionId or correlationId is required")
+                        .asRuntimeException());
+                }
                 return pipelineExecutionService.completeAwaitInteraction(new $T(
                         request.getTenantId(),
                         request.getInteractionId(),
@@ -736,6 +747,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                     .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
                         System.nanoTime() - startTime));
                 """,
+                uni,
+                ClassName.get("io.grpc", "Status"),
+                uni,
+                ClassName.get("io.grpc", "Status"),
                 command,
                 System.class,
                 responseType,
@@ -772,12 +787,23 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .addParameter(requestType, "request")
             .addStatement("long startTime = System.nanoTime()")
             .addCode("""
+                if (request.getTenantId() == null || request.getTenantId().isBlank()) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("tenantId is required")
+                        .asRuntimeException());
+                }
+                if (request.getLimit() < 0) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("limit must be >= 0")
+                        .asRuntimeException());
+                }
+                int validatedLimit = request.getLimit() == 0 ? 50 : $T.min(request.getLimit(), 500);
                 return pipelineExecutionService.queryPendingAwaitInteractions(
                         request.getTenantId(),
                         request.getAssignee(),
                         request.getGroup(),
                         request.getStepId(),
-                        request.getLimit())
+                        validatedLimit)
                     .onItem().transform(records -> {
                         $T.Builder builder = $T.newBuilder();
                         for (var record : records) {
@@ -800,6 +826,11 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                     .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
                         System.nanoTime() - startTime));
                 """,
+                uni,
+                ClassName.get("io.grpc", "Status"),
+                uni,
+                ClassName.get("io.grpc", "Status"),
+                Math.class,
                 responseType,
                 responseType,
                 ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -366,14 +366,17 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
 
         @Override
         public void printMessage(Diagnostic.Kind kind, CharSequence msg) {
+            print(kind, msg, null, null, null);
         }
 
         @Override
         public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e) {
+            print(kind, msg, e, null, null);
         }
 
         @Override
         public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a) {
+            print(kind, msg, e, a, null);
         }
 
         @Override
@@ -383,6 +386,24 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             Element e,
             AnnotationMirror a,
             AnnotationValue v) {
+            print(kind, msg, e, a, v);
+        }
+
+        private void print(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a, AnnotationValue v) {
+            StringBuilder line = new StringBuilder("OrchestratorGrpcRenderer diagnostic [")
+                .append(kind)
+                .append("] ")
+                .append(msg);
+            if (e != null) {
+                line.append(" element=").append(e);
+            }
+            if (a != null) {
+                line.append(" annotation=").append(a);
+            }
+            if (v != null) {
+                line.append(" value=").append(v);
+            }
+            System.err.println(line);
         }
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -214,6 +214,15 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
                     .addMember("value", "$S", "x-tenant-id")
                     .build())
                 .build())
+            .beginControlFlow("if (tenantId == null || tenantId.isBlank())")
+            .addStatement("throw new $T($S)", badRequestException, "tenantId header is required")
+            .endControlFlow()
+            .beginControlFlow("if (request == null)")
+            .addStatement("throw new $T($S)", badRequestException, "completion request is required")
+            .endControlFlow()
+            .beginControlFlow("if ((request.interactionId() == null || request.interactionId().isBlank()) && (request.correlationId() == null || request.correlationId().isBlank()))")
+            .addStatement("throw new $T($S)", badRequestException, "interactionId or correlationId is required")
+            .endControlFlow()
             .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
                 awaitCompletionCommand,
                 System.class,
@@ -242,6 +251,9 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
+            .beginControlFlow("if (tenantId == null || tenantId.isBlank())")
+            .addStatement("throw new $T($S)", badRequestException, "tenantId header is required")
+            .endControlFlow()
             .beginControlFlow("if (limit != null && limit < 0)")
             .addStatement("throw new $T($S)", badRequestException, "limit must be >= 0")
             .endControlFlow()

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -205,9 +205,8 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
                     .addMember("value", "$S", "x-tenant-id")
                     .build())
                 .build())
-            .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId == null || tenantId.isBlank() ? $S : tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
+            .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
                 awaitCompletionCommand,
-                "default",
                 System.class,
                 awaitDtoMapper)
             .build();
@@ -231,10 +230,10 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(String.class, "stepId")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "stepId").build())
                 .build())
-            .addParameter(ParameterSpec.builder(int.class, "limit")
+            .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
-            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? 0 : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
                 awaitDtoMapper)
             .build();
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -47,6 +47,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         ClassName pathParam = ClassName.get("jakarta.ws.rs", "PathParam");
         ClassName queryParam = ClassName.get("jakarta.ws.rs", "QueryParam");
         ClassName headerParam = ClassName.get("jakarta.ws.rs", "HeaderParam");
+        ClassName badRequestException = ClassName.get("jakarta.ws.rs", "BadRequestException");
         ClassName consumes = ClassName.get("jakarta.ws.rs", "Consumes");
         ClassName produces = ClassName.get("jakarta.ws.rs", "Produces");
         ClassName restStream = ClassName.get("org.jboss.resteasy.reactive", "RestStreamElementType");
@@ -74,6 +75,10 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         FieldSpec defaultPendingAwaitLimitField = FieldSpec.builder(int.class, "DEFAULT_PENDING_AWAIT_LIMIT",
                 Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
             .initializer("$L", 50)
+            .build();
+        FieldSpec maxPendingAwaitLimitField = FieldSpec.builder(int.class, "MAX_PENDING_AWAIT_LIMIT",
+                Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+            .initializer("$L", 500)
             .build();
 
         MethodSpec.Builder runMethod = MethodSpec.methodBuilder("run")
@@ -237,7 +242,11 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
-            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? DEFAULT_PENDING_AWAIT_LIMIT : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+            .beginControlFlow("if (limit != null && limit < 0)")
+            .addStatement("throw new $T($S)", badRequestException, "limit must be >= 0")
+            .endControlFlow()
+            .addStatement("int validatedLimit = limit == null ? DEFAULT_PENDING_AWAIT_LIMIT : $T.min(limit, MAX_PENDING_AWAIT_LIMIT)", Math.class)
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, validatedLimit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
                 awaitDtoMapper)
             .build();
 
@@ -258,6 +267,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addAnnotation(applicationScoped)
             .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/pipeline").build())
             .addField(defaultPendingAwaitLimitField)
+            .addField(maxPendingAwaitLimitField)
             .addField(executionField)
             .addField(outputBusField)
             .addMethod(runMethod.build())

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -71,6 +71,10 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         FieldSpec outputBusField = FieldSpec.builder(outputBus, "pipelineOutputBus", Modifier.PRIVATE)
             .addAnnotation(inject)
             .build();
+        FieldSpec defaultPendingAwaitLimitField = FieldSpec.builder(int.class, "DEFAULT_PENDING_AWAIT_LIMIT",
+                Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+            .initializer("$L", 50)
+            .build();
 
         MethodSpec.Builder runMethod = MethodSpec.methodBuilder("run")
             .addModifiers(Modifier.PUBLIC)
@@ -233,7 +237,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
-            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? 0 : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? DEFAULT_PENDING_AWAIT_LIMIT : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
                 awaitDtoMapper)
             .build();
 
@@ -253,6 +257,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(applicationScoped)
             .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/pipeline").build())
+            .addField(defaultPendingAwaitLimitField)
             .addField(executionField)
             .addField(outputBusField)
             .addMethod(runMethod.build())

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -45,6 +45,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         ClassName post = ClassName.get("jakarta.ws.rs", "POST");
         ClassName get = ClassName.get("jakarta.ws.rs", "GET");
         ClassName pathParam = ClassName.get("jakarta.ws.rs", "PathParam");
+        ClassName queryParam = ClassName.get("jakarta.ws.rs", "QueryParam");
         ClassName headerParam = ClassName.get("jakarta.ws.rs", "HeaderParam");
         ClassName consumes = ClassName.get("jakarta.ws.rs", "Consumes");
         ClassName produces = ClassName.get("jakarta.ws.rs", "Produces");
@@ -55,6 +56,11 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         ClassName outputBus = ClassName.get("org.pipelineframework", "PipelineOutputBus");
         ClassName runAsyncAcceptedDto = ClassName.get("org.pipelineframework.orchestrator.dto", "RunAsyncAcceptedDto");
         ClassName executionStatusDto = ClassName.get("org.pipelineframework.orchestrator.dto", "ExecutionStatusDto");
+        ClassName awaitCompletionCommand = ClassName.get("org.pipelineframework.awaitable", "AwaitCompletionCommand");
+        ClassName awaitCompletionRequestDto = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitCompletionRequestDto");
+        ClassName awaitCompletionResponseDto = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitCompletionResponseDto");
+        ClassName awaitInteractionDto = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitInteractionDto");
+        ClassName awaitDtoMapper = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitDtoMapper");
 
         ClassName inputType = ClassName.get(binding.basePackage() + ".common.dto", binding.inputTypeName() + "Dto");
         ClassName outputType = ClassName.get(binding.basePackage() + ".common.dto", binding.outputTypeName() + "Dto");
@@ -188,6 +194,50 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
                 binding.outputStreaming())
             .build();
 
+        MethodSpec completeAwaitMethod = MethodSpec.methodBuilder("completeAwait")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(post)
+            .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/interactions/complete").build())
+            .returns(ParameterizedTypeName.get(uni, awaitCompletionResponseDto))
+            .addParameter(awaitCompletionRequestDto, "request")
+            .addParameter(ParameterSpec.builder(String.class, "tenantId")
+                .addAnnotation(AnnotationSpec.builder(headerParam)
+                    .addMember("value", "$S", "x-tenant-id")
+                    .build())
+                .build())
+            .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId == null || tenantId.isBlank() ? $S : tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
+                awaitCompletionCommand,
+                "default",
+                System.class,
+                awaitDtoMapper)
+            .build();
+
+        MethodSpec pendingAwaitMethod = MethodSpec.methodBuilder("pendingAwait")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(get)
+            .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/interactions/pending").build())
+            .returns(ParameterizedTypeName.get(uni, ParameterizedTypeName.get(ClassName.get(List.class), awaitInteractionDto)))
+            .addParameter(ParameterSpec.builder(String.class, "tenantId")
+                .addAnnotation(AnnotationSpec.builder(headerParam)
+                    .addMember("value", "$S", "x-tenant-id")
+                    .build())
+                .build())
+            .addParameter(ParameterSpec.builder(String.class, "assignee")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "assignee").build())
+                .build())
+            .addParameter(ParameterSpec.builder(String.class, "group")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "group").build())
+                .build())
+            .addParameter(ParameterSpec.builder(String.class, "stepId")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "stepId").build())
+                .build())
+            .addParameter(ParameterSpec.builder(int.class, "limit")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
+                .build())
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+                awaitDtoMapper)
+            .build();
+
         MethodSpec subscribeMethod = MethodSpec.methodBuilder("subscribe")
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(get)
@@ -211,6 +261,8 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addMethod(ingestMethod)
             .addMethod(statusMethod)
             .addMethod(resultMethod)
+            .addMethod(completeAwaitMethod)
+            .addMethod(pendingAwaitMethod)
             .addMethod(subscribeMethod)
             .build();
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorRpcConstants.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorRpcConstants.java
@@ -15,6 +15,8 @@ public final class OrchestratorRpcConstants {
     public static final String RUN_ASYNC_METHOD = "RunAsync";
     public static final String GET_EXECUTION_STATUS_METHOD = "GetExecutionStatus";
     public static final String GET_EXECUTION_RESULT_METHOD = "GetExecutionResult";
+    public static final String COMPLETE_AWAIT_METHOD = "CompleteAwait";
+    public static final String LIST_PENDING_AWAIT_METHOD = "ListPendingAwait";
     public static final String INGEST_METHOD = "Ingest";
     public static final String SUBSCRIBE_METHOD = "Subscribe";
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineOrderMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineOrderMetadataGenerator.java
@@ -180,8 +180,11 @@ public class PipelineOrderMetadataGenerator {
             if (model.deploymentRole() != DeploymentRole.ORCHESTRATOR_CLIENT || model.sideEffect()) {
                 continue;
             }
+            String resolvedSuffix = model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)
+                ? "AwaitClientStep"
+                : suffix;
             String className = model.servicePackage() + ".pipeline." +
-                model.generatedName().replace("Service", "") + suffix;
+                model.generatedName().replace("Service", "") + resolvedSuffix;
             ordered.add(className);
         }
         return new ArrayList<>(ordered);
@@ -215,6 +218,11 @@ public class PipelineOrderMetadataGenerator {
         String suffix = ctx.getTransportMode().clientStepSuffix();
         Set<String> generated = new LinkedHashSet<>();
         for (PipelineStepModel model : models) {
+            if (model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)) {
+                generated.add(model.servicePackage() + ".pipeline."
+                    + model.generatedName().replace("Service", "") + "AwaitClientStep");
+                continue;
+            }
             if (clientTarget != null && !model.enabledTargets().contains(clientTarget)) {
                 continue;
             }
@@ -297,7 +305,7 @@ public class PipelineOrderMetadataGenerator {
         if (lastDot != -1) {
             simple = simple.substring(lastDot + 1);
         }
-        simple = simple.replaceAll("(Service|GrpcClientStep|RestClientStep|LocalClientStep)(_Subclass)?$", "");
+        simple = simple.replaceAll("(Service|GrpcClientStep|RestClientStep|LocalClientStep|AwaitClientStep)(_Subclass)?$", "");
         return toClassToken(simple);
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineOrderMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineOrderMetadataGenerator.java
@@ -184,7 +184,7 @@ public class PipelineOrderMetadataGenerator {
                 ? "AwaitClientStep"
                 : suffix;
             String className = model.servicePackage() + ".pipeline." +
-                model.generatedName().replace("Service", "") + resolvedSuffix;
+                stripTrailingService(model.generatedName()) + resolvedSuffix;
             ordered.add(className);
         }
         return new ArrayList<>(ordered);
@@ -220,16 +220,26 @@ public class PipelineOrderMetadataGenerator {
         for (PipelineStepModel model : models) {
             if (model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)) {
                 generated.add(model.servicePackage() + ".pipeline."
-                    + model.generatedName().replace("Service", "") + "AwaitClientStep");
+                    + stripTrailingService(model.generatedName()) + "AwaitClientStep");
                 continue;
             }
             if (clientTarget != null && !model.enabledTargets().contains(clientTarget)) {
                 continue;
             }
             generated.add(model.servicePackage() + ".pipeline."
-                + model.generatedName().replace("Service", "") + suffix);
+                + stripTrailingService(model.generatedName()) + suffix);
         }
         return generated;
+    }
+
+    private static String stripTrailingService(String generatedName) {
+        if (generatedName == null) {
+            return "";
+        }
+        if (generatedName.endsWith("Service")) {
+            return generatedName.substring(0, generatedName.length() - "Service".length());
+        }
+        return generatedName;
     }
 
     private boolean isSideEffectClientStep(String className) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/ir/StepDefinitionTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/ir/StepDefinitionTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2023-2025 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.ir;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.template.PipelineTemplateRemoteTarget;
+import org.pipelineframework.config.template.PipelineTemplateStepExecution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StepDefinitionTest {
+
+    private static final ClassName INPUT_TYPE = ClassName.get("com.example", "Input");
+    private static final ClassName OUTPUT_TYPE = ClassName.get("com.example", "Output");
+    private static final ClassName EXECUTION_CLASS = ClassName.get("com.example", "ServiceImpl");
+
+    // ---- AWAIT kind tests ----
+
+    @Test
+    void constructsAwaitStepWithRequiredFields() {
+        StepDefinition step = new StepDefinition(
+            "Fraud Check",
+            StepKind.AWAIT,
+            null,        // executionClass
+            null,        // remoteExecution
+            Map.of("transport", Map.of("type", "webhook")),
+            "PT10M",
+            List.of("orderId"),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE,
+            OUTPUT_TYPE,
+            StreamingShape.UNARY_UNARY);
+
+        assertEquals("Fraud Check", step.name());
+        assertEquals(StepKind.AWAIT, step.kind());
+        assertNull(step.executionClass());
+        assertNull(step.remoteExecution());
+        assertEquals("PT10M", step.timeout());
+        assertEquals(List.of("orderId"), step.idempotencyKeyFields());
+        assertEquals(INPUT_TYPE, step.inputType());
+        assertEquals(OUTPUT_TYPE, step.outputType());
+    }
+
+    @Test
+    void awaitStepDefaultsAwaitConfigToEmptyMapWhenNull() {
+        StepDefinition step = new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            null, null,
+            null,  // awaitConfig null -> should be normalized to Map.of()
+            "PT5M",
+            null,  // idempotencyKeyFields null -> should be normalized to List.of()
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE,
+            OUTPUT_TYPE,
+            null);
+
+        assertEquals(Map.of(), step.awaitConfig());
+        assertEquals(List.of(), step.idempotencyKeyFields());
+    }
+
+    @Test
+    void awaitStepMakesImmutableCopyOfAwaitConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("key", "value");
+
+        StepDefinition step = new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            null, null,
+            config,
+            "PT5M",
+            List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null);
+
+        config.put("extra", "extra-value");  // mutate original
+        assertEquals(1, step.awaitConfig().size());
+        assertThrows(UnsupportedOperationException.class, () -> step.awaitConfig().put("k", "v"));
+    }
+
+    @Test
+    void awaitStepMakesImmutableCopyOfIdempotencyKeyFields() {
+        List<String> fields = new ArrayList<>();
+        fields.add("orderId");
+
+        StepDefinition step = new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            null, null,
+            Map.of(),
+            "PT5M",
+            fields,
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null);
+
+        fields.add("customerId");  // mutate original
+        assertEquals(1, step.idempotencyKeyFields().size());
+        assertThrows(UnsupportedOperationException.class, () -> step.idempotencyKeyFields().add("x"));
+    }
+
+    @Test
+    void awaitStepRejectsNullInputType() {
+        assertThrows(NullPointerException.class, () -> new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            null, null,
+            Map.of(), "PT5M", List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            null,  // null inputType
+            OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void awaitStepRejectsNullOutputType() {
+        assertThrows(NullPointerException.class, () -> new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            null, null,
+            Map.of(), "PT5M", List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE,
+            null,  // null outputType
+            null));
+    }
+
+    @Test
+    void awaitStepRejectsExecutionClass() {
+        assertThrows(IllegalArgumentException.class, () -> new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            EXECUTION_CLASS,  // should not be set for AWAIT
+            null,
+            Map.of(), "PT5M", List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void awaitStepRejectsRemoteExecution() {
+        PipelineTemplateStepExecution remoteExecution = new PipelineTemplateStepExecution(
+            "REMOTE", "operator-id", "PROTOBUF_HTTP_V1", 3000,
+            PipelineTemplateRemoteTarget.ofUrlConfigKey("some.config.key"));
+        assertThrows(IllegalArgumentException.class, () -> new StepDefinition(
+            "Await Step",
+            StepKind.AWAIT,
+            null,
+            remoteExecution,  // should not be set for AWAIT
+            Map.of(), "PT5M", List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    // ---- requireNonRemoteKind tests ----
+
+    @Test
+    void convenienceConstructorRejectsAwaitKind() {
+        // The three-param convenience constructors use requireNonRemoteKind which now also rejects AWAIT
+        assertThrows(IllegalArgumentException.class, () -> new StepDefinition(
+            "step",
+            StepKind.AWAIT,
+            EXECUTION_CLASS,
+            null,  // externalMapper
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void convenienceConstructorRejectsRemoteKind() {
+        assertThrows(IllegalArgumentException.class, () -> new StepDefinition(
+            "step",
+            StepKind.REMOTE,
+            EXECUTION_CLASS,
+            null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    // ---- non-AWAIT validation ----
+
+    @Test
+    void internalStepRequiresExecutionClass() {
+        assertThrows(NullPointerException.class, () -> new StepDefinition(
+            "internal-step",
+            StepKind.INTERNAL,
+            null,  // no execution class
+            null,
+            Map.of(), null, List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void rejectsBlankName() {
+        assertThrows(IllegalArgumentException.class, () -> new StepDefinition(
+            "  ",  // blank name
+            StepKind.INTERNAL,
+            EXECUTION_CLASS,
+            null,
+            Map.of(), null, List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void rejectsNullName() {
+        assertThrows(NullPointerException.class, () -> new StepDefinition(
+            null,
+            StepKind.INTERNAL,
+            EXECUTION_CLASS,
+            null,
+            Map.of(), null, List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void rejectsNullKind() {
+        assertThrows(NullPointerException.class, () -> new StepDefinition(
+            "step",
+            null,  // null kind
+            EXECUTION_CLASS,
+            null,
+            Map.of(), null, List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void rejectsMutuallyExclusiveExecutionClassAndRemoteExecution() {
+        PipelineTemplateStepExecution remoteExecution = new PipelineTemplateStepExecution(
+            "REMOTE", "op-id", "PROTOBUF_HTTP_V1", 3000,
+            PipelineTemplateRemoteTarget.ofUrlConfigKey("some.config.key"));
+        assertThrows(IllegalArgumentException.class, () -> new StepDefinition(
+            "step",
+            StepKind.REMOTE,
+            EXECUTION_CLASS,  // both set
+            remoteExecution,
+            Map.of(), null, List.of(),
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null));
+    }
+
+    @Test
+    void mapperFallbackDefaultsToNoneWhenNull() {
+        StepDefinition step = new StepDefinition(
+            "step",
+            StepKind.INTERNAL,
+            EXECUTION_CLASS,
+            null,
+            Map.of(), null, List.of(),
+            null, null, null,
+            null,  // null -> should default to NONE
+            INPUT_TYPE, OUTPUT_TYPE, null);
+
+        assertEquals(MapperFallbackMode.NONE, step.mapperFallback());
+    }
+
+    @Test
+    void internalStepHasEmptyAwaitConfigByDefault() {
+        StepDefinition step = new StepDefinition(
+            "step",
+            StepKind.INTERNAL,
+            EXECUTION_CLASS,
+            null,
+            null, null, null,  // all await fields null
+            null, null, null,
+            MapperFallbackMode.NONE,
+            INPUT_TYPE, OUTPUT_TYPE, null);
+
+        assertEquals(Map.of(), step.awaitConfig());
+        assertEquals(List.of(), step.idempotencyKeyFields());
+        assertNull(step.timeout());
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -165,6 +165,215 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void rejectsAwaitStepWithServiceField() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Bad Await"
+                kind: "await"
+                service: "com.example.SomeService"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsAwaitStepWithoutTimeout() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "No Timeout Await"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsAwaitStepWithoutAwaitMap() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "No Await Map"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsAwaitStepWithoutTransportTypeInAwaitMap() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Missing Transport Type"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    url: "https://example.com"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsAwaitStepWithoutInputType() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "No Input Await"
+                kind: "await"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsUnsupportedKindValue() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Unknown Kind"
+                kind: "unknown"
+                service: "com.example.Service"
+                input: "com.example.Input"
+                output: "com.example.Output"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())),
+            diagnostics.toString());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("unsupported kind")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void acceptsAwaitStepWithMultipleIdempotencyKeyFields() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Multi Key Await"
+                kind: "await"
+                input: "com.example.MultiKeyRequest"
+                output: "com.example.MultiKeyResult"
+                timeout: "PT30M"
+                idempotencyKeyFields: ["orderId", "customerId", "amount"]
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertEquals(1, steps.size());
+        StepDefinition step = steps.getFirst();
+        assertEquals(StepKind.AWAIT, step.kind());
+        assertEquals(List.of("orderId", "customerId", "amount"), step.idempotencyKeyFields());
+        assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
+    }
+
+    @Test
+    void acceptsAwaitStepWithEmptyIdempotencyKeyFields() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Empty Keys Await"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT5M"
+                idempotencyKeyFields: []
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertEquals(1, steps.size());
+        StepDefinition step = steps.getFirst();
+        assertEquals(List.of(), step.idempotencyKeyFields());
+        assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
+    }
+
+    @Test
+    void awaitKindIsCaseInsensitive() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "AWAIT Step"
+                kind: "AWAIT"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT5M"
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertEquals(1, steps.size());
+        assertEquals(StepKind.AWAIT, steps.getFirst().kind());
+        assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
+    }
+
+    @Test
     void rejectsDelegatedStepWhenOnlyOneTypeIsProvided() throws IOException {
         List<StepDefinition> steps = parse("""
             appName: "Test"

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -135,6 +135,9 @@ class StepDefinitionParserTest {
         assertEquals("PT10M", step.timeout());
         assertEquals(List.of("orderId"), step.idempotencyKeyFields());
         assertEquals("webhook", ((java.util.Map<?, ?>) step.awaitConfig().get("transport")).get("type"));
+        assertEquals("interactionId", ((java.util.Map<?, ?>) step.awaitConfig().get("correlation")).get("strategy"));
+        assertEquals("https://partner.example/check",
+            ((java.util.Map<?, ?>) ((java.util.Map<?, ?>) step.awaitConfig().get("transport")).get("dispatch")).get("url"));
         assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -103,6 +103,65 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void parsesAwaitStepDefinition() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Fraud Check"
+                kind: "await"
+                cardinality: "ONE_TO_ONE"
+                input: "com.example.FraudCheckRequest"
+                output: "com.example.FraudCheckDecision"
+                timeout: "PT10M"
+                idempotencyKeyFields: ["orderId"]
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "webhook"
+                    dispatch:
+                      url: "https://partner.example/check"
+            """, diagnostics);
+
+        assertEquals(1, steps.size());
+        StepDefinition step = steps.getFirst();
+        assertEquals(StepKind.AWAIT, step.kind());
+        assertNull(step.executionClass());
+        assertEquals(ClassName.get("com.example", "FraudCheckRequest"), step.inputType());
+        assertEquals(ClassName.get("com.example", "FraudCheckDecision"), step.outputType());
+        assertEquals("PT10M", step.timeout());
+        assertEquals(List.of("orderId"), step.idempotencyKeyFields());
+        assertEquals("webhook", ((java.util.Map<?, ?>) step.awaitConfig().get("transport")).get("type"));
+        assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
+    }
+
+    @Test
+    void rejectsAwaitStepWithStreamingCardinality() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Bad Await"
+                kind: "await"
+                cardinality: "ONE_TO_MANY"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  transport:
+                    type: "webhook"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("ONE_TO_ONE")), diagnostics.toString());
+    }
+
+    @Test
     void rejectsDelegatedStepWhenOnlyOneTypeIsProvided() throws IOException {
         List<StepDefinition> steps = parse("""
             appName: "Test"

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/AwaitClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/AwaitClientStepRendererTest.java
@@ -1,0 +1,69 @@
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import javax.annotation.processing.ProcessingEnvironment;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class AwaitClientStepRendererTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void targetReturnsAwaitClientStepTarget() {
+        assertEquals(GenerationTarget.AWAIT_CLIENT_STEP, new AwaitClientStepRenderer().target());
+    }
+
+    @Test
+    void rendersReactiveStepThatDelegatesToAwaitSupport() throws IOException {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+            .serviceName("FraudCheck")
+            .generatedName("FraudCheckService")
+            .servicePackage("com.example.fraud")
+            .serviceClassName(ClassName.get("org.pipelineframework.awaitable", "AwaitStepDescriptor"))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .executionMode(ExecutionMode.DEFAULT)
+            .inputMapping(new TypeMapping(ClassName.get("com.example.fraud", "FraudCheckRequest"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.fraud", "FraudCheckDecision"), null, false))
+            .enabledTargets(Set.of(GenerationTarget.AWAIT_CLIENT_STEP))
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .build();
+
+        new AwaitClientStepRenderer().render(model, generationContext());
+
+        String source = Files.readString(tempDir.resolve(
+            "com/example/fraud/pipeline/FraudCheckAwaitClientStep.java"));
+
+        assertTrue(source.contains("implements StepOneToOne<FraudCheckRequest, FraudCheckDecision>"));
+        assertTrue(source.contains("AwaitStepSupport support"));
+        assertTrue(source.contains("AwaitStepDescriptorFactory descriptorFactory"));
+        assertTrue(source.contains("support.awaitOneToOne(descriptorFactory.descriptor(\"FraudCheck\", "
+            + "\"com.example.fraud.FraudCheckRequest\", \"com.example.fraud.FraudCheckDecision\"), input)"));
+    }
+
+    private GenerationContext generationContext() {
+        return new GenerationContext(
+            mock(ProcessingEnvironment.class),
+            tempDir,
+            DeploymentRole.ORCHESTRATOR_CLIENT,
+            Set.of(),
+            null,
+            null);
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/AwaitClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/AwaitClientStepRendererTest.java
@@ -53,8 +53,9 @@ class AwaitClientStepRendererTest {
         assertTrue(source.contains("implements StepOneToOne<FraudCheckRequest, FraudCheckDecision>"));
         assertTrue(source.contains("AwaitStepSupport support"));
         assertTrue(source.contains("AwaitStepDescriptorFactory descriptorFactory"));
-        assertTrue(source.contains("support.awaitOneToOne(descriptorFactory.descriptor(\"FraudCheck\", "
-            + "\"com.example.fraud.FraudCheckRequest\", \"com.example.fraud.FraudCheckDecision\"), input)"));
+        assertTrue(source.contains("descriptorFactory.descriptor(\"FraudCheck\", "
+            + "\"com.example.fraud.FraudCheckRequest\", \"com.example.fraud.FraudCheckDecision\")"
+            + ".onItem().transformToUni(descriptor -> support.awaitOneToOne(descriptor, input))"));
     }
 
     private GenerationContext generationContext() {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
@@ -1,0 +1,312 @@
+package org.pipelineframework.processor.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PipelineOrderMetadataGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesAwaitClientStepToOrderMetadata() throws IOException {
+        Path classOutput = tempDir.resolve("class-output");
+        Path moduleDir = tempDir.resolve("module");
+        Files.createDirectories(moduleDir);
+        Files.writeString(moduleDir.resolve("pipeline.yaml"), """
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            transport: "GRPC"
+            steps:
+              - name: "Fraud Check"
+                kind: "await"
+                input: "com.example.FraudCheckRequest"
+                output: "com.example.FraudCheckDecision"
+                timeout: "PT10M"
+                await:
+                  transport:
+                    type: "webhook"
+            """);
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(java.util.Map.of());
+        when(processingEnv.getFiler()).thenReturn(new PathResourceFiler(classOutput));
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setOrchestratorGenerated(true);
+        ctx.setModuleDir(moduleDir);
+
+        PipelineStepModel awaitModel = new PipelineStepModel.Builder()
+            .serviceName("FraudCheck")
+            .generatedName("FraudCheckService")
+            .servicePackage("com.example.fraud")
+            .serviceClassName(ClassName.get("org.pipelineframework.awaitable", "AwaitStepDescriptor"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.fraud", "FraudCheckRequest"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.fraud", "FraudCheckDecision"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.AWAIT_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .build();
+
+        ctx.setStepModels(List.of(awaitModel));
+
+        new PipelineOrderMetadataGenerator(processingEnv).writeOrderMetadata(ctx);
+
+        Path orderFile = classOutput.resolve("META-INF/pipeline/order.json");
+        assertTrue(Files.exists(orderFile), "order.json should be written");
+
+        JsonObject metadata = new Gson().fromJson(Files.readString(orderFile), JsonObject.class);
+        JsonArray order = metadata.getAsJsonArray("order");
+        assertTrue(order.size() > 0, "Expected at least one ordered step");
+
+        String firstStep = order.get(0).getAsString();
+        assertTrue(firstStep.endsWith("FraudCheckAwaitClientStep"),
+            "Expected generated class to end with FraudCheckAwaitClientStep but was: " + firstStep);
+        assertTrue(firstStep.contains("com.example.fraud.pipeline"),
+            "Expected generated class to be in pipeline package but was: " + firstStep);
+    }
+
+    @Test
+    void normalStepUsesTransportSpecificSuffix() throws IOException {
+        Path classOutput = tempDir.resolve("class-output2");
+        Path moduleDir = tempDir.resolve("module2");
+        Files.createDirectories(moduleDir);
+        Files.writeString(moduleDir.resolve("pipeline.yaml"), """
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            transport: "GRPC"
+            steps:
+              - name: "Charge Card"
+                service: "com.example.ChargeCardService"
+            """);
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(java.util.Map.of());
+        when(processingEnv.getFiler()).thenReturn(new PathResourceFiler(classOutput));
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setOrchestratorGenerated(true);
+        ctx.setModuleDir(moduleDir);
+
+        PipelineStepModel grpcModel = new PipelineStepModel.Builder()
+            .serviceName("ChargeCard")
+            .generatedName("ChargeCardService")
+            .servicePackage("com.example.charge")
+            .serviceClassName(ClassName.get("com.example.charge", "ChargeCardService"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example", "ChargeRequest"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example", "ChargeResult"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .build();
+
+        ctx.setStepModels(List.of(grpcModel));
+
+        new PipelineOrderMetadataGenerator(processingEnv).writeOrderMetadata(ctx);
+
+        Path orderFile = classOutput.resolve("META-INF/pipeline/order.json");
+        assertTrue(Files.exists(orderFile), "order.json should be written");
+
+        JsonObject metadata = new Gson().fromJson(Files.readString(orderFile), JsonObject.class);
+        JsonArray order = metadata.getAsJsonArray("order");
+        assertTrue(order.size() > 0, "Expected at least one ordered step");
+
+        String firstStep = order.get(0).getAsString();
+        assertTrue(firstStep.endsWith("GrpcClientStep"),
+            "Expected GRPC step to end with GrpcClientStep but was: " + firstStep);
+    }
+
+    @Test
+    void doesNothingWhenNoStepModels() throws IOException {
+        Path classOutput = tempDir.resolve("class-output3");
+        Path moduleDir = tempDir.resolve("module3");
+        Files.createDirectories(moduleDir);
+        Files.writeString(moduleDir.resolve("pipeline.yaml"), """
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "review"
+                service: "com.example.ReviewService"
+            """);
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(java.util.Map.of());
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setOrchestratorGenerated(true);
+        ctx.setModuleDir(moduleDir);
+        ctx.setStepModels(List.of());  // no models
+
+        new PipelineOrderMetadataGenerator(processingEnv).writeOrderMetadata(ctx);
+
+        // No file should be written
+        Path orderFile = classOutput.resolve("META-INF/pipeline/order.json");
+        assertTrue(!Files.exists(orderFile), "No order.json should be written when no step models");
+    }
+
+    @Test
+    void stripTrailingServiceHandlesNameWithoutServiceSuffix() throws IOException {
+        // Test indirectly: if generatedName does NOT end with "Service", it should still be included as-is
+        Path classOutput = tempDir.resolve("class-output4");
+        Path moduleDir = tempDir.resolve("module4");
+        Files.createDirectories(moduleDir);
+        Files.writeString(moduleDir.resolve("pipeline.yaml"), """
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            transport: "GRPC"
+            steps:
+              - name: "FraudCheck"
+                kind: "await"
+                input: "com.example.FraudCheckRequest"
+                output: "com.example.FraudCheckDecision"
+                timeout: "PT5M"
+                await:
+                  transport:
+                    type: "webhook"
+            """);
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(java.util.Map.of());
+        when(processingEnv.getFiler()).thenReturn(new PathResourceFiler(classOutput));
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setOrchestratorGenerated(true);
+        ctx.setModuleDir(moduleDir);
+
+        // generatedName does NOT end with "Service" - tests stripTrailingService(name) returns name unchanged
+        PipelineStepModel awaitModel = new PipelineStepModel.Builder()
+            .serviceName("FraudCheck")
+            .generatedName("FraudCheck")  // no "Service" suffix
+            .servicePackage("com.example.fraud")
+            .serviceClassName(ClassName.get("org.pipelineframework.awaitable", "AwaitStepDescriptor"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.fraud", "FraudCheckRequest"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.fraud", "FraudCheckDecision"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.AWAIT_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .build();
+
+        ctx.setStepModels(List.of(awaitModel));
+
+        new PipelineOrderMetadataGenerator(processingEnv).writeOrderMetadata(ctx);
+
+        Path orderFile = classOutput.resolve("META-INF/pipeline/order.json");
+        assertTrue(Files.exists(orderFile), "order.json should be written");
+
+        JsonObject metadata = new Gson().fromJson(Files.readString(orderFile), JsonObject.class);
+        JsonArray order = metadata.getAsJsonArray("order");
+        assertTrue(order.size() > 0, "Expected at least one ordered step");
+
+        // When generatedName = "FraudCheck" (no Service suffix), class should be FraudCheckAwaitClientStep
+        String firstStep = order.get(0).getAsString();
+        assertTrue(firstStep.endsWith("FraudCheckAwaitClientStep"),
+            "Expected class to end with FraudCheckAwaitClientStep but was: " + firstStep);
+    }
+
+    // ---- Helper classes (reused from PipelinePlatformMetadataGeneratorTest pattern) ----
+
+    private static final class PathResourceFiler implements Filer {
+        private final Path outputDir;
+
+        private PathResourceFiler(Path outputDir) {
+            this.outputDir = outputDir;
+        }
+
+        @Override
+        public JavaFileObject createSourceFile(CharSequence name, Element... originatingElements) {
+            throw new UnsupportedOperationException("Source generation is not supported in this test.");
+        }
+
+        @Override
+        public JavaFileObject createClassFile(CharSequence name, Element... originatingElements) {
+            throw new UnsupportedOperationException("Class generation is not supported in this test.");
+        }
+
+        @Override
+        public FileObject createResource(
+            JavaFileManager.Location location,
+            CharSequence pkg,
+            CharSequence relativeName,
+            Element... originatingElements) {
+            Path path = outputDir.resolve(relativeName.toString());
+            return new PathFileObject(path);
+        }
+
+        @Override
+        public FileObject getResource(
+            JavaFileManager.Location location,
+            CharSequence pkg,
+            CharSequence relativeName) {
+            Path path = outputDir.resolve(relativeName.toString());
+            return new PathFileObject(path);
+        }
+    }
+
+    private static final class PathFileObject extends SimpleJavaFileObject {
+        private final Path path;
+
+        private PathFileObject(Path path) {
+            super(path.toUri(), JavaFileObject.Kind.OTHER);
+            this.path = path;
+        }
+
+        @Override
+        public Writer openWriter() throws IOException {
+            Files.createDirectories(path.getParent());
+            return Files.newBufferedWriter(path);
+        }
+
+        @Override
+        public OutputStream openOutputStream() throws IOException {
+            Files.createDirectories(path.getParent());
+            return Files.newOutputStream(path);
+        }
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
@@ -32,6 +32,7 @@ import org.pipelineframework.processor.ir.TransportMode;
 import org.pipelineframework.processor.ir.TypeMapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -184,7 +185,7 @@ class PipelineOrderMetadataGeneratorTest {
 
         // No file should be written
         Path orderFile = classOutput.resolve("META-INF/pipeline/order.json");
-        assertTrue(!Files.exists(orderFile), "No order.json should be written when no step models");
+        assertFalse(Files.exists(orderFile), "No order.json should be written when no step models");
     }
 
     @Test

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -310,31 +310,33 @@ public class PipelineExecutionService {
   }
 
   private Multi<?> executePipelineStreamingFromRecord(ExecutionRecord<Object, Object> record) {
-    Object sourcePayload = record.currentStepIndex() > 0
-        ? record.resumePayload()
-        : record.inputPayload();
-    Object reactiveInput = executionInputPolicy.toReplayInput(sourcePayload);
-    AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
-    AwaitExecutionContextHolder.set(new AwaitExecutionContext(
-        record.tenantId(),
-        record.executionId(),
-        record.currentStepIndex()));
-    try {
-      Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
-      if (result instanceof Multi<?> multi) {
-        return multi;
+    return Multi.createFrom().deferred(() -> {
+      Object sourcePayload = record.currentStepIndex() > 0
+          ? record.resumePayload()
+          : record.inputPayload();
+      Object reactiveInput = executionInputPolicy.toReplayInput(sourcePayload);
+      AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
+      AwaitExecutionContextHolder.set(new AwaitExecutionContext(
+          record.tenantId(),
+          record.executionId(),
+          record.currentStepIndex()));
+      try {
+        Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
+        Multi<?> stream;
+        if (result instanceof Multi<?> multi) {
+          stream = multi;
+        } else if (result instanceof Uni<?> uni) {
+          stream = uni.toMulti();
+        } else {
+          restoreAwaitContext(previous);
+          return Multi.createFrom().failure(new IllegalStateException("Pipeline runner returned unsupported result"));
+        }
+        return stream.onTermination().invoke((failure, cancelled) -> restoreAwaitContext(previous));
+      } catch (Throwable failure) {
+        restoreAwaitContext(previous);
+        return Multi.createFrom().failure(failure);
       }
-      if (result instanceof Uni<?> uni) {
-        return uni.toMulti();
-      }
-      return Multi.createFrom().failure(new IllegalStateException("Pipeline runner returned unsupported result"));
-    } finally {
-      if (previous == null) {
-        AwaitExecutionContextHolder.clear();
-      } else {
-        AwaitExecutionContextHolder.set(previous);
-      }
-    }
+    });
   }
 
   private Object executePipelineStreamingInternalFromStep(Object input, int startStepIndex) {
@@ -346,8 +348,16 @@ public class PipelineExecutionService {
     watch.start();
     Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
     watch.stop();
-    LOG.infof("Pipeline execution assembled from step %d in %d ms", startStepIndex, watch.getTime());
+    LOG.infof("Pipeline assembly from step %d completed in %d ms", startStepIndex, watch.getTime());
     return result;
+  }
+
+  private void restoreAwaitContext(AwaitExecutionContext previous) {
+    if (previous == null) {
+      AwaitExecutionContextHolder.clear();
+    } else {
+      AwaitExecutionContextHolder.set(previous);
+    }
   }
 
   private Uni<?> executePipelineUnaryInternal(Object input) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -34,7 +34,13 @@ import lombok.Getter;
 import org.apache.commons.lang3.time.StopWatch;
 import org.jboss.logging.Logger;
 import org.pipelineframework.config.PipelineConfig;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitExecutionContext;
+import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
 
@@ -65,6 +71,9 @@ public class PipelineExecutionService {
 
   @Inject
   ExecutionHooks executionHooks;
+
+  @Inject
+  ExecutionInputPolicy executionInputPolicy;
 
   @Inject
   QueueAsyncCoordinator queueAsyncCoordinator;
@@ -198,6 +207,25 @@ public class PipelineExecutionService {
   }
 
   /**
+   * Completes a durable await interaction and schedules owning execution continuation.
+   */
+  public Uni<AwaitCompletionResult> completeAwaitInteraction(AwaitCompletionCommand command) {
+    return queueAsyncCoordinator.completeAwait(command);
+  }
+
+  /**
+   * Queries pending durable await interactions.
+   */
+  public Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
+      String tenantId,
+      String assignee,
+      String group,
+      String stepId,
+      int limit) {
+    return queueAsyncCoordinator.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit);
+  }
+
+  /**
    * Handles queue-dispatched work items when using the local event dispatcher.
    */
   void onExecutionWork(@ObservesAsync ExecutionWorkItem workItem) {
@@ -216,7 +244,7 @@ public class PipelineExecutionService {
    * Processes one execution work item and advances lifecycle state.
    */
   public Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem) {
-    return queueAsyncCoordinator.processExecutionWorkItem(workItem, this::executePipelineStreaming);
+    return queueAsyncCoordinator.processExecutionWorkItem(workItem, this::executePipelineStreamingFromRecord);
   }
 
   /**
@@ -279,6 +307,47 @@ public class PipelineExecutionService {
             MessageFormat.format("PipelineRunner returned unexpected type: {0}", result.getClass().getName())));
       }
     });
+  }
+
+  private Multi<?> executePipelineStreamingFromRecord(ExecutionRecord<Object, Object> record) {
+    Object sourcePayload = record.currentStepIndex() > 0
+        ? record.resumePayload()
+        : record.inputPayload();
+    Object reactiveInput = executionInputPolicy.toReplayInput(sourcePayload);
+    AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
+    AwaitExecutionContextHolder.set(new AwaitExecutionContext(
+        record.tenantId(),
+        record.executionId(),
+        record.currentStepIndex()));
+    try {
+      Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
+      if (result instanceof Multi<?> multi) {
+        return multi;
+      }
+      if (result instanceof Uni<?> uni) {
+        return uni.toMulti();
+      }
+      return Multi.createFrom().failure(new IllegalStateException("Pipeline runner returned unsupported result"));
+    } finally {
+      if (previous == null) {
+        AwaitExecutionContextHolder.clear();
+      } else {
+        AwaitExecutionContextHolder.set(previous);
+      }
+    }
+  }
+
+  private Object executePipelineStreamingInternalFromStep(Object input, int startStepIndex) {
+    StopWatch watch = new StopWatch();
+    List<Object> steps = loadStepsForExecution();
+    if (steps == null) {
+      return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
+    }
+    watch.start();
+    Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
+    watch.stop();
+    LOG.infof("Pipeline execution assembled from step %d in %d ms", startStepIndex, watch.getTime());
+    return result;
   }
 
   private Uni<?> executePipelineUnaryInternal(Object input) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -345,10 +345,13 @@ public class PipelineExecutionService {
     if (steps == null) {
       return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
     }
-    watch.start();
     Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
-    watch.stop();
-    LOG.infof("Pipeline assembly from step %d completed in %d ms", startStepIndex, watch.getTime());
+    if (result instanceof Multi<?> multi) {
+      return executionHooks.attachMultiHooks(multi, watch);
+    }
+    if (result instanceof Uni<?> uni) {
+      return executionHooks.attachMultiHooks(uni.toMulti(), watch);
+    }
     return result;
   }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -321,6 +321,16 @@ public class PipelineExecutionService {
           record.executionId(),
           record.currentStepIndex()));
       try {
+        RuntimeException healthFailure = healthCheckFailure();
+        if (healthFailure != null) {
+          restoreAwaitContext(previous);
+          return Multi.createFrom().failure(healthFailure);
+        }
+        RuntimeException inputFailure = validateInputShape(reactiveInput);
+        if (inputFailure != null) {
+          restoreAwaitContext(previous);
+          return Multi.createFrom().failure(inputFailure);
+        }
         Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
         Multi<?> stream;
         if (result instanceof Multi<?> multi) {
@@ -352,7 +362,13 @@ public class PipelineExecutionService {
     if (result instanceof Uni<?> uni) {
       return executionHooks.attachMultiHooks(uni.toMulti(), watch);
     }
-    return result;
+    String resultType = result == null ? "null" : result.getClass().getName();
+    Multi<?> failed = Multi.createFrom().failure(new IllegalStateException(
+        MessageFormat.format(
+            "PipelineRunner returned unexpected type from step index {0}: {1}",
+            startStepIndex,
+            resultType)));
+    return executionHooks.attachMultiHooks(failed, watch);
   }
 
   private void restoreAwaitContext(AwaitExecutionContext previous) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
@@ -32,6 +32,8 @@ import org.pipelineframework.config.ParallelismPolicy;
 import org.pipelineframework.config.PipelineConfig;
 import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
+import org.pipelineframework.awaitable.AwaitExecutionContext;
+import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
 import org.pipelineframework.step.Configurable;
 import org.pipelineframework.step.ConfigFactory;
 import org.pipelineframework.step.StepOneToOne;
@@ -90,6 +92,18 @@ public class PipelineRunner implements AutoCloseable {
      * @throws IllegalArgumentException if {@code input} is not a Uni or a Multi
      */
     public Object run(Object input, List<Object> steps) {
+        return runFromStep(input, steps, 0);
+    }
+
+    /**
+     * Run a configured sequence starting at a specific ordered step index.
+     *
+     * @param input reactive source to process
+     * @param steps ordered or orderable step instances
+     * @param startStepIndex first ordered step index to execute
+     * @return final reactive result
+     */
+    public Object runFromStep(Object input, List<Object> steps, int startStepIndex) {
         Objects.requireNonNull(steps, "Steps list must not be null");
         if (!(input instanceof Uni<?> || input instanceof Multi<?>)) {
             throw new IllegalArgumentException(MessageFormat.format(
@@ -98,6 +112,9 @@ public class PipelineRunner implements AutoCloseable {
         }
 
         List<Object> orderedSteps = stepOrderer.orderSteps(steps);
+        if (startStepIndex < 0 || startStepIndex > orderedSteps.size()) {
+            throw new IllegalArgumentException("startStepIndex is out of range: " + startStepIndex);
+        }
 
         Object current = input;
         ParallelismPolicy parallelismPolicy = parallelismPolicyResolver.resolveParallelismPolicy(pipelineConfig);
@@ -108,10 +125,15 @@ public class PipelineRunner implements AutoCloseable {
 
         PipelineContext contextSnapshot = PipelineContextHolder.get();
         CacheReadSupport cacheReadSupport = cacheSupportFactory.buildCacheReadSupport();
-        for (Object step : orderedSteps) {
+        AwaitExecutionContext awaitContext = AwaitExecutionContextHolder.get();
+        for (int index = startStepIndex; index < orderedSteps.size(); index++) {
+            Object step = orderedSteps.get(index);
             if (step == null) {
                 logger.warn("Warning: Found null step in configuration, skipping...");
                 continue;
+            }
+            if (awaitContext != null) {
+                awaitContext.currentStepIndex(index);
             }
 
             if (step instanceof Configurable configurable) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -22,6 +22,12 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.jboss.logging.Logger;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitSuspendedException;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
 import org.pipelineframework.orchestrator.DeadLetterPublisher;
 import org.pipelineframework.orchestrator.ExecutionCreateCommand;
@@ -64,6 +70,9 @@ class QueueAsyncCoordinator {
 
   @Inject
   CheckpointPublicationService checkpointPublicationService;
+
+  @Inject
+  AwaitCoordinator awaitCoordinator;
 
   private final ScheduledExecutorService queueSweepExecutor = Executors.newSingleThreadScheduledExecutor(
       runnable -> {
@@ -228,7 +237,7 @@ class QueueAsyncCoordinator {
         });
   }
 
-  Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, Function<Object, Multi<?>> executeStreaming) {
+  Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming) {
     if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
       return Uni.createFrom().voidItem();
     }
@@ -245,7 +254,7 @@ class QueueAsyncCoordinator {
           }
           ExecutionRecord<Object, Object> record = claimed.get();
           String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-          return runAsyncExecution(record.inputPayload(), executeStreaming)
+          return runAsyncExecution(record, executeStreaming)
               .onItem().transformToUni(resultPayload -> checkpointPublicationService
                   .publishIfConfigured(record, singleResult(resultPayload))
                   .replaceWith(resultPayload))
@@ -257,6 +266,8 @@ class QueueAsyncCoordinator {
                       resultPayload,
                       System.currentTimeMillis()))
               .onItem().transformToUni(updated -> Uni.createFrom().voidItem())
+              .onFailure(AwaitSuspendedException.class).recoverWithUni(
+                  failure -> markWaitingExternal(record, (AwaitSuspendedException) failure, transitionKey))
               .onFailure().recoverWithUni(
                   failure -> executionFailureHandler.handleExecutionFailure(
                       record,
@@ -273,7 +284,8 @@ class QueueAsyncCoordinator {
       return;
     }
     long now = System.currentTimeMillis();
-    executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit())
+    sweepTimedOutAwaitInteractions(now)
+        .onItem().transformToUni(ignored -> executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit()))
         .onItem().transformToUni(due -> {
           if (due.isEmpty()) {
             return Uni.createFrom().voidItem();
@@ -294,9 +306,97 @@ class QueueAsyncCoordinator {
             failure -> LOG.errorf(failure, "Failed sweeping due async executions"));
   }
 
-  private Uni<List<?>> runAsyncExecution(Object inputPayload, Function<Object, Multi<?>> executeStreaming) {
-    Object reactiveInput = executionInputPolicy.toReplayInput(inputPayload);
-    return executeStreaming.apply(reactiveInput)
+  Uni<AwaitCompletionResult> completeAwait(AwaitCompletionCommand command) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    return awaitCoordinator.complete(command)
+        .onItem().transformToUni(result -> executionStateStore.markAwaitCompleted(
+                result.record().tenantId(),
+                result.record().executionId(),
+                result.record().interactionId(),
+                coerceAwaitPayload(result.record()),
+                result.record().stepIndex() + 1,
+                command.nowEpochMs())
+            .onItem().transformToUni(updated -> {
+              if (updated.isPresent()) {
+                return workDispatcher.enqueueNow(new ExecutionWorkItem(
+                        updated.get().tenantId(),
+                        updated.get().executionId()))
+                    .replaceWith(result);
+              }
+              return Uni.createFrom().item(result);
+            }));
+  }
+
+  Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
+      String tenantId,
+      String assignee,
+      String group,
+      String stepId,
+      int limit) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+    return awaitCoordinator.queryPending(resolvedTenant, assignee, group, stepId, limit <= 0 ? 100 : limit);
+  }
+
+  private Uni<Void> markWaitingExternal(
+      ExecutionRecord<Object, Object> record,
+      AwaitSuspendedException suspended,
+      String transitionKey) {
+    return executionStateStore.markWaitingExternal(
+            record.tenantId(),
+            record.executionId(),
+            record.version(),
+            transitionKey,
+            suspended.interactionId(),
+            suspended.stepIndex(),
+            System.currentTimeMillis())
+        .replaceWithVoid();
+  }
+
+  private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
+    if (awaitCoordinator == null) {
+      return Uni.createFrom().voidItem();
+    }
+    return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
+        .onItem().transformToUni(records -> {
+          if (records.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          List<Uni<Void>> operations = new ArrayList<>(records.size());
+          for (AwaitInteractionRecord record : records) {
+            operations.add(awaitCoordinator.markTimedOut(record, now)
+                .onItem().transformToUni(updated -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
+                .onItem().transformToUni(execution -> {
+                  if (execution.isEmpty() || execution.get().status().terminal()) {
+                    return Uni.createFrom().voidItem();
+                  }
+                  ExecutionRecord<Object, Object> executionRecord = execution.get();
+                  return executionStateStore.markTerminalFailure(
+                          executionRecord.tenantId(),
+                          executionRecord.executionId(),
+                          executionRecord.version(),
+                          ExecutionStatus.FAILED,
+                          transitionKey(executionRecord.executionId(), executionRecord.currentStepIndex(), executionRecord.attempt()),
+                          "AWAIT_TIMEOUT",
+                          "Await interaction timed out: " + record.interactionId(),
+                          now)
+                      .replaceWithVoid();
+                }));
+          }
+          return Uni.join().all(operations).andCollectFailures().replaceWithVoid();
+        });
+  }
+
+  private Uni<List<?>> runAsyncExecution(
+      ExecutionRecord<Object, Object> record,
+      Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming) {
+    return executeStreaming.apply(record)
         .select().first(2)
         .collect().asList()
         .onItem().transformToUni(items -> {
@@ -313,6 +413,25 @@ class QueueAsyncCoordinator {
       return null;
     }
     return items.getFirst();
+  }
+
+  private Object coerceAwaitPayload(AwaitInteractionRecord record) {
+    Object payload = record.responsePayload();
+    if (payload == null || record.outputType() == null || record.outputType().isBlank()) {
+      return payload;
+    }
+    try {
+      Class<?> outputType = Class.forName(record.outputType());
+      if (outputType.isInstance(payload)) {
+        return payload;
+      }
+      if (payload instanceof String json && (json.startsWith("{") || json.startsWith("["))) {
+        return PipelineJson.mapper().readValue(json, outputType);
+      }
+      return PipelineJson.mapper().convertValue(payload, outputType);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed converting await response payload to " + record.outputType(), e);
+    }
   }
 
   private ExecutionStateStore selectExecutionStateStore(String providerName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.NotFoundException;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.jboss.logging.Logger;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
 import org.pipelineframework.config.pipeline.PipelineJson;
@@ -320,11 +321,18 @@ class QueueAsyncCoordinator {
         command.actor(),
         command.nowEpochMs());
     return awaitCoordinator.complete(normalized)
-        .onItem().transformToUni(result -> executionStateStore.markAwaitCompleted(
+        .onFailure().transform(failure -> new IllegalStateException(
+            "Failed completing await interaction tenant=" + normalized.tenantId()
+                + ", interactionId=" + normalized.interactionId()
+                + ", correlationId=" + normalized.correlationId(),
+            failure))
+        .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
+            .onItem().transformToUni(validated -> coerceAwaitPayloadAsync(validated.record()))
+            .onItem().transformToUni(resumePayload -> executionStateStore.markAwaitCompleted(
                 result.record().tenantId(),
                 result.record().executionId(),
                 result.record().interactionId(),
-                coerceAwaitPayload(result.record()),
+                resumePayload,
                 result.record().stepIndex() + 1,
                 normalized.nowEpochMs())
             .onItem().transformToUni(updated -> {
@@ -335,7 +343,7 @@ class QueueAsyncCoordinator {
                     .replaceWith(result);
               }
               return Uni.createFrom().item(result);
-            }));
+            })));
   }
 
   Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
@@ -382,6 +390,10 @@ class QueueAsyncCoordinator {
                     return Uni.createFrom().voidItem();
                   }
                   ExecutionRecord<Object, Object> executionRecord = execution.get();
+                  if (executionRecord.status() != ExecutionStatus.WAITING_EXTERNAL
+                      || !record.interactionId().equals(executionRecord.awaitInteractionId())) {
+                    return Uni.createFrom().voidItem();
+                  }
                   return executionStateStore.markTerminalFailure(
                           executionRecord.tenantId(),
                           executionRecord.executionId(),
@@ -440,6 +452,22 @@ class QueueAsyncCoordinator {
     } catch (Exception e) {
       throw new IllegalStateException("Failed converting await response payload to " + record.outputType(), e);
     }
+  }
+
+  private Uni<Object> coerceAwaitPayloadAsync(AwaitInteractionRecord record) {
+    return Uni.createFrom().item(() -> coerceAwaitPayload(record))
+        .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+  }
+
+  private Uni<AwaitCompletionResult> validateAwaitCompletionTenant(
+      AwaitCompletionResult result,
+      AwaitCompletionCommand command) {
+    if (!command.tenantId().equals(result.record().tenantId())) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Await completion tenant mismatch: command tenant=" + command.tenantId()
+              + ", record tenant=" + result.record().tenantId()));
+    }
+    return Uni.createFrom().item(result);
   }
 
   private ExecutionStateStore selectExecutionStateStore(String providerName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -311,14 +311,22 @@ class QueueAsyncCoordinator {
       return Uni.createFrom().failure(new IllegalStateException(
           "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
     }
-    return awaitCoordinator.complete(command)
+    AwaitCompletionCommand normalized = new AwaitCompletionCommand(
+        executionInputPolicy.normalizeTenant(command.tenantId()),
+        command.interactionId(),
+        command.correlationId(),
+        command.idempotencyKey(),
+        command.responsePayload(),
+        command.actor(),
+        command.nowEpochMs());
+    return awaitCoordinator.complete(normalized)
         .onItem().transformToUni(result -> executionStateStore.markAwaitCompleted(
                 result.record().tenantId(),
                 result.record().executionId(),
                 result.record().interactionId(),
                 coerceAwaitPayload(result.record()),
                 result.record().stepIndex() + 1,
-                command.nowEpochMs())
+                normalized.nowEpochMs())
             .onItem().transformToUni(updated -> {
               if (updated.isPresent()) {
                 return workDispatcher.enqueueNow(new ExecutionWorkItem(
@@ -360,9 +368,6 @@ class QueueAsyncCoordinator {
   }
 
   private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
-    if (awaitCoordinator == null) {
-      return Uni.createFrom().voidItem();
-    }
     return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
         .onItem().transformToUni(records -> {
           if (records.isEmpty()) {
@@ -425,8 +430,11 @@ class QueueAsyncCoordinator {
       if (outputType.isInstance(payload)) {
         return payload;
       }
-      if (payload instanceof String json && (json.startsWith("{") || json.startsWith("["))) {
-        return PipelineJson.mapper().readValue(json, outputType);
+      if (payload instanceof String json) {
+        String trimmed = json.trim();
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+          return PipelineJson.mapper().readValue(trimmed, outputType);
+        }
       }
       return PipelineJson.mapper().convertValue(payload, outputType);
     } catch (Exception e) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -438,7 +438,7 @@ class QueueAsyncCoordinator {
       return payload;
     }
     try {
-      Class<?> outputType = Class.forName(record.outputType());
+      Class<?> outputType = Thread.currentThread().getContextClassLoader().loadClass(record.outputType());
       if (outputType.isInstance(payload)) {
         return payload;
       }

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -327,23 +327,28 @@ class QueueAsyncCoordinator {
                 + ", correlationId=" + normalized.correlationId(),
             failure))
         .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
-            .onItem().transformToUni(validated -> coerceAwaitPayloadAsync(validated.record()))
-            .onItem().transformToUni(resumePayload -> executionStateStore.markAwaitCompleted(
-                result.record().tenantId(),
-                result.record().executionId(),
-                result.record().interactionId(),
-                resumePayload,
-                result.record().stepIndex() + 1,
-                normalized.nowEpochMs())
-            .onItem().transformToUni(updated -> {
-              if (updated.isPresent()) {
-                return workDispatcher.enqueueNow(new ExecutionWorkItem(
-                        updated.get().tenantId(),
-                        updated.get().executionId()))
-                    .replaceWith(result);
+            .onItem().transformToUni(validated -> {
+              if (validated.duplicate()) {
+                return Uni.createFrom().item(validated);
               }
-              return Uni.createFrom().item(result);
-            })));
+              return coerceAwaitPayloadAsync(validated.record())
+                  .onItem().transformToUni(resumePayload -> executionStateStore.markAwaitCompleted(
+                      validated.record().tenantId(),
+                      validated.record().executionId(),
+                      validated.record().interactionId(),
+                      resumePayload,
+                      validated.record().stepIndex() + 1,
+                      normalized.nowEpochMs()))
+                  .onItem().transformToUni(updated -> {
+                    if (updated.isPresent()) {
+                      return workDispatcher.enqueueNow(new ExecutionWorkItem(
+                              updated.get().tenantId(),
+                              updated.get().executionId()))
+                          .replaceWith(validated);
+                    }
+                    return Uni.createFrom().item(validated);
+                  });
+            }));
   }
 
   Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
@@ -1,0 +1,26 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Command representing a correlated external completion.
+ */
+public record AwaitCompletionCommand(
+    String tenantId,
+    String interactionId,
+    String correlationId,
+    String idempotencyKey,
+    Object responsePayload,
+    String actor,
+    long nowEpochMs
+) {
+    public AwaitCompletionCommand {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        if ((interactionId == null || interactionId.isBlank()) && (correlationId == null || correlationId.isBlank())) {
+            throw new IllegalArgumentException("interactionId or correlationId must be supplied");
+        }
+        if (nowEpochMs <= 0) {
+            nowEpochMs = System.currentTimeMillis();
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
@@ -21,9 +21,6 @@ public record AwaitCompletionCommand(
         if (interactionId == null && correlationId == null) {
             throw new IllegalArgumentException("interactionId or correlationId must be supplied");
         }
-        if (idempotencyKey == null || idempotencyKey.isBlank()) {
-            throw new IllegalArgumentException("idempotencyKey must not be blank");
-        }
         if (nowEpochMs <= 0) {
             nowEpochMs = System.currentTimeMillis();
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
@@ -19,6 +19,9 @@ public record AwaitCompletionCommand(
         if ((interactionId == null || interactionId.isBlank()) && (correlationId == null || correlationId.isBlank())) {
             throw new IllegalArgumentException("interactionId or correlationId must be supplied");
         }
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new IllegalArgumentException("idempotencyKey must not be blank");
+        }
         if (nowEpochMs <= 0) {
             nowEpochMs = System.currentTimeMillis();
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
@@ -16,7 +16,9 @@ public record AwaitCompletionCommand(
         if (tenantId == null || tenantId.isBlank()) {
             throw new IllegalArgumentException("tenantId must not be blank");
         }
-        if ((interactionId == null || interactionId.isBlank()) && (correlationId == null || correlationId.isBlank())) {
+        interactionId = normalizeOptionalIdentifier(interactionId);
+        correlationId = normalizeOptionalIdentifier(correlationId);
+        if (interactionId == null && correlationId == null) {
             throw new IllegalArgumentException("interactionId or correlationId must be supplied");
         }
         if (idempotencyKey == null || idempotencyKey.isBlank()) {
@@ -25,5 +27,12 @@ public record AwaitCompletionCommand(
         if (nowEpochMs <= 0) {
             nowEpochMs = System.currentTimeMillis();
         }
+    }
+
+    private static String normalizeOptionalIdentifier(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionResult.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionResult.java
@@ -1,0 +1,10 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Completion admission result.
+ *
+ * @param record completed record
+ * @param duplicate true when the completion was already accepted earlier
+ */
+public record AwaitCompletionResult(AwaitInteractionRecord record, boolean duplicate) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -76,11 +76,10 @@ public class AwaitCoordinator {
     public Uni<AwaitInteractionRecord> dispatch(AwaitStepDescriptor descriptor, AwaitInteractionRecord interaction) {
         AwaitTransportAdapter<Object> adapter = (AwaitTransportAdapter<Object>) adapter(descriptor.transportType());
         long nowEpochMs = System.currentTimeMillis();
-        return store().markDispatched(
+        return store().markDispatching(
                 interaction.tenantId(),
                 interaction.interactionId(),
                 interaction.version(),
-                Map.of(),
                 nowEpochMs)
             .onItem().transform(optional -> optional.orElseThrow(() ->
                 new IllegalStateException("Await interaction dispatch transition lost OCC race: "

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -3,6 +3,7 @@ package org.pipelineframework.awaitable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -24,10 +25,13 @@ public class AwaitCoordinator {
     Instance<AwaitInteractionStore> stores;
 
     @Inject
-    Instance<AwaitTransportAdapter<?, ?>> adapters;
+    Instance<AwaitTransportAdapter<?>> adapters;
 
     @Inject
     PipelineOrchestratorConfig orchestratorConfig;
+
+    private volatile AwaitInteractionStore resolvedStore;
+    private final Map<String, AwaitTransportAdapter<?>> resolvedAdapters = new ConcurrentHashMap<>();
 
     /**
      * Creates or returns an active interaction for an await step.
@@ -70,7 +74,7 @@ public class AwaitCoordinator {
      */
     @SuppressWarnings("unchecked")
     public Uni<AwaitInteractionRecord> dispatch(AwaitStepDescriptor descriptor, AwaitInteractionRecord interaction) {
-        AwaitTransportAdapter<Object, Object> adapter = (AwaitTransportAdapter<Object, Object>) adapter(descriptor.transportType());
+        AwaitTransportAdapter<Object> adapter = (AwaitTransportAdapter<Object>) adapter(descriptor.transportType());
         long nowEpochMs = System.currentTimeMillis();
         return store().markDispatched(
                 interaction.tenantId(),
@@ -85,6 +89,13 @@ public class AwaitCoordinator {
                     descriptor,
                     claimedInteraction,
                     claimedInteraction.requestPayload()))
+                .onFailure().call(failure -> store().fail(
+                    claimedInteraction.tenantId(),
+                    claimedInteraction.interactionId(),
+                    claimedInteraction.version(),
+                    failure.getMessage(),
+                    System.currentTimeMillis())
+                    .replaceWith(failure))
                 .onItem().transformToUni(result -> store().markDispatched(
                     claimedInteraction.tenantId(),
                     claimedInteraction.interactionId(),
@@ -93,14 +104,7 @@ public class AwaitCoordinator {
                     System.currentTimeMillis()))
                 .onItem().transform(optional -> optional.orElseThrow(() ->
                     new IllegalStateException("Await interaction metadata update lost OCC race: "
-                        + claimedInteraction.interactionId())))
-                .onFailure().call(failure -> store().fail(
-                    claimedInteraction.tenantId(),
-                    claimedInteraction.interactionId(),
-                    claimedInteraction.version(),
-                    failure.getMessage(),
-                    System.currentTimeMillis())
-                    .replaceWith(failure)));
+                        + claimedInteraction.interactionId()))));
     }
 
     /**
@@ -137,23 +141,36 @@ public class AwaitCoordinator {
     }
 
     private AwaitInteractionStore store() {
+        AwaitInteractionStore cached = resolvedStore;
+        if (cached != null) {
+            return cached;
+        }
         String provider = orchestratorConfig == null ? null : orchestratorConfig.stateProvider();
-        return stores.stream()
-            .filter(candidate -> provider == null || provider.isBlank() || provider.equalsIgnoreCase(candidate.providerName()))
-            .sorted((left, right) -> {
-                int priorityComparison = Integer.compare(right.priority(), left.priority());
-                if (priorityComparison != 0) {
-                    return priorityComparison;
-                }
-                return left.providerName().compareToIgnoreCase(right.providerName());
-            })
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("No AwaitInteractionStore provider is available"
-                + (provider == null || provider.isBlank() ? "" : " for provider " + provider)));
+        synchronized (this) {
+            if (resolvedStore == null) {
+                resolvedStore = stores.stream()
+                    .filter(candidate -> provider == null || provider.isBlank() || provider.equalsIgnoreCase(candidate.providerName()))
+                    .sorted((left, right) -> {
+                        int priorityComparison = Integer.compare(right.priority(), left.priority());
+                        if (priorityComparison != 0) {
+                            return priorityComparison;
+                        }
+                        return left.providerName().compareToIgnoreCase(right.providerName());
+                    })
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No AwaitInteractionStore provider is available"
+                        + (provider == null || provider.isBlank() ? "" : " for provider " + provider)));
+            }
+            return resolvedStore;
+        }
     }
 
-    private AwaitTransportAdapter<?, ?> adapter(String type) {
-        List<AwaitTransportAdapter<?, ?>> matching = adapters.stream()
+    private AwaitTransportAdapter<?> adapter(String type) {
+        return resolvedAdapters.computeIfAbsent(type.toLowerCase(java.util.Locale.ROOT), ignored -> resolveAdapter(type));
+    }
+
+    private AwaitTransportAdapter<?> resolveAdapter(String type) {
+        List<AwaitTransportAdapter<?>> matching = adapters.stream()
             .filter(candidate -> type.equalsIgnoreCase(candidate.type()))
             .toList();
         if (matching.isEmpty()) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -93,7 +93,14 @@ public class AwaitCoordinator {
                     System.currentTimeMillis()))
                 .onItem().transform(optional -> optional.orElseThrow(() ->
                     new IllegalStateException("Await interaction metadata update lost OCC race: "
-                        + claimedInteraction.interactionId()))));
+                        + claimedInteraction.interactionId())))
+                .onFailure().call(failure -> store().fail(
+                    claimedInteraction.tenantId(),
+                    claimedInteraction.interactionId(),
+                    claimedInteraction.version(),
+                    failure.getMessage(),
+                    System.currentTimeMillis())
+                    .replaceWith(failure)));
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -71,19 +71,29 @@ public class AwaitCoordinator {
     @SuppressWarnings("unchecked")
     public Uni<AwaitInteractionRecord> dispatch(AwaitStepDescriptor descriptor, AwaitInteractionRecord interaction) {
         AwaitTransportAdapter<Object, Object> adapter = (AwaitTransportAdapter<Object, Object>) adapter(descriptor.transportType());
-        return adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
-                descriptor,
-                interaction,
-                interaction.requestPayload()))
-            .onItem().transformToUni(result -> store().markDispatched(
+        long nowEpochMs = System.currentTimeMillis();
+        return store().markDispatched(
                 interaction.tenantId(),
                 interaction.interactionId(),
                 interaction.version(),
-                result.metadata(),
-                System.currentTimeMillis()))
+                Map.of(),
+                nowEpochMs)
             .onItem().transform(optional -> optional.orElseThrow(() ->
                 new IllegalStateException("Await interaction dispatch transition lost OCC race: "
-                    + interaction.interactionId())));
+                    + interaction.interactionId())))
+            .onItem().transformToUni(claimedInteraction -> adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                    descriptor,
+                    claimedInteraction,
+                    claimedInteraction.requestPayload()))
+                .onItem().transformToUni(result -> store().markDispatched(
+                    claimedInteraction.tenantId(),
+                    claimedInteraction.interactionId(),
+                    claimedInteraction.version(),
+                    result.metadata(),
+                    System.currentTimeMillis()))
+                .onItem().transform(optional -> optional.orElseThrow(() ->
+                    new IllegalStateException("Await interaction metadata update lost OCC race: "
+                        + claimedInteraction.interactionId()))));
     }
 
     /**
@@ -123,17 +133,32 @@ public class AwaitCoordinator {
         String provider = orchestratorConfig == null ? null : orchestratorConfig.stateProvider();
         return stores.stream()
             .filter(candidate -> provider == null || provider.isBlank() || provider.equalsIgnoreCase(candidate.providerName()))
-            .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
+            .sorted((left, right) -> {
+                int priorityComparison = Integer.compare(right.priority(), left.priority());
+                if (priorityComparison != 0) {
+                    return priorityComparison;
+                }
+                return left.providerName().compareToIgnoreCase(right.providerName());
+            })
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("No AwaitInteractionStore provider is available"
                 + (provider == null || provider.isBlank() ? "" : " for provider " + provider)));
     }
 
     private AwaitTransportAdapter<?, ?> adapter(String type) {
-        return adapters.stream()
+        List<AwaitTransportAdapter<?, ?>> matching = adapters.stream()
             .filter(candidate -> type.equalsIgnoreCase(candidate.type()))
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("No AwaitTransportAdapter provider is available for type " + type));
+            .toList();
+        if (matching.isEmpty()) {
+            throw new IllegalStateException("No AwaitTransportAdapter provider is available for type " + type);
+        }
+        if (matching.size() > 1) {
+            String providerInfo = matching.stream()
+                .map(candidate -> candidate.getClass().getName())
+                .collect(java.util.stream.Collectors.joining(", "));
+            throw new IllegalStateException("Ambiguous AwaitTransportAdapter providers for type " + type + ": " + providerInfo);
+        }
+        return matching.get(0);
     }
 
     private String deriveCorrelationId(

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -1,0 +1,166 @@
+package org.pipelineframework.awaitable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.spi.AwaitInteractionStore;
+import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+
+/**
+ * Coordinates await interaction persistence, dispatch, completion admission, and query paths.
+ */
+@ApplicationScoped
+public class AwaitCoordinator {
+
+    @Inject
+    Instance<AwaitInteractionStore> stores;
+
+    @Inject
+    Instance<AwaitTransportAdapter<?, ?>> adapters;
+
+    @Inject
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    /**
+     * Creates or returns an active interaction for an await step.
+     */
+    public Uni<AwaitCreateResult> createOrGet(
+        AwaitStepDescriptor descriptor,
+        String tenantId,
+        String executionId,
+        int stepIndex,
+        String causationId,
+        Object requestPayload,
+        String assignee,
+        String group
+    ) {
+        long now = System.currentTimeMillis();
+        long deadline = now + descriptor.timeout().toMillis();
+        long ttl = Instant.ofEpochMilli(deadline).plusSeconds(86_400).getEpochSecond();
+        String idempotencyKey = deriveIdempotencyKey(descriptor, executionId, requestPayload);
+        String correlationId = deriveCorrelationId(descriptor, tenantId, executionId, idempotencyKey);
+        return store().createOrGet(new AwaitCreateCommand(
+            tenantId,
+            executionId,
+            descriptor.stepId(),
+            stepIndex,
+            descriptor.outputType(),
+            causationId,
+            idempotencyKey,
+            correlationId,
+            requestPayload,
+            assignee,
+            group,
+            descriptor.transportType(),
+            now,
+            deadline,
+            ttl));
+    }
+
+    /**
+     * Dispatches an existing interaction through its configured transport adapter.
+     */
+    @SuppressWarnings("unchecked")
+    public Uni<AwaitInteractionRecord> dispatch(AwaitStepDescriptor descriptor, AwaitInteractionRecord interaction) {
+        AwaitTransportAdapter<Object, Object> adapter = (AwaitTransportAdapter<Object, Object>) adapter(descriptor.transportType());
+        return adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction,
+                interaction.requestPayload()))
+            .onItem().transformToUni(result -> store().markDispatched(
+                interaction.tenantId(),
+                interaction.interactionId(),
+                interaction.version(),
+                result.metadata(),
+                System.currentTimeMillis()))
+            .onItem().transform(optional -> optional.orElseThrow(() ->
+                new IllegalStateException("Await interaction dispatch transition lost OCC race: "
+                    + interaction.interactionId())));
+    }
+
+    /**
+     * Accepts a correlated completion.
+     */
+    public Uni<AwaitCompletionResult> complete(AwaitCompletionCommand command) {
+        return store().complete(command);
+    }
+
+    /**
+     * Queries pending interactions.
+     */
+    public Uni<List<AwaitInteractionRecord>> queryPending(
+        String tenantId,
+        String assignee,
+        String group,
+        String stepId,
+        int limit) {
+        return store().queryPending(tenantId, assignee, group, stepId, limit);
+    }
+
+    /**
+     * Finds interactions past their deadline.
+     */
+    public Uni<List<AwaitInteractionRecord>> findTimedOut(long nowEpochMs, int limit) {
+        return store().findTimedOut(nowEpochMs, limit);
+    }
+
+    /**
+     * Marks an interaction as timed out.
+     */
+    public Uni<java.util.Optional<AwaitInteractionRecord>> markTimedOut(AwaitInteractionRecord record, long nowEpochMs) {
+        return store().markTimedOut(record.tenantId(), record.interactionId(), record.version(), nowEpochMs);
+    }
+
+    private AwaitInteractionStore store() {
+        String provider = orchestratorConfig == null ? null : orchestratorConfig.stateProvider();
+        return stores.stream()
+            .filter(candidate -> provider == null || provider.isBlank() || provider.equalsIgnoreCase(candidate.providerName()))
+            .sorted((left, right) -> Integer.compare(right.priority(), left.priority()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No AwaitInteractionStore provider is available"
+                + (provider == null || provider.isBlank() ? "" : " for provider " + provider)));
+    }
+
+    private AwaitTransportAdapter<?, ?> adapter(String type) {
+        return adapters.stream()
+            .filter(candidate -> type.equalsIgnoreCase(candidate.type()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No AwaitTransportAdapter provider is available for type " + type));
+    }
+
+    private String deriveCorrelationId(
+        AwaitStepDescriptor descriptor,
+        String tenantId,
+        String executionId,
+        String idempotencyKey) {
+        String basis = tenantId + ":" + executionId + ":" + descriptor.stepId() + ":" + idempotencyKey;
+        return switch (descriptor.correlationStrategy()) {
+            case "interactionId", "signedResumeToken" -> java.util.UUID.nameUUIDFromBytes(
+                basis.getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString();
+            default -> java.util.UUID.nameUUIDFromBytes(
+                (descriptor.correlationStrategy() + ":" + basis).getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString();
+        };
+    }
+
+    private String deriveIdempotencyKey(AwaitStepDescriptor descriptor, String executionId, Object requestPayload) {
+        if (descriptor.idempotencyKeyFields().isEmpty()) {
+            return executionId + ":" + descriptor.stepId();
+        }
+        JsonNode node = PipelineJson.mapper().valueToTree(requestPayload);
+        StringBuilder builder = new StringBuilder(descriptor.stepId());
+        for (String field : descriptor.idempotencyKeyFields()) {
+            builder.append(':').append(field).append('=');
+            JsonNode value = node == null ? null : node.get(field);
+            builder.append(value == null || value.isNull() ? "<null>" : value.asText());
+        }
+        return builder.toString();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
@@ -88,6 +88,8 @@ public record AwaitCreateCommand(
         }
         if (ttlEpochS <= 0) {
             ttlEpochS = Instant.ofEpochMilli(deadlineEpochMs).plusSeconds(86_400).getEpochSecond();
+        } else if (ttlEpochS < Instant.ofEpochMilli(deadlineEpochMs).getEpochSecond()) {
+            throw new IllegalArgumentException("ttlEpochS must not be before deadlineEpochMs");
         }
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
@@ -1,0 +1,93 @@
+package org.pipelineframework.awaitable;
+
+import java.time.Instant;
+
+/**
+ * Command used to create or deduplicate an await interaction.
+ */
+public record AwaitCreateCommand(
+    String tenantId,
+    String executionId,
+    String stepId,
+    int stepIndex,
+    String outputType,
+    String causationId,
+    String idempotencyKey,
+    String correlationId,
+    Object requestPayload,
+    String assignee,
+    String group,
+    String transportType,
+    long nowEpochMs,
+    long deadlineEpochMs,
+    long ttlEpochS
+) {
+    /**
+     * Backward-compatible constructor for tests/callers created before step index and output type were persisted.
+     */
+    public AwaitCreateCommand(
+        String tenantId,
+        String executionId,
+        String stepId,
+        String causationId,
+        String idempotencyKey,
+        String correlationId,
+        Object requestPayload,
+        String assignee,
+        String group,
+        String transportType,
+        long nowEpochMs,
+        long deadlineEpochMs,
+        long ttlEpochS
+    ) {
+        this(
+            tenantId,
+            executionId,
+            stepId,
+            0,
+            Object.class.getName(),
+            causationId,
+            idempotencyKey,
+            correlationId,
+            requestPayload,
+            assignee,
+            group,
+            transportType,
+            nowEpochMs,
+            deadlineEpochMs,
+            ttlEpochS);
+    }
+
+    public AwaitCreateCommand {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        if (executionId == null || executionId.isBlank()) {
+            throw new IllegalArgumentException("executionId must not be blank");
+        }
+        if (stepId == null || stepId.isBlank()) {
+            throw new IllegalArgumentException("stepId must not be blank");
+        }
+        if (outputType == null || outputType.isBlank()) {
+            throw new IllegalArgumentException("outputType must not be blank");
+        }
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new IllegalArgumentException("idempotencyKey must not be blank");
+        }
+        if (correlationId == null || correlationId.isBlank()) {
+            throw new IllegalArgumentException("correlationId must not be blank");
+        }
+        if (transportType == null || transportType.isBlank()) {
+            throw new IllegalArgumentException("transportType must not be blank");
+        }
+        if (nowEpochMs <= 0) {
+            nowEpochMs = System.currentTimeMillis();
+        }
+        if (deadlineEpochMs <= nowEpochMs) {
+            throw new IllegalArgumentException("deadlineEpochMs must be after nowEpochMs");
+        }
+        if (ttlEpochS <= 0) {
+            ttlEpochS = Instant.ofEpochMilli(deadlineEpochMs).plusSeconds(86_400).getEpochSecond();
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
@@ -68,6 +68,9 @@ public record AwaitCreateCommand(
         if (stepId == null || stepId.isBlank()) {
             throw new IllegalArgumentException("stepId must not be blank");
         }
+        if (stepIndex < 0) {
+            throw new IllegalArgumentException("stepIndex must not be negative");
+        }
         if (outputType == null || outputType.isBlank()) {
             throw new IllegalArgumentException("outputType must not be blank");
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateResult.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateResult.java
@@ -1,0 +1,10 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Result of create-or-get for an await interaction.
+ *
+ * @param record interaction record
+ * @param duplicate true when an existing active interaction was returned
+ */
+public record AwaitCreateResult(AwaitInteractionRecord record, boolean duplicate) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContext.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContext.java
@@ -15,6 +15,9 @@ public final class AwaitExecutionContext {
         if (executionId == null || executionId.isBlank()) {
             throw new IllegalArgumentException("executionId must not be blank");
         }
+        if (currentStepIndex < 0) {
+            throw new IllegalArgumentException("currentStepIndex must be non-negative");
+        }
         this.tenantId = tenantId;
         this.executionId = executionId;
         this.currentStepIndex = currentStepIndex;
@@ -33,6 +36,9 @@ public final class AwaitExecutionContext {
     }
 
     public void currentStepIndex(int currentStepIndex) {
+        if (currentStepIndex < 0) {
+            throw new IllegalArgumentException("currentStepIndex must be non-negative");
+        }
         this.currentStepIndex = currentStepIndex;
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContext.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContext.java
@@ -1,0 +1,38 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Internal queue-async execution context used by generated await steps.
+ */
+public final class AwaitExecutionContext {
+    private final String tenantId;
+    private final String executionId;
+    private int currentStepIndex;
+
+    public AwaitExecutionContext(String tenantId, String executionId, int currentStepIndex) {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        if (executionId == null || executionId.isBlank()) {
+            throw new IllegalArgumentException("executionId must not be blank");
+        }
+        this.tenantId = tenantId;
+        this.executionId = executionId;
+        this.currentStepIndex = currentStepIndex;
+    }
+
+    public String tenantId() {
+        return tenantId;
+    }
+
+    public String executionId() {
+        return executionId;
+    }
+
+    public int currentStepIndex() {
+        return currentStepIndex;
+    }
+
+    public void currentStepIndex(int currentStepIndex) {
+        this.currentStepIndex = currentStepIndex;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContextHolder.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContextHolder.java
@@ -1,0 +1,23 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Thread-local holder for internal await execution context.
+ */
+public final class AwaitExecutionContextHolder {
+    private static final ThreadLocal<AwaitExecutionContext> CURRENT = new ThreadLocal<>();
+
+    private AwaitExecutionContextHolder() {
+    }
+
+    public static AwaitExecutionContext get() {
+        return CURRENT.get();
+    }
+
+    public static void set(AwaitExecutionContext context) {
+        CURRENT.set(context);
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContextHolder.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContextHolder.java
@@ -2,6 +2,24 @@ package org.pipelineframework.awaitable;
 
 /**
  * Thread-local holder for internal await execution context.
+ *
+ * <p>Callers that invoke {@link #set(AwaitExecutionContext)} must restore the previous value or call
+ * {@link #clear()} in a {@code finally} block when the execution scope ends. This holder is intentionally
+ * narrow: it is only safe while framework-managed await execution remains on the same thread.</p>
+ *
+ * <p>Because this is backed by {@link ThreadLocal}, pooled threads can leak stale context if cleanup is missed,
+ * and reactive thread-hopping or virtual-thread handoff can lose context unless the framework explicitly
+ * propagates it. Code that cannot guarantee same-thread execution should use a managed context-propagation
+ * mechanism instead of reading {@link #get()} directly.</p>
+ *
+ * <p>TODO: replace this with a framework-managed scope abstraction, for example Java {@code ScopedValue}
+ * where suitable or Quarkus/SmallRye context propagation, so cleanup is enforced centrally.</p>
+ *
+ * <ul>
+ * <li>{@link #get()} returns the current thread's context, or {@code null} when none is installed.</li>
+ * <li>{@link #set(AwaitExecutionContext)} installs context for the current thread only.</li>
+ * <li>{@link #clear()} removes the current thread's context and should be called at scope end.</li>
+ * </ul>
  */
 public final class AwaitExecutionContextHolder {
     private static final ThreadLocal<AwaitExecutionContext> CURRENT = new ThreadLocal<>();

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitInteractionRecord.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitInteractionRecord.java
@@ -1,0 +1,85 @@
+package org.pipelineframework.awaitable;
+
+import java.util.Map;
+
+/**
+ * Durable projection for a single await interaction.
+ *
+ * @param tenantId tenant id
+ * @param executionId owning execution id
+ * @param stepId owning await step id
+ * @param stepIndex owning await step index
+ * @param outputType expected await output Java type
+ * @param interactionId framework-owned interaction id
+ * @param correlationId adapter-visible correlation id
+ * @param causationId id that caused this interaction
+ * @param idempotencyKey duplicate suppression key
+ * @param version optimistic-concurrency version
+ * @param status interaction status
+ * @param requestPayload request snapshot
+ * @param responsePayload response snapshot
+ * @param actor completing actor, if any
+ * @param assignee assigned user, if any
+ * @param group assigned group, if any
+ * @param transportType adapter type
+ * @param transportMetadata transport metadata
+ * @param deadlineEpochMs absolute deadline
+ * @param createdAtEpochMs creation timestamp
+ * @param updatedAtEpochMs update timestamp
+ * @param ttlEpochS expiry timestamp
+ */
+public record AwaitInteractionRecord(
+    String tenantId,
+    String executionId,
+    String stepId,
+    int stepIndex,
+    String outputType,
+    String interactionId,
+    String correlationId,
+    String causationId,
+    String idempotencyKey,
+    long version,
+    AwaitInteractionStatus status,
+    Object requestPayload,
+    Object responsePayload,
+    String actor,
+    String assignee,
+    String group,
+    String transportType,
+    Map<String, Object> transportMetadata,
+    long deadlineEpochMs,
+    long createdAtEpochMs,
+    long updatedAtEpochMs,
+    long ttlEpochS
+) {
+    public AwaitInteractionRecord {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        if (executionId == null || executionId.isBlank()) {
+            throw new IllegalArgumentException("executionId must not be blank");
+        }
+        if (stepId == null || stepId.isBlank()) {
+            throw new IllegalArgumentException("stepId must not be blank");
+        }
+        if (stepIndex < 0) {
+            throw new IllegalArgumentException("stepIndex must not be negative");
+        }
+        if (outputType == null || outputType.isBlank()) {
+            throw new IllegalArgumentException("outputType must not be blank");
+        }
+        if (interactionId == null || interactionId.isBlank()) {
+            throw new IllegalArgumentException("interactionId must not be blank");
+        }
+        if (correlationId == null || correlationId.isBlank()) {
+            throw new IllegalArgumentException("correlationId must not be blank");
+        }
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new IllegalArgumentException("idempotencyKey must not be blank");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("status must not be null");
+        }
+        transportMetadata = transportMetadata == null ? Map.of() : Map.copyOf(transportMetadata);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitInteractionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitInteractionStatus.java
@@ -1,0 +1,23 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Durable lifecycle status for an await interaction.
+ */
+public enum AwaitInteractionStatus {
+    WAITING,
+    DISPATCHED,
+    COMPLETED,
+    FAILED,
+    TIMED_OUT,
+    CANCELLED,
+    EXPIRED;
+
+    /**
+     * Whether this interaction can no longer be completed.
+     *
+     * @return true when terminal
+     */
+    public boolean terminal() {
+        return this == COMPLETED || this == FAILED || this == TIMED_OUT || this == CANCELLED || this == EXPIRED;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitInteractionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitInteractionStatus.java
@@ -5,6 +5,7 @@ package org.pipelineframework.awaitable;
  */
 public enum AwaitInteractionStatus {
     WAITING,
+    DISPATCHING,
     DISPATCHED,
     COMPLETED,
     FAILED,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptor.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptor.java
@@ -1,0 +1,51 @@
+package org.pipelineframework.awaitable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runtime descriptor for one generated await step.
+ *
+ * @param stepId stable generated step id
+ * @param inputType input domain type
+ * @param outputType output domain type
+ * @param timeout maximum wait duration
+ * @param correlationStrategy strategy used to derive adapter-visible correlation ids
+ * @param transportType adapter type
+ * @param transportConfig transport-specific adapter config
+ * @param idempotencyKeyFields fields used to derive stable idempotency keys
+ */
+public record AwaitStepDescriptor(
+    String stepId,
+    String inputType,
+    String outputType,
+    Duration timeout,
+    String correlationStrategy,
+    String transportType,
+    Map<String, Object> transportConfig,
+    List<String> idempotencyKeyFields
+) {
+    public AwaitStepDescriptor {
+        if (stepId == null || stepId.isBlank()) {
+            throw new IllegalArgumentException("stepId must not be blank");
+        }
+        if (inputType == null || inputType.isBlank()) {
+            throw new IllegalArgumentException("inputType must not be blank");
+        }
+        if (outputType == null || outputType.isBlank()) {
+            throw new IllegalArgumentException("outputType must not be blank");
+        }
+        if (timeout == null || timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+        if (transportType == null || transportType.isBlank()) {
+            throw new IllegalArgumentException("transportType must not be blank");
+        }
+        correlationStrategy = correlationStrategy == null || correlationStrategy.isBlank()
+            ? "interactionId"
+            : correlationStrategy;
+        transportConfig = transportConfig == null ? Map.of() : Map.copyOf(transportConfig);
+        idempotencyKeyFields = idempotencyKeyFields == null ? List.of() : List.copyOf(idempotencyKeyFields);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
@@ -1,0 +1,72 @@
+package org.pipelineframework.awaitable;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.pipelineframework.config.pipeline.PipelineYamlConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfigLoader;
+import org.pipelineframework.config.pipeline.PipelineYamlConfigLocator;
+import org.pipelineframework.config.pipeline.PipelineYamlStep;
+
+/**
+ * Builds await descriptors from runtime pipeline YAML.
+ */
+@ApplicationScoped
+public class AwaitStepDescriptorFactory {
+    private final Map<String, AwaitStepDescriptor> descriptors = new ConcurrentHashMap<>();
+
+    /**
+     * Resolves the descriptor for a generated await step.
+     */
+    public AwaitStepDescriptor descriptor(String serviceName, String inputType, String outputType) {
+        return descriptors.computeIfAbsent(serviceName, key -> loadDescriptor(key, inputType, outputType));
+    }
+
+    private AwaitStepDescriptor loadDescriptor(String serviceName, String inputType, String outputType) {
+        Path base = Path.of("").toAbsolutePath();
+        Path configPath = new PipelineYamlConfigLocator().locate(base)
+            .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for await step " + serviceName));
+        PipelineYamlConfig config = new PipelineYamlConfigLoader().load(configPath);
+        PipelineYamlStep step = config.steps().stream()
+            .filter(candidate -> serviceName.equals(toServiceName(candidate.name())))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No await YAML step found for generated service " + serviceName));
+        if (!"await".equalsIgnoreCase(step.kind())) {
+            throw new IllegalStateException("Generated await service " + serviceName + " maps to non-await YAML step");
+        }
+        if (step.awaitConfig() == null || step.awaitConfig().transport() == null) {
+            throw new IllegalStateException("Await step " + serviceName + " is missing await.transport configuration");
+        }
+        return new AwaitStepDescriptor(
+            serviceName,
+            inputType,
+            outputType,
+            Duration.parse(step.timeout()),
+            step.awaitConfig().correlation().strategy(),
+            step.awaitConfig().transport().type(),
+            step.awaitConfig().transport().config(),
+            step.idempotencyKeyFields());
+    }
+
+    private static String toServiceName(String stepName) {
+        if (stepName == null || stepName.isBlank()) {
+            return "ProcessStepService";
+        }
+        String stripped = stepName.startsWith("Process ") ? stepName.substring("Process ".length()) : stepName;
+        StringBuilder formatted = new StringBuilder();
+        for (String part : stripped.split(" ")) {
+            if (part == null || part.isBlank()) {
+                continue;
+            }
+            String lower = part.toLowerCase(java.util.Locale.ROOT);
+            formatted.append(Character.toUpperCase(lower.charAt(0)));
+            if (lower.length() > 1) {
+                formatted.append(lower.substring(1));
+            }
+        }
+        return formatted.isEmpty() ? "ProcessStepService" : "Process" + formatted + "Service";
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
@@ -37,14 +37,32 @@ public class AwaitStepDescriptorFactory {
         if (!"await".equalsIgnoreCase(step.kind())) {
             throw new IllegalStateException("Generated await service " + serviceName + " maps to non-await YAML step");
         }
-        if (step.awaitConfig() == null || step.awaitConfig().transport() == null) {
+        if (step.awaitConfig() == null) {
+            throw new IllegalStateException("Await step " + serviceName + " is missing await configuration");
+        }
+        if (step.awaitConfig().transport() == null) {
             throw new IllegalStateException("Await step " + serviceName + " is missing await.transport configuration");
+        }
+        if (step.awaitConfig().correlation() == null) {
+            throw new IllegalStateException("Await step " + serviceName + " is missing await.correlation configuration");
+        }
+        if (step.awaitConfig().correlation().strategy() == null || step.awaitConfig().correlation().strategy().isBlank()) {
+            throw new IllegalArgumentException("Await step " + serviceName + " is missing await.correlation.strategy");
+        }
+        if (step.timeout() == null || step.timeout().isBlank()) {
+            throw new IllegalArgumentException("Await step " + serviceName + " is missing timeout");
+        }
+        Duration timeout;
+        try {
+            timeout = Duration.parse(step.timeout());
+        } catch (java.time.format.DateTimeParseException ex) {
+            throw new IllegalArgumentException("Await step " + serviceName + " has invalid timeout format: " + step.timeout(), ex);
         }
         return new AwaitStepDescriptor(
             serviceName,
             inputType,
             outputType,
-            Duration.parse(step.timeout()),
+            timeout,
             step.awaitConfig().correlation().strategy(),
             step.awaitConfig().transport().type(),
             step.awaitConfig().transport().config(),

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
@@ -3,12 +3,16 @@ package org.pipelineframework.awaitable;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import io.smallrye.mutiny.Uni;
 import org.pipelineframework.config.pipeline.PipelineYamlConfig;
 import org.pipelineframework.config.pipeline.PipelineYamlConfigLoader;
 import org.pipelineframework.config.pipeline.PipelineYamlConfigLocator;
@@ -19,31 +23,43 @@ import org.pipelineframework.config.pipeline.PipelineYamlStep;
  */
 @ApplicationScoped
 public class AwaitStepDescriptorFactory {
+    private static final int DESCRIPTOR_LOADER_THREADS = Math.max(2, Runtime.getRuntime().availableProcessors());
+    private static final int DESCRIPTOR_LOADER_QUEUE_SIZE = 256;
+
     private final Map<String, AwaitStepDescriptor> descriptors = new ConcurrentHashMap<>();
-    private final Executor blockingExecutor = Executors.newCachedThreadPool(r -> {
-        Thread t = new Thread(r);
-        t.setDaemon(true);
-        t.setName("await-descriptor-loader");
-        return t;
-    });
+    private final AtomicInteger threadCounter = new AtomicInteger();
+    private final ExecutorService blockingExecutor = new ThreadPoolExecutor(
+        1,
+        DESCRIPTOR_LOADER_THREADS,
+        60L,
+        TimeUnit.SECONDS,
+        new ArrayBlockingQueue<>(DESCRIPTOR_LOADER_QUEUE_SIZE),
+        r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            t.setName("await-descriptor-loader-" + threadCounter.incrementAndGet());
+            return t;
+        });
 
     /**
      * Resolves the descriptor for a generated await step.
      */
-    public AwaitStepDescriptor descriptor(String serviceName, String inputType, String outputType) {
+    public Uni<AwaitStepDescriptor> descriptor(String serviceName, String inputType, String outputType) {
         AwaitStepDescriptor cached = descriptors.get(serviceName);
         if (cached != null) {
-            return cached;
+            return Uni.createFrom().item(cached);
         }
-        return CompletableFuture.supplyAsync(() -> loadDescriptor(serviceName, inputType, outputType), blockingExecutor)
-            .join();
+        return Uni.createFrom()
+            .item(() -> descriptors.computeIfAbsent(serviceName, key -> loadDescriptor(key, inputType, outputType)))
+            .runSubscriptionOn(blockingExecutor);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        blockingExecutor.shutdown();
     }
 
     private AwaitStepDescriptor loadDescriptor(String serviceName, String inputType, String outputType) {
-        AwaitStepDescriptor existing = descriptors.get(serviceName);
-        if (existing != null) {
-            return existing;
-        }
         Path base = Path.of("").toAbsolutePath();
         Path configPath = new PipelineYamlConfigLocator().locate(base)
             .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for await step " + serviceName));
@@ -85,7 +101,6 @@ public class AwaitStepDescriptorFactory {
             step.awaitConfig().transport().type(),
             step.awaitConfig().transport().config(),
             step.idempotencyKeyFields());
-        descriptors.putIfAbsent(serviceName, descriptor);
         return descriptor;
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
@@ -3,7 +3,10 @@ package org.pipelineframework.awaitable;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.pipelineframework.config.pipeline.PipelineYamlConfig;
@@ -17,15 +20,30 @@ import org.pipelineframework.config.pipeline.PipelineYamlStep;
 @ApplicationScoped
 public class AwaitStepDescriptorFactory {
     private final Map<String, AwaitStepDescriptor> descriptors = new ConcurrentHashMap<>();
+    private final Executor blockingExecutor = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r);
+        t.setDaemon(true);
+        t.setName("await-descriptor-loader");
+        return t;
+    });
 
     /**
      * Resolves the descriptor for a generated await step.
      */
     public AwaitStepDescriptor descriptor(String serviceName, String inputType, String outputType) {
-        return descriptors.computeIfAbsent(serviceName, key -> loadDescriptor(key, inputType, outputType));
+        AwaitStepDescriptor cached = descriptors.get(serviceName);
+        if (cached != null) {
+            return cached;
+        }
+        return CompletableFuture.supplyAsync(() -> loadDescriptor(serviceName, inputType, outputType), blockingExecutor)
+            .join();
     }
 
     private AwaitStepDescriptor loadDescriptor(String serviceName, String inputType, String outputType) {
+        AwaitStepDescriptor existing = descriptors.get(serviceName);
+        if (existing != null) {
+            return existing;
+        }
         Path base = Path.of("").toAbsolutePath();
         Path configPath = new PipelineYamlConfigLocator().locate(base)
             .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for await step " + serviceName));
@@ -58,7 +76,7 @@ public class AwaitStepDescriptorFactory {
         } catch (java.time.format.DateTimeParseException ex) {
             throw new IllegalArgumentException("Await step " + serviceName + " has invalid timeout format: " + step.timeout(), ex);
         }
-        return new AwaitStepDescriptor(
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
             serviceName,
             inputType,
             outputType,
@@ -67,6 +85,8 @@ public class AwaitStepDescriptorFactory {
             step.awaitConfig().transport().type(),
             step.awaitConfig().transport().config(),
             step.idempotencyKeyFields());
+        descriptors.putIfAbsent(serviceName, descriptor);
+        return descriptor;
     }
 
     private static String toServiceName(String stepName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -24,6 +24,9 @@ public class AwaitStepSupport {
      */
     @SuppressWarnings("unchecked")
     public <I, O> Uni<O> awaitOneToOne(AwaitStepDescriptor descriptor, I input) {
+        if (descriptor == null) {
+            throw new IllegalArgumentException("descriptor must not be null");
+        }
         if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
             return Uni.createFrom().failure(new IllegalStateException(
                 "Await steps require pipeline.orchestrator.mode=QUEUE_ASYNC."));
@@ -61,6 +64,9 @@ public class AwaitStepSupport {
      * Resolves an await descriptor reactively before creating/dispatching the await interaction.
      */
     public <I, O> Uni<O> awaitOneToOne(Uni<AwaitStepDescriptor> descriptor, I input) {
+        if (descriptor == null) {
+            throw new IllegalArgumentException("descriptor must not be null");
+        }
         return descriptor.onItem().transformToUni(resolved -> awaitOneToOne(resolved, input));
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -56,4 +56,11 @@ public class AwaitStepSupport {
                         stepIndex)));
             });
     }
+
+    /**
+     * Resolves an await descriptor reactively before creating/dispatching the await interaction.
+     */
+    public <I, O> Uni<O> awaitOneToOne(Uni<AwaitStepDescriptor> descriptor, I input) {
+        return descriptor.onItem().transformToUni(resolved -> awaitOneToOne(resolved, input));
+    }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -1,0 +1,59 @@
+package org.pipelineframework.awaitable;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+
+/**
+ * Runtime bridge used by generated await step beans.
+ */
+@ApplicationScoped
+public class AwaitStepSupport {
+
+    @Inject
+    AwaitCoordinator awaitCoordinator;
+
+    @Inject
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    /**
+     * Creates/dispatches an await interaction and suspends queue-async execution.
+     */
+    @SuppressWarnings("unchecked")
+    public <I, O> Uni<O> awaitOneToOne(AwaitStepDescriptor descriptor, I input) {
+        if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+            return Uni.createFrom().failure(new IllegalStateException(
+                "Await steps require pipeline.orchestrator.mode=QUEUE_ASYNC."));
+        }
+        AwaitExecutionContext context = AwaitExecutionContextHolder.get();
+        if (context == null) {
+            return Uni.createFrom().failure(new IllegalStateException(
+                "Await step executed without queue-async execution context."));
+        }
+        int stepIndex = context.currentStepIndex();
+        return awaitCoordinator.createOrGet(
+                descriptor,
+                context.tenantId(),
+                context.executionId(),
+                stepIndex,
+                context.executionId() + ":" + stepIndex,
+                input,
+                null,
+                null)
+            .onItem().transformToUni(created -> {
+                AwaitInteractionRecord record = created.record();
+                Uni<AwaitInteractionRecord> dispatched = record.status() == AwaitInteractionStatus.WAITING
+                    ? awaitCoordinator.dispatch(descriptor, record)
+                    : Uni.createFrom().item(record);
+                return dispatched.onItem().transformToUni(updated ->
+                    Uni.createFrom().failure(new AwaitSuspendedException(
+                        context.tenantId(),
+                        context.executionId(),
+                        updated.interactionId(),
+                        stepIndex)));
+            });
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitSuspendedException.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitSuspendedException.java
@@ -1,0 +1,35 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Internal signal used to suspend queue-async execution at an await step.
+ */
+public class AwaitSuspendedException extends RuntimeException {
+    private final String tenantId;
+    private final String executionId;
+    private final String interactionId;
+    private final int stepIndex;
+
+    public AwaitSuspendedException(String tenantId, String executionId, String interactionId, int stepIndex) {
+        super("Pipeline execution is waiting for await interaction " + interactionId);
+        this.tenantId = tenantId;
+        this.executionId = executionId;
+        this.interactionId = interactionId;
+        this.stepIndex = stepIndex;
+    }
+
+    public String tenantId() {
+        return tenantId;
+    }
+
+    public String executionId() {
+        return executionId;
+    }
+
+    public String interactionId() {
+        return interactionId;
+    }
+
+    public int stepIndex() {
+        return stepIndex;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitSuspendedException.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitSuspendedException.java
@@ -10,11 +10,27 @@ public class AwaitSuspendedException extends RuntimeException {
     private final int stepIndex;
 
     public AwaitSuspendedException(String tenantId, String executionId, String interactionId, int stepIndex) {
-        super("Pipeline execution is waiting for await interaction " + interactionId);
+        super(message(tenantId, executionId, interactionId, stepIndex));
         this.tenantId = tenantId;
         this.executionId = executionId;
         this.interactionId = interactionId;
         this.stepIndex = stepIndex;
+    }
+
+    private static String message(String tenantId, String executionId, String interactionId, int stepIndex) {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        if (executionId == null || executionId.isBlank()) {
+            throw new IllegalArgumentException("executionId must not be blank");
+        }
+        if (interactionId == null || interactionId.isBlank()) {
+            throw new IllegalArgumentException("interactionId must not be blank");
+        }
+        if (stepIndex < 0) {
+            throw new IllegalArgumentException("stepIndex must be >= 0");
+        }
+        return "Pipeline execution is waiting for await interaction " + interactionId;
     }
 
     public String tenantId() {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/InteractionApiAwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/InteractionApiAwaitTransportAdapter.java
@@ -1,0 +1,24 @@
+package org.pipelineframework.awaitable;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
+
+/**
+ * Built-in no-op dispatch adapter for UI/mock-provider interaction APIs.
+ */
+@ApplicationScoped
+public class InteractionApiAwaitTransportAdapter implements AwaitTransportAdapter<Object, Object> {
+    @Override
+    public String type() {
+        return "interaction-api";
+    }
+
+    @Override
+    public Uni<AwaitDispatchResult> dispatch(AwaitDispatchRequest<Object> request) {
+        return Uni.createFrom().item(new AwaitDispatchResult(java.util.Map.of(
+            "adapter", type(),
+            "dispatchedAtEpochMs", System.currentTimeMillis())));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/InteractionApiAwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/InteractionApiAwaitTransportAdapter.java
@@ -9,7 +9,7 @@ import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
  * Built-in no-op dispatch adapter for UI/mock-provider interaction APIs.
  */
 @ApplicationScoped
-public class InteractionApiAwaitTransportAdapter implements AwaitTransportAdapter<Object, Object> {
+public class InteractionApiAwaitTransportAdapter implements AwaitTransportAdapter<Object> {
     @Override
     public String type() {
         return "interaction-api";

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionRequestDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionRequestDto.java
@@ -1,0 +1,13 @@
+package org.pipelineframework.awaitable.dto;
+
+/**
+ * REST/gRPC-neutral request DTO for completing an await interaction.
+ */
+public record AwaitCompletionRequestDto(
+    String interactionId,
+    String correlationId,
+    String idempotencyKey,
+    Object responsePayload,
+    String actor
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionResponseDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionResponseDto.java
@@ -1,0 +1,15 @@
+package org.pipelineframework.awaitable.dto;
+
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+
+/**
+ * Response DTO returned after completion admission.
+ */
+public record AwaitCompletionResponseDto(
+    String interactionId,
+    String executionId,
+    String stepId,
+    AwaitInteractionStatus status,
+    boolean duplicate
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
@@ -1,0 +1,41 @@
+package org.pipelineframework.awaitable.dto;
+
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+
+/**
+ * Maps await runtime records to transport DTOs.
+ */
+public final class AwaitDtoMapper {
+    private AwaitDtoMapper() {
+    }
+
+    public static AwaitCompletionResponseDto toCompletionResponse(AwaitCompletionResult result) {
+        AwaitInteractionRecord record = result.record();
+        return new AwaitCompletionResponseDto(
+            record.interactionId(),
+            record.executionId(),
+            record.stepId(),
+            record.status(),
+            result.duplicate());
+    }
+
+    public static AwaitInteractionDto toDto(AwaitInteractionRecord record) {
+        return new AwaitInteractionDto(
+            record.interactionId(),
+            record.correlationId(),
+            record.executionId(),
+            record.stepId(),
+            record.stepIndex(),
+            record.outputType(),
+            record.status(),
+            record.requestPayload(),
+            record.assignee(),
+            record.group(),
+            record.transportType(),
+            record.transportMetadata(),
+            record.deadlineEpochMs(),
+            record.createdAtEpochMs(),
+            record.updatedAtEpochMs());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
@@ -1,5 +1,7 @@
 package org.pipelineframework.awaitable.dto;
 
+import java.util.Objects;
+
 import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
 
@@ -11,7 +13,13 @@ public final class AwaitDtoMapper {
     }
 
     public static AwaitCompletionResponseDto toCompletionResponse(AwaitCompletionResult result) {
-        AwaitInteractionRecord record = result.record();
+        AwaitInteractionRecord record = Objects.requireNonNull(
+            Objects.requireNonNull(result, "result must not be null").record(),
+            "result.record must not be null");
+        Objects.requireNonNull(record.interactionId(), "record.interactionId must not be null");
+        Objects.requireNonNull(record.executionId(), "record.executionId must not be null");
+        Objects.requireNonNull(record.stepId(), "record.stepId must not be null");
+        Objects.requireNonNull(record.status(), "record.status must not be null");
         return new AwaitCompletionResponseDto(
             record.interactionId(),
             record.executionId(),

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitInteractionDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitInteractionDto.java
@@ -1,0 +1,27 @@
+package org.pipelineframework.awaitable.dto;
+
+import java.util.Map;
+
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+
+/**
+ * Query projection for pending await interactions.
+ */
+public record AwaitInteractionDto(
+    String interactionId,
+    String correlationId,
+    String executionId,
+    String stepId,
+    int stepIndex,
+    String outputType,
+    AwaitInteractionStatus status,
+    Object requestPayload,
+    String assignee,
+    String group,
+    String transportType,
+    Map<String, Object> transportMetadata,
+    long deadlineEpochMs,
+    long createdAtEpochMs,
+    long updatedAtEpochMs
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitInteractionStore.java
@@ -60,7 +60,17 @@ public interface AwaitInteractionStore {
     Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId);
 
     /**
-     * Marks an interaction as dispatched.
+     * Claims an interaction for dispatch. Only WAITING interactions may be claimed.
+     */
+    Uni<Optional<AwaitInteractionRecord>> markDispatching(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs);
+
+    /**
+     * Marks a claimed interaction as dispatched and stores adapter metadata.
+     * Only DISPATCHING interactions may be completed as dispatched.
      *
      * @param tenantId tenant id
      * @param interactionId interaction id

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitInteractionStore.java
@@ -1,0 +1,130 @@
+package org.pipelineframework.awaitable.spi;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCreateCommand;
+import org.pipelineframework.awaitable.AwaitCreateResult;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+
+/**
+ * Control-plane persistence SPI for await interactions.
+ */
+public interface AwaitInteractionStore {
+
+    /**
+     * Provider name used for configuration-based selection.
+     *
+     * @return provider name
+     */
+    default String providerName() {
+        return "memory";
+    }
+
+    /**
+     * Provider priority used when multiple stores are available.
+     *
+     * @return provider priority
+     */
+    default int priority() {
+        return 0;
+    }
+
+    /**
+     * Creates a new interaction or returns an active duplicate for the same idempotency key.
+     *
+     * @param command create command
+     * @return create result
+     */
+    Uni<AwaitCreateResult> createOrGet(AwaitCreateCommand command);
+
+    /**
+     * Fetches one interaction by tenant and interaction id.
+     *
+     * @param tenantId tenant id
+     * @param interactionId interaction id
+     * @return matching interaction
+     */
+    Uni<Optional<AwaitInteractionRecord>> get(String tenantId, String interactionId);
+
+    /**
+     * Fetches one interaction by tenant and correlation id.
+     *
+     * @param tenantId tenant id
+     * @param correlationId correlation id
+     * @return matching interaction
+     */
+    Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId);
+
+    /**
+     * Marks an interaction as dispatched.
+     *
+     * @param tenantId tenant id
+     * @param interactionId interaction id
+     * @param expectedVersion expected version
+     * @param transportMetadata transport metadata captured after dispatch
+     * @param nowEpochMs current time
+     * @return updated record when the transition succeeds
+     */
+    Uni<Optional<AwaitInteractionRecord>> markDispatched(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        java.util.Map<String, Object> transportMetadata,
+        long nowEpochMs);
+
+    /**
+     * Accepts a correlated completion.
+     *
+     * @param command completion command
+     * @return completion result
+     */
+    Uni<AwaitCompletionResult> complete(AwaitCompletionCommand command);
+
+    /**
+     * Marks an interaction as failed.
+     */
+    Uni<Optional<AwaitInteractionRecord>> fail(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs);
+
+    /**
+     * Marks an interaction as cancelled.
+     */
+    Uni<Optional<AwaitInteractionRecord>> cancel(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs);
+
+    /**
+     * Marks an interaction as timed out.
+     */
+    Uni<Optional<AwaitInteractionRecord>> markTimedOut(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs);
+
+    /**
+     * Returns active interactions whose deadline has passed.
+     */
+    Uni<List<AwaitInteractionRecord>> findTimedOut(long nowEpochMs, int limit);
+
+    /**
+     * Returns active interactions matching query filters.
+     */
+    Uni<List<AwaitInteractionRecord>> queryPending(
+        String tenantId,
+        String assignee,
+        String group,
+        String stepId,
+        int limit);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitTransportAdapter.java
@@ -1,0 +1,64 @@
+package org.pipelineframework.awaitable.spi;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitStepDescriptor;
+
+/**
+ * Adapter SPI for dispatching await interactions to external systems.
+ *
+ * @param <I> request payload type
+ * @param <O> completion payload type
+ */
+public interface AwaitTransportAdapter<I, O> {
+
+    /**
+     * Adapter type used in YAML.
+     *
+     * @return adapter type
+     */
+    String type();
+
+    /**
+     * Dispatches an await request to the external system.
+     *
+     * @param request dispatch request
+     * @return dispatch result metadata
+     */
+    Uni<AwaitDispatchResult> dispatch(AwaitDispatchRequest<I> request);
+
+    /**
+     * Cancels an already dispatched interaction when supported by the adapter.
+     *
+     * @param request cancel request
+     * @return completion signal
+     */
+    default Uni<Void> cancel(AwaitCancelRequest request) {
+        return Uni.createFrom().voidItem();
+    }
+
+    /**
+     * Dispatch request passed to adapters.
+     */
+    record AwaitDispatchRequest<I>(
+        AwaitStepDescriptor descriptor,
+        AwaitInteractionRecord interaction,
+        I payload
+    ) {
+    }
+
+    /**
+     * Dispatch metadata returned by adapters.
+     */
+    record AwaitDispatchResult(java.util.Map<String, Object> metadata) {
+        public AwaitDispatchResult {
+            metadata = metadata == null ? java.util.Map.of() : java.util.Map.copyOf(metadata);
+        }
+    }
+
+    /**
+     * Cancel request passed to adapters.
+     */
+    record AwaitCancelRequest(AwaitStepDescriptor descriptor, AwaitInteractionRecord interaction, String reason) {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitTransportAdapter.java
@@ -8,9 +8,8 @@ import org.pipelineframework.awaitable.AwaitStepDescriptor;
  * Adapter SPI for dispatching await interactions to external systems.
  *
  * @param <I> request payload type
- * @param <O> completion payload type
  */
-public interface AwaitTransportAdapter<I, O> {
+public interface AwaitTransportAdapter<I> {
 
     /**
      * Adapter type used in YAML.

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -1,0 +1,677 @@
+package org.pipelineframework.awaitable.store;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCreateCommand;
+import org.pipelineframework.awaitable.AwaitCreateResult;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.spi.AwaitInteractionStore;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.Put;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * DynamoDB-backed await interaction store.
+ */
+@ApplicationScoped
+public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
+    private static final Logger LOG = Logger.getLogger(DynamoAwaitInteractionStore.class);
+
+    private static final String TENANT_ID = "tenant_id";
+    private static final String INTERACTION_ID = "interaction_id";
+    private static final String LOOKUP_KEY = "lookup_key";
+    private static final String LOOKUP_KIND = "lookup_kind";
+    private static final String EXECUTION_ID = "execution_id";
+    private static final String STEP_ID = "step_id";
+    private static final String STEP_INDEX = "step_index";
+    private static final String OUTPUT_TYPE = "output_type";
+    private static final String CORRELATION_ID = "correlation_id";
+    private static final String CAUSATION_ID = "causation_id";
+    private static final String IDEMPOTENCY_KEY = "idempotency_key";
+    private static final String VERSION = "version";
+    private static final String STATUS = "status";
+    private static final String REQUEST_PAYLOAD_JSON = "request_payload_json";
+    private static final String RESPONSE_PAYLOAD_JSON = "response_payload_json";
+    private static final String ACTOR = "actor";
+    private static final String ASSIGNEE = "assignee";
+    private static final String GROUP = "group_name";
+    private static final String TRANSPORT_TYPE = "transport_type";
+    private static final String TRANSPORT_METADATA_JSON = "transport_metadata_json";
+    private static final String DEADLINE_EPOCH_MS = "deadline_epoch_ms";
+    private static final String CREATED_AT_EPOCH_MS = "created_at_epoch_ms";
+    private static final String UPDATED_AT_EPOCH_MS = "updated_at_epoch_ms";
+    private static final String TTL_EPOCH_S = "ttl_epoch_s";
+    private static final String ENCODED_JAVA_CLASS = "_tpf_java_class";
+    private static final String ENCODED_PAYLOAD = "_tpf_payload";
+
+    @Inject
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    private volatile DynamoDbClient client;
+
+    /**
+     * Default constructor for CDI.
+     */
+    public DynamoAwaitInteractionStore() {
+    }
+
+    DynamoAwaitInteractionStore(DynamoDbClient client, PipelineOrchestratorConfig orchestratorConfig) {
+        this.client = client;
+        this.orchestratorConfig = orchestratorConfig;
+    }
+
+    @Override
+    public String providerName() {
+        return "dynamo";
+    }
+
+    @Override
+    public int priority() {
+        return -1000;
+    }
+
+    @Override
+    public Uni<AwaitCreateResult> createOrGet(AwaitCreateCommand command) {
+        return blocking(() -> createOrGetBlocking(command));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> get(String tenantId, String interactionId) {
+        return blocking(() -> getBlocking(tenantId, interactionId, System.currentTimeMillis()));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId) {
+        return blocking(() -> findByLookup(lookupKey("correlation", tenantId, correlationId), tenantId));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> markDispatched(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.DISPATCHED,
+            null,
+            null,
+            transportMetadata,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<AwaitCompletionResult> complete(AwaitCompletionCommand command) {
+        return blocking(() -> completeBlocking(command));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> fail(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.FAILED,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> cancel(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.CANCELLED,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> markTimedOut(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.TIMED_OUT,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<List<AwaitInteractionRecord>> findTimedOut(long nowEpochMs, int limit) {
+        return blocking(() -> {
+            if (limit <= 0) {
+                return List.of();
+            }
+            Map<String, String> names = Map.of(
+                "#status", STATUS,
+                "#deadline", DEADLINE_EPOCH_MS,
+                "#ttl", TTL_EPOCH_S);
+            Map<String, AttributeValue> values = Map.of(
+                ":now", avN(nowEpochMs),
+                ":completed", avS(AwaitInteractionStatus.COMPLETED.name()),
+                ":failed", avS(AwaitInteractionStatus.FAILED.name()),
+                ":timedOut", avS(AwaitInteractionStatus.TIMED_OUT.name()),
+                ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
+                ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
+                ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+            var response = dynamoClient().scan(ScanRequest.builder()
+                .tableName(interactionTable())
+                .filterExpression("#deadline <= :now AND #status <> :completed AND #status <> :failed "
+                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .limit(limit)
+                .build());
+            if (response.items() == null || response.items().isEmpty()) {
+                return List.of();
+            }
+            List<AwaitInteractionRecord> records = new ArrayList<>();
+            for (Map<String, AttributeValue> item : response.items()) {
+                records.add(toRecord(item));
+            }
+            records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
+            return List.copyOf(records);
+        });
+    }
+
+    @Override
+    public Uni<List<AwaitInteractionRecord>> queryPending(
+        String tenantId,
+        String assignee,
+        String group,
+        String stepId,
+        int limit) {
+        return blocking(() -> {
+            if (limit <= 0) {
+                return List.of();
+            }
+            Map<String, String> names = Map.of("#tenant", TENANT_ID, "#status", STATUS, "#ttl", TTL_EPOCH_S);
+            Map<String, AttributeValue> values = Map.of(
+                ":tenant", avS(tenantId),
+                ":completed", avS(AwaitInteractionStatus.COMPLETED.name()),
+                ":failed", avS(AwaitInteractionStatus.FAILED.name()),
+                ":timedOut", avS(AwaitInteractionStatus.TIMED_OUT.name()),
+                ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
+                ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
+                ":nowSec", avN(Instant.now().getEpochSecond()));
+            var response = dynamoClient().scan(ScanRequest.builder()
+                .tableName(interactionTable())
+                .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
+                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .limit(Math.max(limit * 3, limit))
+                .build());
+            if (response.items() == null || response.items().isEmpty()) {
+                return List.of();
+            }
+            List<AwaitInteractionRecord> records = new ArrayList<>();
+            for (Map<String, AttributeValue> item : response.items()) {
+                AwaitInteractionRecord record = toRecord(item);
+                if (assignee != null && !Objects.equals(assignee, record.assignee())) {
+                    continue;
+                }
+                if (group != null && !Objects.equals(group, record.group())) {
+                    continue;
+                }
+                if (stepId != null && !Objects.equals(stepId, record.stepId())) {
+                    continue;
+                }
+                records.add(record);
+            }
+            records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
+            return List.copyOf(records.subList(0, Math.min(records.size(), limit)));
+        });
+    }
+
+    @PreDestroy
+    void closeClient() {
+        DynamoDbClient active = client;
+        if (active == null) {
+            return;
+        }
+        synchronized (this) {
+            active = client;
+            if (active == null) {
+                return;
+            }
+            try {
+                active.close();
+            } catch (Exception e) {
+                LOG.debug("Failed closing DynamoDB client during shutdown.", e);
+            } finally {
+                client = null;
+            }
+        }
+    }
+
+    private AwaitCreateResult createOrGetBlocking(AwaitCreateCommand command) {
+        Optional<AwaitInteractionRecord> existing = findByLookup(
+            lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
+            command.tenantId());
+        if (existing.isPresent() && !existing.get().status().terminal()) {
+            return new AwaitCreateResult(existing.get(), true);
+        }
+
+        String interactionId = UUID.randomUUID().toString();
+        AwaitInteractionRecord created = new AwaitInteractionRecord(
+            command.tenantId(),
+            command.executionId(),
+            command.stepId(),
+            command.stepIndex(),
+            command.outputType(),
+            interactionId,
+            command.correlationId(),
+            command.causationId(),
+            command.idempotencyKey(),
+            0L,
+            AwaitInteractionStatus.WAITING,
+            command.requestPayload(),
+            null,
+            null,
+            command.assignee(),
+            command.group(),
+            command.transportType(),
+            Map.of(),
+            command.deadlineEpochMs(),
+            command.nowEpochMs(),
+            command.nowEpochMs(),
+            command.ttlEpochS());
+
+        try {
+            dynamoClient().transactWriteItems(TransactWriteItemsRequest.builder()
+                .transactItems(
+                    TransactWriteItem.builder().put(Put.builder()
+                        .tableName(interactionTable())
+                        .item(toItem(created))
+                        .conditionExpression("attribute_not_exists(#tenant) AND attribute_not_exists(#interaction)")
+                        .expressionAttributeNames(Map.of("#tenant", TENANT_ID, "#interaction", INTERACTION_ID))
+                        .build()).build(),
+                    TransactWriteItem.builder().put(lookupPut(
+                        "idempotency",
+                        command.tenantId(),
+                        command.stepId() + ":" + command.idempotencyKey(),
+                        interactionId,
+                        command.ttlEpochS())).build(),
+                    TransactWriteItem.builder().put(lookupPut(
+                        "correlation",
+                        command.tenantId(),
+                        command.correlationId(),
+                        interactionId,
+                        command.ttlEpochS())).build())
+                .build());
+            return new AwaitCreateResult(created, false);
+        } catch (TransactionCanceledException | ConditionalCheckFailedException ignored) {
+            return findByLookup(
+                lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
+                command.tenantId())
+                .map(record -> new AwaitCreateResult(record, true))
+                .orElseThrow(() -> ignored);
+        }
+    }
+
+    private AwaitCompletionResult completeBlocking(AwaitCompletionCommand command) {
+        AwaitInteractionRecord current = resolveForCompletion(command)
+            .orElseThrow(() -> new IllegalArgumentException("No await interaction matches completion"));
+        if (current.status() == AwaitInteractionStatus.COMPLETED) {
+            return new AwaitCompletionResult(current, true);
+        }
+        if (current.status().terminal()) {
+            throw new IllegalStateException("Await interaction is terminal: " + current.status());
+        }
+        if (current.deadlineEpochMs() <= command.nowEpochMs()) {
+            transitionStatus(
+                current.tenantId(),
+                current.interactionId(),
+                current.version(),
+                AwaitInteractionStatus.TIMED_OUT,
+                null,
+                null,
+                null,
+                command.nowEpochMs());
+            throw new IllegalStateException("Await interaction timed out before completion");
+        }
+        AwaitInteractionRecord completed = transitionStatus(
+            current.tenantId(),
+            current.interactionId(),
+            current.version(),
+            AwaitInteractionStatus.COMPLETED,
+            command.responsePayload(),
+            command.actor(),
+            null,
+            command.nowEpochMs())
+            .orElseThrow(() -> new IllegalStateException("Await completion transition lost OCC race"));
+        return new AwaitCompletionResult(completed, false);
+    }
+
+    private Optional<AwaitInteractionRecord> resolveForCompletion(AwaitCompletionCommand command) {
+        if (command.interactionId() != null && !command.interactionId().isBlank()) {
+            return getBlocking(command.tenantId(), command.interactionId(), command.nowEpochMs());
+        }
+        if (command.correlationId() != null && !command.correlationId().isBlank()) {
+            return findByLookup(lookupKey("correlation", command.tenantId(), command.correlationId()), command.tenantId());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<AwaitInteractionRecord> transitionStatus(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        AwaitInteractionStatus status,
+        Object responsePayload,
+        String actor,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
+        Map<String, String> names = new HashMap<>();
+        names.put("#version", VERSION);
+        names.put("#status", STATUS);
+        names.put("#response", RESPONSE_PAYLOAD_JSON);
+        names.put("#actor", ACTOR);
+        names.put("#metadata", TRANSPORT_METADATA_JSON);
+        names.put("#updated", UPDATED_AT_EPOCH_MS);
+        names.put("#ttl", TTL_EPOCH_S);
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":expected", avN(expectedVersion));
+        values.put(":status", avS(status.name()));
+        values.put(":one", avN(1));
+        values.put(":now", avN(nowEpochMs));
+        values.put(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+        if (responsePayload != null) {
+            values.put(":response", avS(toJson(responsePayload)));
+        }
+        if (actor != null && !actor.isBlank()) {
+            values.put(":actor", avS(actor));
+        }
+        if (transportMetadata != null) {
+            values.put(":metadata", avS(toJson(transportMetadata)));
+        }
+        StringBuilder update = new StringBuilder("SET #status = :status, #version = #version + :one, #updated = :now");
+        if (responsePayload != null) {
+            update.append(", #response = :response");
+        }
+        if (actor != null && !actor.isBlank()) {
+            update.append(", #actor = :actor");
+        }
+        if (transportMetadata != null) {
+            update.append(", #metadata = :metadata");
+        }
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(UpdateItemRequest.builder()
+                .tableName(interactionTable())
+                .key(primaryKey(tenantId, interactionId))
+                .conditionExpression("#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .updateExpression(update.toString())
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .returnValues(ReturnValue.ALL_NEW)
+                .build()).attributes();
+            return attributes == null || attributes.isEmpty() ? Optional.empty() : Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<AwaitInteractionRecord> getBlocking(String tenantId, String interactionId, long nowEpochMs) {
+        Map<String, AttributeValue> item = dynamoClient().getItem(GetItemRequest.builder()
+            .tableName(interactionTable())
+            .key(primaryKey(tenantId, interactionId))
+            .consistentRead(true)
+            .build()).item();
+        if (item == null || item.isEmpty()) {
+            return Optional.empty();
+        }
+        AwaitInteractionRecord record = toRecord(item);
+        return record.ttlEpochS() > 0 && record.ttlEpochS() <= Instant.ofEpochMilli(nowEpochMs).getEpochSecond()
+            ? Optional.empty()
+            : Optional.of(record);
+    }
+
+    private Optional<AwaitInteractionRecord> findByLookup(String lookupKey, String tenantId) {
+        Map<String, AttributeValue> item = dynamoClient().getItem(GetItemRequest.builder()
+            .tableName(lookupTable())
+            .key(Map.of(LOOKUP_KEY, avS(lookupKey)))
+            .consistentRead(true)
+            .build()).item();
+        if (item == null || item.isEmpty()) {
+            return Optional.empty();
+        }
+        String interactionId = readString(item, INTERACTION_ID);
+        return interactionId == null || interactionId.isBlank()
+            ? Optional.empty()
+            : getBlocking(tenantId, interactionId, System.currentTimeMillis());
+    }
+
+    private Put lookupPut(String kind, String tenantId, String key, String interactionId, long ttlEpochS) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put(LOOKUP_KEY, avS(lookupKey(kind, tenantId, key)));
+        item.put(LOOKUP_KIND, avS(kind));
+        item.put(TENANT_ID, avS(tenantId));
+        item.put(INTERACTION_ID, avS(interactionId));
+        item.put(TTL_EPOCH_S, avN(ttlEpochS));
+        return Put.builder()
+            .tableName(lookupTable())
+            .item(item)
+            .conditionExpression("attribute_not_exists(#lookup)")
+            .expressionAttributeNames(Map.of("#lookup", LOOKUP_KEY))
+            .build();
+    }
+
+    private Map<String, AttributeValue> toItem(AwaitInteractionRecord record) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put(TENANT_ID, avS(record.tenantId()));
+        item.put(INTERACTION_ID, avS(record.interactionId()));
+        item.put(EXECUTION_ID, avS(record.executionId()));
+        item.put(STEP_ID, avS(record.stepId()));
+        item.put(STEP_INDEX, avN(record.stepIndex()));
+        item.put(OUTPUT_TYPE, avS(record.outputType()));
+        item.put(CORRELATION_ID, avS(record.correlationId()));
+        item.put(IDEMPOTENCY_KEY, avS(record.idempotencyKey()));
+        item.put(VERSION, avN(record.version()));
+        item.put(STATUS, avS(record.status().name()));
+        item.put(REQUEST_PAYLOAD_JSON, avS(toJson(record.requestPayload())));
+        item.put(TRANSPORT_TYPE, avS(record.transportType()));
+        item.put(TRANSPORT_METADATA_JSON, avS(toJson(record.transportMetadata())));
+        item.put(DEADLINE_EPOCH_MS, avN(record.deadlineEpochMs()));
+        item.put(CREATED_AT_EPOCH_MS, avN(record.createdAtEpochMs()));
+        item.put(UPDATED_AT_EPOCH_MS, avN(record.updatedAtEpochMs()));
+        item.put(TTL_EPOCH_S, avN(record.ttlEpochS()));
+        putIfPresent(item, CAUSATION_ID, record.causationId());
+        putIfPresent(item, RESPONSE_PAYLOAD_JSON, toJson(record.responsePayload()));
+        putIfPresent(item, ACTOR, record.actor());
+        putIfPresent(item, ASSIGNEE, record.assignee());
+        putIfPresent(item, GROUP, record.group());
+        return item;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AwaitInteractionRecord toRecord(Map<String, AttributeValue> item) {
+        return new AwaitInteractionRecord(
+            readString(item, TENANT_ID),
+            readString(item, EXECUTION_ID),
+            readString(item, STEP_ID),
+            (int) readLong(item, STEP_INDEX),
+            readString(item, OUTPUT_TYPE),
+            readString(item, INTERACTION_ID),
+            readString(item, CORRELATION_ID),
+            readString(item, CAUSATION_ID),
+            readString(item, IDEMPOTENCY_KEY),
+            readLong(item, VERSION),
+            AwaitInteractionStatus.valueOf(readString(item, STATUS)),
+            fromJson(readString(item, REQUEST_PAYLOAD_JSON)),
+            fromJson(readString(item, RESPONSE_PAYLOAD_JSON)),
+            readString(item, ACTOR),
+            readString(item, ASSIGNEE),
+            readString(item, GROUP),
+            readString(item, TRANSPORT_TYPE),
+            (Map<String, Object>) Optional.ofNullable(fromJson(readString(item, TRANSPORT_METADATA_JSON))).orElse(Map.of()),
+            readLong(item, DEADLINE_EPOCH_MS),
+            readLong(item, CREATED_AT_EPOCH_MS),
+            readLong(item, UPDATED_AT_EPOCH_MS),
+            readLong(item, TTL_EPOCH_S));
+    }
+
+    private <T> Uni<T> blocking(Supplier<T> supplier) {
+        return Uni.createFrom().item(supplier).runSubscriptionOn(Infrastructure.getDefaultExecutor());
+    }
+
+    private DynamoDbClient dynamoClient() {
+        DynamoDbClient active = client;
+        if (active != null) {
+            return active;
+        }
+        synchronized (this) {
+            active = client;
+            if (active != null) {
+                return active;
+            }
+            var builder = DynamoDbClient.builder();
+            builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+            orchestratorConfig.dynamo().region().filter(region -> !region.isBlank())
+                .ifPresent(region -> builder.region(Region.of(region)));
+            orchestratorConfig.dynamo().endpointOverride()
+                .filter(endpoint -> !endpoint.isBlank())
+                .ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
+            client = builder.build();
+            return client;
+        }
+    }
+
+    private String interactionTable() {
+        return orchestratorConfig.dynamo().awaitInteractionTable();
+    }
+
+    private String lookupTable() {
+        return orchestratorConfig.dynamo().awaitInteractionKeyTable();
+    }
+
+    private String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return PipelineJson.mapper().writeValueAsString(encode(value));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed serializing await payload to JSON.", e);
+        }
+    }
+
+    private Object fromJson(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            Object decoded = PipelineJson.mapper().readValue(value, Object.class);
+            if (decoded instanceof Map<?, ?> map && map.containsKey(ENCODED_JAVA_CLASS)) {
+                String className = String.valueOf(map.get(ENCODED_JAVA_CLASS));
+                Object payload = map.get(ENCODED_PAYLOAD);
+                return PipelineJson.mapper().convertValue(payload, Class.forName(className));
+            }
+            return decoded;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed deserializing await payload JSON.", e);
+        }
+    }
+
+    private Object encode(Object value) {
+        if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean
+            || value instanceof Map<?, ?> || value instanceof Iterable<?>) {
+            return value;
+        }
+        return Map.of(
+            ENCODED_JAVA_CLASS, value.getClass().getName(),
+            ENCODED_PAYLOAD, PipelineJson.mapper().convertValue(value, Object.class));
+    }
+
+    private static String lookupKey(String kind, String tenantId, String key) {
+        return kind + ":" + tenantId.length() + ":" + tenantId + ":" + key.length() + ":" + key;
+    }
+
+    private static Map<String, AttributeValue> primaryKey(String tenantId, String interactionId) {
+        return Map.of(TENANT_ID, avS(tenantId), INTERACTION_ID, avS(interactionId));
+    }
+
+    private static AttributeValue avS(String value) {
+        return AttributeValue.builder().s(value == null ? "" : value).build();
+    }
+
+    private static AttributeValue avN(long value) {
+        return AttributeValue.builder().n(Long.toString(value)).build();
+    }
+
+    private static String readString(Map<String, AttributeValue> item, String key) {
+        AttributeValue value = item.get(key);
+        return value == null ? null : value.s();
+    }
+
+    private static long readLong(Map<String, AttributeValue> item, String key) {
+        AttributeValue value = item.get(key);
+        if (value == null || value.n() == null || value.n().isBlank()) {
+            return 0L;
+        }
+        return Long.parseLong(value.n());
+    }
+
+    private static void putIfPresent(Map<String, AttributeValue> item, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            item.put(key, avS(value));
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -212,24 +212,33 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
                 ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
                 ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
-            var response = dynamoClient().scan(ScanRequest.builder()
-                .tableName(interactionTable())
-                .filterExpression("#deadline <= :now AND #status <> :completed AND #status <> :failed "
-                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
-                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
-                .expressionAttributeNames(names)
-                .expressionAttributeValues(values)
-                .limit(limit)
-                .build());
-            if (response.items() == null || response.items().isEmpty()) {
-                return List.of();
-            }
             List<AwaitInteractionRecord> records = new ArrayList<>();
-            for (Map<String, AttributeValue> item : response.items()) {
-                records.add(toRecord(item));
-            }
+            Map<String, AttributeValue> lastEvaluatedKey = null;
+            do {
+                ScanRequest.Builder request = ScanRequest.builder()
+                    .tableName(interactionTable())
+                    .filterExpression("#deadline <= :now AND #status <> :completed AND #status <> :failed "
+                        + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                        + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                    .expressionAttributeNames(names)
+                    .expressionAttributeValues(values)
+                    .limit(scanPageLimit(limit));
+                if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+                    request.exclusiveStartKey(lastEvaluatedKey);
+                }
+                var response = dynamoClient().scan(request.build());
+                if (response.items() != null) {
+                    for (Map<String, AttributeValue> item : response.items()) {
+                        records.add(toRecord(item));
+                        if (records.size() >= limit) {
+                            break;
+                        }
+                    }
+                }
+                lastEvaluatedKey = response.lastEvaluatedKey();
+            } while (records.size() < limit && lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty());
             records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
-            return List.copyOf(records);
+            return List.copyOf(records.subList(0, Math.min(records.size(), limit)));
         });
     }
 
@@ -253,32 +262,41 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
                 ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
                 ":nowSec", avN(Instant.now().getEpochSecond()));
-            var response = dynamoClient().scan(ScanRequest.builder()
-                .tableName(interactionTable())
-                .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
-                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
-                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
-                .expressionAttributeNames(names)
-                .expressionAttributeValues(values)
-                .limit(Math.max(limit * 3, limit))
-                .build());
-            if (response.items() == null || response.items().isEmpty()) {
-                return List.of();
-            }
             List<AwaitInteractionRecord> records = new ArrayList<>();
-            for (Map<String, AttributeValue> item : response.items()) {
-                AwaitInteractionRecord record = toRecord(item);
-                if (assignee != null && !Objects.equals(assignee, record.assignee())) {
-                    continue;
+            Map<String, AttributeValue> lastEvaluatedKey = null;
+            do {
+                ScanRequest.Builder request = ScanRequest.builder()
+                    .tableName(interactionTable())
+                    .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
+                        + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                        + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                    .expressionAttributeNames(names)
+                    .expressionAttributeValues(values)
+                    .limit(scanPageLimit(limit));
+                if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+                    request.exclusiveStartKey(lastEvaluatedKey);
                 }
-                if (group != null && !Objects.equals(group, record.group())) {
-                    continue;
+                var response = dynamoClient().scan(request.build());
+                if (response.items() != null) {
+                    for (Map<String, AttributeValue> item : response.items()) {
+                        AwaitInteractionRecord record = toRecord(item);
+                        if (assignee != null && !Objects.equals(assignee, record.assignee())) {
+                            continue;
+                        }
+                        if (group != null && !Objects.equals(group, record.group())) {
+                            continue;
+                        }
+                        if (stepId != null && !Objects.equals(stepId, record.stepId())) {
+                            continue;
+                        }
+                        records.add(record);
+                        if (records.size() >= limit) {
+                            break;
+                        }
+                    }
                 }
-                if (stepId != null && !Objects.equals(stepId, record.stepId())) {
-                    continue;
-                }
-                records.add(record);
-            }
+                lastEvaluatedKey = response.lastEvaluatedKey();
+            } while (records.size() < limit && lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty());
             records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
             return List.copyOf(records.subList(0, Math.min(records.size(), limit)));
         });
@@ -534,9 +552,9 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         item.put(IDEMPOTENCY_KEY, avS(record.idempotencyKey()));
         item.put(VERSION, avN(record.version()));
         item.put(STATUS, avS(record.status().name()));
-        item.put(REQUEST_PAYLOAD_JSON, avS(toJson(record.requestPayload())));
+        putIfPresent(item, REQUEST_PAYLOAD_JSON, toJson(record.requestPayload()));
         item.put(TRANSPORT_TYPE, avS(record.transportType()));
-        item.put(TRANSPORT_METADATA_JSON, avS(toJson(record.transportMetadata())));
+        putIfPresent(item, TRANSPORT_METADATA_JSON, toJson(record.transportMetadata()));
         item.put(DEADLINE_EPOCH_MS, avN(record.deadlineEpochMs()));
         item.put(CREATED_AT_EPOCH_MS, avN(record.createdAtEpochMs()));
         item.put(UPDATED_AT_EPOCH_MS, avN(record.updatedAtEpochMs()));
@@ -657,7 +675,11 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
     }
 
     private static AttributeValue avS(String value) {
-        return AttributeValue.builder().s(value == null ? "" : value).build();
+        return value == null ? null : AttributeValue.builder().s(value).build();
+    }
+
+    private static int scanPageLimit(int limit) {
+        return (int) Math.min(Math.max((long) limit * 3L, (long) limit), 1_000L);
     }
 
     private static AttributeValue avN(long value) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -253,23 +252,39 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             if (limit <= 0) {
                 return List.of();
             }
-            Map<String, String> names = Map.of("#tenant", TENANT_ID, "#status", STATUS, "#ttl", TTL_EPOCH_S);
-            Map<String, AttributeValue> values = Map.of(
+            Map<String, String> names = new HashMap<>(Map.of("#tenant", TENANT_ID, "#status", STATUS, "#ttl", TTL_EPOCH_S));
+            Map<String, AttributeValue> values = new HashMap<>(Map.of(
                 ":tenant", avS(tenantId),
                 ":completed", avS(AwaitInteractionStatus.COMPLETED.name()),
                 ":failed", avS(AwaitInteractionStatus.FAILED.name()),
                 ":timedOut", avS(AwaitInteractionStatus.TIMED_OUT.name()),
                 ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
                 ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
-                ":nowSec", avN(Instant.now().getEpochSecond()));
+                ":nowSec", avN(Instant.now().getEpochSecond())));
+            StringBuilder filter = new StringBuilder("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
+                + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)");
+            if (assignee != null) {
+                names.put("#assignee", ASSIGNEE);
+                values.put(":assignee", avS(assignee));
+                filter.append(" AND #assignee = :assignee");
+            }
+            if (group != null) {
+                names.put("#group", GROUP);
+                values.put(":group", avS(group));
+                filter.append(" AND #group = :group");
+            }
+            if (stepId != null) {
+                names.put("#stepId", STEP_ID);
+                values.put(":stepId", avS(stepId));
+                filter.append(" AND #stepId = :stepId");
+            }
             List<AwaitInteractionRecord> records = new ArrayList<>();
             Map<String, AttributeValue> lastEvaluatedKey = null;
             do {
                 ScanRequest.Builder request = ScanRequest.builder()
                     .tableName(interactionTable())
-                    .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
-                        + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
-                        + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                    .filterExpression(filter.toString())
                     .expressionAttributeNames(names)
                     .expressionAttributeValues(values)
                     .limit(scanPageLimit(limit));
@@ -280,15 +295,6 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 if (response.items() != null) {
                     for (Map<String, AttributeValue> item : response.items()) {
                         AwaitInteractionRecord record = toRecord(item);
-                        if (assignee != null && !Objects.equals(assignee, record.assignee())) {
-                            continue;
-                        }
-                        if (group != null && !Objects.equals(group, record.group())) {
-                            continue;
-                        }
-                        if (stepId != null && !Objects.equals(stepId, record.stepId())) {
-                            continue;
-                        }
                         records.add(record);
                         if (records.size() >= limit) {
                             break;
@@ -328,7 +334,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
             command.tenantId(),
             command.nowEpochMs());
-        if (existing.isPresent() && !existing.get().status().terminal()) {
+        if (existing.isPresent()) {
             return new AwaitCreateResult(existing.get(), true);
         }
 
@@ -400,7 +406,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             throw new IllegalStateException("Await interaction is terminal: " + current.status());
         }
         if (current.deadlineEpochMs() <= command.nowEpochMs()) {
-            transitionStatus(
+            Optional<AwaitInteractionRecord> timedOut = transitionStatus(
                 current.tenantId(),
                 current.interactionId(),
                 current.version(),
@@ -409,6 +415,15 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 null,
                 null,
                 command.nowEpochMs());
+            if (timedOut.isEmpty()) {
+                Optional<AwaitInteractionRecord> refreshed = getBlocking(
+                    current.tenantId(),
+                    current.interactionId(),
+                    command.nowEpochMs());
+                if (refreshed.isPresent() && refreshed.get().status() == AwaitInteractionStatus.COMPLETED) {
+                    return new AwaitCompletionResult(refreshed.get(), true);
+                }
+            }
             throw new IllegalStateException("Await interaction timed out before completion");
         }
         AwaitInteractionRecord completed = transitionStatus(
@@ -573,7 +588,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             readString(item, TENANT_ID),
             readString(item, EXECUTION_ID),
             readString(item, STEP_ID),
-            (int) readLong(item, STEP_INDEX),
+            Math.toIntExact(readLong(item, STEP_INDEX)),
             readString(item, OUTPUT_TYPE),
             readString(item, INTERACTION_ID),
             readString(item, CORRELATION_ID),
@@ -609,7 +624,9 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 return active;
             }
             var builder = DynamoDbClient.builder();
-            builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+            builder.httpClientBuilder(UrlConnectionHttpClient.builder()
+                .connectionTimeout(java.time.Duration.ofSeconds(10))
+                .socketTimeout(java.time.Duration.ofSeconds(30)));
             orchestratorConfig.dynamo().region().filter(region -> !region.isBlank())
                 .ifPresent(region -> builder.region(Region.of(region)));
             orchestratorConfig.dynamo().endpointOverride()

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -112,7 +112,10 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
 
     @Override
     public Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId) {
-        return blocking(() -> findByLookup(lookupKey("correlation", tenantId, correlationId), tenantId));
+        return blocking(() -> findByLookup(
+            lookupKey("correlation", tenantId, correlationId),
+            tenantId,
+            System.currentTimeMillis()));
     }
 
     @Override
@@ -305,7 +308,8 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
     private AwaitCreateResult createOrGetBlocking(AwaitCreateCommand command) {
         Optional<AwaitInteractionRecord> existing = findByLookup(
             lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
-            command.tenantId());
+            command.tenantId(),
+            command.nowEpochMs());
         if (existing.isPresent() && !existing.get().status().terminal()) {
             return new AwaitCreateResult(existing.get(), true);
         }
@@ -361,7 +365,8 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         } catch (TransactionCanceledException | ConditionalCheckFailedException ignored) {
             return findByLookup(
                 lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
-                command.tenantId())
+                command.tenantId(),
+                command.nowEpochMs())
                 .map(record -> new AwaitCreateResult(record, true))
                 .orElseThrow(() -> ignored);
         }
@@ -406,7 +411,10 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             return getBlocking(command.tenantId(), command.interactionId(), command.nowEpochMs());
         }
         if (command.correlationId() != null && !command.correlationId().isBlank()) {
-            return findByLookup(lookupKey("correlation", command.tenantId(), command.correlationId()), command.tenantId());
+            return findByLookup(
+                lookupKey("correlation", command.tenantId(), command.correlationId()),
+                command.tenantId(),
+                command.nowEpochMs());
         }
         return Optional.empty();
     }
@@ -484,7 +492,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             : Optional.of(record);
     }
 
-    private Optional<AwaitInteractionRecord> findByLookup(String lookupKey, String tenantId) {
+    private Optional<AwaitInteractionRecord> findByLookup(String lookupKey, String tenantId, long nowEpochMs) {
         Map<String, AttributeValue> item = dynamoClient().getItem(GetItemRequest.builder()
             .tableName(lookupTable())
             .key(Map.of(LOOKUP_KEY, avS(lookupKey)))
@@ -496,7 +504,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         String interactionId = readString(item, INTERACTION_ID);
         return interactionId == null || interactionId.isBlank()
             ? Optional.empty()
-            : getBlocking(tenantId, interactionId, System.currentTimeMillis());
+            : getBlocking(tenantId, interactionId, nowEpochMs);
     }
 
     private Put lookupPut(String kind, String tenantId, String key, String interactionId, long ttlEpochS) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -118,6 +118,24 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
     }
 
     @Override
+    public Uni<Optional<AwaitInteractionRecord>> markDispatching(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.WAITING,
+            AwaitInteractionStatus.DISPATCHING,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
     public Uni<Optional<AwaitInteractionRecord>> markDispatched(
         String tenantId,
         String interactionId,
@@ -128,6 +146,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             tenantId,
             interactionId,
             expectedVersion,
+            AwaitInteractionStatus.DISPATCHING,
             AwaitInteractionStatus.DISPATCHED,
             null,
             null,
@@ -461,6 +480,28 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         String actor,
         Map<String, Object> transportMetadata,
         long nowEpochMs) {
+        return transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            null,
+            status,
+            responsePayload,
+            actor,
+            transportMetadata,
+            nowEpochMs);
+    }
+
+    private Optional<AwaitInteractionRecord> transitionStatus(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        AwaitInteractionStatus requiredStatus,
+        AwaitInteractionStatus status,
+        Object responsePayload,
+        String actor,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
         Map<String, String> names = new HashMap<>();
         names.put("#version", VERSION);
         names.put("#status", STATUS);
@@ -475,6 +516,9 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         values.put(":one", avN(1));
         values.put(":now", avN(nowEpochMs));
         values.put(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+        if (requiredStatus != null) {
+            values.put(":requiredStatus", avS(requiredStatus.name()));
+        }
         if (responsePayload != null) {
             values.put(":response", avS(toJson(responsePayload)));
         }
@@ -494,11 +538,15 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         if (transportMetadata != null) {
             update.append(", #metadata = :metadata");
         }
+        String condition = "#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)";
+        if (requiredStatus != null) {
+            condition = "#version = :expected AND #status = :requiredStatus AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)";
+        }
         try {
             Map<String, AttributeValue> attributes = dynamoClient().updateItem(UpdateItemRequest.builder()
                 .tableName(interactionTable())
                 .key(primaryKey(tenantId, interactionId))
-                .conditionExpression("#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .conditionExpression(condition)
                 .updateExpression(update.toString())
                 .expressionAttributeNames(names)
                 .expressionAttributeValues(values)

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
@@ -226,6 +226,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
     public Uni<List<AwaitInteractionRecord>> findTimedOut(long nowEpochMs, int limit) {
         return Uni.createFrom().item(() -> {
             synchronized (lock) {
+                purgeExpired(nowEpochMs);
                 List<AwaitInteractionRecord> records = interactionsByScopedId.values().stream()
                     .filter(record -> !record.status().terminal())
                     .filter(record -> record.deadlineEpochMs() <= nowEpochMs)

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
@@ -118,6 +118,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         long expectedVersion,
         Map<String, Object> transportMetadata,
         long nowEpochMs) {
+        Map<String, Object> safeMetadata = transportMetadata == null ? Map.of() : Map.copyOf(new HashMap<>(transportMetadata));
         return transition(tenantId, interactionId, expectedVersion, nowEpochMs, current -> new AwaitInteractionRecord(
             current.tenantId(),
             current.executionId(),
@@ -136,7 +137,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
             current.assignee(),
             current.group(),
             current.transportType(),
-            transportMetadata,
+            safeMetadata,
             current.deadlineEpochMs(),
             current.createdAtEpochMs(),
             nowEpochMs,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
@@ -1,0 +1,366 @@
+package org.pipelineframework.awaitable.store;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCreateCommand;
+import org.pipelineframework.awaitable.AwaitCreateResult;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.spi.AwaitInteractionStore;
+
+/**
+ * In-memory await store intended for local development and tests.
+ */
+@ApplicationScoped
+public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
+
+    private final Object lock = new Object();
+    private final Map<String, AwaitInteractionRecord> interactionsByScopedId = new HashMap<>();
+    private final Map<String, String> interactionIdByScopedIdempotencyKey = new HashMap<>();
+    private final Map<String, String> interactionIdByScopedCorrelation = new HashMap<>();
+
+    @Override
+    public String providerName() {
+        return "memory";
+    }
+
+    @Override
+    public int priority() {
+        return -100;
+    }
+
+    @Override
+    public Uni<AwaitCreateResult> createOrGet(AwaitCreateCommand command) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                purgeExpired(command.nowEpochMs());
+                String scopedKey = scopedIdempotencyKey(command.tenantId(), command.stepId(), command.idempotencyKey());
+                String existingId = interactionIdByScopedIdempotencyKey.get(scopedKey);
+                if (existingId != null) {
+                    AwaitInteractionRecord existing = interactionsByScopedId.get(scopedInteractionId(command.tenantId(), existingId));
+                    if (existing != null && !existing.status().terminal()) {
+                        return new AwaitCreateResult(existing, true);
+                    }
+                }
+                String interactionId = UUID.randomUUID().toString();
+                AwaitInteractionRecord created = new AwaitInteractionRecord(
+                    command.tenantId(),
+                    command.executionId(),
+                    command.stepId(),
+                    command.stepIndex(),
+                    command.outputType(),
+                    interactionId,
+                    command.correlationId(),
+                    command.causationId(),
+                    command.idempotencyKey(),
+                    0L,
+                    AwaitInteractionStatus.WAITING,
+                    command.requestPayload(),
+                    null,
+                    null,
+                    command.assignee(),
+                    command.group(),
+                    command.transportType(),
+                    Map.of(),
+                    command.deadlineEpochMs(),
+                    command.nowEpochMs(),
+                    command.nowEpochMs(),
+                    command.ttlEpochS());
+                interactionsByScopedId.put(scopedInteractionId(created.tenantId(), created.interactionId()), created);
+                interactionIdByScopedIdempotencyKey.put(scopedKey, interactionId);
+                interactionIdByScopedCorrelation.put(scopedCorrelation(command.tenantId(), command.correlationId()), interactionId);
+                return new AwaitCreateResult(created, false);
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> get(String tenantId, String interactionId) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                long now = System.currentTimeMillis();
+                purgeExpired(now);
+                return Optional.ofNullable(interactionsByScopedId.get(scopedInteractionId(tenantId, interactionId)));
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                long now = System.currentTimeMillis();
+                purgeExpired(now);
+                String interactionId = interactionIdByScopedCorrelation.get(scopedCorrelation(tenantId, correlationId));
+                return interactionId == null
+                    ? Optional.empty()
+                    : Optional.ofNullable(interactionsByScopedId.get(scopedInteractionId(tenantId, interactionId)));
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> markDispatched(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs, current -> new AwaitInteractionRecord(
+            current.tenantId(),
+            current.executionId(),
+            current.stepId(),
+            current.stepIndex(),
+            current.outputType(),
+            current.interactionId(),
+            current.correlationId(),
+            current.causationId(),
+            current.idempotencyKey(),
+            current.version() + 1,
+            AwaitInteractionStatus.DISPATCHED,
+            current.requestPayload(),
+            current.responsePayload(),
+            current.actor(),
+            current.assignee(),
+            current.group(),
+            current.transportType(),
+            transportMetadata,
+            current.deadlineEpochMs(),
+            current.createdAtEpochMs(),
+            nowEpochMs,
+            current.ttlEpochS()));
+    }
+
+    @Override
+    public Uni<AwaitCompletionResult> complete(AwaitCompletionCommand command) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                purgeExpired(command.nowEpochMs());
+                AwaitInteractionRecord current = resolveForCompletion(command)
+                    .orElseThrow(() -> new IllegalArgumentException("No await interaction matches completion"));
+                if (current.status() == AwaitInteractionStatus.COMPLETED) {
+                    return new AwaitCompletionResult(current, true);
+                }
+                if (current.status().terminal()) {
+                    throw new IllegalStateException("Await interaction is terminal: " + current.status());
+                }
+                if (current.deadlineEpochMs() <= command.nowEpochMs()) {
+                    AwaitInteractionRecord timedOut = updateStatus(current, AwaitInteractionStatus.TIMED_OUT, command.nowEpochMs(), null, null);
+                    interactionsByScopedId.put(scopedInteractionId(timedOut.tenantId(), timedOut.interactionId()), timedOut);
+                    throw new IllegalStateException("Await interaction timed out before completion");
+                }
+                AwaitInteractionRecord completed = new AwaitInteractionRecord(
+                    current.tenantId(),
+                    current.executionId(),
+                    current.stepId(),
+                    current.stepIndex(),
+                    current.outputType(),
+                    current.interactionId(),
+                    current.correlationId(),
+                    current.causationId(),
+                    current.idempotencyKey(),
+                    current.version() + 1,
+                    AwaitInteractionStatus.COMPLETED,
+                    current.requestPayload(),
+                    command.responsePayload(),
+                    command.actor(),
+                    current.assignee(),
+                    current.group(),
+                    current.transportType(),
+                    current.transportMetadata(),
+                    current.deadlineEpochMs(),
+                    current.createdAtEpochMs(),
+                    command.nowEpochMs(),
+                    current.ttlEpochS());
+                interactionsByScopedId.put(scopedInteractionId(completed.tenantId(), completed.interactionId()), completed);
+                return new AwaitCompletionResult(completed, false);
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> fail(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs) {
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+            current -> updateStatus(current, AwaitInteractionStatus.FAILED, nowEpochMs, null, null));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> cancel(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs) {
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+            current -> updateStatus(current, AwaitInteractionStatus.CANCELLED, nowEpochMs, null, null));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> markTimedOut(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs) {
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+            current -> updateStatus(current, AwaitInteractionStatus.TIMED_OUT, nowEpochMs, null, null));
+    }
+
+    @Override
+    public Uni<List<AwaitInteractionRecord>> findTimedOut(long nowEpochMs, int limit) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                List<AwaitInteractionRecord> records = interactionsByScopedId.values().stream()
+                    .filter(record -> !record.status().terminal())
+                    .filter(record -> record.deadlineEpochMs() <= nowEpochMs)
+                    .sorted(Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs))
+                    .limit(Math.max(0, limit))
+                    .toList();
+                return List.copyOf(records);
+            }
+        });
+    }
+
+    @Override
+    public Uni<List<AwaitInteractionRecord>> queryPending(
+        String tenantId,
+        String assignee,
+        String group,
+        String stepId,
+        int limit) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                long now = System.currentTimeMillis();
+                purgeExpired(now);
+                List<AwaitInteractionRecord> records = new ArrayList<>();
+                for (AwaitInteractionRecord record : interactionsByScopedId.values()) {
+                    if (record.status().terminal() || !Objects.equals(record.tenantId(), tenantId)) {
+                        continue;
+                    }
+                    if (assignee != null && !Objects.equals(assignee, record.assignee())) {
+                        continue;
+                    }
+                    if (group != null && !Objects.equals(group, record.group())) {
+                        continue;
+                    }
+                    if (stepId != null && !Objects.equals(stepId, record.stepId())) {
+                        continue;
+                    }
+                    records.add(record);
+                }
+                records.sort(Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
+                return List.copyOf(records.subList(0, Math.min(records.size(), Math.max(0, limit))));
+            }
+        });
+    }
+
+    private Uni<Optional<AwaitInteractionRecord>> transition(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs,
+        java.util.function.Function<AwaitInteractionRecord, AwaitInteractionRecord> transition) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                purgeExpired(nowEpochMs);
+                String scopedId = scopedInteractionId(tenantId, interactionId);
+                AwaitInteractionRecord current = interactionsByScopedId.get(scopedId);
+                if (current == null || current.version() != expectedVersion || current.status().terminal()) {
+                    return Optional.empty();
+                }
+                AwaitInteractionRecord updated = transition.apply(current);
+                interactionsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
+        });
+    }
+
+    private Optional<AwaitInteractionRecord> resolveForCompletion(AwaitCompletionCommand command) {
+        if (command.interactionId() != null && !command.interactionId().isBlank()) {
+            return Optional.ofNullable(interactionsByScopedId.get(scopedInteractionId(command.tenantId(), command.interactionId())));
+        }
+        String interactionId = interactionIdByScopedCorrelation.get(scopedCorrelation(command.tenantId(), command.correlationId()));
+        return interactionId == null
+            ? Optional.empty()
+            : Optional.ofNullable(interactionsByScopedId.get(scopedInteractionId(command.tenantId(), interactionId)));
+    }
+
+    private AwaitInteractionRecord updateStatus(
+        AwaitInteractionRecord current,
+        AwaitInteractionStatus status,
+        long nowEpochMs,
+        Object responsePayload,
+        String actor) {
+        return new AwaitInteractionRecord(
+            current.tenantId(),
+            current.executionId(),
+            current.stepId(),
+            current.stepIndex(),
+            current.outputType(),
+            current.interactionId(),
+            current.correlationId(),
+            current.causationId(),
+            current.idempotencyKey(),
+            current.version() + 1,
+            status,
+            current.requestPayload(),
+            responsePayload == null ? current.responsePayload() : responsePayload,
+            actor == null ? current.actor() : actor,
+            current.assignee(),
+            current.group(),
+            current.transportType(),
+            current.transportMetadata(),
+            current.deadlineEpochMs(),
+            current.createdAtEpochMs(),
+            nowEpochMs,
+            current.ttlEpochS());
+    }
+
+    private void purgeExpired(long nowEpochMs) {
+        long nowEpochS = Instant.ofEpochMilli(nowEpochMs).getEpochSecond();
+        var iterator = interactionsByScopedId.entrySet().iterator();
+        while (iterator.hasNext()) {
+            AwaitInteractionRecord record = iterator.next().getValue();
+            if (record.ttlEpochS() > 0 && record.ttlEpochS() <= nowEpochS) {
+                iterator.remove();
+                interactionIdByScopedIdempotencyKey.remove(scopedIdempotencyKey(
+                    record.tenantId(), record.stepId(), record.idempotencyKey()));
+                interactionIdByScopedCorrelation.remove(scopedCorrelation(record.tenantId(), record.correlationId()));
+            }
+        }
+    }
+
+    private static String scopedInteractionId(String tenantId, String interactionId) {
+        return compositeScopedKey("tenantId", tenantId, "interactionId", interactionId);
+    }
+
+    private static String scopedIdempotencyKey(String tenantId, String stepId, String idempotencyKey) {
+        return compositeScopedKey("tenantStep", tenantId + ":" + stepId, "idempotencyKey", idempotencyKey);
+    }
+
+    private static String scopedCorrelation(String tenantId, String correlationId) {
+        return compositeScopedKey("tenantId", tenantId, "correlationId", correlationId);
+    }
+
+    private static String compositeScopedKey(String leftName, String left, String rightName, String right) {
+        String safeLeft = Objects.requireNonNull(left, leftName + " must not be null");
+        String safeRight = Objects.requireNonNull(right, rightName + " must not be null");
+        return safeLeft.length() + ":" + safeLeft + ":" + safeRight.length() + ":" + safeRight;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
@@ -26,6 +26,11 @@ import org.pipelineframework.awaitable.spi.AwaitInteractionStore;
 @ApplicationScoped
 public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
 
+    private static final Comparator<AwaitInteractionRecord> PENDING_ORDER =
+        Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs)
+            .thenComparingLong(AwaitInteractionRecord::createdAtEpochMs)
+            .thenComparing(AwaitInteractionRecord::interactionId);
+
     private final Object lock = new Object();
     private final Map<String, AwaitInteractionRecord> interactionsByScopedId = new HashMap<>();
     private final Map<String, String> interactionIdByScopedIdempotencyKey = new HashMap<>();
@@ -231,7 +236,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
                 List<AwaitInteractionRecord> records = interactionsByScopedId.values().stream()
                     .filter(record -> !record.status().terminal())
                     .filter(record -> record.deadlineEpochMs() <= nowEpochMs)
-                    .sorted(Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs))
+                    .sorted(PENDING_ORDER)
                     .limit(Math.max(0, limit))
                     .toList();
                 return List.copyOf(records);
@@ -266,7 +271,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
                     }
                     records.add(record);
                 }
-                records.sort(Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
+                records.sort(PENDING_ORDER);
                 return List.copyOf(records.subList(0, Math.min(records.size(), Math.max(0, limit))));
             }
         });

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
@@ -118,7 +118,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         long expectedVersion,
         Map<String, Object> transportMetadata,
         long nowEpochMs) {
-        Map<String, Object> safeMetadata = transportMetadata == null ? Map.of() : Map.copyOf(new HashMap<>(transportMetadata));
+        Map<String, Object> safeMetadata = transportMetadata == null ? Map.of() : Map.copyOf(transportMetadata);
         return transition(tenantId, interactionId, expectedVersion, nowEpochMs, current -> new AwaitInteractionRecord(
             current.tenantId(),
             current.executionId(),

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStore.java
@@ -117,6 +117,17 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
     }
 
     @Override
+    public Uni<Optional<AwaitInteractionRecord>> markDispatching(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs) {
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+            AwaitInteractionStatus.WAITING,
+            current -> updateStatus(current, AwaitInteractionStatus.DISPATCHING, nowEpochMs, null, null));
+    }
+
+    @Override
     public Uni<Optional<AwaitInteractionRecord>> markDispatched(
         String tenantId,
         String interactionId,
@@ -124,7 +135,9 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         Map<String, Object> transportMetadata,
         long nowEpochMs) {
         Map<String, Object> safeMetadata = transportMetadata == null ? Map.of() : Map.copyOf(transportMetadata);
-        return transition(tenantId, interactionId, expectedVersion, nowEpochMs, current -> new AwaitInteractionRecord(
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+            AwaitInteractionStatus.DISPATCHING,
+            current -> new AwaitInteractionRecord(
             current.tenantId(),
             current.executionId(),
             current.stepId(),
@@ -203,7 +216,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         long expectedVersion,
         String reason,
         long nowEpochMs) {
-        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs, null,
             current -> updateStatus(current, AwaitInteractionStatus.FAILED, nowEpochMs, null, null));
     }
 
@@ -214,7 +227,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         long expectedVersion,
         String reason,
         long nowEpochMs) {
-        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs, null,
             current -> updateStatus(current, AwaitInteractionStatus.CANCELLED, nowEpochMs, null, null));
     }
 
@@ -224,7 +237,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         String interactionId,
         long expectedVersion,
         long nowEpochMs) {
-        return transition(tenantId, interactionId, expectedVersion, nowEpochMs,
+        return transition(tenantId, interactionId, expectedVersion, nowEpochMs, null,
             current -> updateStatus(current, AwaitInteractionStatus.TIMED_OUT, nowEpochMs, null, null));
     }
 
@@ -282,6 +295,7 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
         String interactionId,
         long expectedVersion,
         long nowEpochMs,
+        AwaitInteractionStatus requiredStatus,
         java.util.function.Function<AwaitInteractionRecord, AwaitInteractionRecord> transition) {
         return Uni.createFrom().item(() -> {
             synchronized (lock) {
@@ -289,6 +303,9 @@ public class InMemoryAwaitInteractionStore implements AwaitInteractionStore {
                 String scopedId = scopedInteractionId(tenantId, interactionId);
                 AwaitInteractionRecord current = interactionsByScopedId.get(scopedId);
                 if (current == null || current.version() != expectedVersion || current.status().terminal()) {
+                    return Optional.empty();
+                }
+                if (requiredStatus != null && current.status() != requiredStatus) {
                     return Optional.empty();
                 }
                 AwaitInteractionRecord updated = transition.apply(current);

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitConfig.java
@@ -1,0 +1,19 @@
+package org.pipelineframework.config.pipeline;
+
+/**
+ * Await-step configuration parsed from pipeline.yaml.
+ *
+ * @param correlation correlation configuration
+ * @param transport transport adapter configuration
+ */
+public record PipelineYamlAwaitConfig(
+    PipelineYamlAwaitCorrelation correlation,
+    PipelineYamlAwaitTransport transport
+) {
+    public PipelineYamlAwaitConfig {
+        correlation = correlation == null ? new PipelineYamlAwaitCorrelation("interactionId") : correlation;
+        if (transport == null) {
+            throw new IllegalArgumentException("await.transport must be defined");
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023-2025 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.pipelineframework.config.pipeline;
 
 /**

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitCorrelation.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitCorrelation.java
@@ -1,0 +1,14 @@
+package org.pipelineframework.config.pipeline;
+
+/**
+ * Correlation configuration for an await step.
+ *
+ * @param strategy correlation strategy, for example {@code interactionId} or {@code signedResumeToken}
+ */
+public record PipelineYamlAwaitCorrelation(String strategy) {
+    public PipelineYamlAwaitCorrelation {
+        if (strategy == null || strategy.isBlank()) {
+            strategy = "interactionId";
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitCorrelation.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitCorrelation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023-2025 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.pipelineframework.config.pipeline;
 
 /**

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitTransport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlAwaitTransport.java
@@ -1,0 +1,21 @@
+package org.pipelineframework.config.pipeline;
+
+import java.util.Map;
+
+/**
+ * Transport-specific configuration for an await step.
+ *
+ * <p>The framework owns orchestration and correlation. Adapter modules own the shape of the
+ * transport-specific maps.</p>
+ *
+ * @param type transport adapter type
+ * @param config raw transport config map
+ */
+public record PipelineYamlAwaitTransport(String type, Map<String, Object> config) {
+    public PipelineYamlAwaitTransport {
+        if (type == null || type.isBlank()) {
+            throw new IllegalArgumentException("await.transport.type must be defined");
+        }
+        config = config == null ? Map.of() : Map.copyOf(config);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -44,6 +44,7 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class PipelineYamlConfigLoader {
     private static final Logger LOG = Logger.getLogger(PipelineYamlConfigLoader.class.getName());
+    private static final int MAX_NESTING_DEPTH = 100;
     private final Function<String, String> propertyLookup;
     private final Function<String, String> envLookup;
 
@@ -216,7 +217,7 @@ public class PipelineYamlConfigLoader {
      * Parse the "steps" entry from the YAML root map into a list of PipelineYamlStep objects.
      *
      * @param rootMap the parsed YAML root map potentially containing a "steps" entry
-     * @return a list of PipelineYamlStep instances for entries that have a non-blank name and non-blank output type; returns an empty list if no valid "steps" section is present
+     * @return a list of PipelineYamlStep instances for entries that have a non-blank name; returns an empty list if no valid "steps" section is present
      */
     private List<PipelineYamlStep> readSteps(Map<?, ?> rootMap) {
         Object stepsObj = rootMap.get("steps");
@@ -232,14 +233,14 @@ public class PipelineYamlConfigLoader {
             String name = readString(stepMap, "name");
             String kind = readString(stepMap, "kind");
             String cardinality = readString(stepMap, "cardinality");
-            String inputType = readString(stepMap, "inputTypeName");
+            String inputType = firstNonBlank(readString(stepMap, "inputTypeName"), readString(stepMap, "input"));
             String inboundMapper = readString(stepMap, "inboundMapper");
-            String outputType = readString(stepMap, "outputTypeName");
+            String outputType = firstNonBlank(readString(stepMap, "outputTypeName"), readString(stepMap, "output"));
             String outboundMapper = readString(stepMap, "outboundMapper");
             String timeout = readString(stepMap, "timeout");
             List<String> idempotencyKeyFields = readStringList(stepMap, "idempotencyKeyFields");
             PipelineYamlAwaitConfig awaitConfig = readAwaitConfig(stepMap, name);
-            if (name != null && !name.isBlank() && outputType != null && !outputType.isBlank()) {
+            if (name != null && !name.isBlank()) {
                 stepInfos.add(new PipelineYamlStep(
                     name,
                     kind,
@@ -299,11 +300,19 @@ public class PipelineYamlConfigLoader {
     }
 
     private Object normalizeConfigValue(Object value) {
+        return normalizeConfigValue(value, 0);
+    }
+
+    private Object normalizeConfigValue(Object value, int depth) {
+        if (depth >= MAX_NESTING_DEPTH) {
+            throw new IllegalArgumentException(
+                "pipeline YAML nested configuration exceeds maximum depth of " + MAX_NESTING_DEPTH);
+        }
         if (value instanceof Map<?, ?> map) {
             java.util.LinkedHashMap<String, Object> normalized = new java.util.LinkedHashMap<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 if (entry.getKey() != null) {
-                    normalized.put(entry.getKey().toString(), normalizeConfigValue(entry.getValue()));
+                    normalized.put(entry.getKey().toString(), normalizeConfigValue(entry.getValue(), depth + 1));
                 }
             }
             return java.util.Map.copyOf(normalized);
@@ -311,11 +320,15 @@ public class PipelineYamlConfigLoader {
         if (value instanceof Iterable<?> iterable) {
             java.util.ArrayList<Object> normalized = new java.util.ArrayList<>();
             for (Object item : iterable) {
-                normalized.add(normalizeConfigValue(item));
+                normalized.add(normalizeConfigValue(item, depth + 1));
             }
             return java.util.List.copyOf(normalized);
         }
         return value;
+    }
+
+    private String firstNonBlank(String primary, String fallback) {
+        return primary == null || primary.isBlank() ? fallback : primary;
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -294,7 +294,6 @@ public class PipelineYamlConfigLoader {
         return new PipelineYamlAwaitTransport(type, config);
     }
 
-    @SuppressWarnings("unchecked")
     private Object normalizeConfigValue(Object value) {
         if (value instanceof Map<?, ?> map) {
             java.util.LinkedHashMap<String, Object> normalized = new java.util.LinkedHashMap<>();

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -230,15 +230,89 @@ public class PipelineYamlConfigLoader {
                 continue;
             }
             String name = readString(stepMap, "name");
+            String kind = readString(stepMap, "kind");
+            String cardinality = readString(stepMap, "cardinality");
             String inputType = readString(stepMap, "inputTypeName");
             String inboundMapper = readString(stepMap, "inboundMapper");
             String outputType = readString(stepMap, "outputTypeName");
             String outboundMapper = readString(stepMap, "outboundMapper");
+            String timeout = readString(stepMap, "timeout");
+            List<String> idempotencyKeyFields = readStringList(stepMap, "idempotencyKeyFields");
+            PipelineYamlAwaitConfig awaitConfig = readAwaitConfig(stepMap, name);
             if (name != null && !name.isBlank() && outputType != null && !outputType.isBlank()) {
-                stepInfos.add(new PipelineYamlStep(name, inputType, inboundMapper, outputType, outboundMapper));
+                stepInfos.add(new PipelineYamlStep(
+                    name,
+                    kind,
+                    cardinality,
+                    inputType,
+                    inboundMapper,
+                    outputType,
+                    outboundMapper,
+                    timeout,
+                    idempotencyKeyFields,
+                    awaitConfig));
             }
         }
         return stepInfos;
+    }
+
+    private PipelineYamlAwaitConfig readAwaitConfig(Map<?, ?> stepMap, String stepName) {
+        Object awaitObj = stepMap.get("await");
+        if (awaitObj == null) {
+            return null;
+        }
+        if (!(awaitObj instanceof Map<?, ?> awaitMap)) {
+            throw new IllegalArgumentException("step '" + stepName + "' await must be defined as a map");
+        }
+        PipelineYamlAwaitCorrelation correlation = readAwaitCorrelation(awaitMap);
+        PipelineYamlAwaitTransport transport = readAwaitTransport(awaitMap, stepName);
+        return new PipelineYamlAwaitConfig(correlation, transport);
+    }
+
+    private PipelineYamlAwaitCorrelation readAwaitCorrelation(Map<?, ?> awaitMap) {
+        Object correlationObj = awaitMap.get("correlation");
+        if (!(correlationObj instanceof Map<?, ?> correlationMap)) {
+            return new PipelineYamlAwaitCorrelation("interactionId");
+        }
+        return new PipelineYamlAwaitCorrelation(readString(correlationMap, "strategy"));
+    }
+
+    private PipelineYamlAwaitTransport readAwaitTransport(Map<?, ?> awaitMap, String stepName) {
+        Object transportObj = awaitMap.get("transport");
+        if (!(transportObj instanceof Map<?, ?> transportMap)) {
+            throw new IllegalArgumentException("step '" + stepName + "' await.transport must be defined as a map");
+        }
+        String type = readRequiredString(transportMap, "type", "step '" + stepName + "' await.transport");
+        java.util.LinkedHashMap<String, Object> config = new java.util.LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : transportMap.entrySet()) {
+            String key = entry.getKey() == null ? null : entry.getKey().toString();
+            if (key == null || "type".equals(key)) {
+                continue;
+            }
+            config.put(key, normalizeConfigValue(entry.getValue()));
+        }
+        return new PipelineYamlAwaitTransport(type, config);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object normalizeConfigValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            java.util.LinkedHashMap<String, Object> normalized = new java.util.LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() != null) {
+                    normalized.put(entry.getKey().toString(), normalizeConfigValue(entry.getValue()));
+                }
+            }
+            return java.util.Map.copyOf(normalized);
+        }
+        if (value instanceof Iterable<?> iterable) {
+            java.util.ArrayList<Object> normalized = new java.util.ArrayList<>();
+            for (Object item : iterable) {
+                normalized.add(normalizeConfigValue(item));
+            }
+            return java.util.List.copyOf(normalized);
+        }
+        return value;
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -271,9 +271,13 @@ public class PipelineYamlConfigLoader {
 
     private PipelineYamlAwaitCorrelation readAwaitCorrelation(Map<?, ?> awaitMap) {
         Object correlationObj = awaitMap.get("correlation");
-        if (!(correlationObj instanceof Map<?, ?> correlationMap)) {
+        if (correlationObj == null) {
             return new PipelineYamlAwaitCorrelation("interactionId");
         }
+        if (!(correlationObj instanceof Map<?, ?>)) {
+            throw new IllegalArgumentException("await.correlation must be a map, but got: " + correlationObj.getClass().getName());
+        }
+        Map<?, ?> correlationMap = (Map<?, ?>) correlationObj;
         return new PipelineYamlAwaitCorrelation(readString(correlationMap, "strategy"));
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlStep.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlStep.java
@@ -20,19 +20,45 @@ package org.pipelineframework.config.pipeline;
  * Pipeline step entry parsed from pipeline.yaml.
  *
  * @param name the step name
+ * @param kind the step kind, for example internal, delegated, remote, or await
+ * @param cardinality the declared cardinality
  * @param inputType the input type name
  * @param inboundMapper the optional inbound mapper class name
  * @param outputType the output type name
  * @param outboundMapper the optional outbound mapper class name
+ * @param timeout the await timeout, if this is an await step
+ * @param idempotencyKeyFields fields used to derive await idempotency keys
+ * @param awaitConfig await-step configuration, if this is an await step
  */
 public record PipelineYamlStep(
     String name,
+    String kind,
+    String cardinality,
     String inputType,
     String inboundMapper,
     String outputType,
-    String outboundMapper
+    String outboundMapper,
+    String timeout,
+    java.util.List<String> idempotencyKeyFields,
+    PipelineYamlAwaitConfig awaitConfig
 ) {
+    public PipelineYamlStep {
+        kind = kind == null || kind.isBlank() ? "internal" : kind;
+        cardinality = cardinality == null || cardinality.isBlank() ? "ONE_TO_ONE" : cardinality;
+        idempotencyKeyFields = idempotencyKeyFields == null ? java.util.List.of() : java.util.List.copyOf(idempotencyKeyFields);
+    }
+
+    public PipelineYamlStep(
+        String name,
+        String inputType,
+        String inboundMapper,
+        String outputType,
+        String outboundMapper
+    ) {
+        this(name, "internal", "ONE_TO_ONE", inputType, inboundMapper, outputType, outboundMapper, null, java.util.List.of(), null);
+    }
+
     public PipelineYamlStep(String name, String inputType, String outputType) {
-        this(name, inputType, null, outputType, null);
+        this(name, "internal", "ONE_TO_ONE", inputType, null, outputType, null, null, java.util.List.of(), null);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
@@ -552,6 +552,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             Map.entry("#ttl", TTL_EPOCH_S));
         Map<String, AttributeValue> values = Map.ofEntries(
             Map.entry(":queued", avS(ExecutionStatus.QUEUED.name())),
+            Map.entry(":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name())),
             Map.entry(":step", avN(nextStepIndex)),
             Map.entry(":awaitInteraction", avS(awaitInteractionId)),
             Map.entry(":resume", avS(toJson(resumePayload))),
@@ -564,7 +565,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .tableName(executionTable())
             .key(executionPrimaryKey(tenantId, executionId))
             .conditionExpression(
-                "(attribute_not_exists(#awaitInteraction) OR #awaitInteraction = :awaitInteraction) " +
+                "#status = :waitingExternal " +
+                    "AND (attribute_not_exists(#awaitInteraction) OR #awaitInteraction = :awaitInteraction) " +
                     "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
             .updateExpression(
                 "SET #status = :queued, #version = #version + :one, #step = :step, #nextDue = :now, " +

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
@@ -63,6 +63,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
     private static final String LAST_TRANSITION_KEY = "last_transition_key";
     private static final String INPUT_SHAPE = "input_shape";
     private static final String INPUT_PAYLOAD_JSON = "input_payload_json";
+    private static final String AWAIT_INTERACTION_ID = "await_interaction_id";
+    private static final String RESUME_PAYLOAD_JSON = "resume_payload_json";
     private static final String RESULT_PAYLOAD_JSON = "result_payload_json";
     private static final String ERROR_CODE = "error_code";
     private static final String ERROR_MESSAGE = "error_message";
@@ -278,6 +280,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             null,
             null,
             null,
+            null,
+            null,
             command.nowEpochMs(),
             command.nowEpochMs(),
             command.ttlEpochS());
@@ -340,6 +344,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             ":running", avS(ExecutionStatus.RUNNING.name()),
             ":one", avN(1),
             ":succeeded", avS(ExecutionStatus.SUCCEEDED.name()),
+            ":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name()),
             ":failed", avS(ExecutionStatus.FAILED.name()),
             ":dlq", avS(ExecutionStatus.DLQ.name()),
             ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
@@ -350,7 +355,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .conditionExpression(
                 "#nextDue <= :now " +
                     "AND (attribute_not_exists(#leaseOwner) OR #leaseExpires <= :now) " +
-                    "AND #status <> :succeeded AND #status <> :failed AND #status <> :dlq " +
+                    "AND #status <> :succeeded AND #status <> :waitingExternal AND #status <> :failed AND #status <> :dlq " +
                     "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
             .updateExpression(
                 "SET #status = :running, #leaseOwner = :leaseOwner, #leaseExpires = :leaseExpires, " +
@@ -383,6 +388,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         names.put("#version", VERSION);
         names.put("#transition", LAST_TRANSITION_KEY);
         names.put("#result", RESULT_PAYLOAD_JSON);
+        names.put("#awaitInteraction", AWAIT_INTERACTION_ID);
+        names.put("#resume", RESUME_PAYLOAD_JSON);
         names.put("#errorCode", ERROR_CODE);
         names.put("#errorMessage", ERROR_MESSAGE);
         names.put("#leaseOwner", LEASE_OWNER);
@@ -408,7 +415,161 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .updateExpression(
                 "SET #status = :succeeded, #version = #version + :one, #transition = :transition, " +
                     "#result = :result, #leaseExpires = :zero, #nextDue = :now, #updated = :now " +
-                    "REMOVE #errorCode, #errorMessage, #leaseOwner")
+                    "REMOVE #errorCode, #errorMessage, #leaseOwner, #awaitInteraction, #resume")
+            .expressionAttributeNames(names)
+            .expressionAttributeValues(values)
+            .returnValues(ReturnValue.ALL_NEW)
+            .build();
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(request).attributes();
+            if (attributes == null || attributes.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs
+    ) {
+        return blocking(() -> markWaitingExternalBlocking(
+            tenantId,
+            executionId,
+            expectedVersion,
+            transitionKey,
+            awaitInteractionId,
+            awaitStepIndex,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs
+    ) {
+        return blocking(() -> markAwaitCompletedBlocking(
+            tenantId,
+            executionId,
+            awaitInteractionId,
+            resumePayload,
+            nextStepIndex,
+            nowEpochMs));
+    }
+
+    private Optional<ExecutionRecord<Object, Object>> markWaitingExternalBlocking(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs
+    ) {
+        Map<String, String> names = Map.ofEntries(
+            Map.entry("#status", STATUS),
+            Map.entry("#version", VERSION),
+            Map.entry("#step", CURRENT_STEP_INDEX),
+            Map.entry("#nextDue", NEXT_DUE_EPOCH_MS),
+            Map.entry("#transition", LAST_TRANSITION_KEY),
+            Map.entry("#awaitInteraction", AWAIT_INTERACTION_ID),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
+            Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#errorCode", ERROR_CODE),
+            Map.entry("#errorMessage", ERROR_MESSAGE),
+            Map.entry("#leaseOwner", LEASE_OWNER),
+            Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
+            Map.entry("#updated", UPDATED_AT_EPOCH_MS),
+            Map.entry("#ttl", TTL_EPOCH_S));
+        Map<String, AttributeValue> values = Map.ofEntries(
+            Map.entry(":expected", avN(expectedVersion)),
+            Map.entry(":waiting", avS(ExecutionStatus.WAITING_EXTERNAL.name())),
+            Map.entry(":step", avN(awaitStepIndex)),
+            Map.entry(":awaitInteraction", avS(awaitInteractionId)),
+            Map.entry(":nextDue", avN(Long.MAX_VALUE)),
+            Map.entry(":transition", avS(transitionKey == null ? "" : transitionKey)),
+            Map.entry(":zero", avN(0)),
+            Map.entry(":now", avN(nowEpochMs)),
+            Map.entry(":one", avN(1)),
+            Map.entry(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond())));
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+            .tableName(executionTable())
+            .key(executionPrimaryKey(tenantId, executionId))
+            .conditionExpression("#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+            .updateExpression(
+                "SET #status = :waiting, #version = #version + :one, #step = :step, #nextDue = :nextDue, " +
+                    "#transition = :transition, #awaitInteraction = :awaitInteraction, #leaseExpires = :zero, " +
+                    "#updated = :now REMOVE #resume, #result, #errorCode, #errorMessage, #leaseOwner")
+            .expressionAttributeNames(names)
+            .expressionAttributeValues(values)
+            .returnValues(ReturnValue.ALL_NEW)
+            .build();
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(request).attributes();
+            if (attributes == null || attributes.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<ExecutionRecord<Object, Object>> markAwaitCompletedBlocking(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs
+    ) {
+        Map<String, String> names = Map.ofEntries(
+            Map.entry("#status", STATUS),
+            Map.entry("#version", VERSION),
+            Map.entry("#step", CURRENT_STEP_INDEX),
+            Map.entry("#nextDue", NEXT_DUE_EPOCH_MS),
+            Map.entry("#awaitInteraction", AWAIT_INTERACTION_ID),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
+            Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#errorCode", ERROR_CODE),
+            Map.entry("#errorMessage", ERROR_MESSAGE),
+            Map.entry("#leaseOwner", LEASE_OWNER),
+            Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
+            Map.entry("#updated", UPDATED_AT_EPOCH_MS),
+            Map.entry("#ttl", TTL_EPOCH_S));
+        Map<String, AttributeValue> values = Map.ofEntries(
+            Map.entry(":queued", avS(ExecutionStatus.QUEUED.name())),
+            Map.entry(":step", avN(nextStepIndex)),
+            Map.entry(":awaitInteraction", avS(awaitInteractionId)),
+            Map.entry(":resume", avS(toJson(resumePayload))),
+            Map.entry(":zero", avN(0)),
+            Map.entry(":now", avN(nowEpochMs)),
+            Map.entry(":one", avN(1)),
+            Map.entry(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond())));
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+            .tableName(executionTable())
+            .key(executionPrimaryKey(tenantId, executionId))
+            .conditionExpression(
+                "(attribute_not_exists(#awaitInteraction) OR #awaitInteraction = :awaitInteraction) " +
+                    "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+            .updateExpression(
+                "SET #status = :queued, #version = #version + :one, #step = :step, #nextDue = :now, " +
+                    "#awaitInteraction = :awaitInteraction, #resume = :resume, #leaseExpires = :zero, #updated = :now " +
+                    "REMOVE #result, #errorCode, #errorMessage, #leaseOwner")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)
             .returnValues(ReturnValue.ALL_NEW)
@@ -444,6 +605,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             Map.entry("#errorCode", ERROR_CODE),
             Map.entry("#errorMessage", ERROR_MESSAGE),
             Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#awaitInteraction", AWAIT_INTERACTION_ID),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
             Map.entry("#leaseOwner", LEASE_OWNER),
             Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
             Map.entry("#updated", UPDATED_AT_EPOCH_MS),
@@ -468,7 +631,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .updateExpression(
                 "SET #status = :retry, #version = #version + :one, #attempt = :attempt, #nextDue = :nextDue, " +
                     "#transition = :transition, #errorCode = :errorCode, #errorMessage = :errorMessage, " +
-                    "#leaseExpires = :zero, #updated = :now REMOVE #result, #leaseOwner")
+                    "#leaseExpires = :zero, #updated = :now REMOVE #result, #awaitInteraction, #resume, #leaseOwner")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)
             .returnValues(ReturnValue.ALL_NEW)
@@ -502,6 +665,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             Map.entry("#errorCode", ERROR_CODE),
             Map.entry("#errorMessage", ERROR_MESSAGE),
             Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
             Map.entry("#leaseOwner", LEASE_OWNER),
             Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
             Map.entry("#updated", UPDATED_AT_EPOCH_MS),
@@ -524,7 +688,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .updateExpression(
                 "SET #status = :finalStatus, #version = #version + :one, #nextDue = :now, #transition = :transition, " +
                     "#errorCode = :errorCode, #errorMessage = :errorMessage, #leaseExpires = :zero, #updated = :now " +
-                    "REMOVE #result, #leaseOwner")
+                    "REMOVE #result, #resume, #leaseOwner")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)
             .returnValues(ReturnValue.ALL_NEW)
@@ -550,6 +714,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         Map<String, AttributeValue> values = Map.of(
             ":now", avN(nowEpochMs),
             ":succeeded", avS(ExecutionStatus.SUCCEEDED.name()),
+            ":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name()),
             ":failed", avS(ExecutionStatus.FAILED.name()),
             ":dlq", avS(ExecutionStatus.DLQ.name()),
             ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
@@ -564,7 +729,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
                 .filterExpression(
                     "#nextDue <= :now " +
                         "AND (attribute_not_exists(#leaseOwner) OR #leaseExpires <= :now) " +
-                        "AND #status <> :succeeded AND #status <> :failed AND #status <> :dlq " +
+                        "AND #status <> :succeeded AND #status <> :waitingExternal AND #status <> :failed AND #status <> :dlq " +
                         "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
                 .expressionAttributeNames(names)
                 .expressionAttributeValues(values)
@@ -702,6 +867,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         putIfPresent(item, LEASE_OWNER, record.leaseOwner());
         putIfPresent(item, LAST_TRANSITION_KEY, record.lastTransitionKey());
         putInputPayload(item, record.inputPayload());
+        putIfPresent(item, AWAIT_INTERACTION_ID, record.awaitInteractionId());
+        putIfPresent(item, RESUME_PAYLOAD_JSON, toJson(record.resumePayload()));
         putIfPresent(item, RESULT_PAYLOAD_JSON, toJson(record.resultPayload()));
         putIfPresent(item, ERROR_CODE, record.errorCode());
         putIfPresent(item, ERROR_MESSAGE, record.errorMessage());
@@ -740,6 +907,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         long nextDue = readLong(item, NEXT_DUE_EPOCH_MS);
         String transitionKey = readString(item, LAST_TRANSITION_KEY);
         Object inputPayload = readInputPayload(item);
+        String awaitInteractionId = readString(item, AWAIT_INTERACTION_ID);
+        Object resumePayload = readPayload(item.get(RESUME_PAYLOAD_JSON));
         Object resultPayload = readPayload(item.get(RESULT_PAYLOAD_JSON));
         String errorCode = readString(item, ERROR_CODE);
         String errorMessage = readString(item, ERROR_MESSAGE);
@@ -759,6 +928,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             nextDue,
             transitionKey,
             inputPayload,
+            awaitInteractionId,
+            resumePayload,
             resultPayload,
             errorCode,
             errorMessage,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionRecord.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionRecord.java
@@ -16,6 +16,8 @@ public record ExecutionRecord<I, R>(
     long nextDueEpochMs,
     String lastTransitionKey,
     I inputPayload,
+    String awaitInteractionId,
+    Object resumePayload,
     R resultPayload,
     String errorCode,
     String errorMessage,
@@ -23,6 +25,52 @@ public record ExecutionRecord<I, R>(
     long updatedAtEpochMs,
     long ttlEpochS
 ) {
+    /**
+     * Backward-compatible constructor for records without await resume fields.
+     */
+    public ExecutionRecord(
+        String tenantId,
+        String executionId,
+        String executionKey,
+        ExecutionStatus status,
+        long version,
+        int currentStepIndex,
+        int attempt,
+        String leaseOwner,
+        long leaseExpiresEpochMs,
+        long nextDueEpochMs,
+        String lastTransitionKey,
+        I inputPayload,
+        R resultPayload,
+        String errorCode,
+        String errorMessage,
+        long createdAtEpochMs,
+        long updatedAtEpochMs,
+        long ttlEpochS
+    ) {
+        this(
+            tenantId,
+            executionId,
+            executionKey,
+            status,
+            version,
+            currentStepIndex,
+            attempt,
+            leaseOwner,
+            leaseExpiresEpochMs,
+            nextDueEpochMs,
+            lastTransitionKey,
+            inputPayload,
+            null,
+            null,
+            resultPayload,
+            errorCode,
+            errorMessage,
+            createdAtEpochMs,
+            updatedAtEpochMs,
+            ttlEpochS);
+    }
+
     /**
      * Returns a copy with a new status and timestamp.
      *
@@ -44,6 +92,8 @@ public record ExecutionRecord<I, R>(
             nextDueEpochMs,
             lastTransitionKey,
             inputPayload,
+            awaitInteractionId,
+            resumePayload,
             resultPayload,
             errorCode,
             errorMessage,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
@@ -97,6 +97,33 @@ public interface ExecutionStateStore {
         long nowEpochMs);
 
     /**
+     * Marks an execution as durably waiting on an external await interaction.
+     */
+    default Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().failure(new UnsupportedOperationException("markWaitingExternal is not implemented"));
+    }
+
+    /**
+     * Stores a completed await payload and makes the execution due for continuation.
+     */
+    default Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().failure(new UnsupportedOperationException("markAwaitCompleted is not implemented"));
+    }
+
+    /**
      * Schedules a retry if expected version matches.
      *
      * @param tenantId tenant identifier

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
@@ -98,6 +98,15 @@ public interface ExecutionStateStore {
 
     /**
      * Marks an execution as durably waiting on an external await interaction.
+     *
+     * @param tenantId tenant identifier
+     * @param executionId execution identifier
+     * @param expectedVersion current execution record version for optimistic concurrency
+     * @param transitionKey idempotency key for the suspend transition
+     * @param awaitInteractionId external await interaction id used to correlate and deduplicate completions
+     * @param awaitStepIndex index of the await step that suspended execution
+     * @param nowEpochMs transition timestamp
+     * @return updated waiting execution when the transition wins optimistic concurrency, otherwise empty
      */
     default Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
         String tenantId,
@@ -112,6 +121,19 @@ public interface ExecutionStateStore {
 
     /**
      * Stores a completed await payload and makes the execution due for continuation.
+     *
+     * <p>This method matches by {@link ExecutionStatus#WAITING_EXTERNAL} plus
+     * {@code awaitInteractionId}, not by expected version. Completion admission is idempotent and can race
+     * with duplicate external callbacks, so stores should return empty when the execution is no longer
+     * waiting for that interaction.</p>
+     *
+     * @param tenantId tenant identifier
+     * @param executionId execution identifier
+     * @param awaitInteractionId external await interaction id used to match the waiting execution
+     * @param resumePayload payload used as input for the step after the await boundary
+     * @param nextStepIndex next pipeline step index to execute
+     * @param nowEpochMs transition timestamp
+     * @return updated queued execution when completion is accepted, otherwise empty
      */
     default Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
         String tenantId,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
@@ -4,12 +4,19 @@ package org.pipelineframework.orchestrator;
  * Execution lifecycle status for async orchestrator runs.
  */
 public enum ExecutionStatus {
+    /** Execution is accepted and waiting to be claimed by a queue worker. */
     QUEUED,
+    /** Execution is currently leased and running in a queue worker. */
     RUNNING,
+    /** Execution is paused at an await step until external completion arrives or its deadline expires. */
     WAITING_EXTERNAL,
+    /** Execution failed transiently and is waiting for its retry due time. */
     WAIT_RETRY,
+    /** Execution completed successfully and has a persisted result payload. */
     SUCCEEDED,
+    /** Execution reached a terminal failure before dead-letter publication. */
     FAILED,
+    /** Execution reached a terminal failure and was routed through the dead-letter path. */
     DLQ;
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
@@ -6,6 +6,7 @@ package org.pipelineframework.orchestrator;
 public enum ExecutionStatus {
     QUEUED,
     RUNNING,
+    WAITING_EXTERNAL,
     WAIT_RETRY,
     SUCCEEDED,
     FAILED,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -347,7 +347,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     transitionKey,
                     current.inputPayload(),
                     current.awaitInteractionId(),
-                    current.resumePayload(),
+                    null,
                     null,
                     errorCode,
                     truncate(errorMessage),

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -235,7 +235,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
             synchronized (lock) {
                 String scopedId = scopedExecutionId(tenantId, executionId);
                 ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
-                if (current == null || current.status().terminal()) {
+                if (current == null || current.status() != ExecutionStatus.WAITING_EXTERNAL) {
                     return Optional.empty();
                 }
                 if (current.awaitInteractionId() != null && !current.awaitInteractionId().equals(awaitInteractionId)) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -68,6 +68,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     null,
                     null,
                     null,
+                    null,
+                    null,
                     command.nowEpochMs(),
                     command.nowEpochMs(),
                     command.ttlEpochS());
@@ -101,7 +103,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
             synchronized (lock) {
                 String scopedId = scopedExecutionId(tenantId, executionId);
                 ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
-                if (current == null || current.status().terminal()) {
+                if (current == null || current.status().terminal() || current.status() == ExecutionStatus.WAITING_EXTERNAL) {
                     return Optional.empty();
                 }
                 boolean leaseExpired = current.leaseOwner() == null || current.leaseExpiresEpochMs() <= nowEpochMs;
@@ -122,6 +124,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     current.nextDueEpochMs(),
                     current.lastTransitionKey(),
                     current.inputPayload(),
+                    current.awaitInteractionId(),
+                    current.resumePayload(),
                     current.resultPayload(),
                     current.errorCode(),
                     current.errorMessage(),
@@ -162,7 +166,97 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     nowEpochMs,
                     transitionKey,
                     current.inputPayload(),
+                    null,
+                    null,
                     resultPayload,
+                    null,
+                    null,
+                    current.createdAtEpochMs(),
+                    nowEpochMs,
+                    current.ttlEpochS());
+                executionsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                String scopedId = scopedExecutionId(tenantId, executionId);
+                ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
+                if (current == null || current.version() != expectedVersion) {
+                    return Optional.empty();
+                }
+                ExecutionRecord<Object, Object> updated = new ExecutionRecord<>(
+                    current.tenantId(),
+                    current.executionId(),
+                    current.executionKey(),
+                    ExecutionStatus.WAITING_EXTERNAL,
+                    current.version() + 1,
+                    awaitStepIndex,
+                    current.attempt(),
+                    null,
+                    0L,
+                    Long.MAX_VALUE,
+                    transitionKey,
+                    current.inputPayload(),
+                    awaitInteractionId,
+                    null,
+                    null,
+                    null,
+                    null,
+                    current.createdAtEpochMs(),
+                    nowEpochMs,
+                    current.ttlEpochS());
+                executionsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                String scopedId = scopedExecutionId(tenantId, executionId);
+                ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
+                if (current == null || current.status().terminal()) {
+                    return Optional.empty();
+                }
+                if (current.awaitInteractionId() != null && !current.awaitInteractionId().equals(awaitInteractionId)) {
+                    return Optional.empty();
+                }
+                ExecutionRecord<Object, Object> updated = new ExecutionRecord<>(
+                    current.tenantId(),
+                    current.executionId(),
+                    current.executionKey(),
+                    ExecutionStatus.QUEUED,
+                    current.version() + 1,
+                    nextStepIndex,
+                    current.attempt(),
+                    null,
+                    0L,
+                    nowEpochMs,
+                    current.lastTransitionKey(),
+                    current.inputPayload(),
+                    awaitInteractionId,
+                    resumePayload,
+                    null,
                     null,
                     null,
                     current.createdAtEpochMs(),
@@ -205,6 +299,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     nextDueEpochMs,
                     transitionKey,
                     current.inputPayload(),
+                    null,
+                    null,
                     null,
                     errorCode,
                     truncate(errorMessage),
@@ -250,6 +346,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     nowEpochMs,
                     transitionKey,
                     current.inputPayload(),
+                    current.awaitInteractionId(),
+                    current.resumePayload(),
                     null,
                     errorCode,
                     truncate(errorMessage),
@@ -276,7 +374,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                         executionIdByScopedKey.remove(scopedExecutionKey(record.tenantId(), record.executionKey()));
                         continue;
                     }
-                    if (record.status().terminal()) {
+                    if (record.status().terminal() || record.status() == ExecutionStatus.WAITING_EXTERNAL) {
                         continue;
                     }
                     boolean dueNow = record.nextDueEpochMs() <= nowEpochMs;

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
@@ -196,6 +196,24 @@ public interface PipelineOrchestratorConfig {
         String executionKeyTable();
 
         /**
+         * Await interaction table name.
+         *
+         * @return await interaction table name
+         */
+        @WithName("await-interaction-table")
+        @WithDefault("tpf_await_interaction")
+        String awaitInteractionTable();
+
+        /**
+         * Await interaction lookup table name.
+         *
+         * @return await lookup table name
+         */
+        @WithName("await-interaction-key-table")
+        @WithDefault("tpf_await_interaction_key")
+        String awaitInteractionKeyTable();
+
+        /**
          * Optional region override.
          *
          * @return region when configured

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -742,6 +742,44 @@ public class PipelineProtoGenerator {
         builder.append("message GetExecutionResultResponse {\n");
         builder.append("  repeated ").append(last.outputTypeName()).append(" items = 1;\n");
         builder.append("}\n\n");
+        builder.append("message CompleteAwaitRequest {\n");
+        builder.append("  string tenant_id = 1;\n");
+        builder.append("  string interaction_id = 2;\n");
+        builder.append("  string correlation_id = 3;\n");
+        builder.append("  string idempotency_key = 4;\n");
+        builder.append("  string response_json = 5;\n");
+        builder.append("  string actor = 6;\n");
+        builder.append("}\n\n");
+        builder.append("message CompleteAwaitResponse {\n");
+        builder.append("  string interaction_id = 1;\n");
+        builder.append("  string execution_id = 2;\n");
+        builder.append("  string step_id = 3;\n");
+        builder.append("  string status = 4;\n");
+        builder.append("  bool duplicate = 5;\n");
+        builder.append("}\n\n");
+        builder.append("message ListPendingAwaitRequest {\n");
+        builder.append("  string tenant_id = 1;\n");
+        builder.append("  string assignee = 2;\n");
+        builder.append("  string group = 3;\n");
+        builder.append("  string step_id = 4;\n");
+        builder.append("  int32 limit = 5;\n");
+        builder.append("}\n\n");
+        builder.append("message AwaitInteraction {\n");
+        builder.append("  string interaction_id = 1;\n");
+        builder.append("  string correlation_id = 2;\n");
+        builder.append("  string execution_id = 3;\n");
+        builder.append("  string step_id = 4;\n");
+        builder.append("  int32 step_index = 5;\n");
+        builder.append("  string output_type = 6;\n");
+        builder.append("  string status = 7;\n");
+        builder.append("  string transport_type = 8;\n");
+        builder.append("  int64 deadline_epoch_ms = 9;\n");
+        builder.append("  int64 created_at_epoch_ms = 10;\n");
+        builder.append("  int64 updated_at_epoch_ms = 11;\n");
+        builder.append("}\n\n");
+        builder.append("message ListPendingAwaitResponse {\n");
+        builder.append("  repeated AwaitInteraction interactions = 1;\n");
+        builder.append("}\n\n");
         builder.append("service OrchestratorService {\n");
         builder.append("  rpc Run (");
         if (shape.inputStreaming()) {
@@ -762,6 +800,8 @@ public class PipelineProtoGenerator {
         builder.append("  rpc RunAsync (RunAsyncRequest) returns (RunAsyncResponse);\n");
         builder.append("  rpc GetExecutionStatus (GetExecutionStatusRequest) returns (GetExecutionStatusResponse);\n");
         builder.append("  rpc GetExecutionResult (GetExecutionResultRequest) returns (GetExecutionResultResponse);\n");
+        builder.append("  rpc CompleteAwait (CompleteAwaitRequest) returns (CompleteAwaitResponse);\n");
+        builder.append("  rpc ListPendingAwait (ListPendingAwaitRequest) returns (ListPendingAwaitResponse);\n");
         builder.append("  rpc Subscribe (google.protobuf.Empty) returns (stream ")
             .append(last.outputTypeName())
             .append(");\n");

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -29,6 +29,12 @@ import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitSuspendedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,6 +65,9 @@ class QueueAsyncCoordinatorTest {
     private DeadLetterPublisher deadLetterPublisher;
 
     @Mock
+    private AwaitCoordinator awaitCoordinator;
+
+    @Mock
     private Instance<ExecutionStateStore> executionStateStores;
 
     @Mock
@@ -80,6 +89,7 @@ class QueueAsyncCoordinatorTest {
         coordinator.executionStateStore = executionStateStore;
         coordinator.workDispatcher = workDispatcher;
         coordinator.deadLetterPublisher = deadLetterPublisher;
+        coordinator.awaitCoordinator = awaitCoordinator;
         coordinator.executionStateStores = executionStateStores;
         coordinator.workDispatchers = workDispatchers;
         coordinator.deadLetterPublishers = deadLetterPublishers;
@@ -201,6 +211,8 @@ class QueueAsyncCoordinatorTest {
     void sweepRedispatchesPersistedDueExecutions() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        when(awaitCoordinator.findTimedOut(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of()));
         when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyInt()))
             .thenReturn(Uni.createFrom().item(java.util.List.of(
                 createRecord("tenant-a", "exec-5", "key-5"),
@@ -211,6 +223,138 @@ class QueueAsyncCoordinatorTest {
 
         ArgumentCaptor<ExecutionWorkItem> itemCaptor = ArgumentCaptor.forClass(ExecutionWorkItem.class);
         verify(workDispatcher, timeout(500).times(2)).enqueueNow(itemCaptor.capture());
+    }
+
+    @Test
+    void processExecutionWorkItemMarksWaitingExternalWhenAwaitSuspends() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+        ExecutionRecord<Object, Object> claimed = createRecord("tenant-1", "exec-await", "key-await");
+        when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+        when(executionStateStore.markWaitingExternal(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-await"),
+                org.mockito.ArgumentMatchers.eq(0L),
+                org.mockito.ArgumentMatchers.eq("exec-await:0:0"),
+                org.mockito.ArgumentMatchers.eq("interaction-1"),
+                org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+
+        coordinator.processExecutionWorkItem(
+                new ExecutionWorkItem("tenant-1", "exec-await"),
+                record -> Multi.createFrom().failure(new AwaitSuspendedException(
+                    "tenant-1",
+                    "exec-await",
+                    "interaction-1",
+                    0)))
+            .await().indefinitely();
+
+        verify(executionStateStore).markWaitingExternal(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-await"),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq("exec-await:0:0"),
+            org.mockito.ArgumentMatchers.eq("interaction-1"),
+            org.mockito.ArgumentMatchers.eq(0),
+            org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void completeAwaitStoresResumePayloadAndEnqueuesExecution() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        AwaitInteractionRecord interaction = awaitRecord();
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant-1",
+            "interaction-1",
+            null,
+            null,
+            java.util.Map.of("value", "approved"),
+            "user-1",
+            System.currentTimeMillis());
+        when(awaitCoordinator.complete(command))
+            .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, false)));
+        ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        when(executionStateStore.markAwaitCompleted(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-1"),
+                org.mockito.ArgumentMatchers.eq("interaction-1"),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.eq(3),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(resumed)));
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+        AwaitCompletionResult result = coordinator.completeAwait(command).await().indefinitely();
+
+        assertEquals("interaction-1", result.record().interactionId());
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(executionStateStore).markAwaitCompleted(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-1"),
+            org.mockito.ArgumentMatchers.eq("interaction-1"),
+            payloadCaptor.capture(),
+            org.mockito.ArgumentMatchers.eq(3),
+            org.mockito.ArgumentMatchers.anyLong());
+        assertEquals(new Decision("approved"), payloadCaptor.getValue());
+        verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+    }
+
+    @Test
+    void sweepTimesOutAwaitInteractionsAndFailsOwningExecution() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        AwaitInteractionRecord interaction = awaitRecord();
+        ExecutionRecord<Object, Object> waiting = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionStatus.WAITING_EXTERNAL,
+            7L,
+            2,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            "interaction-1",
+            null,
+            null,
+            1L,
+            1L,
+            99999999L);
+        when(awaitCoordinator.findTimedOut(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of(interaction)));
+        when(awaitCoordinator.markTimedOut(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(executionStateStore.markTerminalFailure(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-1"),
+                org.mockito.ArgumentMatchers.eq(7L),
+                org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+                org.mockito.ArgumentMatchers.eq("exec-1:2:0"),
+                org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
+                org.mockito.ArgumentMatchers.contains("interaction-1"),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of()));
+
+        coordinator.sweepDueExecutions();
+
+        verify(executionStateStore, timeout(500)).markTerminalFailure(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-1"),
+            org.mockito.ArgumentMatchers.eq(7L),
+            org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+            org.mockito.ArgumentMatchers.eq("exec-1:2:0"),
+            org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
+            org.mockito.ArgumentMatchers.contains("interaction-1"),
+            org.mockito.ArgumentMatchers.anyLong());
     }
 
     private void configureQueueModeDefaults() {
@@ -239,5 +383,34 @@ class QueueAsyncCoordinatorTest {
             1L,
             1L,
             99999999L);
+    }
+
+    private AwaitInteractionRecord awaitRecord() {
+        return new AwaitInteractionRecord(
+            "tenant-1",
+            "exec-1",
+            "ProcessApprovalService",
+            2,
+            Decision.class.getName(),
+            "interaction-1",
+            "corr-1",
+            "cause-1",
+            "idem-1",
+            1L,
+            AwaitInteractionStatus.COMPLETED,
+            java.util.Map.of("value", "request"),
+            java.util.Map.of("value", "approved"),
+            "user-1",
+            null,
+            null,
+            "interaction-api",
+            java.util.Map.of(),
+            System.currentTimeMillis() + 1000,
+            1L,
+            2L,
+            99999999L);
+    }
+
+    private record Decision(String value) {
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -276,6 +276,7 @@ class QueueAsyncCoordinatorTest {
         when(awaitCoordinator.complete(command))
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, false)));
         ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        // Uses a Map payload intentionally so coerceAwaitPayload exercises PipelineJson conversion into Decision.
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-1"),
@@ -320,6 +321,8 @@ class QueueAsyncCoordinatorTest {
             null,
             "input",
             "interaction-1",
+            null,
+            null,
             null,
             null,
             1L,

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
@@ -56,18 +56,6 @@ class AwaitCompletionCommandTest {
     }
 
     @Test
-    void rejectsNullIdempotencyKey() {
-        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
-            "tenant1", "interaction-123", null, null, null, null, 1000L));
-    }
-
-    @Test
-    void rejectsBlankIdempotencyKey() {
-        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
-            "tenant1", "interaction-123", null, "  ", null, null, 1000L));
-    }
-
-    @Test
     void autoSetsNowEpochMsWhenZero() {
         long before = System.currentTimeMillis();
         AwaitCompletionCommand command = new AwaitCompletionCommand(

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
@@ -1,0 +1,97 @@
+package org.pipelineframework.awaitable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwaitCompletionCommandTest {
+
+    @Test
+    void constructsWithInteractionId() {
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant1", "interaction-123", null, "idem-1", "response", "alice", 1000L);
+
+        assertEquals("tenant1", command.tenantId());
+        assertEquals("interaction-123", command.interactionId());
+        assertEquals("alice", command.actor());
+        assertEquals("response", command.responsePayload());
+        assertEquals(1000L, command.nowEpochMs());
+    }
+
+    @Test
+    void constructsWithCorrelationIdOnly() {
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant1", null, "corr-456", "idem-1", "response", null, 2000L);
+
+        assertEquals("corr-456", command.correlationId());
+        assertNotNull(command.nowEpochMs());
+    }
+
+    @Test
+    void rejectsBlankTenantId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
+            "", "interaction-123", null, "idem-1", null, null, 1000L));
+    }
+
+    @Test
+    void rejectsNullTenantId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
+            null, "interaction-123", null, "idem-1", null, null, 1000L));
+    }
+
+    @Test
+    void rejectsBothInteractionIdAndCorrelationIdMissing() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
+            "tenant1", null, null, "idem-1", null, null, 1000L));
+    }
+
+    @Test
+    void rejectsBothBlankInteractionIdAndBlankCorrelationId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
+            "tenant1", "  ", "  ", "idem-1", null, null, 1000L));
+    }
+
+    @Test
+    void autoSetsNowEpochMsWhenZero() {
+        long before = System.currentTimeMillis();
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant1", "interaction-123", null, "idem-1", null, null, 0L);
+        long after = System.currentTimeMillis();
+
+        assertTrue(command.nowEpochMs() >= before);
+        assertTrue(command.nowEpochMs() <= after);
+    }
+
+    @Test
+    void autoSetsNowEpochMsWhenNegative() {
+        long before = System.currentTimeMillis();
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant1", "interaction-123", null, "idem-1", null, null, -500L);
+        long after = System.currentTimeMillis();
+
+        assertTrue(command.nowEpochMs() >= before);
+        assertTrue(command.nowEpochMs() <= after);
+    }
+
+    @Test
+    void acceptsOnlyInteractionIdWithNullCorrelation() {
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant1", "interaction-abc", null, "idem-x", "payload", "bob", 5000L);
+
+        assertEquals("interaction-abc", command.interactionId());
+        assertEquals("payload", command.responsePayload());
+        assertEquals("bob", command.actor());
+    }
+
+    @Test
+    void acceptsNullResponsePayload() {
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant1", "interaction-abc", null, "idem-x", null, "alice", 5000L);
+
+        assertEquals("alice", command.actor());
+        assertEquals(null, command.responsePayload());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
@@ -16,6 +16,7 @@ class AwaitCompletionCommandTest {
 
         assertEquals("tenant1", command.tenantId());
         assertEquals("interaction-123", command.interactionId());
+        assertEquals("idem-1", command.idempotencyKey());
         assertEquals("alice", command.actor());
         assertEquals("response", command.responsePayload());
         assertEquals(1000L, command.nowEpochMs());
@@ -52,6 +53,18 @@ class AwaitCompletionCommandTest {
     void rejectsBothBlankInteractionIdAndBlankCorrelationId() {
         assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
             "tenant1", "  ", "  ", "idem-1", null, null, 1000L));
+    }
+
+    @Test
+    void rejectsNullIdempotencyKey() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
+            "tenant1", "interaction-123", null, null, null, null, 1000L));
+    }
+
+    @Test
+    void rejectsBlankIdempotencyKey() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
+            "tenant1", "interaction-123", null, "  ", null, null, 1000L));
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCreateCommandTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCreateCommandTest.java
@@ -148,5 +148,14 @@ class AwaitCreateCommandTest {
 
         assertTrue(command.nowEpochMs() >= before);
         assertTrue(command.nowEpochMs() <= after);
+
+        before = System.currentTimeMillis();
+        AwaitCreateCommand negativeNowCommand = new AwaitCreateCommand(
+            "tenant1", "exec-1", "step-1", 0, "Out.class",
+            "cause", "idem", "corr", null, null, null, "webhook", -1L, futureDeadline, Long.MAX_VALUE);
+        after = System.currentTimeMillis();
+
+        assertTrue(negativeNowCommand.nowEpochMs() >= before);
+        assertTrue(negativeNowCommand.nowEpochMs() <= after);
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCreateCommandTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCreateCommandTest.java
@@ -1,0 +1,152 @@
+package org.pipelineframework.awaitable;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwaitCreateCommandTest {
+
+    private static final long NOW = 10_000L;
+    private static final long DEADLINE = 70_000L;
+
+    @Test
+    void constructsFullCommandWithAllFields() {
+        AwaitCreateCommand command = new AwaitCreateCommand(
+            "tenant1", "exec-1", "step-review", 2, "com.example.Output",
+            "cause-1", "idem-1", "corr-1", "payload", "alice", "finance",
+            "webhook", NOW, DEADLINE, Long.MAX_VALUE);
+
+        assertEquals("tenant1", command.tenantId());
+        assertEquals("exec-1", command.executionId());
+        assertEquals("step-review", command.stepId());
+        assertEquals(2, command.stepIndex());
+        assertEquals("com.example.Output", command.outputType());
+        assertEquals("cause-1", command.causationId());
+        assertEquals("idem-1", command.idempotencyKey());
+        assertEquals("corr-1", command.correlationId());
+        assertEquals("payload", command.requestPayload());
+        assertEquals("alice", command.assignee());
+        assertEquals("finance", command.group());
+        assertEquals("webhook", command.transportType());
+        assertEquals(NOW, command.nowEpochMs());
+        assertEquals(DEADLINE, command.deadlineEpochMs());
+        assertEquals(Long.MAX_VALUE, command.ttlEpochS());
+    }
+
+    @Test
+    void backwardCompatConstructorDefaultsStepIndexAndOutputType() {
+        AwaitCreateCommand command = new AwaitCreateCommand(
+            "tenant1", "exec-1", "step-review",
+            "cause-1", "idem-1", "corr-1", "payload", "alice", "finance",
+            "webhook", NOW, DEADLINE, Long.MAX_VALUE);
+
+        assertEquals(0, command.stepIndex());
+        assertEquals(Object.class.getName(), command.outputType());
+        assertEquals("step-review", command.stepId());
+    }
+
+    @Test
+    void rejectsBlankTenantId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("", "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsNullTenantId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand(null, "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankExecutionId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankStepId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", " ", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankOutputType() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankIdempotencyKey() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "Out.class",
+                "cause", "", "corr", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankCorrelationId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "  ", null, null, null, "webhook", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankTransportType() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "", NOW, DEADLINE, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsDeadlineNotAfterNow() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, NOW, Long.MAX_VALUE));
+
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, NOW - 1, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsTtlBeforeDeadline() {
+        long deadlineEpochMs = DEADLINE;
+        long deadlineEpochS = Instant.ofEpochMilli(deadlineEpochMs).getEpochSecond();
+        long ttlBeforeDeadline = deadlineEpochS - 1;
+
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitCreateCommand("tenant1", "exec-1", "step-1", 0, "Out.class",
+                "cause", "idem", "corr", null, null, null, "webhook", NOW, deadlineEpochMs, ttlBeforeDeadline));
+    }
+
+    @Test
+    void autoSetsTtlWhenZero() {
+        AwaitCreateCommand command = new AwaitCreateCommand(
+            "tenant1", "exec-1", "step-1", 0, "Out.class",
+            "cause", "idem", "corr", null, null, null, "webhook", NOW, DEADLINE, 0L);
+
+        long expectedTtl = Instant.ofEpochMilli(DEADLINE).plusSeconds(86_400).getEpochSecond();
+        assertEquals(expectedTtl, command.ttlEpochS());
+    }
+
+    @Test
+    void autoSetsNowEpochMsWhenZeroOrNegative() {
+        long before = System.currentTimeMillis();
+        long futureDeadline = before + 60_000L;
+        AwaitCreateCommand command = new AwaitCreateCommand(
+            "tenant1", "exec-1", "step-1", 0, "Out.class",
+            "cause", "idem", "corr", null, null, null, "webhook", 0L, futureDeadline, Long.MAX_VALUE);
+        long after = System.currentTimeMillis();
+
+        assertTrue(command.nowEpochMs() >= before);
+        assertTrue(command.nowEpochMs() <= after);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitExecutionContextHolderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitExecutionContextHolderTest.java
@@ -1,0 +1,73 @@
+package org.pipelineframework.awaitable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class AwaitExecutionContextHolderTest {
+
+    @AfterEach
+    void cleanup() {
+        AwaitExecutionContextHolder.clear();
+    }
+
+    @Test
+    void returnsNullWhenNothingSet() {
+        assertNull(AwaitExecutionContextHolder.get());
+    }
+
+    @Test
+    void setsAndGetsContext() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-1", 0);
+        AwaitExecutionContextHolder.set(context);
+
+        assertSame(context, AwaitExecutionContextHolder.get());
+    }
+
+    @Test
+    void clearRemovesContext() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-1", 0);
+        AwaitExecutionContextHolder.set(context);
+        AwaitExecutionContextHolder.clear();
+
+        assertNull(AwaitExecutionContextHolder.get());
+    }
+
+    @Test
+    void overwritesExistingContext() {
+        AwaitExecutionContext first = new AwaitExecutionContext("tenant1", "exec-1", 0);
+        AwaitExecutionContext second = new AwaitExecutionContext("tenant2", "exec-2", 3);
+        AwaitExecutionContextHolder.set(first);
+        AwaitExecutionContextHolder.set(second);
+
+        assertSame(second, AwaitExecutionContextHolder.get());
+        assertEquals("tenant2", AwaitExecutionContextHolder.get().tenantId());
+    }
+
+    @Test
+    void clearIsIdempotent() {
+        AwaitExecutionContextHolder.clear();
+        AwaitExecutionContextHolder.clear();
+
+        assertNull(AwaitExecutionContextHolder.get());
+    }
+
+    @Test
+    void threadLocalIsolation() throws InterruptedException {
+        AwaitExecutionContext mainContext = new AwaitExecutionContext("main-tenant", "main-exec", 0);
+        AwaitExecutionContextHolder.set(mainContext);
+
+        AwaitExecutionContext[] capturedInThread = new AwaitExecutionContext[1];
+        Thread thread = new Thread(() -> capturedInThread[0] = AwaitExecutionContextHolder.get());
+        thread.start();
+        thread.join();
+
+        // Other thread should see null since context is thread-local
+        assertNull(capturedInThread[0]);
+        // Main thread should still have its context
+        assertSame(mainContext, AwaitExecutionContextHolder.get());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitExecutionContextTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitExecutionContextTest.java
@@ -1,0 +1,86 @@
+package org.pipelineframework.awaitable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AwaitExecutionContextTest {
+
+    @Test
+    void constructsWithValidFields() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-123", 2);
+
+        assertEquals("tenant1", context.tenantId());
+        assertEquals("exec-123", context.executionId());
+        assertEquals(2, context.currentStepIndex());
+    }
+
+    @Test
+    void acceptsZeroStepIndex() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-123", 0);
+
+        assertEquals(0, context.currentStepIndex());
+    }
+
+    @Test
+    void rejectsBlankTenantId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitExecutionContext("", "exec-123", 0));
+    }
+
+    @Test
+    void rejectsWhitespaceTenantId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitExecutionContext("   ", "exec-123", 0));
+    }
+
+    @Test
+    void rejectsNullTenantId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitExecutionContext(null, "exec-123", 0));
+    }
+
+    @Test
+    void rejectsBlankExecutionId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitExecutionContext("tenant1", "", 0));
+    }
+
+    @Test
+    void rejectsNullExecutionId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitExecutionContext("tenant1", null, 0));
+    }
+
+    @Test
+    void rejectsNegativeStepIndex() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new AwaitExecutionContext("tenant1", "exec-123", -1));
+    }
+
+    @Test
+    void updatesStepIndexMutation() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-123", 0);
+        context.currentStepIndex(5);
+
+        assertEquals(5, context.currentStepIndex());
+    }
+
+    @Test
+    void rejectsNegativeStepIndexOnMutation() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-123", 0);
+
+        assertThrows(IllegalArgumentException.class, () -> context.currentStepIndex(-1));
+    }
+
+    @Test
+    void allowsIncrementingStepIndexRepeatedly() {
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec-123", 0);
+        context.currentStepIndex(1);
+        context.currentStepIndex(2);
+        context.currentStepIndex(10);
+
+        assertEquals(10, context.currentStepIndex());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitInteractionRecordTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitInteractionRecordTest.java
@@ -1,0 +1,182 @@
+package org.pipelineframework.awaitable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwaitInteractionRecordTest {
+
+    @Test
+    void constructsWithAllRequiredFields() {
+        AwaitInteractionRecord record = sampleRecord();
+
+        assertEquals("tenant1", record.tenantId());
+        assertEquals("exec-1", record.executionId());
+        assertEquals("review", record.stepId());
+        assertEquals(0, record.stepIndex());
+        assertEquals("com.example.Output", record.outputType());
+        assertEquals("interaction-id", record.interactionId());
+        assertEquals("corr-id", record.correlationId());
+        assertEquals("idem-key", record.idempotencyKey());
+        assertEquals(0L, record.version());
+        assertEquals(AwaitInteractionStatus.WAITING, record.status());
+    }
+
+    @Test
+    void normalizesNullTransportMetadataToEmptyMap() {
+        AwaitInteractionRecord record = new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "com.example.Output",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook",
+            null, // null transportMetadata
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE);
+
+        assertEquals(Map.of(), record.transportMetadata());
+    }
+
+    @Test
+    void makesImmutableCopyOfTransportMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("key", "value");
+
+        AwaitInteractionRecord record = new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "com.example.Output",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook",
+            metadata,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE);
+
+        metadata.put("key2", "value2"); // mutate original
+        assertEquals(1, record.transportMetadata().size()); // record not affected
+        assertThrows(UnsupportedOperationException.class, () -> record.transportMetadata().put("k", "v"));
+    }
+
+    @Test
+    void rejectsBlankTenantId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "", "exec-1", "review", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsNullTenantId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            null, "exec-1", "review", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankExecutionId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", " ", "review", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankStepId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsNegativeStepIndex() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", -1, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankOutputType() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "  ",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankInteractionId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "Out.class",
+            "", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankCorrelationId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "Out.class",
+            "interaction-id", "  ", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsBlankIdempotencyKey() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void rejectsNullStatus() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, null,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE));
+    }
+
+    @Test
+    void acceptsZeroStepIndex() {
+        AwaitInteractionRecord record = new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "Out.class",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            null, null, null, null, null, "webhook", null,
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE);
+
+        assertEquals(0, record.stepIndex());
+    }
+
+    private static AwaitInteractionRecord sampleRecord() {
+        return new AwaitInteractionRecord(
+            "tenant1", "exec-1", "review", 0, "com.example.Output",
+            "interaction-id", "corr-id", "cause-id", "idem-key",
+            0L, AwaitInteractionStatus.WAITING,
+            "request", null, null, null, null, "webhook",
+            Map.of("key", "value"),
+            70_000L, 10_000L, 10_000L, Long.MAX_VALUE);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitInteractionStatusTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitInteractionStatusTest.java
@@ -18,6 +18,11 @@ class AwaitInteractionStatusTest {
     }
 
     @Test
+    void dispatchingIsNotTerminal() {
+        assertFalse(AwaitInteractionStatus.DISPATCHING.terminal());
+    }
+
+    @Test
     void completedIsTerminal() {
         assertTrue(AwaitInteractionStatus.COMPLETED.terminal());
     }
@@ -47,15 +52,15 @@ class AwaitInteractionStatusTest {
         long nonTerminalCount = java.util.Arrays.stream(AwaitInteractionStatus.values())
             .filter(s -> !s.terminal())
             .count();
-        // WAITING and DISPATCHED are the only non-terminal states
-        assertTrue(nonTerminalCount == 2,
-            "Expected 2 non-terminal states (WAITING, DISPATCHED), found " + nonTerminalCount);
+        // WAITING, DISPATCHING, and DISPATCHED are the only non-terminal states
+        assertTrue(nonTerminalCount == 3,
+            "Expected 3 non-terminal states (WAITING, DISPATCHING, DISPATCHED), found " + nonTerminalCount);
     }
 
     @Test
     void allEnumValuesAreDeclared() {
         AwaitInteractionStatus[] values = AwaitInteractionStatus.values();
-        assertTrue(values.length == 7,
-            "Expected 7 enum values but found " + values.length);
+        assertTrue(values.length == 8,
+            "Expected 8 enum values but found " + values.length);
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitInteractionStatusTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitInteractionStatusTest.java
@@ -1,0 +1,61 @@
+package org.pipelineframework.awaitable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwaitInteractionStatusTest {
+
+    @Test
+    void waitingIsNotTerminal() {
+        assertFalse(AwaitInteractionStatus.WAITING.terminal());
+    }
+
+    @Test
+    void dispatchedIsNotTerminal() {
+        assertFalse(AwaitInteractionStatus.DISPATCHED.terminal());
+    }
+
+    @Test
+    void completedIsTerminal() {
+        assertTrue(AwaitInteractionStatus.COMPLETED.terminal());
+    }
+
+    @Test
+    void failedIsTerminal() {
+        assertTrue(AwaitInteractionStatus.FAILED.terminal());
+    }
+
+    @Test
+    void timedOutIsTerminal() {
+        assertTrue(AwaitInteractionStatus.TIMED_OUT.terminal());
+    }
+
+    @Test
+    void cancelledIsTerminal() {
+        assertTrue(AwaitInteractionStatus.CANCELLED.terminal());
+    }
+
+    @Test
+    void expiredIsTerminal() {
+        assertTrue(AwaitInteractionStatus.EXPIRED.terminal());
+    }
+
+    @Test
+    void allNonTerminalStatusesHaveExactlyTwoValues() {
+        long nonTerminalCount = java.util.Arrays.stream(AwaitInteractionStatus.values())
+            .filter(s -> !s.terminal())
+            .count();
+        // WAITING and DISPATCHED are the only non-terminal states
+        assertTrue(nonTerminalCount == 2,
+            "Expected 2 non-terminal states (WAITING, DISPATCHED), found " + nonTerminalCount);
+    }
+
+    @Test
+    void allEnumValuesAreDeclared() {
+        AwaitInteractionStatus[] values = AwaitInteractionStatus.values();
+        assertTrue(values.length == 7,
+            "Expected 7 enum values but found " + values.length);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepDescriptorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepDescriptorTest.java
@@ -1,0 +1,164 @@
+package org.pipelineframework.awaitable;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AwaitStepDescriptorTest {
+
+    @Test
+    void constructsWithAllFields() {
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step",
+            "com.example.ReviewRequest",
+            "com.example.ReviewDecision",
+            Duration.ofMinutes(10),
+            "interactionId",
+            "webhook",
+            Map.of("url", "https://example.com"),
+            List.of("orderId", "customerId"));
+
+        assertEquals("review-step", descriptor.stepId());
+        assertEquals("com.example.ReviewRequest", descriptor.inputType());
+        assertEquals("com.example.ReviewDecision", descriptor.outputType());
+        assertEquals(Duration.ofMinutes(10), descriptor.timeout());
+        assertEquals("interactionId", descriptor.correlationStrategy());
+        assertEquals("webhook", descriptor.transportType());
+        assertEquals("https://example.com", descriptor.transportConfig().get("url"));
+        assertEquals(List.of("orderId", "customerId"), descriptor.idempotencyKeyFields());
+    }
+
+    @Test
+    void defaultsCorrelationStrategyToInteractionIdWhenNull() {
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), null, "webhook", null, null);
+
+        assertEquals("interactionId", descriptor.correlationStrategy());
+    }
+
+    @Test
+    void defaultsCorrelationStrategyToInteractionIdWhenBlank() {
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "  ", "webhook", null, null);
+
+        assertEquals("interactionId", descriptor.correlationStrategy());
+    }
+
+    @Test
+    void normalizesNullTransportConfigToEmptyMap() {
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, null);
+
+        assertEquals(Map.of(), descriptor.transportConfig());
+    }
+
+    @Test
+    void makesImmutableCopyOfTransportConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("url", "https://example.com");
+
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", config, null);
+
+        config.put("extra", "value"); // mutate original
+        assertEquals(1, descriptor.transportConfig().size());
+        assertThrows(UnsupportedOperationException.class, () -> descriptor.transportConfig().put("k", "v"));
+    }
+
+    @Test
+    void normalizesNullIdempotencyKeyFieldsToEmptyList() {
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, null);
+
+        assertEquals(List.of(), descriptor.idempotencyKeyFields());
+    }
+
+    @Test
+    void makesImmutableCopyOfIdempotencyKeyFields() {
+        List<String> fields = new ArrayList<>();
+        fields.add("orderId");
+
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "review-step", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, fields);
+
+        fields.add("customerId"); // mutate original
+        assertEquals(1, descriptor.idempotencyKeyFields().size());
+        assertThrows(UnsupportedOperationException.class, () -> descriptor.idempotencyKeyFields().add("x"));
+    }
+
+    @Test
+    void rejectsBlankStepId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "  ", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsNullStepId() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            null, "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsBlankInputType() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsBlankOutputType() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "com.example.Input", "  ",
+            Duration.ofMinutes(5), "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsNullTimeout() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "com.example.Input", "com.example.Output",
+            null, "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsNegativeTimeout() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(-1), "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsZeroDurationTimeout() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "com.example.Input", "com.example.Output",
+            Duration.ZERO, "interactionId", "webhook", null, null));
+    }
+
+    @Test
+    void rejectsBlankTransportType() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", "", null, null));
+    }
+
+    @Test
+    void rejectsNullTransportType() {
+        assertThrows(IllegalArgumentException.class, () -> new AwaitStepDescriptor(
+            "step-id", "com.example.Input", "com.example.Output",
+            Duration.ofMinutes(5), "interactionId", null, null, null));
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -52,6 +52,47 @@ class AwaitStepSupportTest {
         assertTrue(error.getMessage().contains("without queue-async execution context"));
     }
 
+    @Test
+    void awaitOneToOneDelegatesInQueueAsyncMode() {
+        AwaitStepSupport support = support();
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        AwaitExecutionContext context = new AwaitExecutionContext("tenant1", "exec123", 0);
+        AwaitExecutionContextHolder.set(context);
+
+        AwaitStepDescriptor testDescriptor = descriptor();
+        AwaitInteractionRecord mockRecord = new AwaitInteractionRecord(
+            "tenant1", "exec123", "review", 0, String.class.getName(),
+            "interaction-id", "correlation-id", "causation-id", "idem-key",
+            0L, org.pipelineframework.awaitable.AwaitInteractionStatus.WAITING,
+            "input", "output", null, null, null, "interaction-api",
+            Map.of(), System.currentTimeMillis() + 300000, System.currentTimeMillis(),
+            System.currentTimeMillis(), System.currentTimeMillis() + 86400);
+        AwaitCreateResult mockCreateResult = new AwaitCreateResult(mockRecord, false);
+
+        when(awaitCoordinator.createOrGet(
+            org.mockito.ArgumentMatchers.eq(testDescriptor),
+            org.mockito.ArgumentMatchers.eq("tenant1"),
+            org.mockito.ArgumentMatchers.eq("exec123"),
+            org.mockito.ArgumentMatchers.eq(0),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.eq("input"),
+            org.mockito.ArgumentMatchers.isNull(),
+            org.mockito.ArgumentMatchers.isNull()))
+            .thenReturn(io.smallrye.mutiny.Uni.createFrom().item(mockCreateResult));
+
+        String result = support.awaitOneToOne(testDescriptor, "input").await().indefinitely();
+
+        org.mockito.Mockito.verify(awaitCoordinator).createOrGet(
+            org.mockito.ArgumentMatchers.eq(testDescriptor),
+            org.mockito.ArgumentMatchers.eq("tenant1"),
+            org.mockito.ArgumentMatchers.eq("exec123"),
+            org.mockito.ArgumentMatchers.eq(0),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.eq("input"),
+            org.mockito.ArgumentMatchers.isNull(),
+            org.mockito.ArgumentMatchers.isNull());
+    }
+
     private AwaitStepSupport support() {
         AwaitStepSupport support = new AwaitStepSupport();
         support.orchestratorConfig = orchestratorConfig;

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -80,7 +80,7 @@ class AwaitStepSupportTest {
             org.mockito.ArgumentMatchers.isNull()))
             .thenReturn(io.smallrye.mutiny.Uni.createFrom().item(mockCreateResult));
 
-        String result = support.awaitOneToOne(testDescriptor, "input").await().indefinitely();
+        support.awaitOneToOne(testDescriptor, "input").await().indefinitely();
 
         org.mockito.Mockito.verify(awaitCoordinator).createOrGet(
             org.mockito.ArgumentMatchers.eq(testDescriptor),

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -79,8 +79,11 @@ class AwaitStepSupportTest {
             org.mockito.ArgumentMatchers.isNull(),
             org.mockito.ArgumentMatchers.isNull()))
             .thenReturn(io.smallrye.mutiny.Uni.createFrom().item(mockCreateResult));
+        when(awaitCoordinator.dispatch(testDescriptor, mockRecord))
+            .thenReturn(io.smallrye.mutiny.Uni.createFrom().item(mockRecord));
 
-        support.awaitOneToOne(testDescriptor, "input").await().indefinitely();
+        assertThrows(AwaitSuspendedException.class,
+            () -> support.awaitOneToOne(testDescriptor, "input").await().indefinitely());
 
         org.mockito.Mockito.verify(awaitCoordinator).createOrGet(
             org.mockito.ArgumentMatchers.eq(testDescriptor),
@@ -91,6 +94,7 @@ class AwaitStepSupportTest {
             org.mockito.ArgumentMatchers.eq("input"),
             org.mockito.ArgumentMatchers.isNull(),
             org.mockito.ArgumentMatchers.isNull());
+        org.mockito.Mockito.verify(awaitCoordinator).dispatch(testDescriptor, mockRecord);
     }
 
     private AwaitStepSupport support() {

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -1,0 +1,73 @@
+package org.pipelineframework.awaitable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AwaitStepSupportTest {
+
+    @Mock
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    @Mock
+    AwaitCoordinator awaitCoordinator;
+
+    @AfterEach
+    void clearContext() {
+        AwaitExecutionContextHolder.clear();
+    }
+
+    @Test
+    void awaitOneToOneFailsOutsideQueueAsyncMode() {
+        AwaitStepSupport support = support();
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> support.awaitOneToOne(descriptor(), "input").await().indefinitely());
+
+        assertTrue(error.getMessage().contains("pipeline.orchestrator.mode=QUEUE_ASYNC"));
+    }
+
+    @Test
+    void awaitOneToOneFailsWithoutExecutionContext() {
+        AwaitStepSupport support = support();
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> support.awaitOneToOne(descriptor(), "input").await().indefinitely());
+
+        assertTrue(error.getMessage().contains("without queue-async execution context"));
+    }
+
+    private AwaitStepSupport support() {
+        AwaitStepSupport support = new AwaitStepSupport();
+        support.orchestratorConfig = orchestratorConfig;
+        support.awaitCoordinator = awaitCoordinator;
+        return support;
+    }
+
+    private AwaitStepDescriptor descriptor() {
+        return new AwaitStepDescriptor(
+            "review",
+            String.class.getName(),
+            String.class.getName(),
+            Duration.ofMinutes(5),
+            "interactionId",
+            "interaction-api",
+            Map.of(),
+            List.of());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitSuspendedExceptionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitSuspendedExceptionTest.java
@@ -1,0 +1,58 @@
+package org.pipelineframework.awaitable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwaitSuspendedExceptionTest {
+
+    @Test
+    void constructsWithAllFields() {
+        AwaitSuspendedException ex = new AwaitSuspendedException(
+            "tenant1", "exec-123", "interaction-456", 3);
+
+        assertEquals("tenant1", ex.tenantId());
+        assertEquals("exec-123", ex.executionId());
+        assertEquals("interaction-456", ex.interactionId());
+        assertEquals(3, ex.stepIndex());
+    }
+
+    @Test
+    void messageContainsInteractionId() {
+        AwaitSuspendedException ex = new AwaitSuspendedException(
+            "tenant1", "exec-123", "interaction-abc", 0);
+
+        assertTrue(ex.getMessage().contains("interaction-abc"),
+            "Expected message to contain interaction id but was: " + ex.getMessage());
+    }
+
+    @Test
+    void isRuntimeException() {
+        AwaitSuspendedException ex = new AwaitSuspendedException(
+            "tenant1", "exec-123", "interaction-456", 0);
+
+        assertTrue(ex instanceof RuntimeException);
+    }
+
+    @Test
+    void stepIndexZeroIsValid() {
+        AwaitSuspendedException ex = new AwaitSuspendedException(
+            "tenant1", "exec-123", "interaction-456", 0);
+
+        assertEquals(0, ex.stepIndex());
+    }
+
+    @Test
+    void preservesAllFieldsIndependently() {
+        AwaitSuspendedException ex1 = new AwaitSuspendedException("t1", "e1", "i1", 1);
+        AwaitSuspendedException ex2 = new AwaitSuspendedException("t2", "e2", "i2", 2);
+
+        assertEquals("t1", ex1.tenantId());
+        assertEquals("t2", ex2.tenantId());
+        assertEquals("i1", ex1.interactionId());
+        assertEquals("i2", ex2.interactionId());
+        assertEquals(1, ex1.stepIndex());
+        assertEquals(2, ex2.stepIndex());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
@@ -403,7 +403,7 @@ class InMemoryAwaitInteractionStoreTest {
     private AwaitCreateCommand createCommand(String idempotencyKey, long nowEpochMs, long deadlineEpochMs) {
         return new AwaitCreateCommand(
             "tenant",
-
+            "execution-1",
             "review",
             "execution-1",
             idempotencyKey,

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
@@ -349,7 +349,7 @@ class InMemoryAwaitInteractionStoreTest {
     void completionThrowsWhenNoMatchFound() {
         InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
 
-        assertThrows(Exception.class, () -> store.complete(new AwaitCompletionCommand(
+        assertThrows(IllegalArgumentException.class, () -> store.complete(new AwaitCompletionCommand(
             "tenant", "nonexistent-id", null, "completion-1", null, null, 12_000L))
             .await().indefinitely());
     }
@@ -362,7 +362,7 @@ class InMemoryAwaitInteractionStoreTest {
         store.cancel("tenant", created.record().interactionId(), 0L, "cancelled", 15_000L)
             .await().indefinitely();
 
-        assertThrows(Exception.class, () -> store.complete(new AwaitCompletionCommand(
+        assertThrows(IllegalStateException.class, () -> store.complete(new AwaitCompletionCommand(
             "tenant", created.record().interactionId(), null, "completion-1", "result", "alice", 16_000L))
             .await().indefinitely());
     }

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
@@ -1,0 +1,144 @@
+package org.pipelineframework.awaitable.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCreateCommand;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+
+class InMemoryAwaitInteractionStoreTest {
+
+    @Test
+    void createOrGetDeduplicatesActiveInteractionByIdempotencyKey() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        AwaitCreateCommand command = createCommand("idem-1", 10_000L, 70_000L);
+
+        var first = store.createOrGet(command).await().indefinitely();
+        var duplicate = store.createOrGet(command).await().indefinitely();
+
+        assertFalse(first.duplicate());
+        assertTrue(duplicate.duplicate());
+        assertEquals(first.record().interactionId(), duplicate.record().interactionId());
+        assertEquals(AwaitInteractionStatus.WAITING, first.record().status());
+    }
+
+    @Test
+    void markDispatchedUsesOptimisticVersion() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+
+        var stale = store.markDispatched(
+            "tenant",
+            created.record().interactionId(),
+            99L,
+            Map.of("messageId", "m-1"),
+            11_000L).await().indefinitely();
+        var updated = store.markDispatched(
+            "tenant",
+            created.record().interactionId(),
+            created.record().version(),
+            Map.of("messageId", "m-1"),
+            11_000L).await().indefinitely();
+
+        assertTrue(stale.isEmpty());
+        assertTrue(updated.isPresent());
+        assertEquals(AwaitInteractionStatus.DISPATCHED, updated.get().status());
+        assertEquals("m-1", updated.get().transportMetadata().get("messageId"));
+    }
+
+    @Test
+    void completionCanResolveByCorrelationAndIsIdempotent() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+
+        var completed = store.complete(new AwaitCompletionCommand(
+            "tenant",
+            null,
+            created.record().correlationId(),
+            "completion-1",
+            Map.of("decision", "approved"),
+            "alice",
+            12_000L)).await().indefinitely();
+        var duplicate = store.complete(new AwaitCompletionCommand(
+            "tenant",
+            created.record().interactionId(),
+            null,
+            "completion-1",
+            Map.of("decision", "approved"),
+            "alice",
+            13_000L)).await().indefinitely();
+
+        assertFalse(completed.duplicate());
+        assertTrue(duplicate.duplicate());
+        assertEquals(AwaitInteractionStatus.COMPLETED, completed.record().status());
+        assertEquals("alice", completed.record().actor());
+    }
+
+    @Test
+    void completionAfterDeadlineMarksTimedOutAndFails() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 20_000L)).await().indefinitely();
+
+        assertThrows(IllegalStateException.class, () -> store.complete(new AwaitCompletionCommand(
+            "tenant",
+            created.record().interactionId(),
+            null,
+            "completion-1",
+            Map.of("decision", "approved"),
+            "alice",
+            21_000L)).await().indefinitely());
+
+        var stored = store.get("tenant", created.record().interactionId()).await().indefinitely().orElseThrow();
+        assertEquals(AwaitInteractionStatus.TIMED_OUT, stored.status());
+    }
+
+    @Test
+    void queryPendingFiltersByTenantAndAssignee() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        store.createOrGet(new AwaitCreateCommand(
+            "tenant",
+            "execution-2",
+            "review",
+            "execution-2",
+            "idem-2",
+            "corr-2",
+            Map.of("orderId", "o-2"),
+            "bob",
+            "finance",
+            "interaction-api",
+            10_000L,
+            70_000L,
+            Long.MAX_VALUE)).await().indefinitely();
+
+        var alice = store.queryPending("tenant", "alice", null, null, 10).await().indefinitely();
+        var finance = store.queryPending("tenant", null, "finance", null, 10).await().indefinitely();
+
+        assertEquals(1, alice.size());
+        assertEquals("alice", alice.getFirst().assignee());
+        assertEquals(2, finance.size());
+    }
+
+    private AwaitCreateCommand createCommand(String idempotencyKey, long nowEpochMs, long deadlineEpochMs) {
+        return new AwaitCreateCommand(
+            "tenant",
+            "execution-1",
+            "review",
+            "execution-1",
+            idempotencyKey,
+            "corr-1",
+            Map.of("orderId", "o-1"),
+            "alice",
+            "finance",
+            "interaction-api",
+            nowEpochMs,
+            deadlineEpochMs,
+            Long.MAX_VALUE);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
@@ -37,23 +37,54 @@ class InMemoryAwaitInteractionStoreTest {
         InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
         var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
 
-        var stale = store.markDispatched(
+        var stale = store.markDispatching(
             "tenant",
             created.record().interactionId(),
             99L,
-            Map.of("messageId", "m-1"),
+            11_000L).await().indefinitely();
+        var claimed = store.markDispatching(
+            "tenant",
+            created.record().interactionId(),
+            created.record().version(),
             11_000L).await().indefinitely();
         var updated = store.markDispatched(
             "tenant",
             created.record().interactionId(),
-            created.record().version(),
+            claimed.orElseThrow().version(),
             Map.of("messageId", "m-1"),
-            11_000L).await().indefinitely();
+            12_000L).await().indefinitely();
 
         assertTrue(stale.isEmpty());
+        assertTrue(claimed.isPresent());
+        assertEquals(AwaitInteractionStatus.DISPATCHING, claimed.get().status());
         assertTrue(updated.isPresent());
         assertEquals(AwaitInteractionStatus.DISPATCHED, updated.get().status());
         assertEquals("m-1", updated.get().transportMetadata().get("messageId"));
+    }
+
+    @Test
+    void dispatchedInteractionCannotBeClaimedAgain() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        var claimed = store.markDispatching(
+            "tenant",
+            created.record().interactionId(),
+            created.record().version(),
+            11_000L).await().indefinitely().orElseThrow();
+        var dispatched = store.markDispatched(
+            "tenant",
+            created.record().interactionId(),
+            claimed.version(),
+            Map.of("messageId", "m-1"),
+            12_000L).await().indefinitely().orElseThrow();
+
+        var duplicateClaim = store.markDispatching(
+            "tenant",
+            created.record().interactionId(),
+            dispatched.version(),
+            13_000L).await().indefinitely();
+
+        assertTrue(duplicateClaim.isEmpty());
     }
 
     @Test
@@ -392,12 +423,15 @@ class InMemoryAwaitInteractionStoreTest {
         var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
         assertEquals(0L, created.record().version());
 
+        var claimed = store.markDispatching(
+            "tenant", created.record().interactionId(), 0L, 11_000L)
+            .await().indefinitely().orElseThrow();
         var dispatched = store.markDispatched(
-            "tenant", created.record().interactionId(), 0L, Map.of(), 11_000L)
+            "tenant", created.record().interactionId(), claimed.version(), Map.of(), 12_000L)
             .await().indefinitely();
 
         assertTrue(dispatched.isPresent());
-        assertEquals(1L, dispatched.get().version());
+        assertEquals(2L, dispatched.get().version());
     }
 
     private AwaitCreateCommand createCommand(String idempotencyKey, long nowEpochMs, long deadlineEpochMs) {

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitInteractionStoreTest.java
@@ -2,14 +2,18 @@ package org.pipelineframework.awaitable.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
 import org.pipelineframework.awaitable.AwaitCreateCommand;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.awaitable.AwaitInteractionStatus;
 
 class InMemoryAwaitInteractionStoreTest {
@@ -125,10 +129,281 @@ class InMemoryAwaitInteractionStoreTest {
         assertEquals(2, finance.size());
     }
 
+    @Test
+    void getReturnsEmptyForUnknownInteractionId() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+
+        var result = store.get("tenant", "unknown-id").await().indefinitely();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getReturnsRecordAfterCreation() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+
+        var found = store.get("tenant", created.record().interactionId()).await().indefinitely();
+
+        assertTrue(found.isPresent());
+        assertEquals(created.record().interactionId(), found.get().interactionId());
+    }
+
+    @Test
+    void findByCorrelationReturnsEmptyForUnknownId() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+
+        var result = store.findByCorrelation("tenant", "unknown-corr").await().indefinitely();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findByCorrelationReturnsRecordAfterCreation() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        String correlationId = created.record().correlationId();
+
+        var found = store.findByCorrelation("tenant", correlationId).await().indefinitely();
+
+        assertTrue(found.isPresent());
+        assertEquals(created.record().interactionId(), found.get().interactionId());
+    }
+
+    @Test
+    void cancelTransitionsToTerminalState() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        String interactionId = created.record().interactionId();
+
+        var cancelled = store.cancel("tenant", interactionId, 0L, "user request", 15_000L)
+            .await().indefinitely();
+
+        assertTrue(cancelled.isPresent());
+        assertEquals(AwaitInteractionStatus.CANCELLED, cancelled.get().status());
+        assertTrue(cancelled.get().status().terminal());
+    }
+
+    @Test
+    void cancelWithWrongVersionReturnsEmpty() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+
+        var result = store.cancel("tenant", created.record().interactionId(), 999L, "reason", 15_000L)
+            .await().indefinitely();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void failTransitionsToFailedStatus() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        String interactionId = created.record().interactionId();
+
+        var failed = store.fail("tenant", interactionId, 0L, "transport error", 15_000L)
+            .await().indefinitely();
+
+        assertTrue(failed.isPresent());
+        assertEquals(AwaitInteractionStatus.FAILED, failed.get().status());
+    }
+
+    @Test
+    void markTimedOutTransitionsToTimedOutStatus() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        String interactionId = created.record().interactionId();
+
+        var timedOut = store.markTimedOut("tenant", interactionId, 0L, 71_000L)
+            .await().indefinitely();
+
+        assertTrue(timedOut.isPresent());
+        assertEquals(AwaitInteractionStatus.TIMED_OUT, timedOut.get().status());
+    }
+
+    @Test
+    void transitionOnTerminalInteractionReturnsEmpty() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        String interactionId = created.record().interactionId();
+
+        // First cancel
+        store.cancel("tenant", interactionId, 0L, "user request", 15_000L).await().indefinitely();
+        // Attempting to cancel again should return empty since it's terminal
+        var result = store.cancel("tenant", interactionId, 1L, "again", 16_000L).await().indefinitely();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findTimedOutReturnsOnlyExpiredNonTerminal() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        // Create one that will be expired
+        store.createOrGet(createCommand("idem-1", 10_000L, 20_000L)).await().indefinitely();
+        // Create one that won't expire
+        store.createOrGet(new AwaitCreateCommand(
+            "tenant", "execution-2", "review",
+            "execution-2", "idem-2", "corr-2",
+            Map.of(), null, null, "interaction-api",
+            10_000L, 80_000L, Long.MAX_VALUE)).await().indefinitely();
+
+        var timedOut = store.findTimedOut(21_000L, 10).await().indefinitely();
+
+        assertEquals(1, timedOut.size());
+        assertEquals("idem-1", timedOut.getFirst().idempotencyKey());
+    }
+
+    @Test
+    void findTimedOutRespectsLimit() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        // Create multiple expired interactions
+        for (int i = 0; i < 5; i++) {
+            store.createOrGet(new AwaitCreateCommand(
+                "tenant", "execution-" + i, "review",
+                "exec-" + i, "idem-" + i, "corr-" + i,
+                Map.of(), null, null, "interaction-api",
+                10_000L, 20_000L, Long.MAX_VALUE)).await().indefinitely();
+        }
+
+        var timedOut = store.findTimedOut(21_000L, 3).await().indefinitely();
+
+        assertEquals(3, timedOut.size());
+    }
+
+    @Test
+    void queryPendingFiltersByStepId() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        store.createOrGet(new AwaitCreateCommand(
+            "tenant", "execution-2", "fraud-check",
+            "execution-2", "idem-2", "corr-2",
+            Map.of(), "alice", "finance", "interaction-api",
+            10_000L, 70_000L, Long.MAX_VALUE)).await().indefinitely();
+
+        var reviewSteps = store.queryPending("tenant", null, null, "review", 10).await().indefinitely();
+        var fraudSteps = store.queryPending("tenant", null, null, "fraud-check", 10).await().indefinitely();
+
+        assertEquals(1, reviewSteps.size());
+        assertEquals("review", reviewSteps.getFirst().stepId());
+        assertEquals(1, fraudSteps.size());
+        assertEquals("fraud-check", fraudSteps.getFirst().stepId());
+    }
+
+    @Test
+    void queryPendingExcludesTerminalInteractions() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        // Complete the interaction
+        store.complete(new AwaitCompletionCommand(
+            "tenant", created.record().interactionId(), null, "completion-1", "result", "alice", 15_000L))
+            .await().indefinitely();
+
+        var pending = store.queryPending("tenant", null, null, null, 10).await().indefinitely();
+
+        assertTrue(pending.isEmpty());
+    }
+
+    @Test
+    void queryPendingExcludesDifferentTenant() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+
+        var otherTenant = store.queryPending("other-tenant", null, null, null, 10).await().indefinitely();
+        var sameTenant = store.queryPending("tenant", null, null, null, 10).await().indefinitely();
+
+        assertTrue(otherTenant.isEmpty());
+        assertEquals(1, sameTenant.size());
+    }
+
+    @Test
+    void providerNameIsMemory() {
+        assertEquals("memory", new InMemoryAwaitInteractionStore().providerName());
+    }
+
+    @Test
+    void priorityIsNegative() {
+        assertTrue(new InMemoryAwaitInteractionStore().priority() < 0);
+    }
+
+    @Test
+    void completionCanResolveByInteractionId() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+
+        var completed = store.complete(new AwaitCompletionCommand(
+            "tenant",
+            created.record().interactionId(),
+            null,
+            "completion-1",
+            "result-payload",
+            "charlie",
+            12_000L)).await().indefinitely();
+
+        assertFalse(completed.duplicate());
+        assertEquals(AwaitInteractionStatus.COMPLETED, completed.record().status());
+        assertEquals("result-payload", completed.record().responsePayload());
+        assertEquals("charlie", completed.record().actor());
+    }
+
+    @Test
+    void completionThrowsWhenNoMatchFound() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+
+        assertThrows(Exception.class, () -> store.complete(new AwaitCompletionCommand(
+            "tenant", "nonexistent-id", null, "completion-1", null, null, 12_000L))
+            .await().indefinitely());
+    }
+
+    @Test
+    void completionThrowsForOtherTerminalStates() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        // Cancel to put in terminal state
+        store.cancel("tenant", created.record().interactionId(), 0L, "cancelled", 15_000L)
+            .await().indefinitely();
+
+        assertThrows(Exception.class, () -> store.complete(new AwaitCompletionCommand(
+            "tenant", created.record().interactionId(), null, "completion-1", "result", "alice", 16_000L))
+            .await().indefinitely());
+    }
+
+    @Test
+    void createsNewInteractionAfterTerminalDeduplication() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        AwaitCreateCommand command = createCommand("idem-1", 10_000L, 70_000L);
+        var first = store.createOrGet(command).await().indefinitely();
+
+        // Complete the first interaction
+        store.complete(new AwaitCompletionCommand(
+            "tenant", first.record().interactionId(), null, "completion-1", "result", "alice", 15_000L))
+            .await().indefinitely();
+
+        // Create new one with same idempotency key - completed state is terminal, so new record is created
+        var second = store.createOrGet(command).await().indefinitely();
+
+        assertFalse(second.duplicate());
+        // A new interaction id should be generated
+        assertNotNull(second.record().interactionId());
+    }
+
+    @Test
+    void versionIncrementsOnMarkDispatched() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        var created = store.createOrGet(createCommand("idem-1", 10_000L, 70_000L)).await().indefinitely();
+        assertEquals(0L, created.record().version());
+
+        var dispatched = store.markDispatched(
+            "tenant", created.record().interactionId(), 0L, Map.of(), 11_000L)
+            .await().indefinitely();
+
+        assertTrue(dispatched.isPresent());
+        assertEquals(1L, dispatched.get().version());
+    }
+
     private AwaitCreateCommand createCommand(String idempotencyKey, long nowEpochMs, long deadlineEpochMs) {
         return new AwaitCreateCommand(
             "tenant",
-            "execution-1",
+
             "review",
             "execution-1",
             idempotencyKey,

--- a/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
@@ -61,6 +61,42 @@ class PipelineYamlConfigLoaderTest {
     }
 
     @Test
+    void loadsAwaitStepConfiguration() {
+        PipelineYamlConfig config = new PipelineYamlConfigLoader().load(new StringReader("""
+            basePackage: "com.example"
+            transport: "GRPC"
+            platform: "COMPUTE"
+            steps:
+              - name: "Fraud Check"
+                kind: "await"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "com.example.FraudCheckRequest"
+                outputTypeName: "com.example.FraudCheckDecision"
+                timeout: "PT10M"
+                idempotencyKeyFields: ["orderId"]
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "webhook"
+                    dispatch:
+                      url: "https://partner.example/check"
+                    completion:
+                      path: "/pipeline/await/fraud-check/complete"
+            """));
+
+        PipelineYamlStep step = config.steps().getFirst();
+        assertEquals("await", step.kind());
+        assertEquals("ONE_TO_ONE", step.cardinality());
+        assertEquals("PT10M", step.timeout());
+        assertEquals(List.of("orderId"), step.idempotencyKeyFields());
+        assertNotNull(step.awaitConfig());
+        assertEquals("interactionId", step.awaitConfig().correlation().strategy());
+        assertEquals("webhook", step.awaitConfig().transport().type());
+        assertNotNull(step.awaitConfig().transport().config().get("dispatch"));
+    }
+
+    @Test
     void rejectsLegacyConnectorSection() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new PipelineYamlConfigLoader().load(new StringReader("""

--- a/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
@@ -94,6 +94,7 @@ class PipelineYamlConfigLoaderTest {
         assertEquals("interactionId", step.awaitConfig().correlation().strategy());
         assertEquals("webhook", step.awaitConfig().transport().type());
         assertNotNull(step.awaitConfig().transport().config().get("dispatch"));
+        assertNotNull(step.awaitConfig().transport().config().get("completion"));
     }
 
     @Test


### PR DESCRIPTION
## Scope
- Adds the compile-time `kind: await` YAML model for one-to-one await steps.
- Adds await step validation, model extraction, target resolution, pipeline order metadata handling, and generated await client step rendering.
- Adds the await runtime foundation: descriptors, context holder, support guardrails, transport/store SPIs, interaction-api adapter, and in-memory interaction store.

## Out of scope
- Queue-async suspend/resume wiring.
- Dynamo await persistence.
- REST/gRPC completion/query endpoints.
- CSV mock-provider migration and broker/webhook adapters.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime,deployment -Dtest=PipelineYamlConfigLoaderTest,InMemoryAwaitInteractionStoreTest,AwaitStepSupportTest,StepDefinitionParserTest,AwaitClientStepRendererTest test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class "await" steps for durable async interactions with configurable timeout, correlation strategy and idempotency; generated await-client step artefacts and client renderer.
  * New runtime APIs and types to create, dispatch, complete and query await interactions, suspend/resume queue-async execution, a pluggable transport-adapter and store SPI, and an in-memory store implementation for development.

* **Tests**
  * Extensive unit tests covering YAML parsing, model/generation, renderer output, runtime semantics, transport adapters and in-memory store behaviour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->