### PR TITLE
Add durable await queue resume path

### DIFF
--- a/docs/guide/build/configuration/index.md
+++ b/docs/guide/build/configuration/index.md
@@ -206,6 +206,8 @@ Prefix: `pipeline.orchestrator`
 | `pipeline.orchestrator.queue-url` | string | none | Queue URL for external dispatcher providers. |
 | `pipeline.orchestrator.dynamo.execution-table` | string | `tpf_execution` | DynamoDB table used for execution state rows. |
 | `pipeline.orchestrator.dynamo.execution-key-table` | string | `tpf_execution_key` | DynamoDB table used for submit dedupe keys. |
+| `pipeline.orchestrator.dynamo.await-interaction-table` | string | `tpf_await_interaction` | DynamoDB table used for durable await interaction rows. |
+| `pipeline.orchestrator.dynamo.await-interaction-key-table` | string | `tpf_await_interaction_key` | DynamoDB table used for await idempotency and correlation lookup keys. |
 | `pipeline.orchestrator.dynamo.region` | string | none | Optional DynamoDB region override. |
 | `pipeline.orchestrator.dynamo.endpoint-override` | string | none | Optional DynamoDB endpoint override (local/dev). |
 | `pipeline.orchestrator.sqs.region` | string | none | Optional SQS region override. |

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -31,6 +31,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         OrchestratorRpcConstants.GET_EXECUTION_STATUS_METHOD;
     private static final String ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD =
         OrchestratorRpcConstants.GET_EXECUTION_RESULT_METHOD;
+    private static final String ORCHESTRATOR_COMPLETE_AWAIT_METHOD =
+        OrchestratorRpcConstants.COMPLETE_AWAIT_METHOD;
+    private static final String ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD =
+        OrchestratorRpcConstants.LIST_PENDING_AWAIT_METHOD;
     private static final String ORCHESTRATOR_INGEST_METHOD = OrchestratorRpcConstants.INGEST_METHOD;
     private static final String ORCHESTRATOR_SUBSCRIBE_METHOD = OrchestratorRpcConstants.SUBSCRIBE_METHOD;
 
@@ -98,6 +102,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             binding, descriptorSet, ctx, ORCHESTRATOR_GET_EXECUTION_STATUS_METHOD, false, false);
         var resultBinding = safeResolveBinding(
             binding, descriptorSet, ctx, ORCHESTRATOR_GET_EXECUTION_RESULT_METHOD, false, false);
+        var completeAwaitBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_COMPLETE_AWAIT_METHOD, false, false);
+        var listPendingAwaitBinding = safeResolveBinding(
+            binding, descriptorSet, ctx, ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD, false, false);
 
         FieldSpec executionField = FieldSpec.builder(executionService, "pipelineExecutionService", Modifier.PRIVATE)
             .addAnnotation(inject)
@@ -280,6 +288,8 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             resultBinding,
             outputType,
             uni);
+        MethodSpec completeAwaitMethod = buildCompleteAwaitMethod(typeResolver, ctx, completeAwaitBinding, uni);
+        MethodSpec listPendingAwaitMethod = buildListPendingAwaitMethod(typeResolver, ctx, listPendingAwaitBinding, uni);
 
         TypeSpec.Builder serviceBuilder = TypeSpec.classBuilder(GRPC_CLASS)
             .addModifiers(Modifier.PUBLIC)
@@ -298,6 +308,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         }
         if (executionResultMethod != null) {
             serviceBuilder.addMethod(executionResultMethod);
+        }
+        if (completeAwaitMethod != null) {
+            serviceBuilder.addMethod(completeAwaitMethod);
+        }
+        if (listPendingAwaitMethod != null) {
+            serviceBuilder.addMethod(listPendingAwaitMethod);
         }
 
         TypeSpec service = serviceBuilder.build();
@@ -616,5 +632,124 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 ClassName.get("io.grpc", "Status"));
         }
         return method.build();
+    }
+
+    private MethodSpec buildCompleteAwaitMethod(
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding completeAwaitBinding,
+        ClassName uni
+    ) {
+        if (completeAwaitBinding == null) {
+            return null;
+        }
+        var types = typeResolver.resolve(completeAwaitBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = types.grpcParameterType();
+        ClassName responseType = types.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+        ClassName command = ClassName.get("org.pipelineframework.awaitable", "AwaitCompletionCommand");
+        return MethodSpec.methodBuilder("completeAwait")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()")
+            .addCode("""
+                return pipelineExecutionService.completeAwaitInteraction(new $T(
+                        request.getTenantId(),
+                        request.getInteractionId(),
+                        request.getCorrelationId(),
+                        request.getIdempotencyKey(),
+                        request.getResponseJson(),
+                        request.getActor(),
+                        $T.currentTimeMillis()))
+                    .onItem().transform(result -> $T.newBuilder()
+                        .setInteractionId(result.record().interactionId())
+                        .setExecutionId(result.record().executionId())
+                        .setStepId(result.record().stepId())
+                        .setStatus(result.record().status().name())
+                        .setDuplicate(result.duplicate())
+                        .build())
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                command,
+                System.class,
+                responseType,
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_COMPLETE_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_COMPLETE_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"))
+            .build();
+    }
+
+    private MethodSpec buildListPendingAwaitMethod(
+        GrpcJavaTypeResolver typeResolver,
+        GenerationContext ctx,
+        org.pipelineframework.processor.ir.GrpcBinding listPendingAwaitBinding,
+        ClassName uni
+    ) {
+        if (listPendingAwaitBinding == null) {
+            return null;
+        }
+        var types = typeResolver.resolve(listPendingAwaitBinding, ctx.processingEnv().getMessager());
+        ClassName requestType = types.grpcParameterType();
+        ClassName responseType = types.grpcReturnType();
+        if (requestType == null || responseType == null) {
+            return null;
+        }
+        return MethodSpec.methodBuilder("listPendingAwait")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(uni, responseType))
+            .addParameter(requestType, "request")
+            .addStatement("long startTime = System.nanoTime()")
+            .addCode("""
+                return pipelineExecutionService.queryPendingAwaitInteractions(
+                        request.getTenantId(),
+                        request.getAssignee(),
+                        request.getGroup(),
+                        request.getStepId(),
+                        request.getLimit())
+                    .onItem().transform(records -> {
+                        $T.Builder builder = $T.newBuilder();
+                        for (var record : records) {
+                            builder.addInteractionsBuilder()
+                                .setInteractionId(record.interactionId())
+                                .setCorrelationId(record.correlationId())
+                                .setExecutionId(record.executionId())
+                                .setStepId(record.stepId())
+                                .setStepIndex(record.stepIndex())
+                                .setOutputType(record.outputType())
+                                .setStatus(record.status().name())
+                                .setTransportType(record.transportType())
+                                .setDeadlineEpochMs(record.deadlineEpochMs())
+                                .setCreatedAtEpochMs(record.createdAtEpochMs())
+                                .setUpdatedAtEpochMs(record.updatedAtEpochMs());
+                        }
+                        return builder.build();
+                    })
+                    .onItem().invoke(item -> $T.recordGrpcServer($S, $S, $T.OK, System.nanoTime() - startTime))
+                    .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
+                        System.nanoTime() - startTime));
+                """,
+                responseType,
+                responseType,
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"),
+                ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),
+                ORCHESTRATOR_SERVICE,
+                ORCHESTRATOR_LIST_PENDING_AWAIT_METHOD,
+                ClassName.get("io.grpc", "Status"))
+            .build();
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -2,7 +2,13 @@ package org.pipelineframework.processor.renderer;
 
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
+import javax.tools.Diagnostic;
 
 import com.google.protobuf.DescriptorProtos;
 import com.squareup.javapoet.*;
@@ -82,7 +88,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         }
 
         GrpcJavaTypeResolver typeResolver = new GrpcJavaTypeResolver();
-        var grpcTypes = typeResolver.resolve(grpcBinding, ctx.processingEnv().getMessager());
+        var grpcTypes = typeResolver.resolve(grpcBinding, messager(ctx));
         ClassName inputType = grpcTypes.grpcParameterType();
         ClassName outputType = grpcTypes.grpcReturnType();
         if (inputType == null || outputType == null) {
@@ -338,12 +344,45 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                 methodName,
                 inputStreaming,
                 outputStreaming,
-                ctx.processingEnv().getMessager());
+                messager(ctx));
         } catch (IllegalStateException e) {
-            ctx.processingEnv().getMessager().printMessage(
-                javax.tools.Diagnostic.Kind.WARNING,
+            messager(ctx).printMessage(
+                Diagnostic.Kind.WARNING,
                 "Skipping orchestrator gRPC generation: " + e.getMessage());
             return null;
+        }
+    }
+
+    private Messager messager(GenerationContext ctx) {
+        ProcessingEnvironment processingEnv = ctx.processingEnv();
+        if (processingEnv == null || processingEnv.getMessager() == null) {
+            return NoopMessager.INSTANCE;
+        }
+        return processingEnv.getMessager();
+    }
+
+    private enum NoopMessager implements Messager {
+        INSTANCE;
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence msg) {
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e) {
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a) {
+        }
+
+        @Override
+        public void printMessage(
+            Diagnostic.Kind kind,
+            CharSequence msg,
+            Element e,
+            AnnotationMirror a,
+            AnnotationValue v) {
         }
     }
 
@@ -374,7 +413,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (runAsyncBinding == null) {
             return null;
         }
-        var asyncTypes = typeResolver.resolve(runAsyncBinding, ctx.processingEnv().getMessager());
+        var asyncTypes = typeResolver.resolve(runAsyncBinding, messager(ctx));
         ClassName requestType = asyncTypes.grpcParameterType();
         ClassName responseType = asyncTypes.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -485,7 +524,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (statusBinding == null) {
             return null;
         }
-        var statusTypes = typeResolver.resolve(statusBinding, ctx.processingEnv().getMessager());
+        var statusTypes = typeResolver.resolve(statusBinding, messager(ctx));
         ClassName requestType = statusTypes.grpcParameterType();
         ClassName responseType = statusTypes.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -562,7 +601,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (resultBinding == null) {
             return null;
         }
-        var resultTypes = typeResolver.resolve(resultBinding, ctx.processingEnv().getMessager());
+        var resultTypes = typeResolver.resolve(resultBinding, messager(ctx));
         ClassName requestType = resultTypes.grpcParameterType();
         ClassName responseType = resultTypes.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -643,7 +682,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (completeAwaitBinding == null) {
             return null;
         }
-        var types = typeResolver.resolve(completeAwaitBinding, ctx.processingEnv().getMessager());
+        var types = typeResolver.resolve(completeAwaitBinding, messager(ctx));
         ClassName requestType = types.grpcParameterType();
         ClassName responseType = types.grpcReturnType();
         if (requestType == null || responseType == null) {
@@ -699,7 +738,7 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
         if (listPendingAwaitBinding == null) {
             return null;
         }
-        var types = typeResolver.resolve(listPendingAwaitBinding, ctx.processingEnv().getMessager());
+        var types = typeResolver.resolve(listPendingAwaitBinding, messager(ctx));
         ClassName requestType = types.grpcParameterType();
         ClassName responseType = types.grpcReturnType();
         if (requestType == null || responseType == null) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -356,12 +356,12 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
     private Messager messager(GenerationContext ctx) {
         ProcessingEnvironment processingEnv = ctx.processingEnv();
         if (processingEnv == null || processingEnv.getMessager() == null) {
-            return NoopMessager.INSTANCE;
+            return StderrMessager.INSTANCE;
         }
         return processingEnv.getMessager();
     }
 
-    private enum NoopMessager implements Messager {
+    private enum StderrMessager implements Messager {
         INSTANCE;
 
         @Override
@@ -717,6 +717,17 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .addParameter(requestType, "request")
             .addStatement("long startTime = System.nanoTime()")
             .addCode("""
+                if (request.getTenantId() == null || request.getTenantId().isBlank()) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("tenantId is required")
+                        .asRuntimeException());
+                }
+                if ((request.getInteractionId() == null || request.getInteractionId().isBlank())
+                        && (request.getCorrelationId() == null || request.getCorrelationId().isBlank())) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("interactionId or correlationId is required")
+                        .asRuntimeException());
+                }
                 return pipelineExecutionService.completeAwaitInteraction(new $T(
                         request.getTenantId(),
                         request.getInteractionId(),
@@ -736,6 +747,10 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                     .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
                         System.nanoTime() - startTime));
                 """,
+                uni,
+                ClassName.get("io.grpc", "Status"),
+                uni,
+                ClassName.get("io.grpc", "Status"),
                 command,
                 System.class,
                 responseType,
@@ -772,12 +787,23 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             .addParameter(requestType, "request")
             .addStatement("long startTime = System.nanoTime()")
             .addCode("""
+                if (request.getTenantId() == null || request.getTenantId().isBlank()) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("tenantId is required")
+                        .asRuntimeException());
+                }
+                if (request.getLimit() < 0) {
+                    return $T.createFrom().failure($T.INVALID_ARGUMENT
+                        .withDescription("limit must be >= 0")
+                        .asRuntimeException());
+                }
+                int validatedLimit = request.getLimit() == 0 ? 50 : $T.min(request.getLimit(), 500);
                 return pipelineExecutionService.queryPendingAwaitInteractions(
                         request.getTenantId(),
                         request.getAssignee(),
                         request.getGroup(),
                         request.getStepId(),
-                        request.getLimit())
+                        validatedLimit)
                     .onItem().transform(records -> {
                         $T.Builder builder = $T.newBuilder();
                         for (var record : records) {
@@ -800,6 +826,11 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
                     .onFailure().invoke(failure -> $T.recordGrpcServer($S, $S, $T.fromThrowable(failure),
                         System.nanoTime() - startTime));
                 """,
+                uni,
+                ClassName.get("io.grpc", "Status"),
+                uni,
+                ClassName.get("io.grpc", "Status"),
+                Math.class,
                 responseType,
                 responseType,
                 ClassName.get("org.pipelineframework.telemetry", "RpcMetrics"),

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorGrpcRenderer.java
@@ -366,14 +366,17 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
 
         @Override
         public void printMessage(Diagnostic.Kind kind, CharSequence msg) {
+            print(kind, msg, null, null, null);
         }
 
         @Override
         public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e) {
+            print(kind, msg, e, null, null);
         }
 
         @Override
         public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a) {
+            print(kind, msg, e, a, null);
         }
 
         @Override
@@ -383,6 +386,24 @@ public class OrchestratorGrpcRenderer implements PipelineRenderer<OrchestratorBi
             Element e,
             AnnotationMirror a,
             AnnotationValue v) {
+            print(kind, msg, e, a, v);
+        }
+
+        private void print(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a, AnnotationValue v) {
+            StringBuilder line = new StringBuilder("OrchestratorGrpcRenderer diagnostic [")
+                .append(kind)
+                .append("] ")
+                .append(msg);
+            if (e != null) {
+                line.append(" element=").append(e);
+            }
+            if (a != null) {
+                line.append(" annotation=").append(a);
+            }
+            if (v != null) {
+                line.append(" value=").append(v);
+            }
+            System.err.println(line);
         }
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -214,6 +214,15 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
                     .addMember("value", "$S", "x-tenant-id")
                     .build())
                 .build())
+            .beginControlFlow("if (tenantId == null || tenantId.isBlank())")
+            .addStatement("throw new $T($S)", badRequestException, "tenantId header is required")
+            .endControlFlow()
+            .beginControlFlow("if (request == null)")
+            .addStatement("throw new $T($S)", badRequestException, "completion request is required")
+            .endControlFlow()
+            .beginControlFlow("if ((request.interactionId() == null || request.interactionId().isBlank()) && (request.correlationId() == null || request.correlationId().isBlank()))")
+            .addStatement("throw new $T($S)", badRequestException, "interactionId or correlationId is required")
+            .endControlFlow()
             .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
                 awaitCompletionCommand,
                 System.class,
@@ -242,6 +251,9 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
+            .beginControlFlow("if (tenantId == null || tenantId.isBlank())")
+            .addStatement("throw new $T($S)", badRequestException, "tenantId header is required")
+            .endControlFlow()
             .beginControlFlow("if (limit != null && limit < 0)")
             .addStatement("throw new $T($S)", badRequestException, "limit must be >= 0")
             .endControlFlow()

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -205,9 +205,8 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
                     .addMember("value", "$S", "x-tenant-id")
                     .build())
                 .build())
-            .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId == null || tenantId.isBlank() ? $S : tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
+            .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
                 awaitCompletionCommand,
-                "default",
                 System.class,
                 awaitDtoMapper)
             .build();
@@ -231,10 +230,10 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(String.class, "stepId")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "stepId").build())
                 .build())
-            .addParameter(ParameterSpec.builder(int.class, "limit")
+            .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
-            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? 0 : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
                 awaitDtoMapper)
             .build();
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -47,6 +47,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         ClassName pathParam = ClassName.get("jakarta.ws.rs", "PathParam");
         ClassName queryParam = ClassName.get("jakarta.ws.rs", "QueryParam");
         ClassName headerParam = ClassName.get("jakarta.ws.rs", "HeaderParam");
+        ClassName badRequestException = ClassName.get("jakarta.ws.rs", "BadRequestException");
         ClassName consumes = ClassName.get("jakarta.ws.rs", "Consumes");
         ClassName produces = ClassName.get("jakarta.ws.rs", "Produces");
         ClassName restStream = ClassName.get("org.jboss.resteasy.reactive", "RestStreamElementType");
@@ -74,6 +75,10 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         FieldSpec defaultPendingAwaitLimitField = FieldSpec.builder(int.class, "DEFAULT_PENDING_AWAIT_LIMIT",
                 Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
             .initializer("$L", 50)
+            .build();
+        FieldSpec maxPendingAwaitLimitField = FieldSpec.builder(int.class, "MAX_PENDING_AWAIT_LIMIT",
+                Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+            .initializer("$L", 500)
             .build();
 
         MethodSpec.Builder runMethod = MethodSpec.methodBuilder("run")
@@ -237,7 +242,11 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
-            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? DEFAULT_PENDING_AWAIT_LIMIT : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+            .beginControlFlow("if (limit != null && limit < 0)")
+            .addStatement("throw new $T($S)", badRequestException, "limit must be >= 0")
+            .endControlFlow()
+            .addStatement("int validatedLimit = limit == null ? DEFAULT_PENDING_AWAIT_LIMIT : $T.min(limit, MAX_PENDING_AWAIT_LIMIT)", Math.class)
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, validatedLimit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
                 awaitDtoMapper)
             .build();
 
@@ -258,6 +267,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addAnnotation(applicationScoped)
             .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/pipeline").build())
             .addField(defaultPendingAwaitLimitField)
+            .addField(maxPendingAwaitLimitField)
             .addField(executionField)
             .addField(outputBusField)
             .addMethod(runMethod.build())

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -71,6 +71,10 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         FieldSpec outputBusField = FieldSpec.builder(outputBus, "pipelineOutputBus", Modifier.PRIVATE)
             .addAnnotation(inject)
             .build();
+        FieldSpec defaultPendingAwaitLimitField = FieldSpec.builder(int.class, "DEFAULT_PENDING_AWAIT_LIMIT",
+                Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+            .initializer("$L", 50)
+            .build();
 
         MethodSpec.Builder runMethod = MethodSpec.methodBuilder("run")
             .addModifiers(Modifier.PUBLIC)
@@ -233,7 +237,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addParameter(ParameterSpec.builder(Integer.class, "limit")
                 .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
                 .build())
-            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? 0 : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit == null ? DEFAULT_PENDING_AWAIT_LIMIT : limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
                 awaitDtoMapper)
             .build();
 
@@ -253,6 +257,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(applicationScoped)
             .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/pipeline").build())
+            .addField(defaultPendingAwaitLimitField)
             .addField(executionField)
             .addField(outputBusField)
             .addMethod(runMethod.build())

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorRestResourceRenderer.java
@@ -45,6 +45,7 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         ClassName post = ClassName.get("jakarta.ws.rs", "POST");
         ClassName get = ClassName.get("jakarta.ws.rs", "GET");
         ClassName pathParam = ClassName.get("jakarta.ws.rs", "PathParam");
+        ClassName queryParam = ClassName.get("jakarta.ws.rs", "QueryParam");
         ClassName headerParam = ClassName.get("jakarta.ws.rs", "HeaderParam");
         ClassName consumes = ClassName.get("jakarta.ws.rs", "Consumes");
         ClassName produces = ClassName.get("jakarta.ws.rs", "Produces");
@@ -55,6 +56,11 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
         ClassName outputBus = ClassName.get("org.pipelineframework", "PipelineOutputBus");
         ClassName runAsyncAcceptedDto = ClassName.get("org.pipelineframework.orchestrator.dto", "RunAsyncAcceptedDto");
         ClassName executionStatusDto = ClassName.get("org.pipelineframework.orchestrator.dto", "ExecutionStatusDto");
+        ClassName awaitCompletionCommand = ClassName.get("org.pipelineframework.awaitable", "AwaitCompletionCommand");
+        ClassName awaitCompletionRequestDto = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitCompletionRequestDto");
+        ClassName awaitCompletionResponseDto = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitCompletionResponseDto");
+        ClassName awaitInteractionDto = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitInteractionDto");
+        ClassName awaitDtoMapper = ClassName.get("org.pipelineframework.awaitable.dto", "AwaitDtoMapper");
 
         ClassName inputType = ClassName.get(binding.basePackage() + ".common.dto", binding.inputTypeName() + "Dto");
         ClassName outputType = ClassName.get(binding.basePackage() + ".common.dto", binding.outputTypeName() + "Dto");
@@ -188,6 +194,50 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
                 binding.outputStreaming())
             .build();
 
+        MethodSpec completeAwaitMethod = MethodSpec.methodBuilder("completeAwait")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(post)
+            .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/interactions/complete").build())
+            .returns(ParameterizedTypeName.get(uni, awaitCompletionResponseDto))
+            .addParameter(awaitCompletionRequestDto, "request")
+            .addParameter(ParameterSpec.builder(String.class, "tenantId")
+                .addAnnotation(AnnotationSpec.builder(headerParam)
+                    .addMember("value", "$S", "x-tenant-id")
+                    .build())
+                .build())
+            .addStatement("return pipelineExecutionService.completeAwaitInteraction(new $T(tenantId == null || tenantId.isBlank() ? $S : tenantId, request.interactionId(), request.correlationId(), request.idempotencyKey(), request.responsePayload(), request.actor(), $T.currentTimeMillis())).onItem().transform($T::toCompletionResponse)",
+                awaitCompletionCommand,
+                "default",
+                System.class,
+                awaitDtoMapper)
+            .build();
+
+        MethodSpec pendingAwaitMethod = MethodSpec.methodBuilder("pendingAwait")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(get)
+            .addAnnotation(AnnotationSpec.builder(path).addMember("value", "$S", "/interactions/pending").build())
+            .returns(ParameterizedTypeName.get(uni, ParameterizedTypeName.get(ClassName.get(List.class), awaitInteractionDto)))
+            .addParameter(ParameterSpec.builder(String.class, "tenantId")
+                .addAnnotation(AnnotationSpec.builder(headerParam)
+                    .addMember("value", "$S", "x-tenant-id")
+                    .build())
+                .build())
+            .addParameter(ParameterSpec.builder(String.class, "assignee")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "assignee").build())
+                .build())
+            .addParameter(ParameterSpec.builder(String.class, "group")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "group").build())
+                .build())
+            .addParameter(ParameterSpec.builder(String.class, "stepId")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "stepId").build())
+                .build())
+            .addParameter(ParameterSpec.builder(int.class, "limit")
+                .addAnnotation(AnnotationSpec.builder(queryParam).addMember("value", "$S", "limit").build())
+                .build())
+            .addStatement("return pipelineExecutionService.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit).onItem().transform(records -> records.stream().map($T::toDto).toList())",
+                awaitDtoMapper)
+            .build();
+
         MethodSpec subscribeMethod = MethodSpec.methodBuilder("subscribe")
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(get)
@@ -211,6 +261,8 @@ public class OrchestratorRestResourceRenderer implements PipelineRenderer<Orches
             .addMethod(ingestMethod)
             .addMethod(statusMethod)
             .addMethod(resultMethod)
+            .addMethod(completeAwaitMethod)
+            .addMethod(pendingAwaitMethod)
             .addMethod(subscribeMethod)
             .build();
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorRpcConstants.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorRpcConstants.java
@@ -15,6 +15,8 @@ public final class OrchestratorRpcConstants {
     public static final String RUN_ASYNC_METHOD = "RunAsync";
     public static final String GET_EXECUTION_STATUS_METHOD = "GetExecutionStatus";
     public static final String GET_EXECUTION_RESULT_METHOD = "GetExecutionResult";
+    public static final String COMPLETE_AWAIT_METHOD = "CompleteAwait";
+    public static final String LIST_PENDING_AWAIT_METHOD = "ListPendingAwait";
     public static final String INGEST_METHOD = "Ingest";
     public static final String SUBSCRIBE_METHOD = "Subscribe";
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -310,31 +310,33 @@ public class PipelineExecutionService {
   }
 
   private Multi<?> executePipelineStreamingFromRecord(ExecutionRecord<Object, Object> record) {
-    Object sourcePayload = record.currentStepIndex() > 0
-        ? record.resumePayload()
-        : record.inputPayload();
-    Object reactiveInput = executionInputPolicy.toReplayInput(sourcePayload);
-    AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
-    AwaitExecutionContextHolder.set(new AwaitExecutionContext(
-        record.tenantId(),
-        record.executionId(),
-        record.currentStepIndex()));
-    try {
-      Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
-      if (result instanceof Multi<?> multi) {
-        return multi;
+    return Multi.createFrom().deferred(() -> {
+      Object sourcePayload = record.currentStepIndex() > 0
+          ? record.resumePayload()
+          : record.inputPayload();
+      Object reactiveInput = executionInputPolicy.toReplayInput(sourcePayload);
+      AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
+      AwaitExecutionContextHolder.set(new AwaitExecutionContext(
+          record.tenantId(),
+          record.executionId(),
+          record.currentStepIndex()));
+      try {
+        Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
+        Multi<?> stream;
+        if (result instanceof Multi<?> multi) {
+          stream = multi;
+        } else if (result instanceof Uni<?> uni) {
+          stream = uni.toMulti();
+        } else {
+          restoreAwaitContext(previous);
+          return Multi.createFrom().failure(new IllegalStateException("Pipeline runner returned unsupported result"));
+        }
+        return stream.onTermination().invoke((failure, cancelled) -> restoreAwaitContext(previous));
+      } catch (Throwable failure) {
+        restoreAwaitContext(previous);
+        return Multi.createFrom().failure(failure);
       }
-      if (result instanceof Uni<?> uni) {
-        return uni.toMulti();
-      }
-      return Multi.createFrom().failure(new IllegalStateException("Pipeline runner returned unsupported result"));
-    } finally {
-      if (previous == null) {
-        AwaitExecutionContextHolder.clear();
-      } else {
-        AwaitExecutionContextHolder.set(previous);
-      }
-    }
+    });
   }
 
   private Object executePipelineStreamingInternalFromStep(Object input, int startStepIndex) {
@@ -346,8 +348,16 @@ public class PipelineExecutionService {
     watch.start();
     Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
     watch.stop();
-    LOG.infof("Pipeline execution assembled from step %d in %d ms", startStepIndex, watch.getTime());
+    LOG.infof("Pipeline assembly from step %d completed in %d ms", startStepIndex, watch.getTime());
     return result;
+  }
+
+  private void restoreAwaitContext(AwaitExecutionContext previous) {
+    if (previous == null) {
+      AwaitExecutionContextHolder.clear();
+    } else {
+      AwaitExecutionContextHolder.set(previous);
+    }
   }
 
   private Uni<?> executePipelineUnaryInternal(Object input) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -34,7 +34,13 @@ import lombok.Getter;
 import org.apache.commons.lang3.time.StopWatch;
 import org.jboss.logging.Logger;
 import org.pipelineframework.config.PipelineConfig;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitExecutionContext;
+import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
 
@@ -65,6 +71,9 @@ public class PipelineExecutionService {
 
   @Inject
   ExecutionHooks executionHooks;
+
+  @Inject
+  ExecutionInputPolicy executionInputPolicy;
 
   @Inject
   QueueAsyncCoordinator queueAsyncCoordinator;
@@ -198,6 +207,25 @@ public class PipelineExecutionService {
   }
 
   /**
+   * Completes a durable await interaction and schedules owning execution continuation.
+   */
+  public Uni<AwaitCompletionResult> completeAwaitInteraction(AwaitCompletionCommand command) {
+    return queueAsyncCoordinator.completeAwait(command);
+  }
+
+  /**
+   * Queries pending durable await interactions.
+   */
+  public Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
+      String tenantId,
+      String assignee,
+      String group,
+      String stepId,
+      int limit) {
+    return queueAsyncCoordinator.queryPendingAwaitInteractions(tenantId, assignee, group, stepId, limit);
+  }
+
+  /**
    * Handles queue-dispatched work items when using the local event dispatcher.
    */
   void onExecutionWork(@ObservesAsync ExecutionWorkItem workItem) {
@@ -216,7 +244,7 @@ public class PipelineExecutionService {
    * Processes one execution work item and advances lifecycle state.
    */
   public Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem) {
-    return queueAsyncCoordinator.processExecutionWorkItem(workItem, this::executePipelineStreaming);
+    return queueAsyncCoordinator.processExecutionWorkItem(workItem, this::executePipelineStreamingFromRecord);
   }
 
   /**
@@ -279,6 +307,47 @@ public class PipelineExecutionService {
             MessageFormat.format("PipelineRunner returned unexpected type: {0}", result.getClass().getName())));
       }
     });
+  }
+
+  private Multi<?> executePipelineStreamingFromRecord(ExecutionRecord<Object, Object> record) {
+    Object sourcePayload = record.currentStepIndex() > 0
+        ? record.resumePayload()
+        : record.inputPayload();
+    Object reactiveInput = executionInputPolicy.toReplayInput(sourcePayload);
+    AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
+    AwaitExecutionContextHolder.set(new AwaitExecutionContext(
+        record.tenantId(),
+        record.executionId(),
+        record.currentStepIndex()));
+    try {
+      Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
+      if (result instanceof Multi<?> multi) {
+        return multi;
+      }
+      if (result instanceof Uni<?> uni) {
+        return uni.toMulti();
+      }
+      return Multi.createFrom().failure(new IllegalStateException("Pipeline runner returned unsupported result"));
+    } finally {
+      if (previous == null) {
+        AwaitExecutionContextHolder.clear();
+      } else {
+        AwaitExecutionContextHolder.set(previous);
+      }
+    }
+  }
+
+  private Object executePipelineStreamingInternalFromStep(Object input, int startStepIndex) {
+    StopWatch watch = new StopWatch();
+    List<Object> steps = loadStepsForExecution();
+    if (steps == null) {
+      return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
+    }
+    watch.start();
+    Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
+    watch.stop();
+    LOG.infof("Pipeline execution assembled from step %d in %d ms", startStepIndex, watch.getTime());
+    return result;
   }
 
   private Uni<?> executePipelineUnaryInternal(Object input) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -345,10 +345,13 @@ public class PipelineExecutionService {
     if (steps == null) {
       return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
     }
-    watch.start();
     Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
-    watch.stop();
-    LOG.infof("Pipeline assembly from step %d completed in %d ms", startStepIndex, watch.getTime());
+    if (result instanceof Multi<?> multi) {
+      return executionHooks.attachMultiHooks(multi, watch);
+    }
+    if (result instanceof Uni<?> uni) {
+      return executionHooks.attachMultiHooks(uni.toMulti(), watch);
+    }
     return result;
   }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -321,6 +321,16 @@ public class PipelineExecutionService {
           record.executionId(),
           record.currentStepIndex()));
       try {
+        RuntimeException healthFailure = healthCheckFailure();
+        if (healthFailure != null) {
+          restoreAwaitContext(previous);
+          return Multi.createFrom().failure(healthFailure);
+        }
+        RuntimeException inputFailure = validateInputShape(reactiveInput);
+        if (inputFailure != null) {
+          restoreAwaitContext(previous);
+          return Multi.createFrom().failure(inputFailure);
+        }
         Object result = executePipelineStreamingInternalFromStep(reactiveInput, record.currentStepIndex());
         Multi<?> stream;
         if (result instanceof Multi<?> multi) {
@@ -352,7 +362,13 @@ public class PipelineExecutionService {
     if (result instanceof Uni<?> uni) {
       return executionHooks.attachMultiHooks(uni.toMulti(), watch);
     }
-    return result;
+    String resultType = result == null ? "null" : result.getClass().getName();
+    Multi<?> failed = Multi.createFrom().failure(new IllegalStateException(
+        MessageFormat.format(
+            "PipelineRunner returned unexpected type from step index {0}: {1}",
+            startStepIndex,
+            resultType)));
+    return executionHooks.attachMultiHooks(failed, watch);
   }
 
   private void restoreAwaitContext(AwaitExecutionContext previous) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
@@ -32,6 +32,8 @@ import org.pipelineframework.config.ParallelismPolicy;
 import org.pipelineframework.config.PipelineConfig;
 import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
+import org.pipelineframework.awaitable.AwaitExecutionContext;
+import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
 import org.pipelineframework.step.Configurable;
 import org.pipelineframework.step.ConfigFactory;
 import org.pipelineframework.step.StepOneToOne;
@@ -90,6 +92,18 @@ public class PipelineRunner implements AutoCloseable {
      * @throws IllegalArgumentException if {@code input} is not a Uni or a Multi
      */
     public Object run(Object input, List<Object> steps) {
+        return runFromStep(input, steps, 0);
+    }
+
+    /**
+     * Run a configured sequence starting at a specific ordered step index.
+     *
+     * @param input reactive source to process
+     * @param steps ordered or orderable step instances
+     * @param startStepIndex first ordered step index to execute
+     * @return final reactive result
+     */
+    public Object runFromStep(Object input, List<Object> steps, int startStepIndex) {
         Objects.requireNonNull(steps, "Steps list must not be null");
         if (!(input instanceof Uni<?> || input instanceof Multi<?>)) {
             throw new IllegalArgumentException(MessageFormat.format(
@@ -98,6 +112,9 @@ public class PipelineRunner implements AutoCloseable {
         }
 
         List<Object> orderedSteps = stepOrderer.orderSteps(steps);
+        if (startStepIndex < 0 || startStepIndex > orderedSteps.size()) {
+            throw new IllegalArgumentException("startStepIndex is out of range: " + startStepIndex);
+        }
 
         Object current = input;
         ParallelismPolicy parallelismPolicy = parallelismPolicyResolver.resolveParallelismPolicy(pipelineConfig);
@@ -108,10 +125,15 @@ public class PipelineRunner implements AutoCloseable {
 
         PipelineContext contextSnapshot = PipelineContextHolder.get();
         CacheReadSupport cacheReadSupport = cacheSupportFactory.buildCacheReadSupport();
-        for (Object step : orderedSteps) {
+        AwaitExecutionContext awaitContext = AwaitExecutionContextHolder.get();
+        for (int index = startStepIndex; index < orderedSteps.size(); index++) {
+            Object step = orderedSteps.get(index);
             if (step == null) {
                 logger.warn("Warning: Found null step in configuration, skipping...");
                 continue;
+            }
+            if (awaitContext != null) {
+                awaitContext.currentStepIndex(index);
             }
 
             if (step instanceof Configurable configurable) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -22,6 +22,12 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.jboss.logging.Logger;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitSuspendedException;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
 import org.pipelineframework.orchestrator.DeadLetterPublisher;
 import org.pipelineframework.orchestrator.ExecutionCreateCommand;
@@ -64,6 +70,9 @@ class QueueAsyncCoordinator {
 
   @Inject
   CheckpointPublicationService checkpointPublicationService;
+
+  @Inject
+  AwaitCoordinator awaitCoordinator;
 
   private final ScheduledExecutorService queueSweepExecutor = Executors.newSingleThreadScheduledExecutor(
       runnable -> {
@@ -228,7 +237,7 @@ class QueueAsyncCoordinator {
         });
   }
 
-  Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, Function<Object, Multi<?>> executeStreaming) {
+  Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming) {
     if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
       return Uni.createFrom().voidItem();
     }
@@ -245,7 +254,7 @@ class QueueAsyncCoordinator {
           }
           ExecutionRecord<Object, Object> record = claimed.get();
           String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-          return runAsyncExecution(record.inputPayload(), executeStreaming)
+          return runAsyncExecution(record, executeStreaming)
               .onItem().transformToUni(resultPayload -> checkpointPublicationService
                   .publishIfConfigured(record, singleResult(resultPayload))
                   .replaceWith(resultPayload))
@@ -257,6 +266,8 @@ class QueueAsyncCoordinator {
                       resultPayload,
                       System.currentTimeMillis()))
               .onItem().transformToUni(updated -> Uni.createFrom().voidItem())
+              .onFailure(AwaitSuspendedException.class).recoverWithUni(
+                  failure -> markWaitingExternal(record, (AwaitSuspendedException) failure, transitionKey))
               .onFailure().recoverWithUni(
                   failure -> executionFailureHandler.handleExecutionFailure(
                       record,
@@ -273,7 +284,8 @@ class QueueAsyncCoordinator {
       return;
     }
     long now = System.currentTimeMillis();
-    executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit())
+    sweepTimedOutAwaitInteractions(now)
+        .onItem().transformToUni(ignored -> executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit()))
         .onItem().transformToUni(due -> {
           if (due.isEmpty()) {
             return Uni.createFrom().voidItem();
@@ -294,9 +306,97 @@ class QueueAsyncCoordinator {
             failure -> LOG.errorf(failure, "Failed sweeping due async executions"));
   }
 
-  private Uni<List<?>> runAsyncExecution(Object inputPayload, Function<Object, Multi<?>> executeStreaming) {
-    Object reactiveInput = executionInputPolicy.toReplayInput(inputPayload);
-    return executeStreaming.apply(reactiveInput)
+  Uni<AwaitCompletionResult> completeAwait(AwaitCompletionCommand command) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    return awaitCoordinator.complete(command)
+        .onItem().transformToUni(result -> executionStateStore.markAwaitCompleted(
+                result.record().tenantId(),
+                result.record().executionId(),
+                result.record().interactionId(),
+                coerceAwaitPayload(result.record()),
+                result.record().stepIndex() + 1,
+                command.nowEpochMs())
+            .onItem().transformToUni(updated -> {
+              if (updated.isPresent()) {
+                return workDispatcher.enqueueNow(new ExecutionWorkItem(
+                        updated.get().tenantId(),
+                        updated.get().executionId()))
+                    .replaceWith(result);
+              }
+              return Uni.createFrom().item(result);
+            }));
+  }
+
+  Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
+      String tenantId,
+      String assignee,
+      String group,
+      String stepId,
+      int limit) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+    return awaitCoordinator.queryPending(resolvedTenant, assignee, group, stepId, limit <= 0 ? 100 : limit);
+  }
+
+  private Uni<Void> markWaitingExternal(
+      ExecutionRecord<Object, Object> record,
+      AwaitSuspendedException suspended,
+      String transitionKey) {
+    return executionStateStore.markWaitingExternal(
+            record.tenantId(),
+            record.executionId(),
+            record.version(),
+            transitionKey,
+            suspended.interactionId(),
+            suspended.stepIndex(),
+            System.currentTimeMillis())
+        .replaceWithVoid();
+  }
+
+  private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
+    if (awaitCoordinator == null) {
+      return Uni.createFrom().voidItem();
+    }
+    return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
+        .onItem().transformToUni(records -> {
+          if (records.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          List<Uni<Void>> operations = new ArrayList<>(records.size());
+          for (AwaitInteractionRecord record : records) {
+            operations.add(awaitCoordinator.markTimedOut(record, now)
+                .onItem().transformToUni(updated -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
+                .onItem().transformToUni(execution -> {
+                  if (execution.isEmpty() || execution.get().status().terminal()) {
+                    return Uni.createFrom().voidItem();
+                  }
+                  ExecutionRecord<Object, Object> executionRecord = execution.get();
+                  return executionStateStore.markTerminalFailure(
+                          executionRecord.tenantId(),
+                          executionRecord.executionId(),
+                          executionRecord.version(),
+                          ExecutionStatus.FAILED,
+                          transitionKey(executionRecord.executionId(), executionRecord.currentStepIndex(), executionRecord.attempt()),
+                          "AWAIT_TIMEOUT",
+                          "Await interaction timed out: " + record.interactionId(),
+                          now)
+                      .replaceWithVoid();
+                }));
+          }
+          return Uni.join().all(operations).andCollectFailures().replaceWithVoid();
+        });
+  }
+
+  private Uni<List<?>> runAsyncExecution(
+      ExecutionRecord<Object, Object> record,
+      Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming) {
+    return executeStreaming.apply(record)
         .select().first(2)
         .collect().asList()
         .onItem().transformToUni(items -> {
@@ -313,6 +413,25 @@ class QueueAsyncCoordinator {
       return null;
     }
     return items.getFirst();
+  }
+
+  private Object coerceAwaitPayload(AwaitInteractionRecord record) {
+    Object payload = record.responsePayload();
+    if (payload == null || record.outputType() == null || record.outputType().isBlank()) {
+      return payload;
+    }
+    try {
+      Class<?> outputType = Class.forName(record.outputType());
+      if (outputType.isInstance(payload)) {
+        return payload;
+      }
+      if (payload instanceof String json && (json.startsWith("{") || json.startsWith("["))) {
+        return PipelineJson.mapper().readValue(json, outputType);
+      }
+      return PipelineJson.mapper().convertValue(payload, outputType);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed converting await response payload to " + record.outputType(), e);
+    }
   }
 
   private ExecutionStateStore selectExecutionStateStore(String providerName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.NotFoundException;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.jboss.logging.Logger;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
 import org.pipelineframework.config.pipeline.PipelineJson;
@@ -320,11 +321,18 @@ class QueueAsyncCoordinator {
         command.actor(),
         command.nowEpochMs());
     return awaitCoordinator.complete(normalized)
-        .onItem().transformToUni(result -> executionStateStore.markAwaitCompleted(
+        .onFailure().transform(failure -> new IllegalStateException(
+            "Failed completing await interaction tenant=" + normalized.tenantId()
+                + ", interactionId=" + normalized.interactionId()
+                + ", correlationId=" + normalized.correlationId(),
+            failure))
+        .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
+            .onItem().transformToUni(validated -> coerceAwaitPayloadAsync(validated.record()))
+            .onItem().transformToUni(resumePayload -> executionStateStore.markAwaitCompleted(
                 result.record().tenantId(),
                 result.record().executionId(),
                 result.record().interactionId(),
-                coerceAwaitPayload(result.record()),
+                resumePayload,
                 result.record().stepIndex() + 1,
                 normalized.nowEpochMs())
             .onItem().transformToUni(updated -> {
@@ -335,7 +343,7 @@ class QueueAsyncCoordinator {
                     .replaceWith(result);
               }
               return Uni.createFrom().item(result);
-            }));
+            })));
   }
 
   Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
@@ -382,6 +390,10 @@ class QueueAsyncCoordinator {
                     return Uni.createFrom().voidItem();
                   }
                   ExecutionRecord<Object, Object> executionRecord = execution.get();
+                  if (executionRecord.status() != ExecutionStatus.WAITING_EXTERNAL
+                      || !record.interactionId().equals(executionRecord.awaitInteractionId())) {
+                    return Uni.createFrom().voidItem();
+                  }
                   return executionStateStore.markTerminalFailure(
                           executionRecord.tenantId(),
                           executionRecord.executionId(),
@@ -440,6 +452,22 @@ class QueueAsyncCoordinator {
     } catch (Exception e) {
       throw new IllegalStateException("Failed converting await response payload to " + record.outputType(), e);
     }
+  }
+
+  private Uni<Object> coerceAwaitPayloadAsync(AwaitInteractionRecord record) {
+    return Uni.createFrom().item(() -> coerceAwaitPayload(record))
+        .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+  }
+
+  private Uni<AwaitCompletionResult> validateAwaitCompletionTenant(
+      AwaitCompletionResult result,
+      AwaitCompletionCommand command) {
+    if (!command.tenantId().equals(result.record().tenantId())) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Await completion tenant mismatch: command tenant=" + command.tenantId()
+              + ", record tenant=" + result.record().tenantId()));
+    }
+    return Uni.createFrom().item(result);
   }
 
   private ExecutionStateStore selectExecutionStateStore(String providerName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -311,14 +311,22 @@ class QueueAsyncCoordinator {
       return Uni.createFrom().failure(new IllegalStateException(
           "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
     }
-    return awaitCoordinator.complete(command)
+    AwaitCompletionCommand normalized = new AwaitCompletionCommand(
+        executionInputPolicy.normalizeTenant(command.tenantId()),
+        command.interactionId(),
+        command.correlationId(),
+        command.idempotencyKey(),
+        command.responsePayload(),
+        command.actor(),
+        command.nowEpochMs());
+    return awaitCoordinator.complete(normalized)
         .onItem().transformToUni(result -> executionStateStore.markAwaitCompleted(
                 result.record().tenantId(),
                 result.record().executionId(),
                 result.record().interactionId(),
                 coerceAwaitPayload(result.record()),
                 result.record().stepIndex() + 1,
-                command.nowEpochMs())
+                normalized.nowEpochMs())
             .onItem().transformToUni(updated -> {
               if (updated.isPresent()) {
                 return workDispatcher.enqueueNow(new ExecutionWorkItem(
@@ -360,9 +368,6 @@ class QueueAsyncCoordinator {
   }
 
   private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
-    if (awaitCoordinator == null) {
-      return Uni.createFrom().voidItem();
-    }
     return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
         .onItem().transformToUni(records -> {
           if (records.isEmpty()) {
@@ -425,8 +430,11 @@ class QueueAsyncCoordinator {
       if (outputType.isInstance(payload)) {
         return payload;
       }
-      if (payload instanceof String json && (json.startsWith("{") || json.startsWith("["))) {
-        return PipelineJson.mapper().readValue(json, outputType);
+      if (payload instanceof String json) {
+        String trimmed = json.trim();
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+          return PipelineJson.mapper().readValue(trimmed, outputType);
+        }
       }
       return PipelineJson.mapper().convertValue(payload, outputType);
     } catch (Exception e) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -438,7 +438,7 @@ class QueueAsyncCoordinator {
       return payload;
     }
     try {
-      Class<?> outputType = Class.forName(record.outputType());
+      Class<?> outputType = Thread.currentThread().getContextClassLoader().loadClass(record.outputType());
       if (outputType.isInstance(payload)) {
         return payload;
       }

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -327,23 +327,28 @@ class QueueAsyncCoordinator {
                 + ", correlationId=" + normalized.correlationId(),
             failure))
         .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
-            .onItem().transformToUni(validated -> coerceAwaitPayloadAsync(validated.record()))
-            .onItem().transformToUni(resumePayload -> executionStateStore.markAwaitCompleted(
-                result.record().tenantId(),
-                result.record().executionId(),
-                result.record().interactionId(),
-                resumePayload,
-                result.record().stepIndex() + 1,
-                normalized.nowEpochMs())
-            .onItem().transformToUni(updated -> {
-              if (updated.isPresent()) {
-                return workDispatcher.enqueueNow(new ExecutionWorkItem(
-                        updated.get().tenantId(),
-                        updated.get().executionId()))
-                    .replaceWith(result);
+            .onItem().transformToUni(validated -> {
+              if (validated.duplicate()) {
+                return Uni.createFrom().item(validated);
               }
-              return Uni.createFrom().item(result);
-            })));
+              return coerceAwaitPayloadAsync(validated.record())
+                  .onItem().transformToUni(resumePayload -> executionStateStore.markAwaitCompleted(
+                      validated.record().tenantId(),
+                      validated.record().executionId(),
+                      validated.record().interactionId(),
+                      resumePayload,
+                      validated.record().stepIndex() + 1,
+                      normalized.nowEpochMs()))
+                  .onItem().transformToUni(updated -> {
+                    if (updated.isPresent()) {
+                      return workDispatcher.enqueueNow(new ExecutionWorkItem(
+                              updated.get().tenantId(),
+                              updated.get().executionId()))
+                          .replaceWith(validated);
+                    }
+                    return Uni.createFrom().item(validated);
+                  });
+            }));
   }
 
   Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
@@ -21,9 +21,6 @@ public record AwaitCompletionCommand(
         if (interactionId == null && correlationId == null) {
             throw new IllegalArgumentException("interactionId or correlationId must be supplied");
         }
-        if (idempotencyKey == null || idempotencyKey.isBlank()) {
-            throw new IllegalArgumentException("idempotencyKey must not be blank");
-        }
         if (nowEpochMs <= 0) {
             nowEpochMs = System.currentTimeMillis();
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionRequestDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionRequestDto.java
@@ -1,0 +1,13 @@
+package org.pipelineframework.awaitable.dto;
+
+/**
+ * REST/gRPC-neutral request DTO for completing an await interaction.
+ */
+public record AwaitCompletionRequestDto(
+    String interactionId,
+    String correlationId,
+    String idempotencyKey,
+    Object responsePayload,
+    String actor
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionResponseDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionResponseDto.java
@@ -1,0 +1,15 @@
+package org.pipelineframework.awaitable.dto;
+
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+
+/**
+ * Response DTO returned after completion admission.
+ */
+public record AwaitCompletionResponseDto(
+    String interactionId,
+    String executionId,
+    String stepId,
+    AwaitInteractionStatus status,
+    boolean duplicate
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
@@ -1,0 +1,41 @@
+package org.pipelineframework.awaitable.dto;
+
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+
+/**
+ * Maps await runtime records to transport DTOs.
+ */
+public final class AwaitDtoMapper {
+    private AwaitDtoMapper() {
+    }
+
+    public static AwaitCompletionResponseDto toCompletionResponse(AwaitCompletionResult result) {
+        AwaitInteractionRecord record = result.record();
+        return new AwaitCompletionResponseDto(
+            record.interactionId(),
+            record.executionId(),
+            record.stepId(),
+            record.status(),
+            result.duplicate());
+    }
+
+    public static AwaitInteractionDto toDto(AwaitInteractionRecord record) {
+        return new AwaitInteractionDto(
+            record.interactionId(),
+            record.correlationId(),
+            record.executionId(),
+            record.stepId(),
+            record.stepIndex(),
+            record.outputType(),
+            record.status(),
+            record.requestPayload(),
+            record.assignee(),
+            record.group(),
+            record.transportType(),
+            record.transportMetadata(),
+            record.deadlineEpochMs(),
+            record.createdAtEpochMs(),
+            record.updatedAtEpochMs());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitDtoMapper.java
@@ -1,5 +1,7 @@
 package org.pipelineframework.awaitable.dto;
 
+import java.util.Objects;
+
 import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
 
@@ -11,7 +13,13 @@ public final class AwaitDtoMapper {
     }
 
     public static AwaitCompletionResponseDto toCompletionResponse(AwaitCompletionResult result) {
-        AwaitInteractionRecord record = result.record();
+        AwaitInteractionRecord record = Objects.requireNonNull(
+            Objects.requireNonNull(result, "result must not be null").record(),
+            "result.record must not be null");
+        Objects.requireNonNull(record.interactionId(), "record.interactionId must not be null");
+        Objects.requireNonNull(record.executionId(), "record.executionId must not be null");
+        Objects.requireNonNull(record.stepId(), "record.stepId must not be null");
+        Objects.requireNonNull(record.status(), "record.status must not be null");
         return new AwaitCompletionResponseDto(
             record.interactionId(),
             record.executionId(),

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitInteractionDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitInteractionDto.java
@@ -1,0 +1,27 @@
+package org.pipelineframework.awaitable.dto;
+
+import java.util.Map;
+
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+
+/**
+ * Query projection for pending await interactions.
+ */
+public record AwaitInteractionDto(
+    String interactionId,
+    String correlationId,
+    String executionId,
+    String stepId,
+    int stepIndex,
+    String outputType,
+    AwaitInteractionStatus status,
+    Object requestPayload,
+    String assignee,
+    String group,
+    String transportType,
+    Map<String, Object> transportMetadata,
+    long deadlineEpochMs,
+    long createdAtEpochMs,
+    long updatedAtEpochMs
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -1,0 +1,677 @@
+package org.pipelineframework.awaitable.store;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCreateCommand;
+import org.pipelineframework.awaitable.AwaitCreateResult;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.spi.AwaitInteractionStore;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.Put;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * DynamoDB-backed await interaction store.
+ */
+@ApplicationScoped
+public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
+    private static final Logger LOG = Logger.getLogger(DynamoAwaitInteractionStore.class);
+
+    private static final String TENANT_ID = "tenant_id";
+    private static final String INTERACTION_ID = "interaction_id";
+    private static final String LOOKUP_KEY = "lookup_key";
+    private static final String LOOKUP_KIND = "lookup_kind";
+    private static final String EXECUTION_ID = "execution_id";
+    private static final String STEP_ID = "step_id";
+    private static final String STEP_INDEX = "step_index";
+    private static final String OUTPUT_TYPE = "output_type";
+    private static final String CORRELATION_ID = "correlation_id";
+    private static final String CAUSATION_ID = "causation_id";
+    private static final String IDEMPOTENCY_KEY = "idempotency_key";
+    private static final String VERSION = "version";
+    private static final String STATUS = "status";
+    private static final String REQUEST_PAYLOAD_JSON = "request_payload_json";
+    private static final String RESPONSE_PAYLOAD_JSON = "response_payload_json";
+    private static final String ACTOR = "actor";
+    private static final String ASSIGNEE = "assignee";
+    private static final String GROUP = "group_name";
+    private static final String TRANSPORT_TYPE = "transport_type";
+    private static final String TRANSPORT_METADATA_JSON = "transport_metadata_json";
+    private static final String DEADLINE_EPOCH_MS = "deadline_epoch_ms";
+    private static final String CREATED_AT_EPOCH_MS = "created_at_epoch_ms";
+    private static final String UPDATED_AT_EPOCH_MS = "updated_at_epoch_ms";
+    private static final String TTL_EPOCH_S = "ttl_epoch_s";
+    private static final String ENCODED_JAVA_CLASS = "_tpf_java_class";
+    private static final String ENCODED_PAYLOAD = "_tpf_payload";
+
+    @Inject
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    private volatile DynamoDbClient client;
+
+    /**
+     * Default constructor for CDI.
+     */
+    public DynamoAwaitInteractionStore() {
+    }
+
+    DynamoAwaitInteractionStore(DynamoDbClient client, PipelineOrchestratorConfig orchestratorConfig) {
+        this.client = client;
+        this.orchestratorConfig = orchestratorConfig;
+    }
+
+    @Override
+    public String providerName() {
+        return "dynamo";
+    }
+
+    @Override
+    public int priority() {
+        return -1000;
+    }
+
+    @Override
+    public Uni<AwaitCreateResult> createOrGet(AwaitCreateCommand command) {
+        return blocking(() -> createOrGetBlocking(command));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> get(String tenantId, String interactionId) {
+        return blocking(() -> getBlocking(tenantId, interactionId, System.currentTimeMillis()));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId) {
+        return blocking(() -> findByLookup(lookupKey("correlation", tenantId, correlationId), tenantId));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> markDispatched(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.DISPATCHED,
+            null,
+            null,
+            transportMetadata,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<AwaitCompletionResult> complete(AwaitCompletionCommand command) {
+        return blocking(() -> completeBlocking(command));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> fail(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.FAILED,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> cancel(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        String reason,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.CANCELLED,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<Optional<AwaitInteractionRecord>> markTimedOut(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.TIMED_OUT,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<List<AwaitInteractionRecord>> findTimedOut(long nowEpochMs, int limit) {
+        return blocking(() -> {
+            if (limit <= 0) {
+                return List.of();
+            }
+            Map<String, String> names = Map.of(
+                "#status", STATUS,
+                "#deadline", DEADLINE_EPOCH_MS,
+                "#ttl", TTL_EPOCH_S);
+            Map<String, AttributeValue> values = Map.of(
+                ":now", avN(nowEpochMs),
+                ":completed", avS(AwaitInteractionStatus.COMPLETED.name()),
+                ":failed", avS(AwaitInteractionStatus.FAILED.name()),
+                ":timedOut", avS(AwaitInteractionStatus.TIMED_OUT.name()),
+                ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
+                ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
+                ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+            var response = dynamoClient().scan(ScanRequest.builder()
+                .tableName(interactionTable())
+                .filterExpression("#deadline <= :now AND #status <> :completed AND #status <> :failed "
+                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .limit(limit)
+                .build());
+            if (response.items() == null || response.items().isEmpty()) {
+                return List.of();
+            }
+            List<AwaitInteractionRecord> records = new ArrayList<>();
+            for (Map<String, AttributeValue> item : response.items()) {
+                records.add(toRecord(item));
+            }
+            records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
+            return List.copyOf(records);
+        });
+    }
+
+    @Override
+    public Uni<List<AwaitInteractionRecord>> queryPending(
+        String tenantId,
+        String assignee,
+        String group,
+        String stepId,
+        int limit) {
+        return blocking(() -> {
+            if (limit <= 0) {
+                return List.of();
+            }
+            Map<String, String> names = Map.of("#tenant", TENANT_ID, "#status", STATUS, "#ttl", TTL_EPOCH_S);
+            Map<String, AttributeValue> values = Map.of(
+                ":tenant", avS(tenantId),
+                ":completed", avS(AwaitInteractionStatus.COMPLETED.name()),
+                ":failed", avS(AwaitInteractionStatus.FAILED.name()),
+                ":timedOut", avS(AwaitInteractionStatus.TIMED_OUT.name()),
+                ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
+                ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
+                ":nowSec", avN(Instant.now().getEpochSecond()));
+            var response = dynamoClient().scan(ScanRequest.builder()
+                .tableName(interactionTable())
+                .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
+                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .limit(Math.max(limit * 3, limit))
+                .build());
+            if (response.items() == null || response.items().isEmpty()) {
+                return List.of();
+            }
+            List<AwaitInteractionRecord> records = new ArrayList<>();
+            for (Map<String, AttributeValue> item : response.items()) {
+                AwaitInteractionRecord record = toRecord(item);
+                if (assignee != null && !Objects.equals(assignee, record.assignee())) {
+                    continue;
+                }
+                if (group != null && !Objects.equals(group, record.group())) {
+                    continue;
+                }
+                if (stepId != null && !Objects.equals(stepId, record.stepId())) {
+                    continue;
+                }
+                records.add(record);
+            }
+            records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
+            return List.copyOf(records.subList(0, Math.min(records.size(), limit)));
+        });
+    }
+
+    @PreDestroy
+    void closeClient() {
+        DynamoDbClient active = client;
+        if (active == null) {
+            return;
+        }
+        synchronized (this) {
+            active = client;
+            if (active == null) {
+                return;
+            }
+            try {
+                active.close();
+            } catch (Exception e) {
+                LOG.debug("Failed closing DynamoDB client during shutdown.", e);
+            } finally {
+                client = null;
+            }
+        }
+    }
+
+    private AwaitCreateResult createOrGetBlocking(AwaitCreateCommand command) {
+        Optional<AwaitInteractionRecord> existing = findByLookup(
+            lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
+            command.tenantId());
+        if (existing.isPresent() && !existing.get().status().terminal()) {
+            return new AwaitCreateResult(existing.get(), true);
+        }
+
+        String interactionId = UUID.randomUUID().toString();
+        AwaitInteractionRecord created = new AwaitInteractionRecord(
+            command.tenantId(),
+            command.executionId(),
+            command.stepId(),
+            command.stepIndex(),
+            command.outputType(),
+            interactionId,
+            command.correlationId(),
+            command.causationId(),
+            command.idempotencyKey(),
+            0L,
+            AwaitInteractionStatus.WAITING,
+            command.requestPayload(),
+            null,
+            null,
+            command.assignee(),
+            command.group(),
+            command.transportType(),
+            Map.of(),
+            command.deadlineEpochMs(),
+            command.nowEpochMs(),
+            command.nowEpochMs(),
+            command.ttlEpochS());
+
+        try {
+            dynamoClient().transactWriteItems(TransactWriteItemsRequest.builder()
+                .transactItems(
+                    TransactWriteItem.builder().put(Put.builder()
+                        .tableName(interactionTable())
+                        .item(toItem(created))
+                        .conditionExpression("attribute_not_exists(#tenant) AND attribute_not_exists(#interaction)")
+                        .expressionAttributeNames(Map.of("#tenant", TENANT_ID, "#interaction", INTERACTION_ID))
+                        .build()).build(),
+                    TransactWriteItem.builder().put(lookupPut(
+                        "idempotency",
+                        command.tenantId(),
+                        command.stepId() + ":" + command.idempotencyKey(),
+                        interactionId,
+                        command.ttlEpochS())).build(),
+                    TransactWriteItem.builder().put(lookupPut(
+                        "correlation",
+                        command.tenantId(),
+                        command.correlationId(),
+                        interactionId,
+                        command.ttlEpochS())).build())
+                .build());
+            return new AwaitCreateResult(created, false);
+        } catch (TransactionCanceledException | ConditionalCheckFailedException ignored) {
+            return findByLookup(
+                lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
+                command.tenantId())
+                .map(record -> new AwaitCreateResult(record, true))
+                .orElseThrow(() -> ignored);
+        }
+    }
+
+    private AwaitCompletionResult completeBlocking(AwaitCompletionCommand command) {
+        AwaitInteractionRecord current = resolveForCompletion(command)
+            .orElseThrow(() -> new IllegalArgumentException("No await interaction matches completion"));
+        if (current.status() == AwaitInteractionStatus.COMPLETED) {
+            return new AwaitCompletionResult(current, true);
+        }
+        if (current.status().terminal()) {
+            throw new IllegalStateException("Await interaction is terminal: " + current.status());
+        }
+        if (current.deadlineEpochMs() <= command.nowEpochMs()) {
+            transitionStatus(
+                current.tenantId(),
+                current.interactionId(),
+                current.version(),
+                AwaitInteractionStatus.TIMED_OUT,
+                null,
+                null,
+                null,
+                command.nowEpochMs());
+            throw new IllegalStateException("Await interaction timed out before completion");
+        }
+        AwaitInteractionRecord completed = transitionStatus(
+            current.tenantId(),
+            current.interactionId(),
+            current.version(),
+            AwaitInteractionStatus.COMPLETED,
+            command.responsePayload(),
+            command.actor(),
+            null,
+            command.nowEpochMs())
+            .orElseThrow(() -> new IllegalStateException("Await completion transition lost OCC race"));
+        return new AwaitCompletionResult(completed, false);
+    }
+
+    private Optional<AwaitInteractionRecord> resolveForCompletion(AwaitCompletionCommand command) {
+        if (command.interactionId() != null && !command.interactionId().isBlank()) {
+            return getBlocking(command.tenantId(), command.interactionId(), command.nowEpochMs());
+        }
+        if (command.correlationId() != null && !command.correlationId().isBlank()) {
+            return findByLookup(lookupKey("correlation", command.tenantId(), command.correlationId()), command.tenantId());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<AwaitInteractionRecord> transitionStatus(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        AwaitInteractionStatus status,
+        Object responsePayload,
+        String actor,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
+        Map<String, String> names = new HashMap<>();
+        names.put("#version", VERSION);
+        names.put("#status", STATUS);
+        names.put("#response", RESPONSE_PAYLOAD_JSON);
+        names.put("#actor", ACTOR);
+        names.put("#metadata", TRANSPORT_METADATA_JSON);
+        names.put("#updated", UPDATED_AT_EPOCH_MS);
+        names.put("#ttl", TTL_EPOCH_S);
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":expected", avN(expectedVersion));
+        values.put(":status", avS(status.name()));
+        values.put(":one", avN(1));
+        values.put(":now", avN(nowEpochMs));
+        values.put(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+        if (responsePayload != null) {
+            values.put(":response", avS(toJson(responsePayload)));
+        }
+        if (actor != null && !actor.isBlank()) {
+            values.put(":actor", avS(actor));
+        }
+        if (transportMetadata != null) {
+            values.put(":metadata", avS(toJson(transportMetadata)));
+        }
+        StringBuilder update = new StringBuilder("SET #status = :status, #version = #version + :one, #updated = :now");
+        if (responsePayload != null) {
+            update.append(", #response = :response");
+        }
+        if (actor != null && !actor.isBlank()) {
+            update.append(", #actor = :actor");
+        }
+        if (transportMetadata != null) {
+            update.append(", #metadata = :metadata");
+        }
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(UpdateItemRequest.builder()
+                .tableName(interactionTable())
+                .key(primaryKey(tenantId, interactionId))
+                .conditionExpression("#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .updateExpression(update.toString())
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .returnValues(ReturnValue.ALL_NEW)
+                .build()).attributes();
+            return attributes == null || attributes.isEmpty() ? Optional.empty() : Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<AwaitInteractionRecord> getBlocking(String tenantId, String interactionId, long nowEpochMs) {
+        Map<String, AttributeValue> item = dynamoClient().getItem(GetItemRequest.builder()
+            .tableName(interactionTable())
+            .key(primaryKey(tenantId, interactionId))
+            .consistentRead(true)
+            .build()).item();
+        if (item == null || item.isEmpty()) {
+            return Optional.empty();
+        }
+        AwaitInteractionRecord record = toRecord(item);
+        return record.ttlEpochS() > 0 && record.ttlEpochS() <= Instant.ofEpochMilli(nowEpochMs).getEpochSecond()
+            ? Optional.empty()
+            : Optional.of(record);
+    }
+
+    private Optional<AwaitInteractionRecord> findByLookup(String lookupKey, String tenantId) {
+        Map<String, AttributeValue> item = dynamoClient().getItem(GetItemRequest.builder()
+            .tableName(lookupTable())
+            .key(Map.of(LOOKUP_KEY, avS(lookupKey)))
+            .consistentRead(true)
+            .build()).item();
+        if (item == null || item.isEmpty()) {
+            return Optional.empty();
+        }
+        String interactionId = readString(item, INTERACTION_ID);
+        return interactionId == null || interactionId.isBlank()
+            ? Optional.empty()
+            : getBlocking(tenantId, interactionId, System.currentTimeMillis());
+    }
+
+    private Put lookupPut(String kind, String tenantId, String key, String interactionId, long ttlEpochS) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put(LOOKUP_KEY, avS(lookupKey(kind, tenantId, key)));
+        item.put(LOOKUP_KIND, avS(kind));
+        item.put(TENANT_ID, avS(tenantId));
+        item.put(INTERACTION_ID, avS(interactionId));
+        item.put(TTL_EPOCH_S, avN(ttlEpochS));
+        return Put.builder()
+            .tableName(lookupTable())
+            .item(item)
+            .conditionExpression("attribute_not_exists(#lookup)")
+            .expressionAttributeNames(Map.of("#lookup", LOOKUP_KEY))
+            .build();
+    }
+
+    private Map<String, AttributeValue> toItem(AwaitInteractionRecord record) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put(TENANT_ID, avS(record.tenantId()));
+        item.put(INTERACTION_ID, avS(record.interactionId()));
+        item.put(EXECUTION_ID, avS(record.executionId()));
+        item.put(STEP_ID, avS(record.stepId()));
+        item.put(STEP_INDEX, avN(record.stepIndex()));
+        item.put(OUTPUT_TYPE, avS(record.outputType()));
+        item.put(CORRELATION_ID, avS(record.correlationId()));
+        item.put(IDEMPOTENCY_KEY, avS(record.idempotencyKey()));
+        item.put(VERSION, avN(record.version()));
+        item.put(STATUS, avS(record.status().name()));
+        item.put(REQUEST_PAYLOAD_JSON, avS(toJson(record.requestPayload())));
+        item.put(TRANSPORT_TYPE, avS(record.transportType()));
+        item.put(TRANSPORT_METADATA_JSON, avS(toJson(record.transportMetadata())));
+        item.put(DEADLINE_EPOCH_MS, avN(record.deadlineEpochMs()));
+        item.put(CREATED_AT_EPOCH_MS, avN(record.createdAtEpochMs()));
+        item.put(UPDATED_AT_EPOCH_MS, avN(record.updatedAtEpochMs()));
+        item.put(TTL_EPOCH_S, avN(record.ttlEpochS()));
+        putIfPresent(item, CAUSATION_ID, record.causationId());
+        putIfPresent(item, RESPONSE_PAYLOAD_JSON, toJson(record.responsePayload()));
+        putIfPresent(item, ACTOR, record.actor());
+        putIfPresent(item, ASSIGNEE, record.assignee());
+        putIfPresent(item, GROUP, record.group());
+        return item;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AwaitInteractionRecord toRecord(Map<String, AttributeValue> item) {
+        return new AwaitInteractionRecord(
+            readString(item, TENANT_ID),
+            readString(item, EXECUTION_ID),
+            readString(item, STEP_ID),
+            (int) readLong(item, STEP_INDEX),
+            readString(item, OUTPUT_TYPE),
+            readString(item, INTERACTION_ID),
+            readString(item, CORRELATION_ID),
+            readString(item, CAUSATION_ID),
+            readString(item, IDEMPOTENCY_KEY),
+            readLong(item, VERSION),
+            AwaitInteractionStatus.valueOf(readString(item, STATUS)),
+            fromJson(readString(item, REQUEST_PAYLOAD_JSON)),
+            fromJson(readString(item, RESPONSE_PAYLOAD_JSON)),
+            readString(item, ACTOR),
+            readString(item, ASSIGNEE),
+            readString(item, GROUP),
+            readString(item, TRANSPORT_TYPE),
+            (Map<String, Object>) Optional.ofNullable(fromJson(readString(item, TRANSPORT_METADATA_JSON))).orElse(Map.of()),
+            readLong(item, DEADLINE_EPOCH_MS),
+            readLong(item, CREATED_AT_EPOCH_MS),
+            readLong(item, UPDATED_AT_EPOCH_MS),
+            readLong(item, TTL_EPOCH_S));
+    }
+
+    private <T> Uni<T> blocking(Supplier<T> supplier) {
+        return Uni.createFrom().item(supplier).runSubscriptionOn(Infrastructure.getDefaultExecutor());
+    }
+
+    private DynamoDbClient dynamoClient() {
+        DynamoDbClient active = client;
+        if (active != null) {
+            return active;
+        }
+        synchronized (this) {
+            active = client;
+            if (active != null) {
+                return active;
+            }
+            var builder = DynamoDbClient.builder();
+            builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+            orchestratorConfig.dynamo().region().filter(region -> !region.isBlank())
+                .ifPresent(region -> builder.region(Region.of(region)));
+            orchestratorConfig.dynamo().endpointOverride()
+                .filter(endpoint -> !endpoint.isBlank())
+                .ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
+            client = builder.build();
+            return client;
+        }
+    }
+
+    private String interactionTable() {
+        return orchestratorConfig.dynamo().awaitInteractionTable();
+    }
+
+    private String lookupTable() {
+        return orchestratorConfig.dynamo().awaitInteractionKeyTable();
+    }
+
+    private String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return PipelineJson.mapper().writeValueAsString(encode(value));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed serializing await payload to JSON.", e);
+        }
+    }
+
+    private Object fromJson(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            Object decoded = PipelineJson.mapper().readValue(value, Object.class);
+            if (decoded instanceof Map<?, ?> map && map.containsKey(ENCODED_JAVA_CLASS)) {
+                String className = String.valueOf(map.get(ENCODED_JAVA_CLASS));
+                Object payload = map.get(ENCODED_PAYLOAD);
+                return PipelineJson.mapper().convertValue(payload, Class.forName(className));
+            }
+            return decoded;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed deserializing await payload JSON.", e);
+        }
+    }
+
+    private Object encode(Object value) {
+        if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean
+            || value instanceof Map<?, ?> || value instanceof Iterable<?>) {
+            return value;
+        }
+        return Map.of(
+            ENCODED_JAVA_CLASS, value.getClass().getName(),
+            ENCODED_PAYLOAD, PipelineJson.mapper().convertValue(value, Object.class));
+    }
+
+    private static String lookupKey(String kind, String tenantId, String key) {
+        return kind + ":" + tenantId.length() + ":" + tenantId + ":" + key.length() + ":" + key;
+    }
+
+    private static Map<String, AttributeValue> primaryKey(String tenantId, String interactionId) {
+        return Map.of(TENANT_ID, avS(tenantId), INTERACTION_ID, avS(interactionId));
+    }
+
+    private static AttributeValue avS(String value) {
+        return AttributeValue.builder().s(value == null ? "" : value).build();
+    }
+
+    private static AttributeValue avN(long value) {
+        return AttributeValue.builder().n(Long.toString(value)).build();
+    }
+
+    private static String readString(Map<String, AttributeValue> item, String key) {
+        AttributeValue value = item.get(key);
+        return value == null ? null : value.s();
+    }
+
+    private static long readLong(Map<String, AttributeValue> item, String key) {
+        AttributeValue value = item.get(key);
+        if (value == null || value.n() == null || value.n().isBlank()) {
+            return 0L;
+        }
+        return Long.parseLong(value.n());
+    }
+
+    private static void putIfPresent(Map<String, AttributeValue> item, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            item.put(key, avS(value));
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -212,24 +212,33 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
                 ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
                 ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
-            var response = dynamoClient().scan(ScanRequest.builder()
-                .tableName(interactionTable())
-                .filterExpression("#deadline <= :now AND #status <> :completed AND #status <> :failed "
-                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
-                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
-                .expressionAttributeNames(names)
-                .expressionAttributeValues(values)
-                .limit(limit)
-                .build());
-            if (response.items() == null || response.items().isEmpty()) {
-                return List.of();
-            }
             List<AwaitInteractionRecord> records = new ArrayList<>();
-            for (Map<String, AttributeValue> item : response.items()) {
-                records.add(toRecord(item));
-            }
+            Map<String, AttributeValue> lastEvaluatedKey = null;
+            do {
+                ScanRequest.Builder request = ScanRequest.builder()
+                    .tableName(interactionTable())
+                    .filterExpression("#deadline <= :now AND #status <> :completed AND #status <> :failed "
+                        + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                        + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                    .expressionAttributeNames(names)
+                    .expressionAttributeValues(values)
+                    .limit(scanPageLimit(limit));
+                if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+                    request.exclusiveStartKey(lastEvaluatedKey);
+                }
+                var response = dynamoClient().scan(request.build());
+                if (response.items() != null) {
+                    for (Map<String, AttributeValue> item : response.items()) {
+                        records.add(toRecord(item));
+                        if (records.size() >= limit) {
+                            break;
+                        }
+                    }
+                }
+                lastEvaluatedKey = response.lastEvaluatedKey();
+            } while (records.size() < limit && lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty());
             records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
-            return List.copyOf(records);
+            return List.copyOf(records.subList(0, Math.min(records.size(), limit)));
         });
     }
 
@@ -253,32 +262,41 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
                 ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
                 ":nowSec", avN(Instant.now().getEpochSecond()));
-            var response = dynamoClient().scan(ScanRequest.builder()
-                .tableName(interactionTable())
-                .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
-                    + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
-                    + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
-                .expressionAttributeNames(names)
-                .expressionAttributeValues(values)
-                .limit(Math.max(limit * 3, limit))
-                .build());
-            if (response.items() == null || response.items().isEmpty()) {
-                return List.of();
-            }
             List<AwaitInteractionRecord> records = new ArrayList<>();
-            for (Map<String, AttributeValue> item : response.items()) {
-                AwaitInteractionRecord record = toRecord(item);
-                if (assignee != null && !Objects.equals(assignee, record.assignee())) {
-                    continue;
+            Map<String, AttributeValue> lastEvaluatedKey = null;
+            do {
+                ScanRequest.Builder request = ScanRequest.builder()
+                    .tableName(interactionTable())
+                    .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
+                        + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                        + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                    .expressionAttributeNames(names)
+                    .expressionAttributeValues(values)
+                    .limit(scanPageLimit(limit));
+                if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+                    request.exclusiveStartKey(lastEvaluatedKey);
                 }
-                if (group != null && !Objects.equals(group, record.group())) {
-                    continue;
+                var response = dynamoClient().scan(request.build());
+                if (response.items() != null) {
+                    for (Map<String, AttributeValue> item : response.items()) {
+                        AwaitInteractionRecord record = toRecord(item);
+                        if (assignee != null && !Objects.equals(assignee, record.assignee())) {
+                            continue;
+                        }
+                        if (group != null && !Objects.equals(group, record.group())) {
+                            continue;
+                        }
+                        if (stepId != null && !Objects.equals(stepId, record.stepId())) {
+                            continue;
+                        }
+                        records.add(record);
+                        if (records.size() >= limit) {
+                            break;
+                        }
+                    }
                 }
-                if (stepId != null && !Objects.equals(stepId, record.stepId())) {
-                    continue;
-                }
-                records.add(record);
-            }
+                lastEvaluatedKey = response.lastEvaluatedKey();
+            } while (records.size() < limit && lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty());
             records.sort(java.util.Comparator.comparingLong(AwaitInteractionRecord::deadlineEpochMs));
             return List.copyOf(records.subList(0, Math.min(records.size(), limit)));
         });
@@ -534,9 +552,9 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         item.put(IDEMPOTENCY_KEY, avS(record.idempotencyKey()));
         item.put(VERSION, avN(record.version()));
         item.put(STATUS, avS(record.status().name()));
-        item.put(REQUEST_PAYLOAD_JSON, avS(toJson(record.requestPayload())));
+        putIfPresent(item, REQUEST_PAYLOAD_JSON, toJson(record.requestPayload()));
         item.put(TRANSPORT_TYPE, avS(record.transportType()));
-        item.put(TRANSPORT_METADATA_JSON, avS(toJson(record.transportMetadata())));
+        putIfPresent(item, TRANSPORT_METADATA_JSON, toJson(record.transportMetadata()));
         item.put(DEADLINE_EPOCH_MS, avN(record.deadlineEpochMs()));
         item.put(CREATED_AT_EPOCH_MS, avN(record.createdAtEpochMs()));
         item.put(UPDATED_AT_EPOCH_MS, avN(record.updatedAtEpochMs()));
@@ -657,7 +675,11 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
     }
 
     private static AttributeValue avS(String value) {
-        return AttributeValue.builder().s(value == null ? "" : value).build();
+        return value == null ? null : AttributeValue.builder().s(value).build();
+    }
+
+    private static int scanPageLimit(int limit) {
+        return (int) Math.min(Math.max((long) limit * 3L, (long) limit), 1_000L);
     }
 
     private static AttributeValue avN(long value) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -253,23 +252,39 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             if (limit <= 0) {
                 return List.of();
             }
-            Map<String, String> names = Map.of("#tenant", TENANT_ID, "#status", STATUS, "#ttl", TTL_EPOCH_S);
-            Map<String, AttributeValue> values = Map.of(
+            Map<String, String> names = new HashMap<>(Map.of("#tenant", TENANT_ID, "#status", STATUS, "#ttl", TTL_EPOCH_S));
+            Map<String, AttributeValue> values = new HashMap<>(Map.of(
                 ":tenant", avS(tenantId),
                 ":completed", avS(AwaitInteractionStatus.COMPLETED.name()),
                 ":failed", avS(AwaitInteractionStatus.FAILED.name()),
                 ":timedOut", avS(AwaitInteractionStatus.TIMED_OUT.name()),
                 ":cancelled", avS(AwaitInteractionStatus.CANCELLED.name()),
                 ":expired", avS(AwaitInteractionStatus.EXPIRED.name()),
-                ":nowSec", avN(Instant.now().getEpochSecond()));
+                ":nowSec", avN(Instant.now().getEpochSecond())));
+            StringBuilder filter = new StringBuilder("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
+                + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
+                + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)");
+            if (assignee != null) {
+                names.put("#assignee", ASSIGNEE);
+                values.put(":assignee", avS(assignee));
+                filter.append(" AND #assignee = :assignee");
+            }
+            if (group != null) {
+                names.put("#group", GROUP);
+                values.put(":group", avS(group));
+                filter.append(" AND #group = :group");
+            }
+            if (stepId != null) {
+                names.put("#stepId", STEP_ID);
+                values.put(":stepId", avS(stepId));
+                filter.append(" AND #stepId = :stepId");
+            }
             List<AwaitInteractionRecord> records = new ArrayList<>();
             Map<String, AttributeValue> lastEvaluatedKey = null;
             do {
                 ScanRequest.Builder request = ScanRequest.builder()
                     .tableName(interactionTable())
-                    .filterExpression("#tenant = :tenant AND #status <> :completed AND #status <> :failed "
-                        + "AND #status <> :timedOut AND #status <> :cancelled AND #status <> :expired "
-                        + "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                    .filterExpression(filter.toString())
                     .expressionAttributeNames(names)
                     .expressionAttributeValues(values)
                     .limit(scanPageLimit(limit));
@@ -280,15 +295,6 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 if (response.items() != null) {
                     for (Map<String, AttributeValue> item : response.items()) {
                         AwaitInteractionRecord record = toRecord(item);
-                        if (assignee != null && !Objects.equals(assignee, record.assignee())) {
-                            continue;
-                        }
-                        if (group != null && !Objects.equals(group, record.group())) {
-                            continue;
-                        }
-                        if (stepId != null && !Objects.equals(stepId, record.stepId())) {
-                            continue;
-                        }
                         records.add(record);
                         if (records.size() >= limit) {
                             break;
@@ -328,7 +334,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
             command.tenantId(),
             command.nowEpochMs());
-        if (existing.isPresent() && !existing.get().status().terminal()) {
+        if (existing.isPresent()) {
             return new AwaitCreateResult(existing.get(), true);
         }
 
@@ -400,7 +406,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             throw new IllegalStateException("Await interaction is terminal: " + current.status());
         }
         if (current.deadlineEpochMs() <= command.nowEpochMs()) {
-            transitionStatus(
+            Optional<AwaitInteractionRecord> timedOut = transitionStatus(
                 current.tenantId(),
                 current.interactionId(),
                 current.version(),
@@ -409,6 +415,15 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 null,
                 null,
                 command.nowEpochMs());
+            if (timedOut.isEmpty()) {
+                Optional<AwaitInteractionRecord> refreshed = getBlocking(
+                    current.tenantId(),
+                    current.interactionId(),
+                    command.nowEpochMs());
+                if (refreshed.isPresent() && refreshed.get().status() == AwaitInteractionStatus.COMPLETED) {
+                    return new AwaitCompletionResult(refreshed.get(), true);
+                }
+            }
             throw new IllegalStateException("Await interaction timed out before completion");
         }
         AwaitInteractionRecord completed = transitionStatus(
@@ -573,7 +588,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             readString(item, TENANT_ID),
             readString(item, EXECUTION_ID),
             readString(item, STEP_ID),
-            (int) readLong(item, STEP_INDEX),
+            Math.toIntExact(readLong(item, STEP_INDEX)),
             readString(item, OUTPUT_TYPE),
             readString(item, INTERACTION_ID),
             readString(item, CORRELATION_ID),
@@ -609,7 +624,9 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
                 return active;
             }
             var builder = DynamoDbClient.builder();
-            builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+            builder.httpClientBuilder(UrlConnectionHttpClient.builder()
+                .connectionTimeout(java.time.Duration.ofSeconds(10))
+                .socketTimeout(java.time.Duration.ofSeconds(30)));
             orchestratorConfig.dynamo().region().filter(region -> !region.isBlank())
                 .ifPresent(region -> builder.region(Region.of(region)));
             orchestratorConfig.dynamo().endpointOverride()

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -112,7 +112,10 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
 
     @Override
     public Uni<Optional<AwaitInteractionRecord>> findByCorrelation(String tenantId, String correlationId) {
-        return blocking(() -> findByLookup(lookupKey("correlation", tenantId, correlationId), tenantId));
+        return blocking(() -> findByLookup(
+            lookupKey("correlation", tenantId, correlationId),
+            tenantId,
+            System.currentTimeMillis()));
     }
 
     @Override
@@ -305,7 +308,8 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
     private AwaitCreateResult createOrGetBlocking(AwaitCreateCommand command) {
         Optional<AwaitInteractionRecord> existing = findByLookup(
             lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
-            command.tenantId());
+            command.tenantId(),
+            command.nowEpochMs());
         if (existing.isPresent() && !existing.get().status().terminal()) {
             return new AwaitCreateResult(existing.get(), true);
         }
@@ -361,7 +365,8 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         } catch (TransactionCanceledException | ConditionalCheckFailedException ignored) {
             return findByLookup(
                 lookupKey("idempotency", command.tenantId(), command.stepId() + ":" + command.idempotencyKey()),
-                command.tenantId())
+                command.tenantId(),
+                command.nowEpochMs())
                 .map(record -> new AwaitCreateResult(record, true))
                 .orElseThrow(() -> ignored);
         }
@@ -406,7 +411,10 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             return getBlocking(command.tenantId(), command.interactionId(), command.nowEpochMs());
         }
         if (command.correlationId() != null && !command.correlationId().isBlank()) {
-            return findByLookup(lookupKey("correlation", command.tenantId(), command.correlationId()), command.tenantId());
+            return findByLookup(
+                lookupKey("correlation", command.tenantId(), command.correlationId()),
+                command.tenantId(),
+                command.nowEpochMs());
         }
         return Optional.empty();
     }
@@ -484,7 +492,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             : Optional.of(record);
     }
 
-    private Optional<AwaitInteractionRecord> findByLookup(String lookupKey, String tenantId) {
+    private Optional<AwaitInteractionRecord> findByLookup(String lookupKey, String tenantId, long nowEpochMs) {
         Map<String, AttributeValue> item = dynamoClient().getItem(GetItemRequest.builder()
             .tableName(lookupTable())
             .key(Map.of(LOOKUP_KEY, avS(lookupKey)))
@@ -496,7 +504,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         String interactionId = readString(item, INTERACTION_ID);
         return interactionId == null || interactionId.isBlank()
             ? Optional.empty()
-            : getBlocking(tenantId, interactionId, System.currentTimeMillis());
+            : getBlocking(tenantId, interactionId, nowEpochMs);
     }
 
     private Put lookupPut(String kind, String tenantId, String key, String interactionId, long ttlEpochS) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitInteractionStore.java
@@ -118,6 +118,24 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
     }
 
     @Override
+    public Uni<Optional<AwaitInteractionRecord>> markDispatching(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        long nowEpochMs) {
+        return blocking(() -> transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            AwaitInteractionStatus.WAITING,
+            AwaitInteractionStatus.DISPATCHING,
+            null,
+            null,
+            null,
+            nowEpochMs));
+    }
+
+    @Override
     public Uni<Optional<AwaitInteractionRecord>> markDispatched(
         String tenantId,
         String interactionId,
@@ -128,6 +146,7 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
             tenantId,
             interactionId,
             expectedVersion,
+            AwaitInteractionStatus.DISPATCHING,
             AwaitInteractionStatus.DISPATCHED,
             null,
             null,
@@ -461,6 +480,28 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         String actor,
         Map<String, Object> transportMetadata,
         long nowEpochMs) {
+        return transitionStatus(
+            tenantId,
+            interactionId,
+            expectedVersion,
+            null,
+            status,
+            responsePayload,
+            actor,
+            transportMetadata,
+            nowEpochMs);
+    }
+
+    private Optional<AwaitInteractionRecord> transitionStatus(
+        String tenantId,
+        String interactionId,
+        long expectedVersion,
+        AwaitInteractionStatus requiredStatus,
+        AwaitInteractionStatus status,
+        Object responsePayload,
+        String actor,
+        Map<String, Object> transportMetadata,
+        long nowEpochMs) {
         Map<String, String> names = new HashMap<>();
         names.put("#version", VERSION);
         names.put("#status", STATUS);
@@ -475,6 +516,9 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         values.put(":one", avN(1));
         values.put(":now", avN(nowEpochMs));
         values.put(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+        if (requiredStatus != null) {
+            values.put(":requiredStatus", avS(requiredStatus.name()));
+        }
         if (responsePayload != null) {
             values.put(":response", avS(toJson(responsePayload)));
         }
@@ -494,11 +538,15 @@ public class DynamoAwaitInteractionStore implements AwaitInteractionStore {
         if (transportMetadata != null) {
             update.append(", #metadata = :metadata");
         }
+        String condition = "#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)";
+        if (requiredStatus != null) {
+            condition = "#version = :expected AND #status = :requiredStatus AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)";
+        }
         try {
             Map<String, AttributeValue> attributes = dynamoClient().updateItem(UpdateItemRequest.builder()
                 .tableName(interactionTable())
                 .key(primaryKey(tenantId, interactionId))
-                .conditionExpression("#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+                .conditionExpression(condition)
                 .updateExpression(update.toString())
                 .expressionAttributeNames(names)
                 .expressionAttributeValues(values)

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
@@ -552,6 +552,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             Map.entry("#ttl", TTL_EPOCH_S));
         Map<String, AttributeValue> values = Map.ofEntries(
             Map.entry(":queued", avS(ExecutionStatus.QUEUED.name())),
+            Map.entry(":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name())),
             Map.entry(":step", avN(nextStepIndex)),
             Map.entry(":awaitInteraction", avS(awaitInteractionId)),
             Map.entry(":resume", avS(toJson(resumePayload))),
@@ -564,7 +565,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .tableName(executionTable())
             .key(executionPrimaryKey(tenantId, executionId))
             .conditionExpression(
-                "(attribute_not_exists(#awaitInteraction) OR #awaitInteraction = :awaitInteraction) " +
+                "#status = :waitingExternal " +
+                    "AND (attribute_not_exists(#awaitInteraction) OR #awaitInteraction = :awaitInteraction) " +
                     "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
             .updateExpression(
                 "SET #status = :queued, #version = #version + :one, #step = :step, #nextDue = :now, " +

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
@@ -63,6 +63,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
     private static final String LAST_TRANSITION_KEY = "last_transition_key";
     private static final String INPUT_SHAPE = "input_shape";
     private static final String INPUT_PAYLOAD_JSON = "input_payload_json";
+    private static final String AWAIT_INTERACTION_ID = "await_interaction_id";
+    private static final String RESUME_PAYLOAD_JSON = "resume_payload_json";
     private static final String RESULT_PAYLOAD_JSON = "result_payload_json";
     private static final String ERROR_CODE = "error_code";
     private static final String ERROR_MESSAGE = "error_message";
@@ -278,6 +280,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             null,
             null,
             null,
+            null,
+            null,
             command.nowEpochMs(),
             command.nowEpochMs(),
             command.ttlEpochS());
@@ -340,6 +344,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             ":running", avS(ExecutionStatus.RUNNING.name()),
             ":one", avN(1),
             ":succeeded", avS(ExecutionStatus.SUCCEEDED.name()),
+            ":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name()),
             ":failed", avS(ExecutionStatus.FAILED.name()),
             ":dlq", avS(ExecutionStatus.DLQ.name()),
             ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
@@ -350,7 +355,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .conditionExpression(
                 "#nextDue <= :now " +
                     "AND (attribute_not_exists(#leaseOwner) OR #leaseExpires <= :now) " +
-                    "AND #status <> :succeeded AND #status <> :failed AND #status <> :dlq " +
+                    "AND #status <> :succeeded AND #status <> :waitingExternal AND #status <> :failed AND #status <> :dlq " +
                     "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
             .updateExpression(
                 "SET #status = :running, #leaseOwner = :leaseOwner, #leaseExpires = :leaseExpires, " +
@@ -383,6 +388,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         names.put("#version", VERSION);
         names.put("#transition", LAST_TRANSITION_KEY);
         names.put("#result", RESULT_PAYLOAD_JSON);
+        names.put("#awaitInteraction", AWAIT_INTERACTION_ID);
+        names.put("#resume", RESUME_PAYLOAD_JSON);
         names.put("#errorCode", ERROR_CODE);
         names.put("#errorMessage", ERROR_MESSAGE);
         names.put("#leaseOwner", LEASE_OWNER);
@@ -408,7 +415,161 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .updateExpression(
                 "SET #status = :succeeded, #version = #version + :one, #transition = :transition, " +
                     "#result = :result, #leaseExpires = :zero, #nextDue = :now, #updated = :now " +
-                    "REMOVE #errorCode, #errorMessage, #leaseOwner")
+                    "REMOVE #errorCode, #errorMessage, #leaseOwner, #awaitInteraction, #resume")
+            .expressionAttributeNames(names)
+            .expressionAttributeValues(values)
+            .returnValues(ReturnValue.ALL_NEW)
+            .build();
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(request).attributes();
+            if (attributes == null || attributes.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs
+    ) {
+        return blocking(() -> markWaitingExternalBlocking(
+            tenantId,
+            executionId,
+            expectedVersion,
+            transitionKey,
+            awaitInteractionId,
+            awaitStepIndex,
+            nowEpochMs));
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs
+    ) {
+        return blocking(() -> markAwaitCompletedBlocking(
+            tenantId,
+            executionId,
+            awaitInteractionId,
+            resumePayload,
+            nextStepIndex,
+            nowEpochMs));
+    }
+
+    private Optional<ExecutionRecord<Object, Object>> markWaitingExternalBlocking(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs
+    ) {
+        Map<String, String> names = Map.ofEntries(
+            Map.entry("#status", STATUS),
+            Map.entry("#version", VERSION),
+            Map.entry("#step", CURRENT_STEP_INDEX),
+            Map.entry("#nextDue", NEXT_DUE_EPOCH_MS),
+            Map.entry("#transition", LAST_TRANSITION_KEY),
+            Map.entry("#awaitInteraction", AWAIT_INTERACTION_ID),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
+            Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#errorCode", ERROR_CODE),
+            Map.entry("#errorMessage", ERROR_MESSAGE),
+            Map.entry("#leaseOwner", LEASE_OWNER),
+            Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
+            Map.entry("#updated", UPDATED_AT_EPOCH_MS),
+            Map.entry("#ttl", TTL_EPOCH_S));
+        Map<String, AttributeValue> values = Map.ofEntries(
+            Map.entry(":expected", avN(expectedVersion)),
+            Map.entry(":waiting", avS(ExecutionStatus.WAITING_EXTERNAL.name())),
+            Map.entry(":step", avN(awaitStepIndex)),
+            Map.entry(":awaitInteraction", avS(awaitInteractionId)),
+            Map.entry(":nextDue", avN(Long.MAX_VALUE)),
+            Map.entry(":transition", avS(transitionKey == null ? "" : transitionKey)),
+            Map.entry(":zero", avN(0)),
+            Map.entry(":now", avN(nowEpochMs)),
+            Map.entry(":one", avN(1)),
+            Map.entry(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond())));
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+            .tableName(executionTable())
+            .key(executionPrimaryKey(tenantId, executionId))
+            .conditionExpression("#version = :expected AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+            .updateExpression(
+                "SET #status = :waiting, #version = #version + :one, #step = :step, #nextDue = :nextDue, " +
+                    "#transition = :transition, #awaitInteraction = :awaitInteraction, #leaseExpires = :zero, " +
+                    "#updated = :now REMOVE #resume, #result, #errorCode, #errorMessage, #leaseOwner")
+            .expressionAttributeNames(names)
+            .expressionAttributeValues(values)
+            .returnValues(ReturnValue.ALL_NEW)
+            .build();
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(request).attributes();
+            if (attributes == null || attributes.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<ExecutionRecord<Object, Object>> markAwaitCompletedBlocking(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs
+    ) {
+        Map<String, String> names = Map.ofEntries(
+            Map.entry("#status", STATUS),
+            Map.entry("#version", VERSION),
+            Map.entry("#step", CURRENT_STEP_INDEX),
+            Map.entry("#nextDue", NEXT_DUE_EPOCH_MS),
+            Map.entry("#awaitInteraction", AWAIT_INTERACTION_ID),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
+            Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#errorCode", ERROR_CODE),
+            Map.entry("#errorMessage", ERROR_MESSAGE),
+            Map.entry("#leaseOwner", LEASE_OWNER),
+            Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
+            Map.entry("#updated", UPDATED_AT_EPOCH_MS),
+            Map.entry("#ttl", TTL_EPOCH_S));
+        Map<String, AttributeValue> values = Map.ofEntries(
+            Map.entry(":queued", avS(ExecutionStatus.QUEUED.name())),
+            Map.entry(":step", avN(nextStepIndex)),
+            Map.entry(":awaitInteraction", avS(awaitInteractionId)),
+            Map.entry(":resume", avS(toJson(resumePayload))),
+            Map.entry(":zero", avN(0)),
+            Map.entry(":now", avN(nowEpochMs)),
+            Map.entry(":one", avN(1)),
+            Map.entry(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond())));
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+            .tableName(executionTable())
+            .key(executionPrimaryKey(tenantId, executionId))
+            .conditionExpression(
+                "(attribute_not_exists(#awaitInteraction) OR #awaitInteraction = :awaitInteraction) " +
+                    "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+            .updateExpression(
+                "SET #status = :queued, #version = #version + :one, #step = :step, #nextDue = :now, " +
+                    "#awaitInteraction = :awaitInteraction, #resume = :resume, #leaseExpires = :zero, #updated = :now " +
+                    "REMOVE #result, #errorCode, #errorMessage, #leaseOwner")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)
             .returnValues(ReturnValue.ALL_NEW)
@@ -444,6 +605,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             Map.entry("#errorCode", ERROR_CODE),
             Map.entry("#errorMessage", ERROR_MESSAGE),
             Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#awaitInteraction", AWAIT_INTERACTION_ID),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
             Map.entry("#leaseOwner", LEASE_OWNER),
             Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
             Map.entry("#updated", UPDATED_AT_EPOCH_MS),
@@ -468,7 +631,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .updateExpression(
                 "SET #status = :retry, #version = #version + :one, #attempt = :attempt, #nextDue = :nextDue, " +
                     "#transition = :transition, #errorCode = :errorCode, #errorMessage = :errorMessage, " +
-                    "#leaseExpires = :zero, #updated = :now REMOVE #result, #leaseOwner")
+                    "#leaseExpires = :zero, #updated = :now REMOVE #result, #awaitInteraction, #resume, #leaseOwner")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)
             .returnValues(ReturnValue.ALL_NEW)
@@ -502,6 +665,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             Map.entry("#errorCode", ERROR_CODE),
             Map.entry("#errorMessage", ERROR_MESSAGE),
             Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#resume", RESUME_PAYLOAD_JSON),
             Map.entry("#leaseOwner", LEASE_OWNER),
             Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
             Map.entry("#updated", UPDATED_AT_EPOCH_MS),
@@ -524,7 +688,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             .updateExpression(
                 "SET #status = :finalStatus, #version = #version + :one, #nextDue = :now, #transition = :transition, " +
                     "#errorCode = :errorCode, #errorMessage = :errorMessage, #leaseExpires = :zero, #updated = :now " +
-                    "REMOVE #result, #leaseOwner")
+                    "REMOVE #result, #resume, #leaseOwner")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)
             .returnValues(ReturnValue.ALL_NEW)
@@ -550,6 +714,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         Map<String, AttributeValue> values = Map.of(
             ":now", avN(nowEpochMs),
             ":succeeded", avS(ExecutionStatus.SUCCEEDED.name()),
+            ":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name()),
             ":failed", avS(ExecutionStatus.FAILED.name()),
             ":dlq", avS(ExecutionStatus.DLQ.name()),
             ":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
@@ -564,7 +729,7 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
                 .filterExpression(
                     "#nextDue <= :now " +
                         "AND (attribute_not_exists(#leaseOwner) OR #leaseExpires <= :now) " +
-                        "AND #status <> :succeeded AND #status <> :failed AND #status <> :dlq " +
+                        "AND #status <> :succeeded AND #status <> :waitingExternal AND #status <> :failed AND #status <> :dlq " +
                         "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
                 .expressionAttributeNames(names)
                 .expressionAttributeValues(values)
@@ -702,6 +867,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         putIfPresent(item, LEASE_OWNER, record.leaseOwner());
         putIfPresent(item, LAST_TRANSITION_KEY, record.lastTransitionKey());
         putInputPayload(item, record.inputPayload());
+        putIfPresent(item, AWAIT_INTERACTION_ID, record.awaitInteractionId());
+        putIfPresent(item, RESUME_PAYLOAD_JSON, toJson(record.resumePayload()));
         putIfPresent(item, RESULT_PAYLOAD_JSON, toJson(record.resultPayload()));
         putIfPresent(item, ERROR_CODE, record.errorCode());
         putIfPresent(item, ERROR_MESSAGE, record.errorMessage());
@@ -740,6 +907,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
         long nextDue = readLong(item, NEXT_DUE_EPOCH_MS);
         String transitionKey = readString(item, LAST_TRANSITION_KEY);
         Object inputPayload = readInputPayload(item);
+        String awaitInteractionId = readString(item, AWAIT_INTERACTION_ID);
+        Object resumePayload = readPayload(item.get(RESUME_PAYLOAD_JSON));
         Object resultPayload = readPayload(item.get(RESULT_PAYLOAD_JSON));
         String errorCode = readString(item, ERROR_CODE);
         String errorMessage = readString(item, ERROR_MESSAGE);
@@ -759,6 +928,8 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             nextDue,
             transitionKey,
             inputPayload,
+            awaitInteractionId,
+            resumePayload,
             resultPayload,
             errorCode,
             errorMessage,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionRecord.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionRecord.java
@@ -16,6 +16,8 @@ public record ExecutionRecord<I, R>(
     long nextDueEpochMs,
     String lastTransitionKey,
     I inputPayload,
+    String awaitInteractionId,
+    Object resumePayload,
     R resultPayload,
     String errorCode,
     String errorMessage,
@@ -23,6 +25,52 @@ public record ExecutionRecord<I, R>(
     long updatedAtEpochMs,
     long ttlEpochS
 ) {
+    /**
+     * Backward-compatible constructor for records without await resume fields.
+     */
+    public ExecutionRecord(
+        String tenantId,
+        String executionId,
+        String executionKey,
+        ExecutionStatus status,
+        long version,
+        int currentStepIndex,
+        int attempt,
+        String leaseOwner,
+        long leaseExpiresEpochMs,
+        long nextDueEpochMs,
+        String lastTransitionKey,
+        I inputPayload,
+        R resultPayload,
+        String errorCode,
+        String errorMessage,
+        long createdAtEpochMs,
+        long updatedAtEpochMs,
+        long ttlEpochS
+    ) {
+        this(
+            tenantId,
+            executionId,
+            executionKey,
+            status,
+            version,
+            currentStepIndex,
+            attempt,
+            leaseOwner,
+            leaseExpiresEpochMs,
+            nextDueEpochMs,
+            lastTransitionKey,
+            inputPayload,
+            null,
+            null,
+            resultPayload,
+            errorCode,
+            errorMessage,
+            createdAtEpochMs,
+            updatedAtEpochMs,
+            ttlEpochS);
+    }
+
     /**
      * Returns a copy with a new status and timestamp.
      *
@@ -44,6 +92,8 @@ public record ExecutionRecord<I, R>(
             nextDueEpochMs,
             lastTransitionKey,
             inputPayload,
+            awaitInteractionId,
+            resumePayload,
             resultPayload,
             errorCode,
             errorMessage,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
@@ -97,6 +97,33 @@ public interface ExecutionStateStore {
         long nowEpochMs);
 
     /**
+     * Marks an execution as durably waiting on an external await interaction.
+     */
+    default Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().failure(new UnsupportedOperationException("markWaitingExternal is not implemented"));
+    }
+
+    /**
+     * Stores a completed await payload and makes the execution due for continuation.
+     */
+    default Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().failure(new UnsupportedOperationException("markAwaitCompleted is not implemented"));
+    }
+
+    /**
      * Schedules a retry if expected version matches.
      *
      * @param tenantId tenant identifier

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
@@ -98,6 +98,15 @@ public interface ExecutionStateStore {
 
     /**
      * Marks an execution as durably waiting on an external await interaction.
+     *
+     * @param tenantId tenant identifier
+     * @param executionId execution identifier
+     * @param expectedVersion current execution record version for optimistic concurrency
+     * @param transitionKey idempotency key for the suspend transition
+     * @param awaitInteractionId external await interaction id used to correlate and deduplicate completions
+     * @param awaitStepIndex index of the await step that suspended execution
+     * @param nowEpochMs transition timestamp
+     * @return updated waiting execution when the transition wins optimistic concurrency, otherwise empty
      */
     default Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
         String tenantId,
@@ -112,6 +121,19 @@ public interface ExecutionStateStore {
 
     /**
      * Stores a completed await payload and makes the execution due for continuation.
+     *
+     * <p>This method matches by {@link ExecutionStatus#WAITING_EXTERNAL} plus
+     * {@code awaitInteractionId}, not by expected version. Completion admission is idempotent and can race
+     * with duplicate external callbacks, so stores should return empty when the execution is no longer
+     * waiting for that interaction.</p>
+     *
+     * @param tenantId tenant identifier
+     * @param executionId execution identifier
+     * @param awaitInteractionId external await interaction id used to match the waiting execution
+     * @param resumePayload payload used as input for the step after the await boundary
+     * @param nextStepIndex next pipeline step index to execute
+     * @param nowEpochMs transition timestamp
+     * @return updated queued execution when completion is accepted, otherwise empty
      */
     default Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
         String tenantId,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
@@ -4,12 +4,19 @@ package org.pipelineframework.orchestrator;
  * Execution lifecycle status for async orchestrator runs.
  */
 public enum ExecutionStatus {
+    /** Execution is accepted and waiting to be claimed by a queue worker. */
     QUEUED,
+    /** Execution is currently leased and running in a queue worker. */
     RUNNING,
+    /** Execution is paused at an await step until external completion arrives or its deadline expires. */
     WAITING_EXTERNAL,
+    /** Execution failed transiently and is waiting for its retry due time. */
     WAIT_RETRY,
+    /** Execution completed successfully and has a persisted result payload. */
     SUCCEEDED,
+    /** Execution reached a terminal failure before dead-letter publication. */
     FAILED,
+    /** Execution reached a terminal failure and was routed through the dead-letter path. */
     DLQ;
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStatus.java
@@ -6,6 +6,7 @@ package org.pipelineframework.orchestrator;
 public enum ExecutionStatus {
     QUEUED,
     RUNNING,
+    WAITING_EXTERNAL,
     WAIT_RETRY,
     SUCCEEDED,
     FAILED,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -347,7 +347,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     transitionKey,
                     current.inputPayload(),
                     current.awaitInteractionId(),
-                    current.resumePayload(),
+                    null,
                     null,
                     errorCode,
                     truncate(errorMessage),

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -235,7 +235,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
             synchronized (lock) {
                 String scopedId = scopedExecutionId(tenantId, executionId);
                 ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
-                if (current == null || current.status().terminal()) {
+                if (current == null || current.status() != ExecutionStatus.WAITING_EXTERNAL) {
                     return Optional.empty();
                 }
                 if (current.awaitInteractionId() != null && !current.awaitInteractionId().equals(awaitInteractionId)) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -68,6 +68,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     null,
                     null,
                     null,
+                    null,
+                    null,
                     command.nowEpochMs(),
                     command.nowEpochMs(),
                     command.ttlEpochS());
@@ -101,7 +103,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
             synchronized (lock) {
                 String scopedId = scopedExecutionId(tenantId, executionId);
                 ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
-                if (current == null || current.status().terminal()) {
+                if (current == null || current.status().terminal() || current.status() == ExecutionStatus.WAITING_EXTERNAL) {
                     return Optional.empty();
                 }
                 boolean leaseExpired = current.leaseOwner() == null || current.leaseExpiresEpochMs() <= nowEpochMs;
@@ -122,6 +124,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     current.nextDueEpochMs(),
                     current.lastTransitionKey(),
                     current.inputPayload(),
+                    current.awaitInteractionId(),
+                    current.resumePayload(),
                     current.resultPayload(),
                     current.errorCode(),
                     current.errorMessage(),
@@ -162,7 +166,97 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     nowEpochMs,
                     transitionKey,
                     current.inputPayload(),
+                    null,
+                    null,
                     resultPayload,
+                    null,
+                    null,
+                    current.createdAtEpochMs(),
+                    nowEpochMs,
+                    current.ttlEpochS());
+                executionsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+        String tenantId,
+        String executionId,
+        long expectedVersion,
+        String transitionKey,
+        String awaitInteractionId,
+        int awaitStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                String scopedId = scopedExecutionId(tenantId, executionId);
+                ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
+                if (current == null || current.version() != expectedVersion) {
+                    return Optional.empty();
+                }
+                ExecutionRecord<Object, Object> updated = new ExecutionRecord<>(
+                    current.tenantId(),
+                    current.executionId(),
+                    current.executionKey(),
+                    ExecutionStatus.WAITING_EXTERNAL,
+                    current.version() + 1,
+                    awaitStepIndex,
+                    current.attempt(),
+                    null,
+                    0L,
+                    Long.MAX_VALUE,
+                    transitionKey,
+                    current.inputPayload(),
+                    awaitInteractionId,
+                    null,
+                    null,
+                    null,
+                    null,
+                    current.createdAtEpochMs(),
+                    nowEpochMs,
+                    current.ttlEpochS());
+                executionsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
+        });
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+        String tenantId,
+        String executionId,
+        String awaitInteractionId,
+        Object resumePayload,
+        int nextStepIndex,
+        long nowEpochMs) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                String scopedId = scopedExecutionId(tenantId, executionId);
+                ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
+                if (current == null || current.status().terminal()) {
+                    return Optional.empty();
+                }
+                if (current.awaitInteractionId() != null && !current.awaitInteractionId().equals(awaitInteractionId)) {
+                    return Optional.empty();
+                }
+                ExecutionRecord<Object, Object> updated = new ExecutionRecord<>(
+                    current.tenantId(),
+                    current.executionId(),
+                    current.executionKey(),
+                    ExecutionStatus.QUEUED,
+                    current.version() + 1,
+                    nextStepIndex,
+                    current.attempt(),
+                    null,
+                    0L,
+                    nowEpochMs,
+                    current.lastTransitionKey(),
+                    current.inputPayload(),
+                    awaitInteractionId,
+                    resumePayload,
+                    null,
                     null,
                     null,
                     current.createdAtEpochMs(),
@@ -205,6 +299,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     nextDueEpochMs,
                     transitionKey,
                     current.inputPayload(),
+                    null,
+                    null,
                     null,
                     errorCode,
                     truncate(errorMessage),
@@ -250,6 +346,8 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                     nowEpochMs,
                     transitionKey,
                     current.inputPayload(),
+                    current.awaitInteractionId(),
+                    current.resumePayload(),
                     null,
                     errorCode,
                     truncate(errorMessage),
@@ -276,7 +374,7 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                         executionIdByScopedKey.remove(scopedExecutionKey(record.tenantId(), record.executionKey()));
                         continue;
                     }
-                    if (record.status().terminal()) {
+                    if (record.status().terminal() || record.status() == ExecutionStatus.WAITING_EXTERNAL) {
                         continue;
                     }
                     boolean dueNow = record.nextDueEpochMs() <= nowEpochMs;

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
@@ -196,6 +196,24 @@ public interface PipelineOrchestratorConfig {
         String executionKeyTable();
 
         /**
+         * Await interaction table name.
+         *
+         * @return await interaction table name
+         */
+        @WithName("await-interaction-table")
+        @WithDefault("tpf_await_interaction")
+        String awaitInteractionTable();
+
+        /**
+         * Await interaction lookup table name.
+         *
+         * @return await lookup table name
+         */
+        @WithName("await-interaction-key-table")
+        @WithDefault("tpf_await_interaction_key")
+        String awaitInteractionKeyTable();
+
+        /**
          * Optional region override.
          *
          * @return region when configured

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -742,6 +742,44 @@ public class PipelineProtoGenerator {
         builder.append("message GetExecutionResultResponse {\n");
         builder.append("  repeated ").append(last.outputTypeName()).append(" items = 1;\n");
         builder.append("}\n\n");
+        builder.append("message CompleteAwaitRequest {\n");
+        builder.append("  string tenant_id = 1;\n");
+        builder.append("  string interaction_id = 2;\n");
+        builder.append("  string correlation_id = 3;\n");
+        builder.append("  string idempotency_key = 4;\n");
+        builder.append("  string response_json = 5;\n");
+        builder.append("  string actor = 6;\n");
+        builder.append("}\n\n");
+        builder.append("message CompleteAwaitResponse {\n");
+        builder.append("  string interaction_id = 1;\n");
+        builder.append("  string execution_id = 2;\n");
+        builder.append("  string step_id = 3;\n");
+        builder.append("  string status = 4;\n");
+        builder.append("  bool duplicate = 5;\n");
+        builder.append("}\n\n");
+        builder.append("message ListPendingAwaitRequest {\n");
+        builder.append("  string tenant_id = 1;\n");
+        builder.append("  string assignee = 2;\n");
+        builder.append("  string group = 3;\n");
+        builder.append("  string step_id = 4;\n");
+        builder.append("  int32 limit = 5;\n");
+        builder.append("}\n\n");
+        builder.append("message AwaitInteraction {\n");
+        builder.append("  string interaction_id = 1;\n");
+        builder.append("  string correlation_id = 2;\n");
+        builder.append("  string execution_id = 3;\n");
+        builder.append("  string step_id = 4;\n");
+        builder.append("  int32 step_index = 5;\n");
+        builder.append("  string output_type = 6;\n");
+        builder.append("  string status = 7;\n");
+        builder.append("  string transport_type = 8;\n");
+        builder.append("  int64 deadline_epoch_ms = 9;\n");
+        builder.append("  int64 created_at_epoch_ms = 10;\n");
+        builder.append("  int64 updated_at_epoch_ms = 11;\n");
+        builder.append("}\n\n");
+        builder.append("message ListPendingAwaitResponse {\n");
+        builder.append("  repeated AwaitInteraction interactions = 1;\n");
+        builder.append("}\n\n");
         builder.append("service OrchestratorService {\n");
         builder.append("  rpc Run (");
         if (shape.inputStreaming()) {
@@ -762,6 +800,8 @@ public class PipelineProtoGenerator {
         builder.append("  rpc RunAsync (RunAsyncRequest) returns (RunAsyncResponse);\n");
         builder.append("  rpc GetExecutionStatus (GetExecutionStatusRequest) returns (GetExecutionStatusResponse);\n");
         builder.append("  rpc GetExecutionResult (GetExecutionResultRequest) returns (GetExecutionResultResponse);\n");
+        builder.append("  rpc CompleteAwait (CompleteAwaitRequest) returns (CompleteAwaitResponse);\n");
+        builder.append("  rpc ListPendingAwait (ListPendingAwaitRequest) returns (ListPendingAwaitResponse);\n");
         builder.append("  rpc Subscribe (google.protobuf.Empty) returns (stream ")
             .append(last.outputTypeName())
             .append(");\n");

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -29,6 +29,12 @@ import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitSuspendedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,6 +65,9 @@ class QueueAsyncCoordinatorTest {
     private DeadLetterPublisher deadLetterPublisher;
 
     @Mock
+    private AwaitCoordinator awaitCoordinator;
+
+    @Mock
     private Instance<ExecutionStateStore> executionStateStores;
 
     @Mock
@@ -80,6 +89,7 @@ class QueueAsyncCoordinatorTest {
         coordinator.executionStateStore = executionStateStore;
         coordinator.workDispatcher = workDispatcher;
         coordinator.deadLetterPublisher = deadLetterPublisher;
+        coordinator.awaitCoordinator = awaitCoordinator;
         coordinator.executionStateStores = executionStateStores;
         coordinator.workDispatchers = workDispatchers;
         coordinator.deadLetterPublishers = deadLetterPublishers;
@@ -201,6 +211,8 @@ class QueueAsyncCoordinatorTest {
     void sweepRedispatchesPersistedDueExecutions() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        when(awaitCoordinator.findTimedOut(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of()));
         when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyInt()))
             .thenReturn(Uni.createFrom().item(java.util.List.of(
                 createRecord("tenant-a", "exec-5", "key-5"),
@@ -211,6 +223,138 @@ class QueueAsyncCoordinatorTest {
 
         ArgumentCaptor<ExecutionWorkItem> itemCaptor = ArgumentCaptor.forClass(ExecutionWorkItem.class);
         verify(workDispatcher, timeout(500).times(2)).enqueueNow(itemCaptor.capture());
+    }
+
+    @Test
+    void processExecutionWorkItemMarksWaitingExternalWhenAwaitSuspends() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+        ExecutionRecord<Object, Object> claimed = createRecord("tenant-1", "exec-await", "key-await");
+        when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+        when(executionStateStore.markWaitingExternal(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-await"),
+                org.mockito.ArgumentMatchers.eq(0L),
+                org.mockito.ArgumentMatchers.eq("exec-await:0:0"),
+                org.mockito.ArgumentMatchers.eq("interaction-1"),
+                org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+
+        coordinator.processExecutionWorkItem(
+                new ExecutionWorkItem("tenant-1", "exec-await"),
+                record -> Multi.createFrom().failure(new AwaitSuspendedException(
+                    "tenant-1",
+                    "exec-await",
+                    "interaction-1",
+                    0)))
+            .await().indefinitely();
+
+        verify(executionStateStore).markWaitingExternal(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-await"),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq("exec-await:0:0"),
+            org.mockito.ArgumentMatchers.eq("interaction-1"),
+            org.mockito.ArgumentMatchers.eq(0),
+            org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void completeAwaitStoresResumePayloadAndEnqueuesExecution() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        AwaitInteractionRecord interaction = awaitRecord();
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant-1",
+            "interaction-1",
+            null,
+            null,
+            java.util.Map.of("value", "approved"),
+            "user-1",
+            System.currentTimeMillis());
+        when(awaitCoordinator.complete(command))
+            .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, false)));
+        ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        when(executionStateStore.markAwaitCompleted(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-1"),
+                org.mockito.ArgumentMatchers.eq("interaction-1"),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.eq(3),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(resumed)));
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+        AwaitCompletionResult result = coordinator.completeAwait(command).await().indefinitely();
+
+        assertEquals("interaction-1", result.record().interactionId());
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(executionStateStore).markAwaitCompleted(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-1"),
+            org.mockito.ArgumentMatchers.eq("interaction-1"),
+            payloadCaptor.capture(),
+            org.mockito.ArgumentMatchers.eq(3),
+            org.mockito.ArgumentMatchers.anyLong());
+        assertEquals(new Decision("approved"), payloadCaptor.getValue());
+        verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+    }
+
+    @Test
+    void sweepTimesOutAwaitInteractionsAndFailsOwningExecution() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        AwaitInteractionRecord interaction = awaitRecord();
+        ExecutionRecord<Object, Object> waiting = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionStatus.WAITING_EXTERNAL,
+            7L,
+            2,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            "interaction-1",
+            null,
+            null,
+            1L,
+            1L,
+            99999999L);
+        when(awaitCoordinator.findTimedOut(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of(interaction)));
+        when(awaitCoordinator.markTimedOut(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(executionStateStore.markTerminalFailure(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-1"),
+                org.mockito.ArgumentMatchers.eq(7L),
+                org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+                org.mockito.ArgumentMatchers.eq("exec-1:2:0"),
+                org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
+                org.mockito.ArgumentMatchers.contains("interaction-1"),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of()));
+
+        coordinator.sweepDueExecutions();
+
+        verify(executionStateStore, timeout(500)).markTerminalFailure(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-1"),
+            org.mockito.ArgumentMatchers.eq(7L),
+            org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+            org.mockito.ArgumentMatchers.eq("exec-1:2:0"),
+            org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
+            org.mockito.ArgumentMatchers.contains("interaction-1"),
+            org.mockito.ArgumentMatchers.anyLong());
     }
 
     private void configureQueueModeDefaults() {
@@ -239,5 +383,34 @@ class QueueAsyncCoordinatorTest {
             1L,
             1L,
             99999999L);
+    }
+
+    private AwaitInteractionRecord awaitRecord() {
+        return new AwaitInteractionRecord(
+            "tenant-1",
+            "exec-1",
+            "ProcessApprovalService",
+            2,
+            Decision.class.getName(),
+            "interaction-1",
+            "corr-1",
+            "cause-1",
+            "idem-1",
+            1L,
+            AwaitInteractionStatus.COMPLETED,
+            java.util.Map.of("value", "request"),
+            java.util.Map.of("value", "approved"),
+            "user-1",
+            null,
+            null,
+            "interaction-api",
+            java.util.Map.of(),
+            System.currentTimeMillis() + 1000,
+            1L,
+            2L,
+            99999999L);
+    }
+
+    private record Decision(String value) {
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -276,6 +276,7 @@ class QueueAsyncCoordinatorTest {
         when(awaitCoordinator.complete(command))
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, false)));
         ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        // Uses a Map payload intentionally so coerceAwaitPayload exercises PipelineJson conversion into Decision.
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-1"),
@@ -320,6 +321,8 @@ class QueueAsyncCoordinatorTest {
             null,
             "input",
             "interaction-1",
+            null,
+            null,
             null,
             null,
             1L,

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionCommandTest.java
@@ -56,18 +56,6 @@ class AwaitCompletionCommandTest {
     }
 
     @Test
-    void rejectsNullIdempotencyKey() {
-        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
-            "tenant1", "interaction-123", null, null, null, null, 1000L));
-    }
-
-    @Test
-    void rejectsBlankIdempotencyKey() {
-        assertThrows(IllegalArgumentException.class, () -> new AwaitCompletionCommand(
-            "tenant1", "interaction-123", null, "  ", null, null, 1000L));
-    }
-
-    @Test
     void autoSetsNowEpochMsWhenZero() {
         long before = System.currentTimeMillis();
         AwaitCompletionCommand command = new AwaitCompletionCommand(


### PR DESCRIPTION
## Scope
- Adds durable queue-async suspend/resume for generated await steps.
- Adds `WAITING_EXTERNAL`, await interaction id, resume payload, and start-from-step-index execution support.
- Adds REST and gRPC completion/query APIs for await interactions.
- Adds Dynamo await interaction persistence plus execution-state resume fields.
- Adds timeout sweeping to fail owning executions with `AWAIT_TIMEOUT`.

## Out of scope
- CSV mock-provider migration.
- Kafka, RabbitMQ, and webhook await transports.
- Multi-cardinality await steps.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime,deployment -Dtest=PipelineYamlConfigLoaderTest,InMemoryAwaitInteractionStoreTest,AwaitStepSupportTest,StepDefinitionParserTest,QueueAsyncCoordinatorTest,DynamoExecutionStateStoreTest,AwaitClientStepRendererTest test`
- `git diff --check`
