### PR TITLE
Add Kafka await support and validate deployment configurations

### DIFF
--- a/docs/guide/development/orchestrator-runtime.md
+++ b/docs/guide/development/orchestrator-runtime.md
@@ -180,7 +180,7 @@ Failure channel split:
 
 Await steps suspend `QUEUE_ASYNC` execution at an external boundary. TPF persists the interaction, dispatches through the configured adapter, and resumes the owning execution after a correlated completion is admitted.
 
-The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope.
+The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope. The built-in `kafka` adapter publishes a request envelope to Kafka and admits response envelopes from a configured response channel.
 
 ```yaml
 steps:
@@ -204,7 +204,44 @@ steps:
 
 Webhook dispatch sends an envelope containing the interaction id, correlation id, resume token, deadline, request payload, tenant id, step id, output type, and callback metadata when configured. Completion is submitted through the generated REST/gRPC completion APIs; TPF validates the token before accepting the response snapshot.
 
-`pipeline.orchestrator.resume-token-secret` must be stable for the lifetime of outstanding webhook interactions. If `pipeline.orchestrator.resume-token-secret` is missing, webhook dispatch and token validation fail with a clear error rather than allowing insecure or unsigned resumptions.
+```yaml
+steps:
+  - name: "Brokered Fraud Check"
+    kind: "await"
+    cardinality: "ONE_TO_ONE"
+    input: "com.example.FraudCheckRequest"
+    output: "com.example.FraudCheckDecision"
+    timeout: "PT10M"
+    idempotencyKeyFields: ["orderId"]
+    await:
+      correlation:
+        strategy: "signedResumeToken"
+      transport:
+        type: "kafka"
+        request:
+          topic: "fraud-check.requests"
+          key: "correlationId" # optional: interactionId or correlationId
+        response:
+          topic: "fraud-check.decisions"
+        consumer:
+          group: "fraud-check-orchestrator" # optional; channel config remains authoritative
+        headers:
+          x-source: "tpf"
+```
+
+Kafka dispatch sends a framework-owned JSON envelope containing tenant id, execution id, interaction id, correlation id, step id, deadline, input/output types, resume token, request payload, and dispatch metadata. The response envelope is consumed by TPF and completed directly through `AwaitCoordinator`, not by looping back through REST. Use the generated REST/gRPC completion APIs for human/UI or webhook clients that are not broker consumers.
+
+Add the Quarkus Kafka messaging extension to the application that hosts the orchestrator, enable the default Kafka bridge with `pipeline.await.kafka.reactive-messaging.enabled=true`, then configure the SmallRye channels:
+
+```properties
+mp.messaging.outgoing.tpf-await-kafka-requests.connector=smallrye-kafka
+mp.messaging.outgoing.tpf-await-kafka-requests.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.incoming.tpf-await-kafka-responses.connector=smallrye-kafka
+mp.messaging.incoming.tpf-await-kafka-responses.topic=fraud-check.decisions
+mp.messaging.incoming.tpf-await-kafka-responses.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+```
+
+`pipeline.orchestrator.resume-token-secret` must be stable for the lifetime of outstanding webhook and Kafka interactions. If `pipeline.orchestrator.resume-token-secret` is missing, signed dispatch and token validation fail with a clear error rather than allowing insecure or unsigned resumptions.
 
 Execution lifecycle (one transition per worker claim):
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -509,17 +509,26 @@ public class StepDefinitionParser {
             report(Diagnostic.Kind.ERROR, message);
             return null;
         }
+        if ("kafka".equalsIgnoreCase(transportType) && !validateKafkaAwaitTransport(transportMap, stepName)) {
+            return null;
+        }
         Object correlationObj = awaitMap.get("correlation");
-        if (correlationObj instanceof Map<?, ?> correlationMap) {
-            String strategy = stringValue(correlationMap.get("strategy"));
-            if (isBlank(strategy)) {
-                String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
-                LOG.warn(message);
-                report(Diagnostic.Kind.ERROR, message);
-                return null;
-            }
-        } else if (correlationObj != null) {
-            String message = "Skipping step '" + stepName + "': await.correlation must be a map";
+        if (!(correlationObj instanceof Map<?, ?> correlationMap)) {
+            String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
+        String strategy = stringValue(correlationMap.get("strategy"));
+        strategy = strategy == null ? null : strategy.trim();
+        if (isBlank(strategy)) {
+            String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return null;
+        }
+        if (!"interactionId".equals(strategy) && !"signedResumeToken".equals(strategy)) {
+            String message = "Skipping step '" + stepName + "': unsupported await.correlation.strategy '" + strategy + "'";
             LOG.warn(message);
             report(Diagnostic.Kind.ERROR, message);
             return null;
@@ -537,6 +546,32 @@ public class StepDefinitionParser {
         }
         Object dispatchObj = transportMap.get("dispatch");
         return dispatchObj instanceof Map<?, ?> dispatchMap && !isBlank(stringValue(dispatchMap.get("url")));
+    }
+
+    private boolean validateKafkaAwaitTransport(Map<?, ?> transportMap, String stepName) {
+        Object requestObj = transportMap.get("request");
+        if (!(requestObj instanceof Map<?, ?> requestMap) || isBlank(stringValue(requestMap.get("topic")))) {
+            String message = "Skipping step '" + stepName + "': kafka await transport must declare request.topic";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        String key = stringValue(requestMap.get("key"));
+        key = key == null ? null : key.trim();
+        if (!isBlank(key) && !"interactionId".equals(key) && !"correlationId".equals(key)) {
+            String message = "Skipping step '" + stepName + "': kafka await transport request.key must be interactionId or correlationId";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        Object responseObj = transportMap.get("response");
+        if (!(responseObj instanceof Map<?, ?> responseMap) || isBlank(stringValue(responseMap.get("topic")))) {
+            String message = "Skipping step '" + stepName + "': kafka await transport must declare response.topic";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        return true;
     }
 
     private List<String> parseStringList(Object value, String stepName, String fieldName) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -201,6 +201,8 @@ class StepDefinitionParserTest {
                 input: "com.example.Input"
                 output: "com.example.Output"
                 await:
+                  correlation:
+                    strategy: "interactionId"
                   transport:
                     type: "interaction-api"
             """, diagnostics);
@@ -281,6 +283,176 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void parsesKafkaAwaitStepDefinition() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Kafka Fraud Check"
+                kind: "await"
+                input: "com.example.FraudCheckRequest"
+                output: "com.example.FraudCheckDecision"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "signedResumeToken"
+                  transport:
+                    type: "kafka"
+                    request:
+                      topic: "fraud-check.requests"
+                      key: "correlationId"
+                    response:
+                      topic: "fraud-check.decisions"
+            """, diagnostics);
+
+        assertEquals(1, steps.size());
+        StepDefinition step = steps.getFirst();
+        assertEquals(StepKind.AWAIT, step.kind());
+        java.util.Map<?, ?> transport = (java.util.Map<?, ?>) step.awaitConfig().get("transport");
+        assertEquals("kafka", transport.get("type"));
+        assertEquals("fraud-check.requests", ((java.util.Map<?, ?>) transport.get("request")).get("topic"));
+        assertEquals("fraud-check.decisions", ((java.util.Map<?, ?>) transport.get("response")).get("topic"));
+        assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
+    }
+
+    @Test
+    void rejectsKafkaAwaitStepWithoutRequestTopic() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Kafka Missing Request Topic"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "kafka"
+                    request:
+                      key: "interactionId"
+                    response:
+                      topic: "decisions"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("request.topic")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsKafkaAwaitStepWithoutResponseTopic() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Kafka Missing Response Topic"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "kafka"
+                    request:
+                      topic: "requests"
+                    response: {}
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("response.topic")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsKafkaAwaitStepWithInvalidKeyStrategy() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Kafka Invalid Key"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "kafka"
+                    request:
+                      topic: "requests"
+                      key: "orderId"
+                    response:
+                      topic: "responses"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("request.key")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsAwaitStepWithoutCorrelationStrategy() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Missing Correlation"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  transport:
+                    type: "interaction-api"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("await.correlation.strategy must be declared")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsAwaitStepWithUnsupportedCorrelationStrategy() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Unsupported Correlation"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "custom"
+                  transport:
+                    type: "interaction-api"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("unsupported await.correlation.strategy")),
+            diagnostics.toString());
+    }
+
+    @Test
     void rejectsAwaitStepWithNonMapCorrelation() throws IOException {
         List<String> diagnostics = new ArrayList<>();
         List<StepDefinition> steps = parse("""
@@ -300,7 +472,7 @@ class StepDefinitionParserTest {
             """, diagnostics);
 
         assertTrue(steps.isEmpty());
-        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("await.correlation must be a map")),
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("await.correlation.strategy must be declared")),
             diagnostics.toString());
     }
 
@@ -317,6 +489,8 @@ class StepDefinitionParserTest {
                 output: "com.example.Output"
                 timeout: "PT10M"
                 await:
+                  correlation:
+                    strategy: "interactionId"
                   transport:
                     type: "webhook"
                     request:
@@ -365,6 +539,8 @@ class StepDefinitionParserTest {
                 timeout: "PT30M"
                 idempotencyKeyFields: ["orderId", "customerId", "amount"]
                 await:
+                  correlation:
+                    strategy: "interactionId"
                   transport:
                     type: "interaction-api"
             """, diagnostics);
@@ -391,6 +567,8 @@ class StepDefinitionParserTest {
                 timeout: "PT5M"
                 idempotencyKeyFields: []
                 await:
+                  correlation:
+                    strategy: "interactionId"
                   transport:
                     type: "interaction-api"
             """, diagnostics);
@@ -415,6 +593,8 @@ class StepDefinitionParserTest {
                 output: "com.example.Output"
                 timeout: "PT5M"
                 await:
+                  correlation:
+                    strategy: "interactionId"
                   transport:
                     type: "interaction-api"
             """, diagnostics);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
@@ -59,6 +59,8 @@ class PipelineOrderMetadataGeneratorTest {
                 output: "com.example.FraudCheckDecision"
                 timeout: "PT10M"
                 await:
+                  correlation:
+                    strategy: "signedResumeToken"
                   transport:
                     type: "webhook"
                     request:
@@ -208,6 +210,8 @@ class PipelineOrderMetadataGeneratorTest {
                 output: "com.example.FraudCheckDecision"
                 timeout: "PT5M"
                 await:
+                  correlation:
+                    strategy: "signedResumeToken"
                   transport:
                     type: "webhook"
                     request:

--- a/framework/runtime/pom.xml
+++ b/framework/runtime/pom.xml
@@ -76,6 +76,14 @@
             <artifactId>quarkus-smallrye-context-propagation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-kafka-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli</artifactId>
             <optional>true</optional>

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/KafkaAwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/KafkaAwaitTransportAdapter.java
@@ -149,6 +149,9 @@ public class KafkaAwaitTransportAdapter implements AwaitTransportAdapter<Object>
         Map<String, String> headers
     ) {
         static KafkaConfig from(Map<String, Object> transportConfig) {
+            if (transportConfig == null) {
+                throw new IllegalArgumentException("transportConfig must not be null");
+            }
             Map<?, ?> request = requiredMap(transportConfig.get("request"), "kafka await transport requires request.topic");
             Map<?, ?> response = requiredMap(transportConfig.get("response"), "kafka await transport requires response.topic");
             String requestTopic = requiredString(request.get("topic"), "kafka await transport requires request.topic");

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/KafkaAwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/KafkaAwaitTransportAdapter.java
@@ -1,0 +1,209 @@
+package org.pipelineframework.awaitable;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.pipelineframework.awaitable.kafka.KafkaAwaitDispatchEnvelope;
+import org.pipelineframework.awaitable.kafka.KafkaAwaitPublishRequest;
+import org.pipelineframework.awaitable.kafka.KafkaAwaitPublisher;
+import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+/**
+ * Await transport adapter that publishes one interaction request to Kafka.
+ */
+@ApplicationScoped
+public class KafkaAwaitTransportAdapter implements AwaitTransportAdapter<Object> {
+
+    private static final String DEFAULT_KEY_STRATEGY = "interactionId";
+
+    @Inject
+    Instance<KafkaAwaitPublisher> publishers;
+
+    @Inject
+    AwaitResumeTokenService resumeTokenService;
+
+    private final KafkaAwaitPublisher explicitPublisher;
+
+    public KafkaAwaitTransportAdapter() {
+        this(null);
+    }
+
+    KafkaAwaitTransportAdapter(KafkaAwaitPublisher explicitPublisher) {
+        this.explicitPublisher = explicitPublisher;
+    }
+
+    @Override
+    public String type() {
+        return "kafka";
+    }
+
+    @Override
+    public Uni<AwaitDispatchResult> dispatch(AwaitDispatchRequest<Object> request) {
+        Objects.requireNonNull(request, "request must not be null");
+        AwaitStepDescriptor descriptor = request.descriptor();
+        AwaitInteractionRecord interaction = request.interaction();
+        KafkaConfig config = KafkaConfig.from(descriptor.transportConfig());
+        String resumeToken = resumeTokenService.sign(interaction, System.currentTimeMillis());
+        Map<String, Object> metadata = dispatchMetadata(config, interaction);
+        KafkaAwaitDispatchEnvelope envelope = KafkaAwaitDispatchEnvelope.from(
+            descriptor,
+            interaction,
+            request.payload(),
+            resumeToken,
+            metadata);
+        return Uni.createFrom().item(() -> serializeEnvelope(envelope))
+            .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+            .onItem().transformToUni(body -> {
+                KafkaAwaitPublishRequest publishRequest = new KafkaAwaitPublishRequest(
+                    config.requestTopic(),
+                    key(config.keyStrategy(), interaction),
+                    headers(config, interaction),
+                    body);
+                return publisher().publish(publishRequest)
+                    .replaceWith(new AwaitDispatchResult(metadata));
+            });
+    }
+
+    private KafkaAwaitPublisher publisher() {
+        if (explicitPublisher != null) {
+            return explicitPublisher;
+        }
+        if (publishers == null) {
+            throw noPublisherFailure();
+        }
+        List<KafkaAwaitPublisher> candidates = publishers.stream().toList();
+        if (candidates.isEmpty()) {
+            throw noPublisherFailure();
+        }
+        if (candidates.size() > 1) {
+            String providers = candidates.stream()
+                .map(candidate -> candidate.getClass().getName())
+                .collect(java.util.stream.Collectors.joining(", "));
+            throw new IllegalStateException("Ambiguous KafkaAwaitPublisher providers: " + providers);
+        }
+        return candidates.getFirst();
+    }
+
+    private static IllegalStateException noPublisherFailure() {
+        return new IllegalStateException(
+            "Kafka await transport requires a KafkaAwaitPublisher provider. "
+                + "Enable pipeline.await.kafka.reactive-messaging.enabled=true and configure the TPF await Kafka channels, "
+                + "or provide a CDI KafkaAwaitPublisher bean.");
+    }
+
+    private static Map<String, Object> dispatchMetadata(KafkaConfig config, AwaitInteractionRecord interaction) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("adapter", "kafka");
+        metadata.put("requestTopic", config.requestTopic());
+        metadata.put("responseTopic", config.responseTopic());
+        metadata.put("keyStrategy", config.keyStrategy());
+        metadata.put("key", key(config.keyStrategy(), interaction));
+        if (config.consumerGroup() != null) {
+            metadata.put("consumerGroup", config.consumerGroup());
+        }
+        metadata.put("dispatchedAtEpochMs", System.currentTimeMillis());
+        return metadata;
+    }
+
+    private static Map<String, String> headers(KafkaConfig config, AwaitInteractionRecord interaction) {
+        Map<String, String> headers = new LinkedHashMap<>(config.headers());
+        headers.put("tpf-tenant-id", interaction.tenantId());
+        headers.put("tpf-execution-id", interaction.executionId());
+        headers.put("tpf-interaction-id", interaction.interactionId());
+        headers.put("tpf-correlation-id", interaction.correlationId());
+        headers.put("tpf-step-id", interaction.stepId());
+        headers.put("tpf-response-topic", config.responseTopic());
+        return headers;
+    }
+
+    private static String key(String strategy, AwaitInteractionRecord interaction) {
+        return switch (strategy) {
+            case "interactionId" -> interaction.interactionId();
+            case "correlationId" -> interaction.correlationId();
+            default -> throw new IllegalArgumentException("Unsupported kafka await request.key: " + strategy);
+        };
+    }
+
+    private static String serializeEnvelope(KafkaAwaitDispatchEnvelope envelope) {
+        try {
+            return PipelineJson.mapper().writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed serializing Kafka await dispatch envelope", e);
+        }
+    }
+
+    record KafkaConfig(
+        String requestTopic,
+        String responseTopic,
+        String keyStrategy,
+        String consumerGroup,
+        Map<String, String> headers
+    ) {
+        static KafkaConfig from(Map<String, Object> transportConfig) {
+            Map<?, ?> request = requiredMap(transportConfig.get("request"), "kafka await transport requires request.topic");
+            Map<?, ?> response = requiredMap(transportConfig.get("response"), "kafka await transport requires response.topic");
+            String requestTopic = requiredString(request.get("topic"), "kafka await transport requires request.topic");
+            String responseTopic = requiredString(response.get("topic"), "kafka await transport requires response.topic");
+            String keyStrategy = optionalString(request.get("key"), DEFAULT_KEY_STRATEGY);
+            if (!"interactionId".equals(keyStrategy) && !"correlationId".equals(keyStrategy)) {
+                throw new IllegalArgumentException("Unsupported kafka await request.key: " + keyStrategy);
+            }
+            String consumerGroup = optionalString(transportConfig.get("consumerGroup"), null);
+            Object consumerObj = transportConfig.get("consumer");
+            if (consumerObj instanceof Map<?, ?> consumerMap) {
+                consumerGroup = optionalString(consumerMap.get("group"), consumerGroup);
+            }
+            return new KafkaConfig(
+                requestTopic,
+                responseTopic,
+                keyStrategy,
+                consumerGroup,
+                stringMap(transportConfig.get("headers")));
+        }
+
+        private static Map<?, ?> requiredMap(Object value, String message) {
+            if (value instanceof Map<?, ?> map) {
+                return map;
+            }
+            throw new IllegalArgumentException(message);
+        }
+
+        private static String requiredString(Object value, String message) {
+            String result = optionalString(value, null);
+            if (result == null || result.isBlank()) {
+                throw new IllegalArgumentException(message);
+            }
+            return result;
+        }
+
+        private static String optionalString(Object value, String fallback) {
+            if (value == null) {
+                return fallback;
+            }
+            String text = value.toString().trim();
+            return text.isBlank() ? fallback : text;
+        }
+
+        private static Map<String, String> stringMap(Object value) {
+            if (!(value instanceof Map<?, ?> source)) {
+                return Map.of();
+            }
+            Map<String, String> result = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : source.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    result.put(entry.getKey().toString(), entry.getValue().toString());
+                }
+            }
+            return Map.copyOf(result);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumer.java
@@ -1,0 +1,64 @@
+package org.pipelineframework.awaitable.kafka;
+
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+/**
+ * SmallRye Reactive Messaging consumer that admits Kafka await completions.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "pipeline.await.kafka.reactive-messaging.enabled", stringValue = "true")
+public class KafkaAwaitCompletionConsumer {
+
+    public static final String INCOMING_CHANNEL = "tpf-await-kafka-responses";
+
+    @Inject
+    AwaitCoordinator coordinator;
+
+    public KafkaAwaitCompletionConsumer() {
+    }
+
+    KafkaAwaitCompletionConsumer(AwaitCoordinator coordinator) {
+        this.coordinator = coordinator;
+    }
+
+    @Incoming(INCOMING_CHANNEL)
+    public CompletionStage<Void> consume(Message<String> message) {
+        Objects.requireNonNull(message, "message must not be null");
+        return Uni.createFrom().item(() -> parseEnvelope(message.getPayload()))
+            .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+            .onItem().transformToUni(envelope -> coordinator.complete(new AwaitCompletionCommand(
+                envelope.tenantId(),
+                envelope.interactionId(),
+                envelope.correlationId(),
+                envelope.resumeToken(),
+                envelope.idempotencyKey(),
+                envelope.responsePayload(),
+                envelope.actor(),
+                System.currentTimeMillis())))
+            .replaceWithVoid()
+            .subscribeAsCompletionStage()
+            .thenCompose(ignored -> message.ack())
+            .exceptionallyCompose(failure -> message.nack(failure));
+    }
+
+    private static KafkaAwaitCompletionEnvelope parseEnvelope(String payload) {
+        try {
+            return PipelineJson.mapper().readValue(payload, KafkaAwaitCompletionEnvelope.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Kafka await completion envelope", e);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionEnvelope.java
@@ -1,0 +1,46 @@
+package org.pipelineframework.awaitable.kafka;
+
+import java.util.Objects;
+
+/**
+ * Framework-owned Kafka await response envelope.
+ *
+ * @param tenantId required tenant id
+ * @param interactionId interaction id when completing by interaction id; one of interactionId or correlationId is required
+ * @param correlationId correlation id when completing by correlation id; one of interactionId or correlationId is required
+ * @param resumeToken optional signed resume token, required when the interaction was dispatched with signed-token admission
+ * @param idempotencyKey optional external completion idempotency key
+ * @param responsePayload response snapshot to resume the owning execution with
+ * @param actor optional actor or system principal that produced the completion
+ */
+public record KafkaAwaitCompletionEnvelope(
+    String tenantId,
+    String interactionId,
+    String correlationId,
+    String resumeToken,
+    String idempotencyKey,
+    Object responsePayload,
+    String actor
+) {
+    public KafkaAwaitCompletionEnvelope {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        interactionId = normalize(interactionId);
+        correlationId = normalize(correlationId);
+        resumeToken = normalize(resumeToken);
+        idempotencyKey = normalize(idempotencyKey);
+        actor = normalize(actor);
+        if (interactionId == null && correlationId == null) {
+            throw new IllegalArgumentException("interactionId or correlationId must be supplied");
+        }
+        responsePayload = Objects.requireNonNull(responsePayload, "responsePayload must not be null");
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionEnvelope.java
@@ -23,7 +23,8 @@ public record KafkaAwaitCompletionEnvelope(
     String actor
 ) {
     public KafkaAwaitCompletionEnvelope {
-        if (tenantId == null || tenantId.isBlank()) {
+        tenantId = normalize(tenantId);
+        if (tenantId == null) {
             throw new IllegalArgumentException("tenantId must not be blank");
         }
         interactionId = normalize(interactionId);

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitDispatchEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitDispatchEnvelope.java
@@ -1,0 +1,47 @@
+package org.pipelineframework.awaitable.kafka;
+
+import java.util.Map;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitStepDescriptor;
+
+/**
+ * Framework-owned Kafka await request envelope.
+ */
+public record KafkaAwaitDispatchEnvelope(
+    String tenantId,
+    String executionId,
+    String interactionId,
+    String correlationId,
+    String stepId,
+    long deadlineEpochMs,
+    String inputType,
+    String outputType,
+    String resumeToken,
+    Object requestPayload,
+    Map<String, Object> transportMetadata
+) {
+    public KafkaAwaitDispatchEnvelope {
+        transportMetadata = transportMetadata == null ? Map.of() : Map.copyOf(transportMetadata);
+    }
+
+    public static KafkaAwaitDispatchEnvelope from(
+        AwaitStepDescriptor descriptor,
+        AwaitInteractionRecord interaction,
+        Object payload,
+        String resumeToken,
+        Map<String, Object> transportMetadata) {
+        return new KafkaAwaitDispatchEnvelope(
+            interaction.tenantId(),
+            interaction.executionId(),
+            interaction.interactionId(),
+            interaction.correlationId(),
+            interaction.stepId(),
+            interaction.deadlineEpochMs(),
+            descriptor.inputType(),
+            descriptor.outputType(),
+            resumeToken,
+            payload,
+            transportMetadata);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitPublishRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitPublishRequest.java
@@ -12,9 +12,11 @@ public record KafkaAwaitPublishRequest(
     String body
 ) {
     public KafkaAwaitPublishRequest {
-        if (topic == null || topic.isBlank()) {
+        String trimmed = topic == null ? null : topic.trim();
+        if (trimmed == null || trimmed.isBlank()) {
             throw new IllegalArgumentException("topic must not be blank");
         }
+        topic = trimmed;
         headers = headers == null ? Map.of() : Map.copyOf(headers);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitPublishRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitPublishRequest.java
@@ -1,0 +1,20 @@
+package org.pipelineframework.awaitable.kafka;
+
+import java.util.Map;
+
+/**
+ * Request sent by the await Kafka adapter to the configured broker client.
+ */
+public record KafkaAwaitPublishRequest(
+    String topic,
+    String key,
+    Map<String, String> headers,
+    String body
+) {
+    public KafkaAwaitPublishRequest {
+        if (topic == null || topic.isBlank()) {
+            throw new IllegalArgumentException("topic must not be blank");
+        }
+        headers = headers == null ? Map.of() : Map.copyOf(headers);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitPublisher.java
@@ -1,0 +1,17 @@
+package org.pipelineframework.awaitable.kafka;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Broker boundary used by the Kafka await transport adapter.
+ */
+public interface KafkaAwaitPublisher {
+
+    /**
+     * Publishes one await request envelope.
+     *
+     * @param request publish request
+     * @return completion signal
+     */
+    Uni<Void> publish(KafkaAwaitPublishRequest request);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/ReactiveMessagingKafkaAwaitPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/ReactiveMessagingKafkaAwaitPublisher.java
@@ -1,0 +1,44 @@
+package org.pipelineframework.awaitable.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * SmallRye Reactive Messaging backed Kafka publisher for await dispatch.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "pipeline.await.kafka.reactive-messaging.enabled", stringValue = "true")
+public class ReactiveMessagingKafkaAwaitPublisher implements KafkaAwaitPublisher {
+
+    public static final String OUTGOING_CHANNEL = "tpf-await-kafka-requests";
+
+    @Inject
+    @Channel(OUTGOING_CHANNEL)
+    MutinyEmitter<String> emitter;
+
+    @Override
+    public Uni<Void> publish(KafkaAwaitPublishRequest request) {
+        RecordHeaders kafkaHeaders = new RecordHeaders();
+        for (Map.Entry<String, String> entry : request.headers().entrySet()) {
+            kafkaHeaders.add(entry.getKey(), entry.getValue().getBytes(StandardCharsets.UTF_8));
+        }
+        OutgoingKafkaRecordMetadata<String> metadata = OutgoingKafkaRecordMetadata.<String>builder()
+            .withTopic(request.topic())
+            .withKey(request.key())
+            .withHeaders(kafkaHeaders)
+            .build();
+        Message<String> message = Message.of(request.body()).addMetadata(metadata);
+        return emitter.sendMessage(message);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/KafkaAwaitTransportAdapterTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/KafkaAwaitTransportAdapterTest.java
@@ -1,0 +1,170 @@
+package org.pipelineframework.awaitable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.kafka.KafkaAwaitPublishRequest;
+import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+class KafkaAwaitTransportAdapterTest {
+
+    @Test
+    void dispatchPublishesFrameworkEnvelope() throws Exception {
+        AtomicReference<KafkaAwaitPublishRequest> publishRef = new AtomicReference<>();
+        KafkaAwaitTransportAdapter adapter = adapter(request -> {
+            publishRef.set(request);
+            return Uni.createFrom().voidItem();
+        });
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of(
+                "topic", "fraud-check.requests",
+                "key", "correlationId"),
+            "response", Map.of("topic", "fraud-check.decisions"),
+            "headers", Map.of("x-source", "tpf")));
+
+        var result = adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+            descriptor,
+            interaction(),
+            Map.of("orderId", "o-1"))).await().atMost(Duration.ofSeconds(5));
+
+        KafkaAwaitPublishRequest request = publishRef.get();
+        assertEquals("fraud-check.requests", request.topic());
+        assertEquals("corr-1", request.key());
+        assertEquals("tpf", request.headers().get("x-source"));
+        assertEquals("tenant-1", request.headers().get("tpf-tenant-id"));
+        assertEquals("fraud-check.decisions", request.headers().get("tpf-response-topic"));
+        JsonNode body = PipelineJson.mapper().readTree(request.body());
+        assertEquals("tenant-1", body.get("tenantId").asText());
+        assertEquals("exec-1", body.get("executionId").asText());
+        assertEquals("interaction-1", body.get("interactionId").asText());
+        assertEquals("corr-1", body.get("correlationId").asText());
+        assertEquals("FraudCheck", body.get("stepId").asText());
+        assertTrue(body.hasNonNull("resumeToken"));
+        assertEquals("o-1", body.get("requestPayload").get("orderId").asText());
+        assertEquals("fraud-check.requests", result.metadata().get("requestTopic"));
+        assertEquals("fraud-check.decisions", result.metadata().get("responseTopic"));
+        assertEquals("correlationId", result.metadata().get("keyStrategy"));
+    }
+
+    @Test
+    void dispatchDefaultsKeyToInteractionId() {
+        AtomicReference<KafkaAwaitPublishRequest> publishRef = new AtomicReference<>();
+        KafkaAwaitTransportAdapter adapter = adapter(request -> {
+            publishRef.set(request);
+            return Uni.createFrom().voidItem();
+        });
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("topic", "requests"),
+            "response", Map.of("topic", "responses")));
+
+        adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+            descriptor,
+            interaction(),
+            Map.of())).await().atMost(Duration.ofSeconds(5));
+
+        assertEquals("interaction-1", publishRef.get().key());
+    }
+
+    @Test
+    void dispatchFailsWhenPublisherFails() {
+        KafkaAwaitTransportAdapter adapter = adapter(request ->
+            Uni.createFrom().failure(new IllegalStateException("broker unavailable")));
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("topic", "requests"),
+            "response", Map.of("topic", "responses")));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+
+        assertEquals("broker unavailable", exception.getMessage());
+    }
+
+    @Test
+    void dispatchFailsWithoutPublisherProvider() {
+        KafkaAwaitTransportAdapter adapter = new KafkaAwaitTransportAdapter();
+        adapter.resumeTokenService = new AwaitResumeTokenService("secret-value-for-tests");
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("topic", "requests"),
+            "response", Map.of("topic", "responses")));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(exception.getMessage().contains("KafkaAwaitPublisher"));
+    }
+
+    @Test
+    void dispatchRejectsInvalidKeyStrategy() {
+        KafkaAwaitTransportAdapter adapter = adapter(request -> Uni.createFrom().voidItem());
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of(
+                "topic", "requests",
+                "key", "orderId"),
+            "response", Map.of("topic", "responses")));
+
+        assertThrows(IllegalArgumentException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+    }
+
+    private static KafkaAwaitTransportAdapter adapter(org.pipelineframework.awaitable.kafka.KafkaAwaitPublisher publisher) {
+        KafkaAwaitTransportAdapter adapter = new KafkaAwaitTransportAdapter(publisher);
+        adapter.resumeTokenService = new AwaitResumeTokenService("secret-value-for-tests");
+        return adapter;
+    }
+
+    private static AwaitStepDescriptor descriptor(Map<String, Object> config) {
+        return new AwaitStepDescriptor(
+            "FraudCheck",
+            "com.example.Request",
+            "com.example.Decision",
+            Duration.ofMinutes(10),
+            "signedResumeToken",
+            "kafka",
+            config,
+            java.util.List.of("orderId"));
+    }
+
+    private static AwaitInteractionRecord interaction() {
+        return new AwaitInteractionRecord(
+            "tenant-1",
+            "exec-1",
+            "FraudCheck",
+            1,
+            "com.example.Decision",
+            "interaction-1",
+            "corr-1",
+            "cause-1",
+            "idem-1",
+            1L,
+            AwaitInteractionStatus.DISPATCHING,
+            Map.of("orderId", "o-1"),
+            null,
+            null,
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            99_999_999_999L,
+            1_000L,
+            2_000L,
+            99_999L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumerTest.java
@@ -1,0 +1,136 @@
+package org.pipelineframework.awaitable.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+class KafkaAwaitCompletionConsumerTest {
+
+    @Test
+    void consumesCompletionEnvelopeThroughCoordinator() throws Exception {
+        AwaitCoordinator coordinator = org.mockito.Mockito.mock(AwaitCoordinator.class);
+        when(coordinator.complete(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record(), false)));
+        KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(coordinator);
+        String body = PipelineJson.mapper().writeValueAsString(new KafkaAwaitCompletionEnvelope(
+            "tenant-1",
+            "interaction-1",
+            null,
+            "resume-token",
+            "completion-1",
+            Map.of("decision", "approved"),
+            "fraud-service"));
+        AtomicReference<Boolean> acked = new AtomicReference<>(false);
+
+        consumer.consume(message(body, acked, new AtomicReference<>()))
+            .toCompletableFuture()
+            .get();
+
+        assertEquals(Boolean.TRUE, acked.get());
+        ArgumentCaptor<AwaitCompletionCommand> captor = ArgumentCaptor.forClass(AwaitCompletionCommand.class);
+        verify(coordinator).complete(captor.capture());
+        AwaitCompletionCommand command = captor.getValue();
+        assertEquals("tenant-1", command.tenantId());
+        assertEquals("interaction-1", command.interactionId());
+        assertEquals("resume-token", command.resumeToken());
+        assertEquals("completion-1", command.idempotencyKey());
+        assertEquals("fraud-service", command.actor());
+    }
+
+    @Test
+    void invalidEnvelopeNacksMessage() {
+        AwaitCoordinator coordinator = org.mockito.Mockito.mock(AwaitCoordinator.class);
+        KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(coordinator);
+        AtomicReference<Throwable> nacked = new AtomicReference<>();
+
+        consumer.consume(message("not-json", new AtomicReference<>(), nacked))
+            .toCompletableFuture()
+            .orTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+            .join();
+
+        assertNotNull(nacked.get());
+    }
+
+    @Test
+    void coordinatorFailureNacksMessage() {
+        AwaitCoordinator coordinator = org.mockito.Mockito.mock(AwaitCoordinator.class);
+        when(coordinator.complete(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().failure(new IllegalStateException("stale")));
+        KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(coordinator);
+        AtomicReference<Throwable> nacked = new AtomicReference<>();
+
+        consumer.consume(message("""
+            {
+              "tenantId": "tenant-1",
+              "interactionId": "interaction-1",
+              "idempotencyKey": "completion-1",
+              "responsePayload": {"decision": "approved"}
+            }
+            """, new AtomicReference<>(), nacked))
+            .toCompletableFuture()
+            .orTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+            .join();
+
+        assertNotNull(nacked.get());
+    }
+
+    private static Message<String> message(
+        String payload,
+        AtomicReference<Boolean> acked,
+        AtomicReference<Throwable> nacked) {
+        return Message.of(
+            payload,
+            () -> {
+                acked.set(true);
+                return CompletableFuture.completedFuture(null);
+            },
+            failure -> {
+                nacked.set(failure);
+                return CompletableFuture.completedFuture(null);
+            });
+    }
+
+    private static AwaitInteractionRecord record() {
+        return new AwaitInteractionRecord(
+            "tenant-1",
+            "exec-1",
+            "FraudCheck",
+            1,
+            "com.example.Decision",
+            "interaction-1",
+            "corr-1",
+            "cause-1",
+            "idem-1",
+            1L,
+            AwaitInteractionStatus.COMPLETED,
+            Map.of("orderId", "o-1"),
+            Map.of("decision", "approved"),
+            "fraud-service",
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            System.currentTimeMillis() + Duration.ofMinutes(5).toMillis(),
+            1_000L,
+            2_000L,
+            99_999L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumerTest.java
@@ -3,12 +3,14 @@ package org.pipelineframework.awaitable.kafka;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.mutiny.Uni;
@@ -26,7 +28,7 @@ class KafkaAwaitCompletionConsumerTest {
 
     @Test
     void consumesCompletionEnvelopeThroughCoordinator() throws Exception {
-        AwaitCoordinator coordinator = org.mockito.Mockito.mock(AwaitCoordinator.class);
+        AwaitCoordinator coordinator = mock(AwaitCoordinator.class);
         when(coordinator.complete(any(AwaitCompletionCommand.class)))
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record(), false)));
         KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(coordinator);
@@ -42,7 +44,8 @@ class KafkaAwaitCompletionConsumerTest {
 
         consumer.consume(message(body, acked, new AtomicReference<>()))
             .toCompletableFuture()
-            .get();
+            .orTimeout(5, TimeUnit.SECONDS)
+            .join();
 
         assertEquals(Boolean.TRUE, acked.get());
         ArgumentCaptor<AwaitCompletionCommand> captor = ArgumentCaptor.forClass(AwaitCompletionCommand.class);
@@ -57,7 +60,7 @@ class KafkaAwaitCompletionConsumerTest {
 
     @Test
     void invalidEnvelopeNacksMessage() {
-        AwaitCoordinator coordinator = org.mockito.Mockito.mock(AwaitCoordinator.class);
+        AwaitCoordinator coordinator = mock(AwaitCoordinator.class);
         KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(coordinator);
         AtomicReference<Throwable> nacked = new AtomicReference<>();
 
@@ -71,7 +74,7 @@ class KafkaAwaitCompletionConsumerTest {
 
     @Test
     void coordinatorFailureNacksMessage() {
-        AwaitCoordinator coordinator = org.mockito.Mockito.mock(AwaitCoordinator.class);
+        AwaitCoordinator coordinator = mock(AwaitCoordinator.class);
         when(coordinator.complete(any(AwaitCompletionCommand.class)))
             .thenReturn(Uni.createFrom().failure(new IllegalStateException("stale")));
         KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(coordinator);


### PR DESCRIPTION
Added Kafka await support with a KafkaAwaitTransportAdapter, framework-owned dispatch/completion envelopes, KafkaAwaitPublisher SPI, and opt-in SmallRye Reactive Messaging publisher/consumer bridge. Deployment parsing now validates Kafka await YAML for request/response topics, key strategy, and supported correlation strategy. Docs cover Kafka YAML/config and note CSV Payments remains a later consumer.Fixed two deployment tests that used transport.type: webhook without the now-required webhook URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kafka transport added for awaitable orchestration steps (request publish + response channel handling) with signed resume-token correlation support.

* **Documentation**
  * Orchestrator guide updated with Kafka configuration examples and runtime setup notes for Kafka response channels.

* **Bug Fixes**
  * Stricter validation for Kafka await configurations and correlation strategy with clearer error responses when required fields or secrets are missing.

* **Tests**
  * Expanded tests covering Kafka validation, dispatch envelopes and completion handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->