### PR TITLE
Clean up CSV await/Kafka semantics and clarify operator boundaries

### DIFF
--- a/docs/guide/build/operators.md
+++ b/docs/guide/build/operators.md
@@ -84,9 +84,23 @@ steps:
 Rules:
 - Remote execution is available only in `version: 2`.
 - Only unary `ONE_TO_ONE` remote execution is supported currently.
+- Remote execution is immediate request/response only. It does not persist durable waiting state or resume later from correlated completion.
 - Exactly one of `execution.target.url` or `execution.target.urlConfigKey` must be set.
 - `execution.target.urlConfigKey` resolves at runtime startup, not at compile time.
 - `pipeline.transport` and the remote operator protocol are orthogonal. TPF can expose the pipeline over REST, gRPC, or local transport while invoking the remote operator over Protobuf-over-HTTP.
+
+## Operator vs Await
+
+Use operators when the external call completes within the current pipeline invocation. Use await steps when the request leaves the current execution turn and the result comes back later.
+
+| External shape | Use |
+| --- | --- |
+| Inline HTTP/gRPC call returning now | Operator / remote execution |
+| Broker request/reply with later correlated message | Await step |
+| Webhook callback later | Await step |
+| UI/human approval | Await step |
+
+If a remote system returns `accepted` now and the final business result arrives later, that is not a remote operator. Model it as `kind: await`.
 
 ## Working Example
 

--- a/docs/guide/development/operators.md
+++ b/docs/guide/development/operators.md
@@ -62,6 +62,21 @@ At runtime, the generated adapter:
 - propagates canonical `x-tpf-*` metadata headers,
 - decodes either the output protobuf message or a `google.rpc.Status` failure envelope.
 
+Remote operators are still immediate request/response steps. The remote implementation may use async I/O internally, but the pipeline execution remains on the same invocation lease and expects the reply inline. If the external system returns `accepted` and the final answer arrives later through a broker, webhook, or human task, model that boundary as `kind: await` instead.
+
+## Operator vs Await
+
+Use this rule to pick the step model:
+
+| External shape | Use |
+| --- | --- |
+| Inline HTTP/gRPC call returning now | Operator / remote execution |
+| Broker request/reply with later correlated message | Await step |
+| Webhook callback later | Await step |
+| UI/human approval | Await step |
+
+Anti-pattern: if the remote system acknowledges the request now and produces the real business result later, do not model that as a remote operator. Remote operators are for immediate replies; await steps are for deferred durable completion.
+
 ## Method Contract Checklist
 
 - Format: `fully.qualified.Class::method`.
@@ -93,6 +108,7 @@ When application domain types differ from operator I/O types, mapper coverage is
 
 - Remote operators are v2-only.
 - Only `ONE_TO_ONE` is supported currently.
+- Remote operators are immediate request/response only; they do not persist durable waiting state or resume later from a correlated completion.
 - The generated adapter sends its HTTP `POST` to the fully configured target URL. If you use `execution.target.url`, include the full path to call. If you use `execution.target.urlConfigKey`, the configured value must also be the full target URL, including any path segment.
 - The value of `execution.target.urlConfigKey` is resolved at application startup; if it is missing or blank, the application will fail to start.
 - `execution.timeoutMs`, when set, caps the outbound HTTP call. The runtime also applies the propagated deadline if one is present, using the smaller of the two budgets.

--- a/docs/guide/development/orchestrator-runtime.md
+++ b/docs/guide/development/orchestrator-runtime.md
@@ -180,7 +180,25 @@ Failure channel split:
 
 Await steps suspend `QUEUE_ASYNC` execution at an external boundary. TPF persists the interaction, dispatches through the configured adapter, and resumes the owning execution after a correlated completion is admitted.
 
+Shipped await shapes in this slice are:
+
+1. `ONE_TO_ONE` for single external interactions.
+2. `MANY_TO_MANY` with `await.dispatch.mode=per-item`, which creates a durable per-item barrier and resumes downstream only after every item completion has been admitted.
+
+`MANY_TO_MANY` per-item await is the shape used by `csv-payments`. It is a runtime barrier over unary external interactions, not a claim that every await cardinality is already supported.
+
 The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope. The built-in `kafka` adapter publishes a request envelope to Kafka and admits response envelopes from a configured response channel.
+
+Await is the only durable suspend/resume primitive in TPF. Use operators or remote execution when the external system replies within the current invocation. Use `kind: await` when the request leaves the current execution turn and the result is admitted later through correlation.
+
+| External shape | Use |
+| --- | --- |
+| Inline HTTP/gRPC call returning now | Operator / remote execution |
+| Broker request/reply with later correlated message | Await step |
+| Webhook callback later | Await step |
+| UI/human approval | Await step |
+
+If a remote system returns `accepted` now and the final business result arrives later, do not model that as a remote operator. That is an await boundary.
 
 ```yaml
 steps:
@@ -231,6 +249,29 @@ steps:
 
 Kafka dispatch sends a framework-owned JSON envelope containing tenant id, execution id, interaction id, correlation id, step id, deadline, input/output types, resume token, request payload, and dispatch metadata. The response envelope is consumed by TPF and completed directly through `AwaitCoordinator`, not by looping back through REST. Use the generated REST/gRPC completion APIs for human/UI or webhook clients that are not broker consumers.
 
+```yaml
+steps:
+  - name: "Await Payment Provider"
+    kind: "await"
+    cardinality: "MANY_TO_MANY"
+    input: "org.pipelineframework.csv.common.domain.PaymentRecord"
+    output: "org.pipelineframework.csv.common.domain.PaymentStatus"
+    timeout: "PT5M"
+    idempotencyKeyFields: ["csvId", "recipient", "amount", "currency"]
+    await:
+      dispatch:
+        mode: "per-item"
+      correlation:
+        strategy: "signedResumeToken"
+      transport:
+        type: "kafka"
+        request:
+          topic: "csv-payments.payment.requests"
+          key: "correlationId"
+        response:
+          topic: "csv-payments.payment.results"
+```
+
 Add the Quarkus Kafka messaging extension to the application that hosts the orchestrator, enable the default Kafka bridge with `pipeline.await.kafka.reactive-messaging.enabled=true`, then configure the SmallRye channels:
 
 ```properties
@@ -262,6 +303,8 @@ Recovery points:
 3. worker death while leased: lease expiry allows takeover.
 
 These guarantees are deterministic for orchestrator state, not for external side effects; downstream step boundaries must accept at-least-once invocation.
+
+That matters for plugin-style side effects after an await boundary. A resumed queue-async execution can replay the remainder of the pipeline after a downstream retry, so once-only side-effect checkpointing is a separate concern from await durability itself.
 
 ## Queue-Async HA Baseline
 

--- a/docs/guide/evolve/template-generator.md
+++ b/docs/guide/evolve/template-generator.md
@@ -100,6 +100,8 @@ You can determine that version with `template-generator --version`, by checking 
 
 The generator copies the authored config into `config/pipeline.yaml` so the build can recreate `.proto` definitions during `generate-sources`.
 
+Await steps are now part of the v2 template schema so CI and automation can validate authored `kind: await` pipeline configs. The current generator still does not scaffold await transport modules or runtime wiring; when an authored config contains await steps, it fails fast with an explicit error instead of silently generating an incompatible project skeleton.
+
 ## Semantic Types and Derived Bindings
 
 In v2, the author normally chooses only the semantic type:

--- a/examples/csv-payments/README.md
+++ b/examples/csv-payments/README.md
@@ -35,6 +35,8 @@ The canonical modular flow is:
 
 This is durable brokered completion, not polling. Kafka delivery remains at-least-once; TPF handles idempotent completion admission and ordered barrier reconstruction for the resumed pipeline.
 
+The CSV example keeps the persistence aspect scoped to pre-await steps only. That is intentional: queue-async resume is at-least-once from the await boundary onward, and this example avoids teaching `persistence.duplicate-key=upsert` as the main answer to replayable post-await side effects. Once-only checkpointing for post-await side effects is a separate runtime concern.
+
 The orchestrator must run in queue-async mode and needs a stable resume-token secret:
 
 ```properties

--- a/examples/csv-payments/config/pipeline.yaml
+++ b/examples/csv-payments/config/pipeline.yaml
@@ -5,9 +5,14 @@ transport: GRPC
 aspects:
   persistence:
     enabled: true
-    scope: GLOBAL
+    scope: STEPS
     position: AFTER_STEP
     config:
+      # Queue-async resume is at-least-once from the await boundary onward. Keep persistence scoped to
+      # pre-await steps until the runtime has durable once-only checkpointing for post-await side effects.
+      targetSteps:
+        - ProcessFolderService
+        - ProcessCsvPaymentsInputService
       pluginImplementationClass: org.pipelineframework.plugin.persistence.PersistenceService
       enabledTargets:
         - GRPC_SERVICE

--- a/examples/csv-payments/monolith-svc/src/main/resources/application.properties
+++ b/examples/csv-payments/monolith-svc/src/main/resources/application.properties
@@ -15,7 +15,6 @@ quarkus.datasource.jdbc.url=${PG_JDBC_URL:jdbc:postgresql://localhost:5432/pipel
 quarkus.datasource.reactive.url=${PG_REACTIVE_URL:${PG_URL:postgresql://localhost:5432/pipeline}}
 quarkus.datasource.username=${PG_USER:postgres}
 quarkus.datasource.password=${PG_PASSWORD:postgres}
-persistence.duplicate-key=upsert
 
 pipeline.client.tls-configuration-name=pipeline-client
 quarkus.tls.pipeline-client.trust-store.jks.path=${CLIENT_TRUSTSTORE_PATH:../target/dev-certs/orchestrator-svc/client-truststore.jks}

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/CsvPaymentsAwaitPersistenceScopeTest.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/CsvPaymentsAwaitPersistenceScopeTest.java
@@ -1,0 +1,93 @@
+package org.pipelineframework.csv.orchestrator.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CsvPaymentsAwaitPersistenceScopeTest {
+
+    @Test
+    void persistenceAspectTargetsOnlyPreAwaitSteps() throws IOException {
+        String pipelineYaml = Files.readString(resolveConfigPath("pipeline.yaml"));
+
+        assertTrue(pipelineYaml.contains("aspects:\n  persistence:"), "Expected persistence aspect in pipeline.yaml");
+        assertTrue(pipelineYaml.contains("scope: STEPS"), "Persistence should be scoped to selected steps");
+        assertTrue(
+                pipelineYaml.contains("- ProcessFolderService"),
+                "Persistence should include the folder ingestion step");
+        assertTrue(
+                pipelineYaml.contains("- ProcessCsvPaymentsInputService"),
+                "Persistence should include the CSV parsing step");
+        assertFalse(
+                pipelineYaml.contains("- ProcessAwaitPaymentProviderService"),
+                "Persistence should not target the replayable await boundary");
+        assertFalse(
+                pipelineYaml.contains("- ProcessPaymentStatusService"),
+                "Persistence should not target post-await status processing");
+        assertFalse(
+                pipelineYaml.contains("- ProcessCsvPaymentsOutputFileService"),
+                "Persistence should not target post-await output generation");
+    }
+
+    @Test
+    void csvRuntimeLayoutsDoNotRelyOnDuplicateKeyUpsert() throws IOException {
+        List<String> configFiles = List.of(
+                "persistence-svc/src/main/resources/application.properties",
+                "pipeline-runtime-svc/src/main/resources/application.properties",
+                "monolith-svc/src/main/resources/application.properties");
+
+        for (String relativePath : configFiles) {
+            String config = Files.readString(resolveExamplePath(relativePath));
+            assertFalse(
+                    config.contains("persistence.duplicate-key=upsert"),
+                    () -> relativePath + " should not hide replay duplicates behind upsert");
+        }
+    }
+
+    private static Path resolveConfigPath(String fileName) {
+        URL resource = Thread.currentThread().getContextClassLoader().getResource("config/" + fileName);
+        if (resource != null) {
+            try {
+                return Path.of(resource.toURI()).normalize();
+            } catch (URISyntaxException e) {
+                throw new IllegalStateException("Invalid config resource URI: " + resource, e);
+            }
+        }
+
+        Path userDir = Path.of(System.getProperty("user.dir", ".")).normalize();
+        Path direct = userDir.resolve("config").resolve(fileName).normalize();
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path parent = userDir.resolve("..").resolve("config").resolve(fileName).normalize();
+        if (Files.exists(parent)) {
+            return parent;
+        }
+
+        throw new IllegalStateException("Could not resolve config/" + fileName);
+    }
+
+    private static Path resolveExamplePath(String relativePath) {
+        Path userDir = Path.of(System.getProperty("user.dir", ".")).normalize();
+        Path direct = userDir.resolve(relativePath).normalize();
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path parent = userDir.resolve("..").resolve(relativePath).normalize();
+        if (Files.exists(parent)) {
+            return parent;
+        }
+
+        throw new IllegalStateException("Could not resolve " + relativePath);
+    }
+}

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/CsvPaymentsAwaitPersistenceScopeTest.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/CsvPaymentsAwaitPersistenceScopeTest.java
@@ -27,7 +27,7 @@ class CsvPaymentsAwaitPersistenceScopeTest {
                 pipelineYaml.contains("- ProcessCsvPaymentsInputService"),
                 "Persistence should include the CSV parsing step");
         assertFalse(
-                pipelineYaml.contains("- ProcessAwaitPaymentProviderService"),
+                pipelineYaml.contains("Await Payment Provider"),
                 "Persistence should not target the replayable await boundary");
         assertFalse(
                 pipelineYaml.contains("- ProcessPaymentStatusService"),

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/CsvPaymentsAwaitPersistenceScopeTest.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/CsvPaymentsAwaitPersistenceScopeTest.java
@@ -27,7 +27,7 @@ class CsvPaymentsAwaitPersistenceScopeTest {
                 pipelineYaml.contains("- ProcessCsvPaymentsInputService"),
                 "Persistence should include the CSV parsing step");
         assertFalse(
-                pipelineYaml.contains("Await Payment Provider"),
+                pipelineYaml.contains("- Await Payment Provider"),
                 "Persistence should not target the replayable await boundary");
         assertFalse(
                 pipelineYaml.contains("- ProcessPaymentStatusService"),

--- a/examples/csv-payments/persistence-svc/src/main/resources/application.properties
+++ b/examples/csv-payments/persistence-svc/src/main/resources/application.properties
@@ -26,7 +26,6 @@ quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.reactive.url=${PG_URL:postgresql://localhost:5432/pipeline}
 %prod.quarkus.datasource.username=${PG_USER:postgres}
 %prod.quarkus.datasource.password=${PG_PASSWORD:postgres}
-persistence.duplicate-key=upsert
 
 # HTTP/2 REST and gRPC endpoint using SSL with a self-signed cert
 quarkus.grpc.server.use-separate-server=false

--- a/examples/csv-payments/pipeline-runtime-svc/src/main/resources/application.properties
+++ b/examples/csv-payments/pipeline-runtime-svc/src/main/resources/application.properties
@@ -50,7 +50,6 @@ csv-payments.payment-provider.wait-milliseconds=100
 pipeline.client.tls-configuration-name=pipeline-client
 quarkus.tls.pipeline-client.trust-store.jks.path=${CLIENT_TRUSTSTORE_PATH:}
 quarkus.tls.pipeline-client.trust-store.jks.password=${CLIENT_TRUSTSTORE_PASSWORD:}
-persistence.duplicate-key=upsert
 
 # Docker image
 quarkus.container-image.builder=jib

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -209,7 +209,9 @@ public class StepDefinitionParser {
         }
         if (awaitStep && (!isBlank(delegatedClassName) || !isBlank(serviceClassName) || remoteExecution != null)) {
             String message = "Skipping step '" + name
-                + "': await steps cannot declare 'service', 'operator', 'delegate', or remote 'execution'";
+                + "': await steps are deferred durable boundaries and cannot declare 'service', 'operator', 'delegate',"
+                + " or remote 'execution'; use operators/remote execution for immediate replies and 'kind: await'"
+                + " for correlated later completion";
             LOG.warn(message);
             report(Diagnostic.Kind.ERROR, message);
             return null;

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -603,6 +603,92 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void rejectsAwaitStepWhenOperatorIsAlsoDeclared() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Await With Operator"
+                kind: "await"
+                operator: "com.example.Operator::process"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "interaction-api"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        String errorSummary = diagnostics.stream().collect(Collectors.joining(" | "));
+        assertTrue(errorSummary.contains("await steps are deferred durable boundaries"), errorSummary);
+        assertTrue(errorSummary.contains("use operators/remote execution for immediate replies"), errorSummary);
+    }
+
+    @Test
+    void rejectsAwaitStepWhenRemoteExecutionIsAlsoDeclared() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Await With Remote Execution"
+                kind: "await"
+                inputTypeName: "Input"
+                outputTypeName: "Output"
+                timeout: "PT10M"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "fraud-check"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  target:
+                    url: "https://operators.example/check"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "interaction-api"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        String errorSummary = diagnostics.stream().collect(Collectors.joining(" | "));
+        assertTrue(errorSummary.contains("await steps are deferred durable boundaries"), errorSummary);
+        assertTrue(errorSummary.contains("kind: await"), errorSummary);
+    }
+
+    @Test
+    void rejectsAwaitStepWhenServiceIsAlsoDeclared() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Await With Service"
+                kind: "await"
+                service: "com.example.Service"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "interactionId"
+                  transport:
+                    type: "interaction-api"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        String errorSummary = diagnostics.stream().collect(Collectors.joining(" | "));
+        assertTrue(errorSummary.contains("await steps are deferred durable boundaries"), errorSummary);
+        assertTrue(errorSummary.contains("correlated later completion"), errorSummary);
+    }
+
+    @Test
     void rejectsUnsupportedKindValue() throws IOException {
         List<String> diagnostics = new ArrayList<>();
         List<StepDefinition> steps = parse("""

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitSuspendedException.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitSuspendedException.java
@@ -1,11 +1,11 @@
 package org.pipelineframework.awaitable;
 
-import org.pipelineframework.step.NonRetryableException;
+import org.pipelineframework.step.PipelineControlFlowException;
 
 /**
  * Internal signal used to suspend queue-async execution at an await step.
  */
-public class AwaitSuspendedException extends NonRetryableException {
+public class AwaitSuspendedException extends PipelineControlFlowException {
     private final String tenantId;
     private final String executionId;
     private final String interactionId;

--- a/framework/runtime/src/main/java/org/pipelineframework/step/Configurable.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/Configurable.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CancellationException;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
-import org.pipelineframework.awaitable.AwaitSuspendedException;
 import org.pipelineframework.config.StepConfig;
 
 /**
@@ -88,9 +87,6 @@ default String backpressureStrategy() { return effectiveConfig().backpressureStr
         if (failure == null) {
             return false;
         }
-        if (containsAwaitSuspension(failure)) {
-            return false;
-        }
         if (containsCancellation(failure)) {
             return false;
         }
@@ -105,10 +101,6 @@ default String backpressureStrategy() { return effectiveConfig().backpressureStr
 
     private boolean containsNonRetryable(Throwable failure) {
         return containsThrowable(failure, NonRetryableException.class);
-    }
-
-    private boolean containsAwaitSuspension(Throwable failure) {
-        return containsThrowable(failure, AwaitSuspendedException.class);
     }
 
     private boolean containsCancellation(Throwable failure) {

--- a/framework/runtime/src/main/java/org/pipelineframework/step/ItemRejectable.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/ItemRejectable.java
@@ -25,7 +25,6 @@ import jakarta.enterprise.inject.CreationException;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import org.jboss.logging.Logger;
-import org.pipelineframework.awaitable.AwaitSuspendedException;
 import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
 import org.pipelineframework.context.TransportDispatchMetadata;
@@ -128,13 +127,13 @@ public interface ItemRejectable<I, O> {
     }
 
     /**
-     * Await suspension is not a business failure and must propagate back to the queue-async coordinator
-     * instead of being routed through reject-and-continue handling.
+     * Runtime control-flow signals are not business failures and must propagate back to the
+     * queue-async coordinator instead of being routed through reject-and-continue handling.
      */
     default boolean shouldPropagateWithoutRecovery(Throwable cause) {
         Throwable current = cause;
         while (current != null) {
-            if (current instanceof AwaitSuspendedException) {
+            if (current instanceof PipelineControlFlowException) {
                 return true;
             }
             current = current.getCause();

--- a/framework/runtime/src/main/java/org/pipelineframework/step/PipelineControlFlowException.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/PipelineControlFlowException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.step;
+
+/**
+ * Internal control-flow signal for pipeline runtime transitions.
+ *
+ * <p>These exceptions are not business failures and must propagate back to the runtime coordinator
+ * instead of being retried or routed through reject-and-continue handling.</p>
+ */
+public abstract class PipelineControlFlowException extends NonRetryableException {
+
+    protected PipelineControlFlowException(String message) {
+        super(message);
+    }
+
+    protected PipelineControlFlowException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/template-generator-node/__tests__/pipeline-generator-v2.test.js
+++ b/template-generator-node/__tests__/pipeline-generator-v2.test.js
@@ -166,6 +166,96 @@ steps:
     expect(config.steps[0].execution.target.urlConfigKey).toBe('tpf.remote-operators.charge-card.url');
   });
 
+  test('loadConfig accepts await step metadata for v2 configs', () => {
+    const generator = new PipelineGenerator();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-generator-'));
+    const configPath = path.join(tempDir, 'await-config.yaml');
+    fs.writeFileSync(configPath, `version: 2
+appName: TestApp
+basePackage: com.example.test
+transport: GRPC
+runtimeLayout: MODULAR
+messages:
+  PaymentRecord:
+    fields:
+      - number: 1
+        name: csvId
+        type: string
+  PaymentStatus:
+    fields:
+      - number: 1
+        name: status
+        type: string
+steps:
+  - name: Await Payment Provider
+    kind: await
+    cardinality: MANY_TO_MANY
+    inputTypeName: PaymentRecord
+    outputTypeName: PaymentStatus
+    timeout: PT5M
+    idempotencyKeyFields: [csvId]
+    await:
+      dispatch:
+        mode: per-item
+      correlation:
+        strategy: signedResumeToken
+      transport:
+        type: kafka
+        request:
+          topic: csv-payments.payment.requests
+          key: correlationId
+        response:
+          topic: csv-payments.payment.results
+`);
+
+    const config = generator.loadConfig(configPath);
+    expect(config.steps[0].kind).toBe('await');
+    expect(config.steps[0].await.transport.type).toBe('kafka');
+    expect(config.steps[0].await.dispatch.mode).toBe('per-item');
+  });
+
+  test('toScaffoldConfig fails clearly for await steps', () => {
+    const generator = new PipelineGenerator();
+    const config = {
+      version: 2,
+      appName: 'TestApp',
+      basePackage: 'com.example.test',
+      transport: 'GRPC',
+      runtimeLayout: 'MODULAR',
+      messages: {
+        PaymentRecord: {
+          fields: [{ number: 1, name: 'csvId', type: 'string' }]
+        },
+        PaymentStatus: {
+          fields: [{ number: 1, name: 'status', type: 'string' }]
+        }
+      },
+      steps: [
+        {
+          name: 'Await Payment Provider',
+          kind: 'await',
+          cardinality: 'MANY_TO_MANY',
+          inputTypeName: 'PaymentRecord',
+          outputTypeName: 'PaymentStatus',
+          timeout: 'PT5M',
+          await: {
+            dispatch: { mode: 'per-item' },
+            correlation: { strategy: 'signedResumeToken' },
+            transport: {
+              type: 'kafka',
+              request: { topic: 'csv-payments.payment.requests', key: 'correlationId' },
+              response: { topic: 'csv-payments.payment.results' }
+            }
+          }
+        }
+      ]
+    };
+
+    expect(() => generator.toScaffoldConfig(config)).toThrow(
+      'Await steps are accepted by the template schema'
+    );
+  });
+
   test('loadConfig rejects non-integer version values', () => {
     const generator = new PipelineGenerator();
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-generator-'));

--- a/template-generator-node/src/pipeline-generator.js
+++ b/template-generator-node/src/pipeline-generator.js
@@ -166,6 +166,16 @@ class PipelineGenerator {
 
     toScaffoldConfig(config) {
         const scaffoldConfig = { ...config };
+        const awaitSteps = Array.isArray(config.steps)
+            ? config.steps.filter((step) => step && step.kind === 'await')
+            : [];
+        if (awaitSteps.length > 0) {
+            const stepNames = awaitSteps.map((step) => step.name).join(', ');
+            throw new Error(
+                `Await steps are accepted by the template schema, but the generator does not scaffold await transport modules yet. ` +
+                `Remove these steps or author them manually in pipeline.yaml: ${stepNames}`
+            );
+        }
         scaffoldConfig.steps = this.processSteps(this.materializeSteps(config));
         return scaffoldConfig;
     }
@@ -265,6 +275,9 @@ class PipelineGenerator {
             return step;
         }
         const normalized = { ...step };
+        if (typeof normalized.kind === 'string') {
+            normalized.kind = normalized.kind.trim().toLowerCase();
+        }
         if (normalized.execution && typeof normalized.execution === 'object') {
             normalized.execution = { ...normalized.execution };
             if (typeof normalized.execution.mode === 'string') {

--- a/template-generator-node/src/pipeline-template-schema.json
+++ b/template-generator-node/src/pipeline-template-schema.json
@@ -579,7 +579,7 @@
               "additionalProperties": true
             }
           },
-          "required": ["transport"],
+          "required": ["transport", "correlation"],
           "additionalProperties": false
         },
         "execution": {

--- a/template-generator-node/src/pipeline-template-schema.json
+++ b/template-generator-node/src/pipeline-template-schema.json
@@ -435,6 +435,10 @@
         "name": {
           "type": "string"
         },
+        "kind": {
+          "type": "string",
+          "enum": ["await"]
+        },
         "cardinality": {
           "type": "string",
           "enum": ["ONE_TO_ONE", "EXPANSION", "REDUCTION", "SIDE_EFFECT", "MANY_TO_MANY", "ONE_TO_MANY", "MANY_TO_ONE"]
@@ -470,11 +474,135 @@
         "parallel": {
           "type": "boolean"
         },
+        "timeout": {
+          "type": "string",
+          "minLength": 1
+        },
+        "idempotencyKeyFields": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "await": {
+          "type": "object",
+          "properties": {
+            "dispatch": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": ["single", "per-item"]
+                }
+              },
+              "additionalProperties": false
+            },
+            "correlation": {
+              "type": "object",
+              "properties": {
+                "strategy": {
+                  "type": "string",
+                  "enum": ["interactionId", "signedResumeToken"]
+                }
+              },
+              "required": ["strategy"],
+              "additionalProperties": false
+            },
+            "transport": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["interaction-api", "webhook", "kafka"]
+                },
+                "request": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "method": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "topic": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "key": {
+                      "type": "string",
+                      "enum": ["interactionId", "correlationId"]
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "response": {
+                  "type": "object",
+                  "properties": {
+                    "topic": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "consumer": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "headers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "callback": {
+                  "type": "object",
+                  "properties": {
+                    "baseUrl": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["transport"],
+          "additionalProperties": false
+        },
         "execution": {
           "$ref": "#/$defs/v2Execution"
         }
       },
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "await"
+              }
+            },
+            "required": ["kind"]
+          },
+          "then": {
+            "required": ["timeout", "await"],
+            "not": {
+              "required": ["execution"]
+            }
+          }
+        },
         {
           "if": {
             "properties": {


### PR DESCRIPTION
## Summary
- remove the hidden CSV `persistence.duplicate-key=upsert` stabilizer and scope persistence to the pre-await steps
- align template-generator and docs with the shipped await/Kafka runtime shape
- clarify that operators/remote execution are immediate request-response boundaries while await remains the durable suspend-resume primitive

## Scope
In scope:
- CSV await/Kafka cleanup and regression coverage
- template-generator await schema support with fail-fast scaffold behavior
- operator vs await compiler diagnostics and docs clarification

Out of scope:
- web-ui and replay-viewer alignment
- renaming public APIs
- making remote operators durable async boundaries

## Validation
- `npm --prefix template-generator-node test -- pipeline-generator-v2.test.js`
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=ConfigurableStepTest,StepOneToOneTest,StepOneToManyTest,StepManyToOneTest,StepManyToManyTest,QueueAsyncCoordinatorTest test`
- `./mvnw -f framework/pom.xml -pl deployment -Dtest=StepDefinitionParserTest test`
- `npm --prefix docs run build`
- `./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -Dtest=CsvPaymentsAwaitPersistenceScopeTest test`
- `./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -am -Dcsv.runtime.layout=monolith -Dcsv.e2e.pipeline.wait.seconds=120 -Dcsv.e2e.orchestrator.wait.seconds=120 -Dtest=CsvPaymentsEndToEndIT#fullPipelineWorks -Dsurefire.failIfNoSpecifiedTests=false test`
- `CSV_E2E_OBSERVABILITY_IMAGE_TAG=cleanup bash ./examples/csv-payments/build-modular-observability-images.sh`
- `./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -am -Dcsv.e2e.tempo.enabled=true -Dcsv.e2e.tempo.image.tag=cleanup -Dcsv.e2e.reader-demand-pacer.rows-per-period=20 -Dcsv.e2e.reader-demand-pacer.millis-period=1000 -Dcsv.e2e.input.file=examples/csv-payments/input-csv-file-processing-svc/csv/payments_1k.csv -Dcsv.e2e.pipeline.wait.seconds=900 -Dcsv.e2e.orchestrator.wait.seconds=900 -Dtest=CsvPaymentsTempoVerificationEndToEndIT -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

## Review note
A local `cr review --prompt-only --base main --config ./AGENTS.md` run was attempted, but the CLI wedged in the remote reviewing phase after setup and was treated as tooling noise rather than a code blocker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when to use operators vs await steps, added mapping tables, examples and anti-pattern guidance; expanded await/durability guidance and examples.

* **New Features**
  * Template generator now recognises and rejects unsupported await steps during scaffolding; schema updated to support await step metadata.

* **Bug Fixes**
  * Removed obsolete persistence upsert settings from example configurations.

* **Tests**
  * Added coverage for await parsing, generator rejection and await persistence scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->