### PR TITLE
Add await scaffolding to the template generator

### DIFF
--- a/docs/guide/development/orchestrator-runtime.md
+++ b/docs/guide/development/orchestrator-runtime.md
@@ -180,7 +180,7 @@ Failure channel split:
 
 Await steps suspend `QUEUE_ASYNC` execution at an external boundary. TPF persists the interaction, dispatches through the configured adapter, and resumes the owning execution after a correlated completion is admitted.
 
-Shipped await shapes in this slice are:
+Currently supported await shapes are:
 
 1. `ONE_TO_ONE` for single external interactions.
 2. `MANY_TO_MANY` with `await.dispatch.mode=per-item`, which creates a durable per-item barrier and resumes downstream only after every item completion has been admitted.

--- a/docs/guide/evolve/template-generator.md
+++ b/docs/guide/evolve/template-generator.md
@@ -100,7 +100,7 @@ You can determine that version with `template-generator --version`, by checking 
 
 The generator copies the authored config into `config/pipeline.yaml` so the build can recreate `.proto` definitions during `generate-sources`.
 
-Await steps are now part of the v2 template schema so CI and automation can validate authored `kind: await` pipeline configs. The current generator still does not scaffold await transport modules or runtime wiring; when an authored config contains await steps, it fails fast with an explicit error instead of silently generating an incompatible project skeleton.
+Await steps are part of the v2 template schema so CI and automation can validate authored `kind: await` pipeline configs. The generator now scaffolds await-aware projects for `interaction-api` and `webhook` transports. It still rejects `kafka` await scaffolding explicitly because the generated project does not yet include the required messaging dependencies and channel configuration.
 
 ## Semantic Types and Derived Bindings
 

--- a/template-generator-node/__tests__/pipeline-generator-v2.test.js
+++ b/template-generator-node/__tests__/pipeline-generator-v2.test.js
@@ -214,7 +214,87 @@ steps:
     expect(config.steps[0].await.dispatch.mode).toBe('per-item');
   });
 
-  test('toScaffoldConfig fails clearly for await steps', () => {
+  test('toScaffoldConfig accepts interaction-api await steps without generating service modules', () => {
+    const generator = new PipelineGenerator();
+    const config = {
+      version: 2,
+      appName: 'TestApp',
+      basePackage: 'com.example.test',
+      transport: 'GRPC',
+      runtimeLayout: 'MODULAR',
+      messages: {
+        PaymentRecord: {
+          fields: [{ number: 1, name: 'csvId', type: 'string' }]
+        },
+        PaymentStatus: {
+          fields: [{ number: 1, name: 'status', type: 'string' }]
+        }
+      },
+      steps: [
+        {
+          name: 'Await Payment Provider',
+          kind: 'await',
+          cardinality: 'ONE_TO_ONE',
+          inputTypeName: 'PaymentRecord',
+          outputTypeName: 'PaymentStatus',
+          timeout: 'PT5M',
+          await: {
+            correlation: { strategy: 'interactionId' },
+            transport: { type: 'interaction-api' }
+          }
+        }
+      ]
+    };
+
+    const scaffold = generator.toScaffoldConfig(config);
+    expect(scaffold.steps[0].isAwaitStep).toBe(true);
+    expect(scaffold.steps[0].awaitTransportType).toBe('interaction-api');
+    expect(scaffold.steps[0].generatesServiceModule).toBe(false);
+    expect(scaffold.steps[0].serviceName).toBe('await-payment-provider-svc');
+  });
+
+  test('toScaffoldConfig accepts webhook await steps without generating service modules', () => {
+    const generator = new PipelineGenerator();
+    const config = {
+      version: 2,
+      appName: 'TestApp',
+      basePackage: 'com.example.test',
+      transport: 'GRPC',
+      runtimeLayout: 'MODULAR',
+      messages: {
+        PaymentRecord: {
+          fields: [{ number: 1, name: 'csvId', type: 'string' }]
+        },
+        PaymentStatus: {
+          fields: [{ number: 1, name: 'status', type: 'string' }]
+        }
+      },
+      steps: [
+        {
+          name: 'Await Payment Provider',
+          kind: 'await',
+          cardinality: 'ONE_TO_ONE',
+          inputTypeName: 'PaymentRecord',
+          outputTypeName: 'PaymentStatus',
+          timeout: 'PT5M',
+          await: {
+            correlation: { strategy: 'signedResumeToken' },
+            transport: {
+              type: 'webhook',
+              request: { url: 'https://partner.example/payments' }
+            }
+          }
+        }
+      ]
+    };
+
+    const scaffold = generator.toScaffoldConfig(config);
+    expect(scaffold.steps[0].isAwaitStep).toBe(true);
+    expect(scaffold.steps[0].awaitTransportType).toBe('webhook');
+    expect(scaffold.steps[0].generatesServiceModule).toBe(false);
+  });
+
+  test('toScaffoldConfig fails clearly for kafka await steps', () => {
     const generator = new PipelineGenerator();
     const config = {
       version: 2,
@@ -252,8 +332,110 @@ steps:
     };
 
     expect(() => generator.toScaffoldConfig(config)).toThrow(
-      'Await steps are accepted by the template schema'
+      'The runtime supports Kafka await steps'
     );
+  });
+
+  test('generateFromConfig scaffolds interaction-api await guidance without creating a step module', async () => {
+    const generator = new PipelineGenerator();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-generator-'));
+    const configPath = path.join(tempDir, 'interaction-await.yaml');
+    const outputPath = path.join(tempDir, 'generated-app');
+    fs.writeFileSync(configPath, `version: 2
+appName: Await UI App
+basePackage: com.example.awaitui
+transport: GRPC
+runtimeLayout: MODULAR
+messages:
+  ApprovalRequest:
+    fields:
+      - number: 1
+        name: orderId
+        type: uuid
+  ApprovalDecision:
+    fields:
+      - number: 1
+        name: status
+        type: string
+steps:
+  - name: Await Approval
+    kind: await
+    cardinality: ONE_TO_ONE
+    inputTypeName: ApprovalRequest
+    outputTypeName: ApprovalDecision
+    timeout: PT10M
+    await:
+      correlation:
+        strategy: interactionId
+      transport:
+        type: interaction-api
+`);
+
+    await generator.generateFromConfig(configPath, outputPath);
+
+    const readme = fs.readFileSync(path.join(outputPath, 'README.md'), 'utf8');
+    expect(readme).toContain('generated await completion and pending-interaction query APIs');
+    expect(readme).toContain('interaction-api await steps');
+    expect(fs.existsSync(path.join(outputPath, 'await-approval-svc'))).toBe(false);
+  });
+
+  test('generateFromConfig scaffolds webhook await projects without creating a step module', async () => {
+    const generator = new PipelineGenerator();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-generator-'));
+    const configPath = path.join(tempDir, 'webhook-await.yaml');
+    const outputPath = path.join(tempDir, 'generated-app');
+    fs.writeFileSync(configPath, `version: 2
+appName: Webhook Await App
+basePackage: com.example.awaitwebhook
+transport: GRPC
+runtimeLayout: MODULAR
+messages:
+  FraudCheckRequest:
+    fields:
+      - number: 1
+        name: orderId
+        type: uuid
+  FraudCheckDecision:
+    fields:
+      - number: 1
+        name: status
+        type: string
+steps:
+  - name: Fraud Check
+    kind: await
+    cardinality: ONE_TO_ONE
+    inputTypeName: FraudCheckRequest
+    outputTypeName: FraudCheckDecision
+    timeout: PT10M
+    await:
+      correlation:
+        strategy: signedResumeToken
+      transport:
+        type: webhook
+        request:
+          url: https://partner.example/fraud-check
+`);
+
+    await generator.generateFromConfig(configPath, outputPath);
+
+    const parentPom = fs.readFileSync(path.join(outputPath, 'pom.xml'), 'utf8');
+    const readme = fs.readFileSync(path.join(outputPath, 'README.md'), 'utf8');
+    const orchestratorProps = fs.readFileSync(
+      path.join(outputPath, 'orchestrator-svc', 'src/main/resources', 'application.properties'),
+      'utf8'
+    );
+    const runtimeMapping = YAML.load(
+      fs.readFileSync(path.join(outputPath, 'config', 'runtime-mapping', 'modular-auto.yaml'), 'utf8')
+    );
+
+    expect(parentPom).not.toContain('<module>fraud-check-svc</module>');
+    expect(fs.existsSync(path.join(outputPath, 'fraud-check-svc'))).toBe(false);
+    expect(fs.existsSync(path.join(outputPath, 'config', 'pipeline.yaml'))).toBe(true);
+    expect(readme).toContain('webhook await steps');
+    expect(readme).toContain('pipeline.orchestrator.resume-token-secret');
+    expect(orchestratorProps).toContain('pipeline.orchestrator.resume-token-secret=change-me');
+    expect(runtimeMapping.modules['fraud-check-svc']).toBeUndefined();
+    expect(runtimeMapping.modules['orchestrator-svc'].steps).toContain('fraud-check');
   });
 
   test('loadConfig rejects non-integer version values', () => {

--- a/template-generator-node/package-lock.json
+++ b/template-generator-node/package-lock.json
@@ -54,7 +54,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1313,7 +1312,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",

--- a/template-generator-node/src/browser-template-engine.js
+++ b/template-generator-node/src/browser-template-engine.js
@@ -343,6 +343,7 @@ class BrowserTemplateEngine {
         const includeCacheInvalidationModule = this.isAspectEnabled(aspectConfig, 'cache')
             || this.isAspectEnabled(aspectConfig, 'cache-invalidate')
             || this.isAspectEnabled(aspectConfig, 'cache-invalidate-all');
+        const generatedServiceSteps = this.generatedServiceSteps(stepsValue);
         // For sequential pipeline, update input types of steps after the first one
         // to match the output type of the previous step
         for (let i = 1; i < stepsValue.length; i++) {
@@ -359,7 +360,7 @@ class BrowserTemplateEngine {
         await this.generateParentPom(
             appNameValue,
             basePackageValue,
-            stepsValue,
+            generatedServiceSteps,
             includePersistenceModule,
             includeCacheInvalidationModule,
             normalizedRuntimeLayout,
@@ -369,12 +370,12 @@ class BrowserTemplateEngine {
         await this.generateCommonModule(appNameValue, basePackageValue, stepsValue, transportMode, normalizedOptions.fileCallback);
 
         // Generate each step service
-        for (let i = 0; i < stepsValue.length; i++) {
-            await this.generateStepService(appNameValue, basePackageValue, stepsValue[i], i, stepsValue, transportMode, normalizedOptions.fileCallback);
+        for (let i = 0; i < generatedServiceSteps.length; i++) {
+            await this.generateStepService(appNameValue, basePackageValue, generatedServiceSteps[i], i, generatedServiceSteps, transportMode, normalizedOptions.fileCallback);
         }
 
         if (includePersistenceModule) {
-            await this.generatePersistenceModule(appNameValue, basePackageValue, stepsValue, normalizedOptions.fileCallback);
+            await this.generatePersistenceModule(appNameValue, basePackageValue, generatedServiceSteps, normalizedOptions.fileCallback);
         }
 
         if (includeCacheInvalidationModule) {
@@ -395,14 +396,14 @@ class BrowserTemplateEngine {
             await this.generatePipelineRuntimeModule(
                 appNameValue,
                 basePackageValue,
-                stepsValue,
+                generatedServiceSteps,
                 normalizedOptions.fileCallback
             );
         } else if (normalizedRuntimeLayout === 'monolith') {
             await this.generateMonolithModule(
                 appNameValue,
                 basePackageValue,
-                stepsValue,
+                generatedServiceSteps,
                 includePersistenceModule,
                 includeCacheInvalidationModule,
                 normalizedOptions.fileCallback
@@ -437,6 +438,7 @@ class BrowserTemplateEngine {
         await this.generateOtherFiles(
             appNameValue,
             stepsValue,
+            generatedServiceSteps,
             includePersistenceModule,
             includeCacheInvalidationModule,
             normalizedOptions.fileCallback);
@@ -932,11 +934,18 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
     async generateOtherFiles(
         appName,
         steps,
+        generatedServiceSteps,
         includePersistenceModule,
         includeCacheInvalidationModule,
         fileCallback) {
+        const awaitSteps = this.awaitSteps(steps);
         // Create README
-        const readmeContext = { appName };
+        const readmeContext = {
+            appName,
+            hasAwaitSteps: awaitSteps.length > 0,
+            hasInteractionApiAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'interaction-api'),
+            hasWebhookAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'webhook')
+        };
         const readmeContent = this.render('readme', readmeContext);
         await fileCallback('README.md', readmeContent);
 
@@ -950,7 +959,7 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
 
         const certScriptContext = {
             appName,
-            steps,
+            serviceModuleSteps: generatedServiceSteps,
             includePersistenceModule,
             includeCacheInvalidationModule
         };
@@ -1145,6 +1154,19 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
             return '';
         }
         return step.serviceName.replace(/-svc$/, '');
+    }
+
+    isAwaitStep(step) {
+        return !!step && (step.isAwaitStep === true
+            || (typeof step.kind === 'string' && step.kind.trim().toLowerCase() === 'await'));
+    }
+
+    awaitSteps(steps) {
+        return (steps || []).filter((step) => this.isAwaitStep(step));
+    }
+
+    generatedServiceSteps(steps) {
+        return (steps || []).filter((step) => step && step.generatesServiceModule !== false);
     }
 
     isTransport(value) {

--- a/template-generator-node/src/browser-template-engine.js
+++ b/template-generator-node/src/browser-template-engine.js
@@ -940,11 +940,36 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
         fileCallback) {
         const awaitSteps = this.awaitSteps(steps);
         // Create README
+        // Compute await transport types from raw step data
+        const hasInteractionApiAwaitSteps = awaitSteps.some((step) => {
+            if (!step) return false;
+            // Check for transport type in step metadata
+            const transportType = step['transport/type'] || step.awaitTransportType;
+            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+            const generatesService = step.generatesServiceModule;
+            // Infer interaction-api from explicit markers or service hints
+            if (transportType === 'interaction-api') return true;
+            if (generatesService === 'interaction-api') return true;
+            if (serviceModuleName.includes('interaction')) return true;
+            return false;
+        });
+        const hasWebhookAwaitSteps = awaitSteps.some((step) => {
+            if (!step) return false;
+            // Check for transport type in step metadata
+            const transportType = step['transport/type'] || step.awaitTransportType;
+            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+            const generatesService = step.generatesServiceModule;
+            // Infer webhook from explicit markers or service hints
+            if (transportType === 'webhook') return true;
+            if (generatesService === 'webhook') return true;
+            if (serviceModuleName.includes('webhook')) return true;
+            return false;
+        });
         const readmeContext = {
             appName,
             hasAwaitSteps: awaitSteps.length > 0,
-            hasInteractionApiAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'interaction-api'),
-            hasWebhookAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'webhook')
+            hasInteractionApiAwaitSteps,
+            hasWebhookAwaitSteps
         };
         const readmeContent = this.render('readme', readmeContext);
         await fileCallback('README.md', readmeContent);

--- a/template-generator-node/src/handlebars-template-engine.js
+++ b/template-generator-node/src/handlebars-template-engine.js
@@ -1179,9 +1179,6 @@ class HandlebarsTemplateEngine {
         // Compute await transport types from raw step data
         context.hasInteractionApiAwaitSteps = awaitSteps.some((step) => {
             if (!step) return false;
-            // Treat step as await if kind is 'await' or awaitTransportType exists
-            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
-            if (!isAwait) return false;
             // Determine transport type from multiple sources
             const transportType = step.awaitTransportType || step['transport/type'];
             const serviceModuleName = step.serviceModuleName || step.serviceName || '';
@@ -1196,9 +1193,6 @@ class HandlebarsTemplateEngine {
         });
         context.hasWebhookAwaitSteps = awaitSteps.some((step) => {
             if (!step) return false;
-            // Treat step as await if kind is 'await' or awaitTransportType exists
-            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
-            if (!isAwait) return false;
             // Determine transport type from multiple sources
             const transportType = step.awaitTransportType || step['transport/type'];
             const serviceModuleName = step.serviceModuleName || step.serviceName || '';
@@ -1567,40 +1561,8 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
 
         // Create README
         // Compute await transport types from raw step data
-        const hasInteractionApiAwaitSteps = awaitSteps.some((step) => {
-            if (!step) return false;
-            // Treat step as await if kind is 'await' or awaitTransportType exists
-            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
-            if (!isAwait) return false;
-            // Determine transport type from multiple sources
-            const transportType = step.awaitTransportType || step['transport/type'];
-            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
-            const generatesService = step.generatesServiceModule;
-            const serviceType = step['service/type'];
-            // Infer interaction-api from explicit markers or service hints
-            if (transportType === 'interaction-api') return true;
-            if (generatesService === 'interaction-api') return true;
-            if (serviceType === 'interaction-api') return true;
-            if (serviceModuleName.includes('interaction')) return true;
-            return false;
-        });
-        const hasWebhookAwaitSteps = awaitSteps.some((step) => {
-            if (!step) return false;
-            // Treat step as await if kind is 'await' or awaitTransportType exists
-            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
-            if (!isAwait) return false;
-            // Determine transport type from multiple sources
-            const transportType = step.awaitTransportType || step['transport/type'];
-            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
-            const generatesService = step.generatesServiceModule;
-            const serviceType = step['service/type'];
-            // Infer webhook from explicit markers or service hints
-            if (transportType === 'webhook') return true;
-            if (generatesService === 'webhook') return true;
-            if (serviceType === 'webhook') return true;
-            if (serviceModuleName.includes('webhook')) return true;
-            return false;
-        });
+        const hasInteractionApiAwaitSteps = awaitSteps.some((step) => this.hasAwaitTransportType(step, 'interaction-api'));
+        const hasWebhookAwaitSteps = awaitSteps.some((step) => this.hasAwaitTransportType(step, 'webhook'));
         const readmeContext = {
             appName,
             basePackage,
@@ -1804,6 +1766,28 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
 
     awaitSteps(steps) {
         return (steps || []).filter((step) => this.isAwaitStep(step));
+    }
+
+    hasAwaitTransportType(step, targetType) {
+        if (!step) return false;
+        // Preserve the existing isAwait condition
+        const isAwait = step.kind === 'await' || !!step.awaitTransportType;
+        if (!isAwait) return false;
+        // Resolve transport and service properties
+        const transportType = step.awaitTransportType || step['transport/type'];
+        const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+        const generatesService = step.generatesServiceModule;
+        const serviceType = step['service/type'];
+        // Check if any of those match targetType
+        if (transportType === targetType) return true;
+        if (generatesService === targetType) return true;
+        if (serviceType === targetType) return true;
+        // For hyphenated types, check if serviceModuleName includes the prefix
+        if (targetType.includes('-')) {
+            const targetPrefix = targetType.split('-')[0];
+            if (serviceModuleName.includes(targetPrefix)) return true;
+        }
+        return false;
     }
 
     generatedServiceSteps(steps) {

--- a/template-generator-node/src/handlebars-template-engine.js
+++ b/template-generator-node/src/handlebars-template-engine.js
@@ -1176,8 +1176,41 @@ class HandlebarsTemplateEngine {
         context.includePersistenceModule = includePersistenceModule;
         context.includeCacheInvalidationModule = includeCacheInvalidationModule;
         context.hasAwaitSteps = awaitSteps.length > 0;
-        context.hasInteractionApiAwaitSteps = awaitSteps.some((step) => step.awaitTransportType === 'interaction-api');
-        context.hasWebhookAwaitSteps = awaitSteps.some((step) => step.awaitTransportType === 'webhook');
+        // Compute await transport types from raw step data
+        context.hasInteractionApiAwaitSteps = awaitSteps.some((step) => {
+            if (!step) return false;
+            // Treat step as await if kind is 'await' or awaitTransportType exists
+            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
+            if (!isAwait) return false;
+            // Determine transport type from multiple sources
+            const transportType = step.awaitTransportType || step['transport/type'];
+            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+            const generatesService = step.generatesServiceModule;
+            const serviceType = step['service/type'];
+            // Infer interaction-api from explicit markers or service hints
+            if (transportType === 'interaction-api') return true;
+            if (generatesService === 'interaction-api') return true;
+            if (serviceType === 'interaction-api') return true;
+            if (serviceModuleName.includes('interaction')) return true;
+            return false;
+        });
+        context.hasWebhookAwaitSteps = awaitSteps.some((step) => {
+            if (!step) return false;
+            // Treat step as await if kind is 'await' or awaitTransportType exists
+            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
+            if (!isAwait) return false;
+            // Determine transport type from multiple sources
+            const transportType = step.awaitTransportType || step['transport/type'];
+            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+            const generatesService = step.generatesServiceModule;
+            const serviceType = step['service/type'];
+            // Infer webhook from explicit markers or service hints
+            if (transportType === 'webhook') return true;
+            if (generatesService === 'webhook') return true;
+            if (serviceType === 'webhook') return true;
+            if (serviceModuleName.includes('webhook')) return true;
+            return false;
+        });
         context.hasCacheAspect = (aspectDefinitions || []).some(aspect => aspect.name === 'cache');
         if (includePersistenceModule) {
             context.persistencePortOffset = generatedServiceSteps.length + 1;
@@ -1533,6 +1566,41 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
         const awaitSteps = this.awaitSteps(steps);
 
         // Create README
+        // Compute await transport types from raw step data
+        const hasInteractionApiAwaitSteps = awaitSteps.some((step) => {
+            if (!step) return false;
+            // Treat step as await if kind is 'await' or awaitTransportType exists
+            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
+            if (!isAwait) return false;
+            // Determine transport type from multiple sources
+            const transportType = step.awaitTransportType || step['transport/type'];
+            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+            const generatesService = step.generatesServiceModule;
+            const serviceType = step['service/type'];
+            // Infer interaction-api from explicit markers or service hints
+            if (transportType === 'interaction-api') return true;
+            if (generatesService === 'interaction-api') return true;
+            if (serviceType === 'interaction-api') return true;
+            if (serviceModuleName.includes('interaction')) return true;
+            return false;
+        });
+        const hasWebhookAwaitSteps = awaitSteps.some((step) => {
+            if (!step) return false;
+            // Treat step as await if kind is 'await' or awaitTransportType exists
+            const isAwait = step.kind === 'await' || !!step.awaitTransportType;
+            if (!isAwait) return false;
+            // Determine transport type from multiple sources
+            const transportType = step.awaitTransportType || step['transport/type'];
+            const serviceModuleName = step.serviceModuleName || step.serviceName || '';
+            const generatesService = step.generatesServiceModule;
+            const serviceType = step['service/type'];
+            // Infer webhook from explicit markers or service hints
+            if (transportType === 'webhook') return true;
+            if (generatesService === 'webhook') return true;
+            if (serviceType === 'webhook') return true;
+            if (serviceModuleName.includes('webhook')) return true;
+            return false;
+        });
         const readmeContext = {
             appName,
             basePackage,
@@ -1541,8 +1609,8 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
             requestTypeName: firstInputTypeName,
             optionsClass,
             hasAwaitSteps: awaitSteps.length > 0,
-            hasInteractionApiAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'interaction-api'),
-            hasWebhookAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'webhook')
+            hasInteractionApiAwaitSteps,
+            hasWebhookAwaitSteps
         };
         const readmeContent = this.render('readme', readmeContext);
         const readmePath = path.join(outputPath, 'README.md');

--- a/template-generator-node/src/handlebars-template-engine.js
+++ b/template-generator-node/src/handlebars-template-engine.js
@@ -439,6 +439,7 @@ class HandlebarsTemplateEngine {
             || this.isAspectEnabled(aspectConfig, 'cache-invalidate')
             || this.isAspectEnabled(aspectConfig, 'cache-invalidate-all');
         const aspectDefinitions = this.getAspectDefinitions(aspectConfig);
+        const generatedServiceSteps = this.generatedServiceSteps(resolvedSteps);
         // For sequential pipeline, update input types of steps after the first one
         // to match the output type of the previous step
         for (let i = 1; i < resolvedSteps.length; i++) {
@@ -458,7 +459,7 @@ class HandlebarsTemplateEngine {
         await this.generateParentPom(
             resolvedAppName,
             resolvedBasePackage,
-            resolvedSteps,
+            generatedServiceSteps,
             includePersistenceModule,
             includeCacheInvalidationModule,
             normalizedRuntimeLayout,
@@ -475,27 +476,27 @@ class HandlebarsTemplateEngine {
         );
 
         // Generate each step service
-        for (let i = 0; i < resolvedSteps.length; i++) {
+        for (let i = 0; i < generatedServiceSteps.length; i++) {
             await this.generateStepService(
                 resolvedAppName,
                 resolvedBasePackage,
-                resolvedSteps[i],
+                generatedServiceSteps[i],
                 options.outputPath,
                 i,
-                resolvedSteps,
+                generatedServiceSteps,
                 transportMode
             );
         }
 
         if (includePersistenceModule) {
-            await this.generatePersistenceModule(resolvedAppName, resolvedBasePackage, resolvedSteps, options.outputPath);
+            await this.generatePersistenceModule(resolvedAppName, resolvedBasePackage, generatedServiceSteps, options.outputPath);
         }
 
         if (includeCacheInvalidationModule) {
             await this.generateCacheInvalidationModule(
                 resolvedAppName,
                 resolvedBasePackage,
-                resolvedSteps,
+                generatedServiceSteps,
                 includePersistenceModule,
                 options.outputPath
             );
@@ -516,13 +517,13 @@ class HandlebarsTemplateEngine {
             await this.generatePipelineRuntimeModule(
                 resolvedAppName,
                 resolvedBasePackage,
-                resolvedSteps,
+                generatedServiceSteps,
                 options.outputPath);
         } else if (normalizedRuntimeLayout === 'monolith') {
             await this.generateMonolithModule(
                 resolvedAppName,
                 resolvedBasePackage,
-                resolvedSteps,
+                generatedServiceSteps,
                 includePersistenceModule,
                 includeCacheInvalidationModule,
                 options.outputPath);
@@ -550,6 +551,7 @@ class HandlebarsTemplateEngine {
             resolvedAppName,
             resolvedBasePackage,
             resolvedSteps,
+            generatedServiceSteps,
             includePersistenceModule,
             includeCacheInvalidationModule,
             options.outputPath);
@@ -1158,6 +1160,8 @@ class HandlebarsTemplateEngine {
         transport,
         orchPath) {
         // Create context for orchestrator properties
+        const generatedServiceSteps = this.generatedServiceSteps(steps);
+        const awaitSteps = this.awaitSteps(steps);
         const context = { appName, basePackage, steps, transport };
         const transportMode = typeof transport === 'string' && transport.trim()
             ? transport.trim().toUpperCase()
@@ -1171,9 +1175,12 @@ class HandlebarsTemplateEngine {
         context.rootProjectName = appName.toLowerCase().replace(/[^a-zA-Z0-9]/g, '-');
         context.includePersistenceModule = includePersistenceModule;
         context.includeCacheInvalidationModule = includeCacheInvalidationModule;
+        context.hasAwaitSteps = awaitSteps.length > 0;
+        context.hasInteractionApiAwaitSteps = awaitSteps.some((step) => step.awaitTransportType === 'interaction-api');
+        context.hasWebhookAwaitSteps = awaitSteps.some((step) => step.awaitTransportType === 'webhook');
         context.hasCacheAspect = (aspectDefinitions || []).some(aspect => aspect.name === 'cache');
         if (includePersistenceModule) {
-            context.persistencePortOffset = steps.length + 1;
+            context.persistencePortOffset = generatedServiceSteps.length + 1;
             const outputTypes = new Set();
             steps.forEach(step => {
                 if (step.outputTypeName) {
@@ -1190,7 +1197,7 @@ class HandlebarsTemplateEngine {
                 .map(aspect => aspect.name);
         }
         if (includeCacheInvalidationModule) {
-            const baseOffset = steps.length + (includePersistenceModule ? 2 : 1);
+            const baseOffset = generatedServiceSteps.length + (includePersistenceModule ? 2 : 1);
             context.cacheInvalidationPortOffset = baseOffset;
             const inputTypes = new Set();
             steps.forEach(step => {
@@ -1222,7 +1229,7 @@ class HandlebarsTemplateEngine {
                 .map(aspect => aspect.name);
         }
         // Process steps to add additional properties for template
-        context.steps = steps.map((step, index) => ({
+        context.steps = generatedServiceSteps.map((step, index) => ({
             ...step,
             portOffset: index + 1,
             serviceNameForPackage: step.serviceName.replace('-svc', '').replace(/-/g, '_'),
@@ -1517,11 +1524,13 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
         appName,
         basePackage,
         steps,
+        generatedServiceSteps,
         includePersistenceModule,
         includeCacheInvalidationModule,
         outputPath) {
         const firstInputTypeName = steps && steps.length ? steps[0].inputTypeName : 'Input';
         const optionsClass = `${firstInputTypeName}Options`;
+        const awaitSteps = this.awaitSteps(steps);
 
         // Create README
         const readmeContext = {
@@ -1530,7 +1539,10 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
             rootProjectName: appName.toLowerCase().replace(/[^a-zA-Z0-9]/g, '-'),
             optionsImport: `${basePackage}.common.util.${optionsClass}`,
             requestTypeName: firstInputTypeName,
-            optionsClass
+            optionsClass,
+            hasAwaitSteps: awaitSteps.length > 0,
+            hasInteractionApiAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'interaction-api'),
+            hasWebhookAwaitSteps: awaitSteps.some((step) => step.awaitTransportType === 'webhook')
         };
         const readmeContent = this.render('readme', readmeContext);
         const readmePath = path.join(outputPath, 'README.md');
@@ -1550,7 +1562,7 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
 
         const certScriptContext = {
             appName,
-            steps,
+            serviceModuleSteps: generatedServiceSteps,
             includePersistenceModule,
             includeCacheInvalidationModule
         };
@@ -1715,6 +1727,19 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
             return '';
         }
         return step.serviceName.replace(/-svc$/, '');
+    }
+
+    isAwaitStep(step) {
+        return !!step && (step.isAwaitStep === true
+            || (typeof step.kind === 'string' && step.kind.trim().toLowerCase() === 'await'));
+    }
+
+    awaitSteps(steps) {
+        return (steps || []).filter((step) => this.isAwaitStep(step));
+    }
+
+    generatedServiceSteps(steps) {
+        return (steps || []).filter((step) => step && step.generatesServiceModule !== false);
     }
 
     buildRuntimeMapping(layout, steps, includePersistenceModule, includeCacheInvalidationModule) {

--- a/template-generator-node/src/pipeline-generator.js
+++ b/template-generator-node/src/pipeline-generator.js
@@ -166,17 +166,19 @@ class PipelineGenerator {
 
     toScaffoldConfig(config) {
         const scaffoldConfig = { ...config };
-        const awaitSteps = Array.isArray(config.steps)
-            ? config.steps.filter((step) => step && step.kind === 'await')
-            : [];
-        if (awaitSteps.length > 0) {
-            const stepNames = awaitSteps.map((step) => step.name).join(', ');
+        const processedSteps = this.processSteps(this.materializeSteps(config));
+        const unsupportedAwaitSteps = processedSteps.filter((step) =>
+            this.isAwaitStep(step) && !this.isSupportedAwaitTransport(step.awaitTransportType)
+        );
+        if (unsupportedAwaitSteps.length > 0) {
+            const stepNames = unsupportedAwaitSteps.map((step) => step.name).join(', ');
             throw new Error(
-                `Await steps are accepted by the template schema, but the generator does not scaffold await transport modules yet. ` +
-                `Remove these steps or author them manually in pipeline.yaml: ${stepNames}`
+                `The runtime supports Kafka await steps, but the generator does not yet scaffold the required messaging ` +
+                `dependencies and channel configuration. Author these steps manually in pipeline.yaml or use ` +
+                `interaction-api/webhook for generated scaffolds: ${stepNames}`
             );
         }
-        scaffoldConfig.steps = this.processSteps(this.materializeSteps(config));
+        scaffoldConfig.steps = processedSteps;
         return scaffoldConfig;
     }
 
@@ -285,6 +287,15 @@ class PipelineGenerator {
             }
             if (typeof normalized.execution.protocol === 'string') {
                 normalized.execution.protocol = normalized.execution.protocol.trim().toUpperCase();
+            }
+        }
+        if (normalized.await && typeof normalized.await === 'object') {
+            normalized.await = { ...normalized.await };
+            if (normalized.await.transport && typeof normalized.await.transport === 'object') {
+                normalized.await.transport = { ...normalized.await.transport };
+                if (typeof normalized.await.transport.type === 'string') {
+                    normalized.await.transport.type = normalized.await.transport.type.trim().toLowerCase();
+                }
             }
         }
         return normalized;
@@ -483,6 +494,12 @@ class PipelineGenerator {
     processSteps(steps) {
         return steps.map((step, i) => {
             const processedStep = { ...step };
+            processedStep.kind = typeof processedStep.kind === 'string'
+                ? processedStep.kind.trim().toLowerCase()
+                : processedStep.kind;
+            processedStep.isAwaitStep = this.isAwaitStep(processedStep);
+            processedStep.awaitTransportType = this.awaitTransportType(processedStep);
+            processedStep.generatesServiceModule = !processedStep.isAwaitStep;
             
             // Add missing properties if not already present
             if (!processedStep.serviceName) {
@@ -536,6 +553,25 @@ class PipelineGenerator {
             
             return processedStep;
         });
+    }
+
+    isAwaitStep(step) {
+        return !!step && typeof step.kind === 'string' && step.kind.trim().toLowerCase() === 'await';
+    }
+
+    awaitTransportType(step) {
+        if (!step || !step.await || typeof step.await !== 'object') {
+            return null;
+        }
+        const transport = step.await.transport;
+        if (!transport || typeof transport !== 'object' || typeof transport.type !== 'string') {
+            return null;
+        }
+        return transport.type.trim().toLowerCase();
+    }
+
+    isSupportedAwaitTransport(type) {
+        return type === 'interaction-api' || type === 'webhook';
     }
 
     /**

--- a/template-generator-node/src/runtime-mapping-builder.js
+++ b/template-generator-node/src/runtime-mapping-builder.js
@@ -3,11 +3,21 @@
  */
 
 function buildModularModules(steps, includePersistenceModule, includeCacheInvalidationModule, stepId) {
-    const modules = {};
+    const modules = {
+        'orchestrator-svc': { runtime: 'orchestrator-svc' }
+    };
+    const orchestratorSteps = [];
     for (const step of steps) {
         const moduleName = step.serviceName;
         const resolvedStepId = stepId(step);
-        if (!moduleName || !resolvedStepId) {
+        if (!resolvedStepId) {
+            continue;
+        }
+        if (step.generatesServiceModule === false) {
+            orchestratorSteps.push(resolvedStepId);
+            continue;
+        }
+        if (!moduleName) {
             continue;
         }
         modules[moduleName] = {
@@ -15,7 +25,9 @@ function buildModularModules(steps, includePersistenceModule, includeCacheInvali
             steps: [resolvedStepId]
         };
     }
-    modules['orchestrator-svc'] = { runtime: 'orchestrator-svc' };
+    if (orchestratorSteps.length > 0) {
+        modules['orchestrator-svc'].steps = orchestratorSteps;
+    }
     if (includePersistenceModule) {
         modules['persistence-svc'] = {
             runtime: 'persistence-svc',

--- a/template-generator-node/templates/generate-dev-certs.sh.hbs
+++ b/template-generator-node/templates/generate-dev-certs.sh.hbs
@@ -59,7 +59,7 @@ openssl pkcs12 -export -in "${CERT_DIR}/quarkus-cert.pem" -inkey "${CERT_DIR}/qu
 
 keytool -import -file "${CERT_DIR}/quarkus-cert.pem" -keystore "${CERT_DIR}/client-truststore.jks" -storepass secret -noprompt -alias server
 
-for svc in{{#if includePersistenceModule}} persistence-svc{{/if}}{{#each steps}} {{serviceName}}{{/each}}{{#if includeCacheInvalidationModule}} cache-invalidation-svc{{/if}} orchestrator-svc; do
+for svc in{{#if includePersistenceModule}} persistence-svc{{/if}}{{#each serviceModuleSteps}} {{serviceName}}{{/each}}{{#if includeCacheInvalidationModule}} cache-invalidation-svc{{/if}} orchestrator-svc; do
     mkdir -p "${OUTPUT_DIR}/${svc}"
     cp "${CERT_DIR}/server-keystore.p12" "${OUTPUT_DIR}/${svc}/server-keystore.jks"
     chmod 644 "${OUTPUT_DIR}/${svc}/server-keystore.jks"

--- a/template-generator-node/templates/orchestrator-application-properties.hbs
+++ b/template-generator-node/templates/orchestrator-application-properties.hbs
@@ -93,6 +93,19 @@ pipeline.cache.provider=redis
 # quarkus.tls.pipeline-client.trust-store.jks.path=${CLIENT_TRUSTSTORE_PATH:../target/dev-certs/orchestrator-svc/client-truststore.jks}
 # quarkus.tls.pipeline-client.trust-store.jks.password=secret
 
+{{#if hasInteractionApiAwaitSteps}}
+# Await interaction-api steps
+# Generated await query/completion APIs can be used by UI or mock-provider clients
+# to list pending interactions and submit the correlated result later.
+{{/if}}
+
+{{#if hasWebhookAwaitSteps}}
+# Await webhook steps
+# Set a stable high-entropy secret before using webhook await flows. The runtime uses
+# this value to sign and verify resume tokens carried by webhook dispatch envelopes.
+# pipeline.orchestrator.resume-token-secret=change-me
+{{/if}}
+
 # Micrometer configuration
 quarkus.micrometer.export.prometheus.enabled=${QUARKUS_MICROMETER_EXPORT_PROMETHEUS_ENABLED:false}
 quarkus.micrometer.export.prometheus.path=/q/metrics

--- a/template-generator-node/templates/readme.hbs
+++ b/template-generator-node/templates/readme.hbs
@@ -28,6 +28,24 @@ Use the Quarkus plugin in IntelliJ IDEA or run with:
 ./mvnw compile quarkus:dev
 ```
 
+{{#if hasAwaitSteps}}
+## Await Steps
+
+This generated application includes await steps. The orchestrator exposes generated await completion and pending-interaction query APIs alongside the configured pipeline transport.
+
+{{#if hasInteractionApiAwaitSteps}}
+### interaction-api await steps
+
+Use the generated await query/completion APIs from a UI, mock provider, or other client that needs to list pending interactions and submit the correlated result later.
+{{/if}}
+
+{{#if hasWebhookAwaitSteps}}
+### webhook await steps
+
+Webhook await dispatch includes a signed resume token in the outbound envelope. Configure a stable high-entropy value for `pipeline.orchestrator.resume-token-secret` before using webhook await flows, and keep it stable for the lifetime of outstanding interactions.
+{{/if}}
+{{/if}}
+
 ## Constructing requests
 
 If your first step uses helper builders, you can construct inputs like this:


### PR DESCRIPTION
## Summary
- add template-generator await scaffolding for `interaction-api` and `webhook`
- keep Kafka await scaffolding explicit fail-fast with a clearer diagnostic
- update generator docs to describe current support without planning-language wording

## Scope
This PR is limited to template-generator project-shape support for await steps.

Included:
- await-step classification in scaffold generation
- no generated `*-svc` module for await steps
- runtime mapping keeps await logical steps attached to the orchestrator where appropriate
- generated README and orchestrator properties guidance for `interaction-api` and `webhook`
- docs wording cleanup for current await support

Explicitly out of scope:
- Kafka await scaffolding
- runtime/compiler changes
- `web-ui`
- replay-viewer

## Validation
- `npm --prefix template-generator-node test`
- `npm --prefix docs run build`
- `git diff --check`

## Notes
- Kafka is intentionally deferred because generator support there needs broker-specific dependencies and `mp.messaging.*` channel config, which is a separate production risk.
- A local CodeRabbit prompt-only pass was attempted first, but the installed CLI is not authenticated in this environment, so the live PR review is the first CR pass for this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scaffold now supports await steps for interaction-api and webhook transports and omits per-step service modules for awaited steps.
  * Kafka await steps are rejected with clear guidance.

* **Documentation**
  * Updated docs, generated READMEs and orchestrator properties with await-step guidance, interaction-api await APIs, and webhook resume-token instructions.

* **Tests**
  * Added tests verifying await-step scaffolding, README content, and absence of step modules where appropriate.

* **Chores**
  * Dev certs and generation flow updated to target scaffolded service modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->