### PR TITLE
Clean up docs and restaurant build warnings

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -383,6 +383,38 @@ export default withMermaid(
         fs: {
           allow: ['../..']
         }
+      },
+      build: {
+        // The docs intentionally ship local search and Mermaid support. Keep
+        // those large features isolated in named chunks, then set the warning
+        // limit to the largest expected feature chunk so routine docs builds
+        // stay quiet without hiding accidental growth in page bundles.
+        chunkSizeWarningLimit: 1800,
+        rollupOptions: {
+          output: {
+            manualChunks(id) {
+              if (!id.includes('node_modules')) {
+                return undefined
+              }
+              if (
+                id.includes('/mermaid/') ||
+                id.includes('/vitepress-plugin-mermaid/') ||
+                id.includes('/@mermaid-js/')
+              ) {
+                return 'mermaid'
+              }
+              if (
+                id.includes('/d3-') ||
+                id.includes('/dagre-d3-es/') ||
+                id.includes('/cytoscape/') ||
+                id.includes('/cytoscape-cose-bilkent/')
+              ) {
+                return 'diagram-layout'
+              }
+              return undefined
+            }
+          }
+        }
       }
     },
 

--- a/examples/restaurant-approval/common/pom.xml
+++ b/examples/restaurant-approval/common/pom.xml
@@ -40,12 +40,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/restaurant-approval/create-pending-approval-svc/pom.xml
+++ b/examples/restaurant-approval/create-pending-approval-svc/pom.xml
@@ -71,7 +71,7 @@
         <!-- Test Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/restaurant-approval/finalize-restaurant-decision-svc/pom.xml
+++ b/examples/restaurant-approval/finalize-restaurant-decision-svc/pom.xml
@@ -71,7 +71,7 @@
         <!-- Test Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/restaurant-approval/monolith-svc/pom.xml
+++ b/examples/restaurant-approval/monolith-svc/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/restaurant-approval/orchestrator-svc/pom.xml
+++ b/examples/restaurant-approval/orchestrator-svc/pom.xml
@@ -57,7 +57,7 @@
         <!-- Tests -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/restaurant-approval/validate-order-request-svc/pom.xml
+++ b/examples/restaurant-approval/validate-order-request-svc/pom.xml
@@ -71,7 +71,7 @@
         <!-- Test Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- closes #317 by replacing relocated Restaurant Approval Quarkus test dependency artifact IDs
- closes #320 by isolating Mermaid/diagram docs bundles and documenting the expected chunk warning limit

## Validation
- ./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -Dtest=RestaurantApprovalAwaitMonolithTest -Dsurefire.failIfNoSpecifiedTests=false test
- npm --prefix docs run build
- rg "quarkus-junit5|quarkus-junit5-mockito" examples framework pom.xml
- git diff --check

## Scope
Warning cleanup only. This intentionally leaves #316, #318, #319, #321, and #322 for separate slices.