### PR TITLE
Abort retry amplification by run context

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionHooks.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionHooks.java
@@ -62,7 +62,14 @@ class ExecutionHooks {
   }
 
   <T> Multi<T> attachMultiHooks(Multi<T> multi, StopWatch watch) {
-    Multi<T> guarded = attachRetryAmplificationGuard(multi);
+    return attachMultiHooks(multi, watch, null);
+  }
+
+  <T> Multi<T> attachMultiHooks(
+      Multi<T> multi,
+      StopWatch watch,
+      PipelineTelemetry.RunContext runContext) {
+    Multi<T> guarded = attachRetryAmplificationGuard(multi, runContext);
     long[] startTime = new long[1];
     return guarded
         .onSubscription().invoke(ignored -> {
@@ -93,7 +100,14 @@ class ExecutionHooks {
   }
 
   <T> Uni<T> attachUniHooks(Uni<T> uni, StopWatch watch) {
-    Uni<T> guarded = attachRetryAmplificationGuard(uni);
+    return attachUniHooks(uni, watch, null);
+  }
+
+  <T> Uni<T> attachUniHooks(
+      Uni<T> uni,
+      StopWatch watch,
+      PipelineTelemetry.RunContext runContext) {
+    Uni<T> guarded = attachRetryAmplificationGuard(uni, runContext);
     long[] startTime = new long[1];
     return guarded
         .onSubscription().invoke(ignored -> {
@@ -120,16 +134,20 @@ class ExecutionHooks {
         });
   }
 
-  private <T> Multi<T> attachRetryAmplificationGuard(Multi<T> multi) {
+  private <T> Multi<T> attachRetryAmplificationGuard(
+      Multi<T> multi,
+      PipelineTelemetry.RunContext runContext) {
     if (telemetry == null || !telemetry.retryAmplificationGuardEnabled()) {
       return multi;
     }
     Duration interval = telemetry.retryAmplificationCheckInterval();
     RetryAmplificationGuardMode mode = telemetry.retryAmplificationMode();
-    return multi.plug(upstream -> new RetryAmplificationGuardMulti<>(upstream, interval, mode));
+    return multi.plug(upstream -> new RetryAmplificationGuardMulti<>(upstream, interval, mode, runContext));
   }
 
-  private <T> Uni<T> attachRetryAmplificationGuard(Uni<T> uni) {
+  private <T> Uni<T> attachRetryAmplificationGuard(
+      Uni<T> uni,
+      PipelineTelemetry.RunContext runContext) {
     if (telemetry == null || !telemetry.retryAmplificationGuardEnabled()) {
       return uni;
     }
@@ -156,14 +174,14 @@ class ExecutionHooks {
           });
       cancellableRef.set(cancellable);
       ScheduledFuture<?> future = killSwitchExecutor.scheduleAtFixedRate(() -> {
-        telemetry.retryAmplificationTrigger().ifPresent(trigger -> {
+        telemetry.retryAmplificationTrigger(runContext).ifPresent(trigger -> {
           if (!logged.compareAndSet(false, true)) {
             return;
           }
           logRetryAmplificationTrigger(trigger, mode);
           PipelineKillSwitchException exception = PipelineKillSwitchException.retryAmplification(trigger);
           if (mode == RetryAmplificationGuardMode.FAIL_FAST) {
-            CompletableFuture.runAsync(() -> telemetry.abortActiveRun(exception), killSwitchBlockingExecutor);
+            CompletableFuture.runAsync(() -> abortRun(runContext, exception), killSwitchBlockingExecutor);
             emitter.fail(exception);
             Cancellable active = cancellableRef.get();
             if (active != null) {
@@ -202,6 +220,14 @@ class ExecutionHooks {
         action);
   }
 
+  private void abortRun(PipelineTelemetry.RunContext runContext, Throwable failure) {
+    if (runContext == null) {
+      telemetry.abortActiveRun(failure);
+      return;
+    }
+    telemetry.abortRun(runContext, failure);
+  }
+
   private boolean isControlFlow(Throwable failure) {
     Throwable current = failure;
     while (current != null) {
@@ -216,35 +242,41 @@ class ExecutionHooks {
   private final class RetryAmplificationGuardMulti<T> extends AbstractMultiOperator<T, T> {
     private final Duration interval;
     private final RetryAmplificationGuardMode mode;
+    private final PipelineTelemetry.RunContext runContext;
 
     private RetryAmplificationGuardMulti(
         Multi<? extends T> upstream,
         Duration interval,
-        RetryAmplificationGuardMode mode) {
+        RetryAmplificationGuardMode mode,
+        PipelineTelemetry.RunContext runContext) {
       super(upstream);
       this.interval = interval;
       this.mode = mode;
+      this.runContext = runContext;
     }
 
     @Override
     public void subscribe(MultiSubscriber<? super T> downstream) {
       RetryAmplificationProcessor<T> processor =
-          new RetryAmplificationProcessor<>(downstream, interval, mode);
+          new RetryAmplificationProcessor<>(downstream, interval, mode, runContext);
       upstream().subscribe(processor);
     }
   }
 
   private final class RetryAmplificationProcessor<T> extends MultiOperatorProcessor<T, T> {
     private final RetryAmplificationGuardMode mode;
+    private final PipelineTelemetry.RunContext runContext;
     private final AtomicBoolean logged;
     private final ScheduledFuture<?> future;
 
     private RetryAmplificationProcessor(
         MultiSubscriber<? super T> downstream,
         Duration interval,
-        RetryAmplificationGuardMode mode) {
+        RetryAmplificationGuardMode mode,
+        PipelineTelemetry.RunContext runContext) {
       super(downstream);
       this.mode = mode;
+      this.runContext = runContext;
       this.logged = new AtomicBoolean(false);
       this.future = killSwitchExecutor.scheduleAtFixedRate(
           this::checkGuard,
@@ -279,7 +311,7 @@ class ExecutionHooks {
     }
 
     private void checkGuard() {
-      telemetry.retryAmplificationTrigger().ifPresent(trigger -> {
+      telemetry.retryAmplificationTrigger(runContext).ifPresent(trigger -> {
         if (!logged.compareAndSet(false, true)) {
           return;
         }
@@ -290,7 +322,7 @@ class ExecutionHooks {
             return;
           }
           PipelineKillSwitchException exception = PipelineKillSwitchException.retryAmplification(trigger);
-          CompletableFuture.runAsync(() -> telemetry.abortActiveRun(exception), killSwitchBlockingExecutor);
+          CompletableFuture.runAsync(() -> abortRun(runContext, exception), killSwitchBlockingExecutor);
           super.onFailure(exception);
         }
       });

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -299,13 +299,14 @@ public class PipelineExecutionService {
         return Multi.createFrom().failure(inputFailure);
       }
 
-      Object result = pipelineRunner.run(input, steps);
+      PipelineRunner.ExecutionResult executionResult = pipelineRunner.runWithContext(input, steps);
+      Object result = executionResult.result();
       if (result == null) {
         return Multi.createFrom().failure(new IllegalStateException("PipelineRunner returned null"));
       } else if (result instanceof Multi<?> multi) {
-        return executionHooks.attachMultiHooks(multi, watch);
+        return executionHooks.attachMultiHooks(multi, watch, executionResult.telemetryContext());
       } else if (result instanceof Uni<?> uni) {
-        return executionHooks.attachMultiHooks(uni.toMulti(), watch);
+        return executionHooks.attachMultiHooks(uni.toMulti(), watch, executionResult.telemetryContext());
       } else {
         return Multi.createFrom().failure(new IllegalStateException(
             MessageFormat.format("PipelineRunner returned unexpected type: {0}", result.getClass().getName())));
@@ -361,12 +362,13 @@ public class PipelineExecutionService {
     if (steps == null) {
       return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
     }
-    Object result = pipelineRunner.runFromStep(input, steps, startStepIndex);
+    PipelineRunner.ExecutionResult executionResult = pipelineRunner.runFromStepWithContext(input, steps, startStepIndex);
+    Object result = executionResult.result();
     if (result instanceof Multi<?> multi) {
-      return executionHooks.attachMultiHooks(multi, watch);
+      return executionHooks.attachMultiHooks(multi, watch, executionResult.telemetryContext());
     }
     if (result instanceof Uni<?> uni) {
-      return executionHooks.attachMultiHooks(uni.toMulti(), watch);
+      return executionHooks.attachMultiHooks(uni.toMulti(), watch, executionResult.telemetryContext());
     }
     String resultType = result == null ? "null" : result.getClass().getName();
     Multi<?> failed = Multi.createFrom().failure(new IllegalStateException(
@@ -374,7 +376,7 @@ public class PipelineExecutionService {
             "PipelineRunner returned unexpected type from step index {0}: {1}",
             startStepIndex,
             resultType)));
-    return executionHooks.attachMultiHooks(failed, watch);
+    return executionHooks.attachMultiHooks(failed, watch, executionResult.telemetryContext());
   }
 
   private void restoreAwaitContext(AwaitExecutionContext previous) {
@@ -401,10 +403,11 @@ public class PipelineExecutionService {
         return Uni.createFrom().failure(inputFailure);
       }
 
-      Object result = pipelineRunner.run(input, steps);
+      PipelineRunner.ExecutionResult executionResult = pipelineRunner.runWithContext(input, steps);
+      Object result = executionResult.result();
       return switch (result) {
         case null -> Uni.createFrom().failure(new IllegalStateException("PipelineRunner returned null"));
-        case Uni<?> uni -> executionHooks.attachUniHooks(uni, watch);
+        case Uni<?> uni -> executionHooks.attachUniHooks(uni, watch, executionResult.telemetryContext());
         case Multi<?> ignored -> Uni.createFrom().failure(new IllegalStateException(
             "PipelineRunner returned stream output where unary output was expected"));
         default -> Uni.createFrom().failure(new IllegalStateException(

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
@@ -92,7 +92,11 @@ public class PipelineRunner implements AutoCloseable {
      * @throws IllegalArgumentException if {@code input} is not a Uni or a Multi
      */
     public Object run(Object input, List<Object> steps) {
-        return runFromStep(input, steps, 0);
+        return runWithContext(input, steps).result();
+    }
+
+    public ExecutionResult runWithContext(Object input, List<Object> steps) {
+        return runFromStepWithContext(input, steps, 0);
     }
 
     /**
@@ -104,6 +108,10 @@ public class PipelineRunner implements AutoCloseable {
      * @return final reactive result
      */
     public Object runFromStep(Object input, List<Object> steps, int startStepIndex) {
+        return runFromStepWithContext(input, steps, startStepIndex).result();
+    }
+
+    public ExecutionResult runFromStepWithContext(Object input, List<Object> steps, int startStepIndex) {
         Objects.requireNonNull(steps, "Steps list must not be null");
         if (!(input instanceof Uni<?> || input instanceof Multi<?>)) {
             throw new IllegalArgumentException(MessageFormat.format(
@@ -158,7 +166,10 @@ public class PipelineRunner implements AutoCloseable {
                 awaitContextSnapshot);
         }
 
-        return telemetry.instrumentRunCompletion(current, telemetryContext);
+        return new ExecutionResult(telemetry.instrumentRunCompletion(current, telemetryContext), telemetryContext);
+    }
+
+    public record ExecutionResult(Object result, PipelineTelemetry.RunContext telemetryContext) {
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/telemetry/PipelineTelemetry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/telemetry/PipelineTelemetry.java
@@ -25,6 +25,7 @@ import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -571,13 +572,24 @@ public class PipelineTelemetry {
         return current;
     }
 
+    public void abortRun(RunContext runContext, Throwable failure) {
+        if (runContext == null || !runContext.enabled()) {
+            return;
+        }
+        endRun(runContext, abortFailure(failure));
+    }
+
     public void abortActiveRun(Throwable failure) {
-        Throwable effectiveFailure = failure == null ? new IllegalStateException("Pipeline aborted.") : failure;
+        Throwable effectiveFailure = abortFailure(failure);
         for (RunContext runContext : List.copyOf(activeRunContexts.values())) {
             if (runContext != null && runContext.enabled()) {
                 endRun(runContext, effectiveFailure);
             }
         }
+    }
+
+    private Throwable abortFailure(Throwable failure) {
+        return failure == null ? new IllegalStateException("Pipeline aborted.") : failure;
     }
 
     /**
@@ -1014,14 +1026,22 @@ public class PipelineTelemetry {
         return retryAmplificationSampleInterval;
     }
 
-    public java.util.Optional<RetryAmplificationGuard.Trigger> retryAmplificationTrigger() {
+    public Optional<RetryAmplificationGuard.Trigger> retryAmplificationTrigger() {
         for (RetryAmplificationMonitor monitor : activeRetryAmplificationMonitors.values()) {
-            java.util.Optional<RetryAmplificationGuard.Trigger> triggered = monitor.triggered();
+            Optional<RetryAmplificationGuard.Trigger> triggered = monitor.triggered();
             if (triggered.isPresent()) {
                 return triggered;
             }
         }
-        return java.util.Optional.empty();
+        return Optional.empty();
+    }
+
+    public Optional<RetryAmplificationGuard.Trigger> retryAmplificationTrigger(RunContext runContext) {
+        if (runContext == null || !runContext.enabled()) {
+            return retryAmplificationTrigger();
+        }
+        RetryAmplificationMonitor monitor = activeRetryAmplificationMonitors.get(runContext.runId());
+        return monitor == null ? Optional.empty() : monitor.triggered();
     }
 
     private void recordRetryInternal(Class<?> stepClass, Throwable failure) {
@@ -1180,8 +1200,8 @@ public class PipelineTelemetry {
             }
         }
 
-        java.util.Optional<RetryAmplificationGuard.Trigger> triggered() {
-            return java.util.Optional.ofNullable(trigger.get());
+        Optional<RetryAmplificationGuard.Trigger> triggered() {
+            return Optional.ofNullable(trigger.get());
         }
 
         private void sample() {
@@ -1210,7 +1230,7 @@ public class PipelineTelemetry {
                 trimSamples(samples);
                 snapshot = new ArrayDeque<>(samples);
             }
-            java.util.Optional<RetryAmplificationGuard.Trigger> candidate = retryAmplificationGuard
+            Optional<RetryAmplificationGuard.Trigger> candidate = retryAmplificationGuard
                 .evaluate("global", snapshot, retryAmplificationWindow, inflightSlopeThreshold,
                     retryAmplificationSustainSamples);
             if (candidate.isPresent()) {

--- a/framework/runtime/src/test/java/org/pipelineframework/telemetry/PipelineTelemetryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/telemetry/PipelineTelemetryTest.java
@@ -33,6 +33,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.api.trace.StatusCode;
 import io.smallrye.mutiny.Multi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,6 +74,35 @@ class PipelineTelemetryTest {
         tracerProvider.shutdown();
         meterProvider.shutdown();
         GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void abortRunOnlyEndsTargetRun() {
+        PipelineTelemetry telemetry = new PipelineTelemetry(new TestPipelineStepConfig());
+        PipelineTelemetry.RunContext target =
+            telemetry.startRun(Multi.createFrom().item(1), 1, ParallelismPolicy.AUTO, 4);
+        PipelineTelemetry.RunContext sibling =
+            telemetry.startRun(Multi.createFrom().item(2), 1, ParallelismPolicy.AUTO, 4);
+
+        telemetry.abortRun(target, new IllegalStateException("retry amplification"));
+
+        assertTrue(target.endSignalled().get(), "Expected target run to be ended by abort");
+        assertFalse(sibling.endSignalled().get(), "Expected sibling run to remain active");
+
+        Multi<Integer> completed =
+            (Multi<Integer>) telemetry.instrumentRunCompletion(Multi.createFrom().item(2), sibling);
+        completed.collect().asList().await().indefinitely();
+
+        List<SpanData> runSpans = exporter.getFinishedSpanItems().stream()
+            .filter(span -> "tpf.pipeline.run".equals(span.getName()))
+            .toList();
+        assertEquals(2, runSpans.size());
+        assertEquals(1, runSpans.stream()
+            .filter(span -> span.getStatus().getStatusCode() == StatusCode.ERROR)
+            .count());
+        assertEquals(1, runSpans.stream()
+            .filter(span -> span.getStatus().getStatusCode() == StatusCode.UNSET)
+            .count());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a run-scoped telemetry abort path for retry-amplification shutdowns
- carry the telemetry run context from PipelineRunner into ExecutionHooks without changing existing runner callers
- keep abortActiveRun as the compatibility wrapper for older callers
- add a sibling-run regression test proving a targeted abort does not end unrelated active runs

Closes #283.

## Validation
- ./mvnw -f framework/pom.xml -pl runtime -am -Dtest=PipelineTelemetryTest,PipelineReplayExecutionTest test