### PR TITLE
Suppress protobuf mapper warning noise

### DIFF
--- a/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/PendingRestaurantApprovalMapper.java
+++ b/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/PendingRestaurantApprovalMapper.java
@@ -1,6 +1,8 @@
 package org.pipelineframework.restaurantapproval.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import org.pipelineframework.restaurantapproval.common.domain.PendingRestaurantApproval;
@@ -21,8 +23,10 @@ public interface PendingRestaurantApprovalMapper
 
   PendingRestaurantApproval fromDto(PendingRestaurantApprovalDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   PipelineTypes.PendingRestaurantApproval toGrpc(PendingRestaurantApprovalDto dto);
 
+  @Mapping(target = "id", ignore = true)
   PendingRestaurantApprovalDto fromGrpc(PipelineTypes.PendingRestaurantApproval grpc);
 
   @Override

--- a/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/PlaceRestaurantOrderRequestMapper.java
+++ b/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/PlaceRestaurantOrderRequestMapper.java
@@ -1,6 +1,8 @@
 package org.pipelineframework.restaurantapproval.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import org.pipelineframework.restaurantapproval.common.domain.PlaceRestaurantOrderRequest;
@@ -21,8 +23,10 @@ public interface PlaceRestaurantOrderRequestMapper
 
   PlaceRestaurantOrderRequest fromDto(PlaceRestaurantOrderRequestDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   PipelineTypes.PlaceRestaurantOrderRequest toGrpc(PlaceRestaurantOrderRequestDto dto);
 
+  @Mapping(target = "id", ignore = true)
   PlaceRestaurantOrderRequestDto fromGrpc(PipelineTypes.PlaceRestaurantOrderRequest grpc);
 
   @Override

--- a/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/TerminalOrderStateMapper.java
+++ b/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/TerminalOrderStateMapper.java
@@ -1,6 +1,8 @@
 package org.pipelineframework.restaurantapproval.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import org.pipelineframework.restaurantapproval.common.domain.TerminalOrderState;
@@ -21,8 +23,10 @@ public interface TerminalOrderStateMapper
 
   TerminalOrderState fromDto(TerminalOrderStateDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   PipelineTypes.TerminalOrderState toGrpc(TerminalOrderStateDto dto);
 
+  @Mapping(target = "id", ignore = true)
   TerminalOrderStateDto fromGrpc(PipelineTypes.TerminalOrderState grpc);
 
   @Override

--- a/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/ValidatedRestaurantOrderRequestMapper.java
+++ b/examples/restaurant-approval/common/src/main/java/org/pipelineframework/restaurantapproval/common/mapper/ValidatedRestaurantOrderRequestMapper.java
@@ -1,6 +1,8 @@
 package org.pipelineframework.restaurantapproval.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import org.pipelineframework.restaurantapproval.common.domain.ValidatedRestaurantOrderRequest;
@@ -21,8 +23,10 @@ public interface ValidatedRestaurantOrderRequestMapper
 
   ValidatedRestaurantOrderRequest fromDto(ValidatedRestaurantOrderRequestDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   PipelineTypes.ValidatedRestaurantOrderRequest toGrpc(ValidatedRestaurantOrderRequestDto dto);
 
+  @Mapping(target = "id", ignore = true)
   ValidatedRestaurantOrderRequestDto fromGrpc(PipelineTypes.ValidatedRestaurantOrderRequest grpc);
 
   @Override

--- a/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/CrawlRequestMapper.java
+++ b/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/CrawlRequestMapper.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.search.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
@@ -21,6 +22,7 @@ public interface CrawlRequestMapper extends org.pipelineframework.mapper.Mapper<
   CrawlRequest fromDto(CrawlRequestDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   org.pipelineframework.search.grpc.PipelineTypes.CrawlRequest toGrpc(CrawlRequestDto dto);
 
   CrawlRequestDto fromGrpc(org.pipelineframework.search.grpc.PipelineTypes.CrawlRequest grpc);

--- a/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/IndexAckMapper.java
+++ b/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/IndexAckMapper.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.search.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
@@ -21,6 +22,7 @@ public interface IndexAckMapper extends org.pipelineframework.mapper.Mapper<Inde
   IndexAck fromDto(IndexAckDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   org.pipelineframework.search.grpc.PipelineTypes.IndexAck toGrpc(IndexAckDto dto);
 
   IndexAckDto fromGrpc(org.pipelineframework.search.grpc.PipelineTypes.IndexAck grpc);

--- a/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/ParsedDocumentMapper.java
+++ b/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/ParsedDocumentMapper.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.search.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
@@ -21,6 +22,7 @@ public interface ParsedDocumentMapper extends org.pipelineframework.mapper.Mappe
   ParsedDocument fromDto(ParsedDocumentDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   org.pipelineframework.search.grpc.PipelineTypes.ParsedDocument toGrpc(ParsedDocumentDto dto);
 
   ParsedDocumentDto fromGrpc(org.pipelineframework.search.grpc.PipelineTypes.ParsedDocument grpc);

--- a/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/RawDocumentMapper.java
+++ b/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/RawDocumentMapper.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.search.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
@@ -21,6 +22,7 @@ public interface RawDocumentMapper extends org.pipelineframework.mapper.Mapper<R
   RawDocument fromDto(RawDocumentDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   org.pipelineframework.search.grpc.PipelineTypes.RawDocument toGrpc(RawDocumentDto dto);
 
   RawDocumentDto fromGrpc(org.pipelineframework.search.grpc.PipelineTypes.RawDocument grpc);

--- a/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/TokenBatchMapper.java
+++ b/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/TokenBatchMapper.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.search.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.BeforeMapping;
 import org.mapstruct.ReportingPolicy;
@@ -22,6 +23,7 @@ public interface TokenBatchMapper extends org.pipelineframework.mapper.Mapper<To
   TokenBatch fromDto(TokenBatchDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   org.pipelineframework.search.grpc.PipelineTypes.TokenBatch toGrpc(TokenBatchDto dto);
 
   TokenBatchDto fromGrpc(org.pipelineframework.search.grpc.PipelineTypes.TokenBatch grpc);

--- a/template-generator-node/templates/mapper.hbs
+++ b/template-generator-node/templates/mapper.hbs
@@ -3,6 +3,7 @@ package {{basePackage}}.common.mapper;
 import {{basePackage}}.common.domain.{{domainClass}};
 import {{basePackage}}.common.dto.{{dtoClass}};
 import {{grpcClass}};
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
@@ -22,6 +23,7 @@ public interface {{className}}Mapper extends org.pipelineframework.mapper.Mapper
   {{domainClass}} fromDto({{dtoClass}} dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   {{grpcClass}}.{{className}} toGrpc({{dtoClass}} dto);
 
   {{dtoClass}} fromGrpc({{grpcClass}}.{{className}} grpc);


### PR DESCRIPTION
## Summary
- suppress protobuf-builder unmapped-target noise only on DTO -> gRPC mapper methods
- explicitly ignore Restaurant Approval DTO id fields that are not represented in the generated gRPC messages
- update the template generator mapper template so new generated mappers use the same boundary-method policy

Closes #318.
Closes #289.

## Validation
- ./mvnw -f examples/search/pom.xml -DskipTests compile
- ./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -Dtest=RestaurantApprovalAwaitMonolithTest -Dsurefire.failIfNoSpecifiedTests=false test
- npm --prefix template-generator-node test

## Notes
- Verified the targeted MapStruct warnings for protobuf builder internals and Restaurant Approval id fields no longer appear in the after-build logs.
- Local CodeRabbit CLI review was attempted but blocked by CLI authentication in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardised data conversion configurations across mapper utilities in the restaurant approval and search modules to improve consistency and stability of internal data transformations. Updated mapper templates to enforce consistent handling of unmapped properties across generated converters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->