### PR TITLE
Disable duplicate Netty metrics in restaurant tests

### DIFF
--- a/examples/restaurant-approval/monolith-svc/src/test/resources/application.properties
+++ b/examples/restaurant-approval/monolith-svc/src/test/resources/application.properties
@@ -29,5 +29,6 @@ quarkus.grpc.server.plain-text=true
 quarkus.micrometer.export.prometheus.enabled=false
 quarkus.micrometer.binder.http-server.enabled=false
 quarkus.micrometer.binder.http-client.enabled=false
+quarkus.micrometer.binder.netty.enabled=false
 quarkus.otel.enabled=false
 quarkus.otel.sdk.disabled=true


### PR DESCRIPTION
## Summary
- Disable the Quarkus Micrometer Netty binder in the Restaurant Approval monolith test profile.
- Removes the duplicate `netty.eventexecutor.workers` gauge registration warning without changing production metrics contracts.
- Closes #321.

## #315 investigation
- `./mvnw -f framework/pom.xml -pl runtime -DskipTests compile` still emits the Quarkus CodeGenerator unavailable-services warning, but the compile succeeds.
- The narrow skip knob, `-Dquarkus.generate-code.skip=true`, removes that phase but breaks runtime compilation because checkpoint gRPC classes are produced by Quarkus code generation.
- Leaving #315 open for a focused Quarkus extension/runtime codegen lifecycle fix instead of widening this PR.

## Validation
- `./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -Dtest=RestaurantApprovalAwaitMonolithTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl runtime -DskipTests compile`
- Verified `/tmp/restaurant-micrometer-after.log` no longer contains `netty.eventexecutor.workers` or `This Gauge has been already registered`.