### PR TITLE
Remove Restaurant monolith deprecation compiler note

### DIFF
--- a/examples/restaurant-approval/create-pending-approval-svc/src/main/java/org/pipelineframework/restaurantapproval/create_pending_approval/service/ProcessCreatePendingApprovalService.java
+++ b/examples/restaurant-approval/create-pending-approval-svc/src/main/java/org/pipelineframework/restaurantapproval/create_pending_approval/service/ProcessCreatePendingApprovalService.java
@@ -3,7 +3,6 @@ package org.pipelineframework.restaurantapproval.create_pending_approval.service
 import org.pipelineframework.restaurantapproval.common.domain.ValidatedRestaurantOrderRequest;
 import org.pipelineframework.restaurantapproval.common.domain.PendingRestaurantApproval;
 import org.pipelineframework.annotation.PipelineStep;
-import org.pipelineframework.rest.RestReactiveServiceAdapter;
 import org.pipelineframework.service.ReactiveService;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -12,15 +11,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
-@PipelineStep(
-    inputType = org.pipelineframework.restaurantapproval.common.domain.ValidatedRestaurantOrderRequest.class,
-    outputType = org.pipelineframework.restaurantapproval.common.domain.PendingRestaurantApproval.class,
-    stepType = org.pipelineframework.step.StepOneToOne.class,
-    backendType = org.pipelineframework.rest.RestReactiveServiceAdapter.class,
-    inboundMapper = org.pipelineframework.restaurantapproval.common.mapper.ValidatedRestaurantOrderRequestMapper.class,
-    outboundMapper = org.pipelineframework.restaurantapproval.common.mapper.PendingRestaurantApprovalMapper.class,
-    runOnVirtualThreads = false
-)
+@PipelineStep
 @ApplicationScoped
 public class ProcessCreatePendingApprovalService
     implements ReactiveService<ValidatedRestaurantOrderRequest, PendingRestaurantApproval> {

--- a/examples/restaurant-approval/finalize-restaurant-decision-svc/src/main/java/org/pipelineframework/restaurantapproval/finalize_restaurant_decision/service/ProcessFinalizeRestaurantDecisionService.java
+++ b/examples/restaurant-approval/finalize-restaurant-decision-svc/src/main/java/org/pipelineframework/restaurantapproval/finalize_restaurant_decision/service/ProcessFinalizeRestaurantDecisionService.java
@@ -4,21 +4,11 @@ import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Objects;
 import org.pipelineframework.annotation.PipelineStep;
-import org.pipelineframework.rest.RestReactiveServiceAdapter;
 import org.pipelineframework.restaurantapproval.common.domain.RestaurantDecision;
 import org.pipelineframework.restaurantapproval.common.domain.TerminalOrderState;
-import org.pipelineframework.restaurantapproval.common.mapper.RestaurantDecisionMapper;
 import org.pipelineframework.service.ReactiveService;
 
-@PipelineStep(
-    inputType = org.pipelineframework.restaurantapproval.common.domain.RestaurantDecision.class,
-    outputType = org.pipelineframework.restaurantapproval.common.domain.TerminalOrderState.class,
-    stepType = org.pipelineframework.step.StepOneToOne.class,
-    backendType = org.pipelineframework.rest.RestReactiveServiceAdapter.class,
-    inboundMapper = org.pipelineframework.restaurantapproval.common.mapper.RestaurantDecisionMapper.class,
-    outboundMapper = org.pipelineframework.restaurantapproval.common.mapper.TerminalOrderStateMapper.class,
-    runOnVirtualThreads = false
-)
+@PipelineStep
 @ApplicationScoped
 public class ProcessFinalizeRestaurantDecisionService
     implements ReactiveService<RestaurantDecision, TerminalOrderState> {

--- a/examples/restaurant-approval/validate-order-request-svc/src/main/java/org/pipelineframework/restaurantapproval/validate_order_request/service/ProcessValidateOrderRequestService.java
+++ b/examples/restaurant-approval/validate-order-request-svc/src/main/java/org/pipelineframework/restaurantapproval/validate_order_request/service/ProcessValidateOrderRequestService.java
@@ -3,7 +3,6 @@ package org.pipelineframework.restaurantapproval.validate_order_request.service;
 import org.pipelineframework.restaurantapproval.common.domain.PlaceRestaurantOrderRequest;
 import org.pipelineframework.restaurantapproval.common.domain.ValidatedRestaurantOrderRequest;
 import org.pipelineframework.annotation.PipelineStep;
-import org.pipelineframework.rest.RestReactiveServiceAdapter;
 import org.pipelineframework.service.ReactiveService;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,15 +10,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Objects;
 
-@PipelineStep(
-    inputType = org.pipelineframework.restaurantapproval.common.domain.PlaceRestaurantOrderRequest.class,
-    outputType = org.pipelineframework.restaurantapproval.common.domain.ValidatedRestaurantOrderRequest.class,
-    stepType = org.pipelineframework.step.StepOneToOne.class,
-    backendType = org.pipelineframework.rest.RestReactiveServiceAdapter.class,
-    inboundMapper = org.pipelineframework.restaurantapproval.common.mapper.PlaceRestaurantOrderRequestMapper.class,
-    outboundMapper = org.pipelineframework.restaurantapproval.common.mapper.ValidatedRestaurantOrderRequestMapper.class,
-    runOnVirtualThreads = false
-)
+@PipelineStep
 @ApplicationScoped
 public class ProcessValidateOrderRequestService
     implements ReactiveService<PlaceRestaurantOrderRequest, ValidatedRestaurantOrderRequest> {


### PR DESCRIPTION
## Summary
- Remove deprecated legacy @PipelineStep members from Restaurant Approval authored step services.
- Keep the @PipelineStep marker and rely on the existing YAML step contract for input/output/cardinality/mapper metadata.
- Closes #322.

## Validation
- ./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -DskipTests -Dmaven.compiler.showDeprecation=true compile
- ./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -Dtest=RestaurantApprovalAwaitMonolithTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw -f examples/restaurant-approval/pom.xml -DskipTests compile
- Verified logs no longer contain the deprecated API note or -Xlint deprecation diagnostics for monolith sources.