### PR TITLE
Remove protobuf split-package warnings from example common modules

### DIFF
--- a/examples/csv-payments/common/pom.xml
+++ b/examples/csv-payments/common/pom.xml
@@ -108,11 +108,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>${protobuf.version}</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>2.1.1</version>
@@ -201,31 +196,6 @@
                             </arguments>
                             <addOutputToClasspath>true</addOutputToClasspath>
                             <classpathScope>compile</classpathScope>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack-google-proto</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.google.protobuf</groupId>
-                                    <artifactId>protobuf-java</artifactId>
-                                    <version>${protobuf.version}</version>
-                                    <includes>google/protobuf/*.proto</includes>
-                                    <outputDirectory>${generated.proto.dir}</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/examples/csv-payments/pom.xml
+++ b/examples/csv-payments/pom.xml
@@ -50,7 +50,6 @@
         <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <protobuf.version>4.33.2</protobuf.version>
         <grpc.version>1.63.0</grpc.version>
         <version.jandex>3.5.0</version.jandex>
         <spotless.plugin.version>2.44.0</spotless.plugin.version>
@@ -88,16 +87,6 @@
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java-util</artifactId>
-                <version>${protobuf.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/examples/restaurant-approval/common/pom.xml
+++ b/examples/restaurant-approval/common/pom.xml
@@ -158,31 +158,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack-google-proto</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.google.protobuf</groupId>
-                                    <artifactId>protobuf-java</artifactId>
-                                    <version>${protobuf.version}</version>
-                                    <includes>google/protobuf/*.proto</includes>
-                                    <outputDirectory>${generated.proto.dir}</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.5.0</version>

--- a/examples/restaurant-approval/pom.xml
+++ b/examples/restaurant-approval/pom.xml
@@ -30,7 +30,6 @@
         <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <protobuf.version>4.28.2</protobuf.version>
         <grpc.version>1.63.0</grpc.version>
         <version.jandex>3.5.0</version.jandex>
         <mockito.version>5.21.0</mockito.version>


### PR DESCRIPTION
## Summary
- Remove the example common-module unpacking of `google/protobuf/*.proto` from `protobuf-java`.
- Remove now-unused explicit protobuf runtime/version pins from Restaurant Approval and CSV Payments.
- Let Quarkus/protoc resolve well-known protobuf types instead of generating Google support Java into example artifacts.

Closes #304.

`tpf-mcp-bridge#4` remains open for generator-template parity so future generated examples inherit the same fix.

## Validation
- `./mvnw -f examples/restaurant-approval/pom.xml clean test -pl monolith-svc -am -Dtest=RestaurantApprovalAwaitMonolithTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./examples/csv-payments/build-monolith.sh -DskipTests -Dquarkus.container-image.build=false`
- `git diff --check`

## Notes
- The earlier exact CSV gate `./examples/csv-payments/build-monolith.sh -DskipTests` reached Quarkus/Jib image creation and failed locally at `docker load` with `unexpected EOF`; the protobuf split-package warning was already absent before that point. The no-image rerun completed successfully.
