### PR TITLE
Scope pipeline compiler options

### DIFF
--- a/examples/csv-payments/common/pom.xml
+++ b/examples/csv-payments/common/pom.xml
@@ -176,6 +176,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs combine.self="override" />
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/restaurant-approval/common/pom.xml
+++ b/examples/restaurant-approval/common/pom.xml
@@ -156,6 +156,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs combine.self="override" />
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/search/common/pom.xml
+++ b/examples/search/common/pom.xml
@@ -161,6 +161,12 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs combine.self="override" />
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>compile-orchestrator-client</id>
                         <configuration>
                             <skipMain>true</skipMain>

--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
                         <target>21</target>
                         <release>21</release>
                         <enablePreview>true</enablePreview>
-                        <compilerArgs>
-                            <arg>-Apipeline.parallelism=${tpf.build.parallelism}</arg>
-                            <arg>-Apipeline.transport=${tpf.build.transport}</arg>
-                            <arg>-Apipeline.platform=${tpf.build.platform}</arg>
-                        </compilerArgs>
                         <annotationProcessorPaths>
                             <!-- lombok must come first -->
                             <path>


### PR DESCRIPTION
## Summary

- remove root-level inherited `-Apipeline.*` compiler args from the top-level Maven compiler configuration
- clear inherited compiler args for generated example `common` modules that do not run the TPF processor
- keep service/module-specific pipeline compiler args in the example parent POMs where `pipelineframework-deployment` is active

Closes The-Pipeline-Framework/pipelineframework#316.

Generator/template parity is tracked separately in The-Pipeline-Framework/tpf-mcp-bridge#6.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime clean compile`
- `./mvnw -f framework/pom.xml -pl runtime -DskipTests test-compile`
- `./mvnw -f examples/restaurant-approval/pom.xml -pl common,monolith-svc -am -DskipTests compile`
- `./mvnw -f examples/restaurant-approval/pom.xml -pl common,monolith-svc -am -DskipTests test-compile`
- `./mvnw -f examples/csv-payments/pom.xml -pl common -am -DskipTests compile`
- `./mvnw -f examples/search/pom.xml -pl common -am -DskipTests compile`
- `git diff --check`

Checked all validation logs for `The following options were not recognized by any processor`; no matches remain in the targeted lanes.

## Notes

This intentionally does not address Maven artifact-overwrite warnings, which remain tracked by #319.

Additional warning classes observed while validating are tracked separately:

- #338 for CSV Payments MapStruct unmapped-target warnings
- #339 for the Search generated mapper deprecation note
