### PR TITLE
Avoid deprecated Search protobuf map accessors

### DIFF
--- a/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/CrawlRequestMapper.java
+++ b/examples/search/common/src/main/java/org/pipelineframework/search/common/mapper/CrawlRequestMapper.java
@@ -1,11 +1,14 @@
 package org.pipelineframework.search.common.mapper;
 
-import org.mapstruct.BeanMapping;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import org.pipelineframework.search.common.domain.CrawlRequest;
 import org.pipelineframework.search.common.dto.CrawlRequestDto;
+import org.pipelineframework.search.grpc.PipelineTypes;
 
 @SuppressWarnings("unused")
 @Mapper(
@@ -22,10 +25,55 @@ public interface CrawlRequestMapper extends org.pipelineframework.mapper.Mapper<
   CrawlRequest fromDto(CrawlRequestDto dto);
 
   // DTO ↔ gRPC
-  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
-  org.pipelineframework.search.grpc.PipelineTypes.CrawlRequest toGrpc(CrawlRequestDto dto);
+  default PipelineTypes.CrawlRequest toGrpc(CrawlRequestDto dto) {
+    if (dto == null) {
+      return null;
+    }
 
-  CrawlRequestDto fromGrpc(org.pipelineframework.search.grpc.PipelineTypes.CrawlRequest grpc);
+    PipelineTypes.CrawlRequest.Builder builder = PipelineTypes.CrawlRequest.newBuilder();
+    if (dto.getDocId() != null) {
+      builder.setDocId(dto.getDocId().toString());
+    }
+    if (dto.getSourceUrl() != null) {
+      builder.setSourceUrl(dto.getSourceUrl());
+    }
+    if (dto.getFetchMethod() != null) {
+      builder.setFetchMethod(dto.getFetchMethod());
+    }
+    if (dto.getAccept() != null) {
+      builder.setAccept(dto.getAccept());
+    }
+    if (dto.getAcceptLanguage() != null) {
+      builder.setAcceptLanguage(dto.getAcceptLanguage());
+    }
+    if (dto.getAuthScope() != null) {
+      builder.setAuthScope(dto.getAuthScope());
+    }
+    Map<String, String> fetchHeaders = dto.getFetchHeaders();
+    if (fetchHeaders != null) {
+      builder.putAllFetchHeaders(fetchHeaders);
+    }
+    return builder.build();
+  }
+
+  default CrawlRequestDto fromGrpc(PipelineTypes.CrawlRequest grpc) {
+    if (grpc == null) {
+      return null;
+    }
+
+    CrawlRequestDto.CrawlRequestDtoBuilder builder = CrawlRequestDto.builder();
+    String docId = grpc.getDocId();
+    if (docId != null && !docId.isBlank()) {
+      builder.docId(UUID.fromString(docId));
+    }
+    builder.sourceUrl(grpc.getSourceUrl());
+    builder.fetchMethod(grpc.getFetchMethod());
+    builder.accept(grpc.getAccept());
+    builder.acceptLanguage(grpc.getAcceptLanguage());
+    builder.authScope(grpc.getAuthScope());
+    builder.fetchHeaders(new LinkedHashMap<>(grpc.getFetchHeadersMap()));
+    return builder.build();
+  }
 
   @Override
   default CrawlRequest fromExternal(CrawlRequestDto external) {
@@ -37,11 +85,11 @@ public interface CrawlRequestMapper extends org.pipelineframework.mapper.Mapper<
     return toDto(domain);
   }
 
-  default org.pipelineframework.search.grpc.PipelineTypes.CrawlRequest toDtoToGrpc(CrawlRequest domain) {
+  default PipelineTypes.CrawlRequest toDtoToGrpc(CrawlRequest domain) {
     return toGrpc(toDto(domain));
   }
 
-  default CrawlRequest fromGrpcFromDto(org.pipelineframework.search.grpc.PipelineTypes.CrawlRequest grpc) {
+  default CrawlRequest fromGrpcFromDto(PipelineTypes.CrawlRequest grpc) {
     return fromDto(fromGrpc(grpc));
   }
 }

--- a/examples/search/common/src/test/java/org/pipelineframework/search/common/mapper/CrawlRequestMapperTest.java
+++ b/examples/search/common/src/test/java/org/pipelineframework/search/common/mapper/CrawlRequestMapperTest.java
@@ -1,0 +1,33 @@
+package org.pipelineframework.search.common.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.search.common.dto.CrawlRequestDto;
+import org.pipelineframework.search.grpc.PipelineTypes;
+
+class CrawlRequestMapperTest {
+
+  @Test
+  void mapsFetchHeadersThroughGrpcMapAccessors() {
+    UUID docId = UUID.randomUUID();
+    CrawlRequestDto dto = CrawlRequestDto.builder()
+        .docId(docId)
+        .sourceUrl("https://example.test")
+        .fetchMethod("GET")
+        .accept("text/html")
+        .acceptLanguage("en-US")
+        .authScope("tenant-1")
+        .fetchHeaders(Map.of("X-Trace", "trace-1"))
+        .build();
+
+    PipelineTypes.CrawlRequest grpc = CrawlRequestMapper.INSTANCE.toGrpc(dto);
+    CrawlRequestDto roundTripped = CrawlRequestMapper.INSTANCE.fromGrpc(grpc);
+
+    assertEquals("trace-1", grpc.getFetchHeadersMap().get("X-Trace"));
+    assertEquals(docId, roundTripped.getDocId());
+    assertEquals("trace-1", roundTripped.getFetchHeaders().get("X-Trace"));
+  }
+}


### PR DESCRIPTION
## Summary

- replace the Search `CrawlRequestMapper` gRPC map conversion with explicit `putAllFetchHeaders` / `getFetchHeadersMap` accessors
- keep MapStruct-generated domain/DTO conversion for the non-protobuf mappings
- add a focused mapper round-trip test for fetch headers through the protobuf map field

Closes The-Pipeline-Framework/pipelineframework#339.

## Validation

- `./mvnw -f examples/search/pom.xml -pl common -am -DskipTests clean compile`
- `./mvnw -f examples/search/pom.xml -pl common -Dtest=CrawlRequestMapperTest test`
- `git diff --check`

The clean compile log no longer contains `uses or overrides a deprecated API` or `Recompile with -Xlint:deprecation` for `CrawlRequestMapperImpl`.

## Notes

The focused test lane still emits existing Jandex missing-directory warnings for generated role class directories; those are tracked separately in #341.

The template-generator counterpart for generated protobuf map accessors is tracked in The-Pipeline-Framework/tpf-mcp-bridge#9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of data conversion operations to ensure robustness with edge cases, including better null value management and field serialisation.

* **Tests**
  * Added comprehensive test coverage for data mapping functionality, validating round-trip conversions and field integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->