### PR TITLE
Unbind Search common role Jandex indexes

### DIFF
--- a/examples/search/common/pom.xml
+++ b/examples/search/common/pom.xml
@@ -296,6 +296,14 @@
                             <jar>${project.build.directory}/${project.build.finalName}.jar</jar>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>make-index-orchestrator-client</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>make-index-plugin-client</id>
+                        <phase>none</phase>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/examples/search/common/pom.xml
+++ b/examples/search/common/pom.xml
@@ -300,6 +300,7 @@
                         <id>make-index-orchestrator-client</id>
                         <phase>none</phase>
                     </execution>
+                    <!-- Disable inherited role-specific Jandex executions; common module does not generate role classes -->
                     <execution>
                         <id>make-index-plugin-client</id>
                         <phase>none</phase>


### PR DESCRIPTION
## Summary

- unbind inherited role-specific Jandex executions in `examples/search/common`
- keep the normal common-module class/jar indexes intact
- avoid missing-directory warnings for absent `target/classes-pipeline/*` role outputs in common module test lanes

Closes The-Pipeline-Framework/pipelineframework#341.

## Validation

- `./mvnw -f examples/search/pom.xml -pl common -Dtest=CrawlRequestMapperTest test`
- `./mvnw -f examples/search/pom.xml -pl common -Dtest='*Test' test`
- `git diff --check`

The before log contained missing-directory Jandex warnings for `classes-pipeline/orchestrator-client` and `classes-pipeline/plugin-client`; the after logs no longer contain `Skipping file set`, `classes-pipeline/orchestrator-client`, or `classes-pipeline/plugin-client` warnings.

## Notes

Generator parity is tracked in The-Pipeline-Framework/tpf-mcp-bridge#10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted example build configuration to disable role-specific indexing in the common example module, reducing unnecessary build steps and clarifying module responsibilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->