### PR TITLE
Remove CSV Payments MapStruct warnings

### DIFF
--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvFolderMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvFolderMapper.java
@@ -16,6 +16,7 @@
 
 package org.pipelineframework.csv.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -32,11 +33,13 @@ public interface CsvFolderMapper extends org.pipelineframework.mapper.Mapper<Csv
 
     CsvFolderDto toDto(CsvFolder domain);
 
+    @Mapping(target = "id", ignore = true)
     CsvFolder fromDto(CsvFolderDto dto);
 
     @Mapping(target = "path", qualifiedByName = "stringToPath")
     CsvFolderDto fromGrpc(PipelineTypes.CsvFolder grpc);
 
+    @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
     @Mapping(target = "path", qualifiedByName = "pathToString")
     PipelineTypes.CsvFolder toGrpc(CsvFolderDto dto);
 

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentsInputFileMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentsInputFileMapper.java
@@ -16,6 +16,7 @@
 
 package org.pipelineframework.csv.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -32,8 +33,11 @@ public interface CsvPaymentsInputFileMapper extends org.pipelineframework.mapper
 
   CsvPaymentsInputFileDto toDto(CsvPaymentsInputFile entity);
 
+  @Mapping(target = "csvFile", ignore = true)
+  @Mapping(target = "csvFolder", ignore = true)
   CsvPaymentsInputFile fromDto(CsvPaymentsInputFileDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   @Mapping(target = "id", qualifiedByName = "uuidToString")
   @Mapping(target = "filepath", qualifiedByName = "pathToString")
   @Mapping(target = "csvFolderPath", qualifiedByName = "pathToString")

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentsOutputFileMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentsOutputFileMapper.java
@@ -16,6 +16,7 @@
 
 package org.pipelineframework.csv.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -33,8 +34,14 @@ public interface CsvPaymentsOutputFileMapper extends org.pipelineframework.mappe
 
   CsvPaymentsOutputFileDto toDto(CsvPaymentsOutputFile domain);
 
+  @Mapping(target = "csvFile", ignore = true)
+  @Mapping(target = "csvFolder", ignore = true)
+  @Mapping(target = "paymentOutputs", ignore = true)
+  @Mapping(target = "sbc", ignore = true)
+  @Mapping(target = "writer", ignore = true)
   CsvPaymentsOutputFile fromDto(CsvPaymentsOutputFileDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   @Mapping(target = "id", qualifiedByName = "uuidToString")
   @Mapping(target = "filepath", qualifiedByName = "pathToString")
   @Mapping(target = "csvFolderPath", qualifiedByName = "pathToString")

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/PaymentOutputMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/PaymentOutputMapper.java
@@ -16,6 +16,7 @@
 
 package org.pipelineframework.csv.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -36,6 +37,7 @@ public interface PaymentOutputMapper extends org.pipelineframework.mapper.Mapper
 
   PaymentOutput fromDto(PaymentOutputDto dto);
 
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   @Mapping(target = "id", qualifiedByName = "uuidToString")
   @Mapping(target = "amount", qualifiedByName = "bigDecimalToString")
   @Mapping(target = "currency", qualifiedByName = "currencyToString")

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/PaymentRecordMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/PaymentRecordMapper.java
@@ -16,6 +16,7 @@
 
 package org.pipelineframework.csv.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -38,6 +39,7 @@ public interface PaymentRecordMapper extends org.pipelineframework.mapper.Mapper
   PaymentRecord fromDto(PaymentRecordDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   @Mapping(target = "id", qualifiedByName = "uuidToString")
   @Mapping(target = "amount", qualifiedByName = "bigDecimalToString")
   @Mapping(target = "currency", qualifiedByName = "currencyToString")

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/PaymentStatusMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/PaymentStatusMapper.java
@@ -16,6 +16,7 @@
 
 package org.pipelineframework.csv.common.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -35,9 +36,11 @@ public interface PaymentStatusMapper extends org.pipelineframework.mapper.Mapper
   // Domain ↔ DTO
   PaymentStatusDto toDto(PaymentStatus entity);
 
+  @Mapping(target = "customerReference", ignore = true)
   PaymentStatus fromDto(PaymentStatusDto dto);
 
   // DTO ↔ gRPC
+  @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
   @Mapping(target = "id", qualifiedByName = "uuidToString")
   @Mapping(target = "fee", qualifiedByName = "bigDecimalToString")
   @Mapping(target = "conversationId", qualifiedByName = "uuidToString")

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentsInputFileMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentsInputFileMapperTest.java
@@ -142,7 +142,7 @@ class CsvPaymentsInputFileMapperTest {
         domain.setCsvFolderPath(Path.of("/test/input"));
 
         // When
-        PipelineTypes.CsvPaymentsInputFile grpc = mapper.toDtoToGrpc(domain);
+        PipelineTypes.CsvPaymentsInputFile grpc = mapper.toExternal(domain);
 
         // Then
         assertNotNull(grpc);
@@ -164,7 +164,7 @@ class CsvPaymentsInputFileMapperTest {
                         .build();
 
         // When
-        CsvPaymentsInputFile domain = mapper.fromGrpcFromDto(grpc);
+        CsvPaymentsInputFile domain = mapper.fromExternal(grpc);
 
         // Then
         assertNotNull(domain);

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentsOutputFileMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentsOutputFileMapperTest.java
@@ -60,7 +60,7 @@ class CsvPaymentsOutputFileMapperTest {
         domain.setCsvFolderPath(Path.of("/test/output"));
 
         // When
-        PipelineTypes.CsvPaymentsOutputFile grpc = mapper.toDtoToGrpc(domain);
+        PipelineTypes.CsvPaymentsOutputFile grpc = mapper.toExternal(domain);
 
         // Then
         assertNotNull(grpc);
@@ -82,7 +82,7 @@ class CsvPaymentsOutputFileMapperTest {
                         .build();
 
         // When
-        CsvPaymentsOutputFile domain = mapper.fromGrpcFromDto(grpc);
+        CsvPaymentsOutputFile domain = mapper.fromExternal(grpc);
 
         // Then
         assertNotNull(domain);

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentOutputMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentOutputMapperTest.java
@@ -251,7 +251,7 @@ class PaymentOutputMapperTest {
     //   domain.setFee(new BigDecimal("1.50"));
 
     //   // When
-    //   PipelineTypes.PaymentOutput grpc = mapper.toDtoToGrpc(domain);
+    //   PipelineTypes.PaymentOutput grpc = mapper.toExternal(domain);
 
     //   // Then
     //   assertNotNull(grpc);
@@ -286,7 +286,7 @@ class PaymentOutputMapperTest {
                         .build();
 
         // When
-        PaymentOutput domain = mapper.fromGrpcFromDto(grpc);
+        PaymentOutput domain = mapper.fromExternal(grpc);
 
         // Then
         assertNotNull(domain);

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentRecordMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentRecordMapperTest.java
@@ -171,7 +171,7 @@ class PaymentRecordMapperTest {
         PaymentRecord domain = createTestPaymentRecord();
 
         // When
-        PipelineTypes.PaymentRecord grpc = mapper.toDtoToGrpc(domain);
+        PipelineTypes.PaymentRecord grpc = mapper.toExternal(domain);
 
         // Then
         assertNotNull(grpc);
@@ -201,7 +201,7 @@ class PaymentRecordMapperTest {
                         .build();
 
         // When
-        PaymentRecord domain = mapper.fromGrpcFromDto(grpc);
+        PaymentRecord domain = mapper.fromExternal(grpc);
 
         // Then
         assertNotNull(domain);
@@ -229,7 +229,7 @@ class PaymentRecordMapperTest {
                         .build();
 
         // When
-        PaymentRecord domain = mapper.fromGrpcFromDto(grpc);
+        PaymentRecord domain = mapper.fromExternal(grpc);
 
         // Then
         assertNotNull(domain);

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentStatusMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentStatusMapperTest.java
@@ -145,7 +145,7 @@ class PaymentStatusMapperTest {
         .setPaymentRecordId(paymentRecordId.toString())
         .build();
 
-    PaymentStatus domain = mapper.fromGrpcFromDto(grpc);
+    PaymentStatus domain = mapper.fromExternal(grpc);
 
     assertNotNull(domain);
     assertEquals(id, domain.getId());


### PR DESCRIPTION
## Summary
- add explicit MapStruct ignores for intentional CSV domain-only fields
- suppress protobuf builder internals only on DTO-to-gRPC mapper methods
- update mapper tests to call current `toExternal` / `fromExternal` APIs instead of deprecated bridge methods

Closes #338.

## Validation
- `./mvnw -f examples/csv-payments/pom.xml -pl common -am -DskipTests compile`
- `./mvnw -f examples/csv-payments/pom.xml -pl common -Dtest='*MapperTest' test`
- `./examples/csv-payments/build-monolith.sh -DskipTests` progressed past mapper compilation with no `Unmapped target` warnings, then failed in local Jib/Docker image loading: `docker load unexpected EOF`
- `git diff --check`

## Notes
- Quarkus Maven extension warnings are tracked by #336.
- Maven artifact overwrite warnings are tracked by #319.
- The monolith build still emits other pre-existing warning classes unrelated to this mapper cleanup.