### PR TITLE
Enable Quarkus extensions for runtime package

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -71,6 +71,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
         <tpf.flatten.skip>true</tpf.flatten.skip>
         <skipUnitTests>false</skipUnitTests>
+        <argLine />
         <surefireArgLine />
     </properties>
 
@@ -139,7 +140,7 @@
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         </systemPropertyVariables>
-                        <argLine>${surefireArgLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar --enable-preview -XX:+EnableDynamicAgentLoading</argLine>
+                        <argLine>@{argLine} ${surefireArgLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar --enable-preview -XX:+EnableDynamicAgentLoading</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/framework/runtime/pom.xml
+++ b/framework/runtime/pom.xml
@@ -229,6 +229,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
             </plugin>
             <plugin>
                 <groupId>io.smallrye</groupId>


### PR DESCRIPTION
## Summary
- enable Maven extensions on the runtime module's `quarkus-maven-plugin`
- preserve Quarkus-injected Surefire JVM args with `@{argLine}` so enabling the extension does not introduce a new warning

Closes #336.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime clean package -DskipTests`

The validation no longer emits:
- `The Maven extensions for the Quarkus Maven plugin are not enabled`
- `explicit 'argLine' is defined in maven-surefire-plugin config, but does not contain '@{argLine}'`

Known remaining Javadoc warnings are tracked separately by #335.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven build configuration for test execution environment.
  * Enhanced Quarkus plugin integration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Pipeline-Framework/pipelineframework/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->