### PR TITLE
Remove runtime Javadoc warning noise

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -285,6 +285,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.6.0</version>
+                        <configuration>
+                            <doclint>all,-missing</doclint>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionCommand.java
@@ -2,6 +2,15 @@ package org.pipelineframework.awaitable;
 
 /**
  * Command representing a correlated external completion.
+ *
+ * @param tenantId tenant that owns the interaction
+ * @param interactionId interaction identifier to complete
+ * @param correlationId external correlation identifier to complete
+ * @param resumeToken signed resume token for webhook-style completion
+ * @param idempotencyKey stable completion idempotency key
+ * @param responsePayload completion payload
+ * @param actor actor submitting the completion
+ * @param nowEpochMs command time in epoch milliseconds
  */
 public record AwaitCompletionCommand(
     String tenantId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCreateCommand.java
@@ -4,6 +4,24 @@ import java.time.Instant;
 
 /**
  * Command used to create or deduplicate an await interaction.
+ *
+ * @param tenantId tenant that owns the execution
+ * @param executionId owning queue-async execution identifier
+ * @param stepId authored await step identifier
+ * @param stepIndex authored await step index
+ * @param outputType expected completion payload type
+ * @param causationId stable causation identifier for deduplication
+ * @param idempotencyKey stable interaction idempotency key
+ * @param correlationId external correlation identifier
+ * @param requestPayload payload dispatched to the external actor
+ * @param assignee optional human assignee
+ * @param group optional human group
+ * @param transportType await transport type
+ * @param unitId durable await unit identifier
+ * @param itemIndex zero-based item index for per-item await interactions
+ * @param nowEpochMs command time in epoch milliseconds
+ * @param deadlineEpochMs completion deadline in epoch milliseconds
+ * @param ttlEpochS expiry time in epoch seconds
  */
 public record AwaitCreateCommand(
     String tenantId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStreamOneToOneStep.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStreamOneToOneStep.java
@@ -5,6 +5,9 @@ import io.smallrye.mutiny.Multi;
 /**
  * Marker for generated await steps that remain unary at the authored model level but can suspend
  * over a streaming upstream by creating one unary await interaction per input item.
+ *
+ * @param <I> input item type
+ * @param <O> output item type
  */
 public interface AwaitStreamOneToOneStep<I, O> {
 

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitUnitCreateCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitUnitCreateCommand.java
@@ -2,6 +2,15 @@ package org.pipelineframework.awaitable;
 
 /**
  * Command used to create or deduplicate an await unit.
+ *
+ * @param tenantId tenant that owns the execution
+ * @param unitId durable await unit identifier
+ * @param executionId owning queue-async execution identifier
+ * @param stepId authored await step identifier
+ * @param stepIndex authored await step index
+ * @param cardinality authored await cardinality
+ * @param nowEpochMs command time in epoch milliseconds
+ * @param ttlEpochS expiry time in epoch seconds
  */
 public record AwaitUnitCreateCommand(
     String tenantId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitUnitRecord.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitUnitRecord.java
@@ -2,6 +2,22 @@ package org.pipelineframework.awaitable;
 
 /**
  * Durable orchestration record for one authored await unit.
+ *
+ * @param tenantId tenant that owns the execution
+ * @param unitId durable await unit identifier
+ * @param executionId owning queue-async execution identifier
+ * @param stepId authored await step identifier
+ * @param stepIndex authored await step index
+ * @param cardinality authored await cardinality
+ * @param version optimistic concurrency version
+ * @param status current await unit status
+ * @param primaryInteractionId primary externally visible interaction identifier
+ * @param expectedItemCount expected item count for multi-item units, when known
+ * @param completedItemCount admitted completed item count
+ * @param dispatchComplete whether dispatch has finished for the unit
+ * @param createdAtEpochMs creation time in epoch milliseconds
+ * @param updatedAtEpochMs last update time in epoch milliseconds
+ * @param ttlEpochS expiry time in epoch seconds
  */
 public record AwaitUnitRecord(
     String tenantId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionRequestDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionRequestDto.java
@@ -2,6 +2,13 @@ package org.pipelineframework.awaitable.dto;
 
 /**
  * REST/gRPC-neutral request DTO for completing an await interaction.
+ *
+ * @param interactionId interaction identifier to complete
+ * @param correlationId external correlation identifier to complete
+ * @param resumeToken signed resume token for webhook-style completion
+ * @param idempotencyKey stable completion idempotency key
+ * @param responsePayload completion payload
+ * @param actor actor submitting the completion
  */
 public record AwaitCompletionRequestDto(
     String interactionId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionResponseDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitCompletionResponseDto.java
@@ -4,6 +4,12 @@ import org.pipelineframework.awaitable.AwaitInteractionStatus;
 
 /**
  * Response DTO returned after completion admission.
+ *
+ * @param interactionId completed interaction identifier
+ * @param executionId owning queue-async execution identifier
+ * @param stepId authored await step identifier
+ * @param status resulting interaction status
+ * @param duplicate whether the completion was already admitted
  */
 public record AwaitCompletionResponseDto(
     String interactionId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitInteractionDto.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/dto/AwaitInteractionDto.java
@@ -6,6 +6,22 @@ import org.pipelineframework.awaitable.AwaitInteractionStatus;
 
 /**
  * Query projection for pending await interactions.
+ *
+ * @param interactionId externally visible interaction identifier
+ * @param correlationId external correlation identifier
+ * @param executionId owning queue-async execution identifier
+ * @param stepId authored await step identifier
+ * @param stepIndex authored await step index
+ * @param outputType expected completion payload type
+ * @param status current interaction status
+ * @param requestPayload payload dispatched to the external actor
+ * @param assignee optional human assignee
+ * @param group optional human group
+ * @param transportType await transport type
+ * @param transportMetadata transport-specific metadata
+ * @param deadlineEpochMs completion deadline in epoch milliseconds
+ * @param createdAtEpochMs creation time in epoch milliseconds
+ * @param updatedAtEpochMs last update time in epoch milliseconds
  */
 public record AwaitInteractionDto(
     String interactionId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitTransportAdapter.java
@@ -57,6 +57,10 @@ public interface AwaitTransportAdapter<I> {
 
     /**
      * Cancel request passed to adapters.
+     *
+     * @param descriptor authored await step descriptor
+     * @param interaction interaction to cancel
+     * @param reason cancellation reason
      */
     record AwaitCancelRequest(AwaitStepDescriptor descriptor, AwaitInteractionRecord interaction, String reason) {
     }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateMaterialization.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateMaterialization.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 /**
  * Pipeline-level representation aspect policies.
+ *
+ * @param aspects materialization aspects configured for the pipeline template
  */
 public record PipelineTemplateMaterialization(List<PipelineTemplateMaterializationAspect> aspects) {
     public PipelineTemplateMaterialization {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateMaterializationAspect.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateMaterializationAspect.java
@@ -23,6 +23,16 @@ import org.pipelineframework.materialization.MaterializationScope;
 
 /**
  * Aspect-like policy for transparent field materialization.
+ *
+ * @param name stable materialization aspect name
+ * @param enabled whether the aspect participates in materialization
+ * @param scope materialization scope
+ * @param position relative insertion position
+ * @param order ordering hint within the same position
+ * @param action materialization action to apply
+ * @param message message contract affected by the action
+ * @param fields message fields affected by the action
+ * @param targetSteps step identifiers targeted by the action
  */
 public record PipelineTemplateMaterializationAspect(
     String name,

--- a/framework/runtime/src/main/java/org/pipelineframework/repository/RepositoryReadResult.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/repository/RepositoryReadResult.java
@@ -18,6 +18,12 @@ package org.pipelineframework.repository;
 
 /**
  * Encoded payload read result from a repository provider.
+ *
+ * @param reference durable payload reference that was read
+ * @param payload encoded payload bytes
+ * @param contentType payload content type, when known
+ * @param codec payload codec name, when encoded
+ * @param checksum payload checksum, when available
  */
 public record RepositoryReadResult(
     PayloadReference reference,

--- a/framework/runtime/src/main/java/org/pipelineframework/repository/RepositoryWriteRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/repository/RepositoryWriteRequest.java
@@ -20,6 +20,15 @@ import java.util.Map;
 
 /**
  * Encoded payload write request for a repository provider.
+ *
+ * @param container repository container or bucket name
+ * @param key normalized repository object key
+ * @param payload encoded payload bytes
+ * @param contentType payload content type, when known
+ * @param codec payload codec name, when encoded
+ * @param checksum payload checksum, when available
+ * @param version provider-specific object version, when available
+ * @param metadata provider-specific metadata copied onto the write
  */
 public record RepositoryWriteRequest(
     String container,


### PR DESCRIPTION
## Summary
- document the runtime public records that were producing package-time record-component Javadoc warnings
- configure the framework release Javadoc jar with `doclint=all,-missing`, preserving real doclint checks while suppressing missing-documentation noise from records/generated sources

Closes #335.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime clean package -DskipTests`

The validation no longer emits `Javadoc Warnings`, `warning: no @param`, `warning: no @return`, `warning: no comment`, or `warning: empty comment`.

Note: this branch is based on current `main`, so the separate Quarkus extension warning from #336 may still appear until #345 merges.
