### PR TITLE
Deduplicate await item completion counts

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -171,7 +171,7 @@ public class AwaitCoordinator {
                     () -> new IllegalStateException("Await unit not found for failed interaction " + record.unitId())));
         }
         Uni<Optional<AwaitUnitRecord>> updated = record.itemInteraction()
-            ? unitStore().recordItemCompleted(record.tenantId(), record.unitId(), nowEpochMs)
+            ? unitStore().recordItemCompleted(record.tenantId(), record.unitId(), record.interactionId(), nowEpochMs)
             : unitStore().markCompleted(record.tenantId(), record.unitId(), nowEpochMs);
         return updated.onItem().transform(optional -> optional.orElseThrow(
             () -> new IllegalStateException("Await unit not found while recording completion: " + record.unitId())));

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitUnitStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/spi/AwaitUnitStore.java
@@ -39,6 +39,7 @@ public interface AwaitUnitStore {
     Uni<Optional<AwaitUnitRecord>> recordItemCompleted(
         String tenantId,
         String unitId,
+        String itemCompletionKey,
         long nowEpochMs);
 
     Uni<Optional<AwaitUnitRecord>> markCompleted(

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitUnitStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/DynamoAwaitUnitStore.java
@@ -44,6 +44,7 @@ public class DynamoAwaitUnitStore implements AwaitUnitStore {
     private static final String PRIMARY_INTERACTION_ID = "primary_interaction_id";
     private static final String EXPECTED_ITEM_COUNT = "expected_item_count";
     private static final String COMPLETED_ITEM_COUNT = "completed_item_count";
+    private static final String COMPLETED_ITEM_KEYS = "completed_item_keys";
     private static final String DISPATCH_COMPLETE = "dispatch_complete";
     private static final String CREATED_AT_EPOCH_MS = "created_at_epoch_ms";
     private static final String UPDATED_AT_EPOCH_MS = "updated_at_epoch_ms";
@@ -146,55 +147,42 @@ public class DynamoAwaitUnitStore implements AwaitUnitStore {
                 values,
                 existingNonTerminalCondition());
             if (dispatchMarked.isEmpty()) {
-                return getBlocking(tenantId, unitId, nowEpochMs);
+                return completeIfReady(getBlocking(tenantId, unitId, nowEpochMs), tenantId, unitId, nowEpochMs);
             }
-            AwaitUnitRecord updated = dispatchMarked.get();
-            if (updated.completedItemCount() < expectedItemCount) {
-                return dispatchMarked;
-            }
-            Optional<AwaitUnitRecord> completed = updateBlocking(tenantId, unitId,
-                "SET #status = :status, #updated = :updated ADD #version :one",
-                Map.of("#status", STATUS, "#completed", COMPLETED_ITEM_COUNT, "#expected", EXPECTED_ITEM_COUNT,
-                    "#updated", UPDATED_AT_EPOCH_MS, "#version", VERSION),
-                Map.of(":status", avS(AwaitUnitStatus.COMPLETED.name()), ":updated", avN(nowEpochMs),
-                    ":one", avN(1)),
-                existingNonTerminalCondition() + " AND #completed >= #expected");
-            return completed.isPresent() ? completed : getBlocking(tenantId, unitId, nowEpochMs);
+            return completeIfReady(dispatchMarked, tenantId, unitId, nowEpochMs);
         });
     }
 
     @Override
-    public Uni<Optional<AwaitUnitRecord>> recordItemCompleted(String tenantId, String unitId, long nowEpochMs) {
+    public Uni<Optional<AwaitUnitRecord>> recordItemCompleted(
+        String tenantId,
+        String unitId,
+        String itemCompletionKey,
+        long nowEpochMs) {
+        if (itemCompletionKey == null || itemCompletionKey.isBlank()) {
+            return Uni.createFrom().failure(new IllegalArgumentException("itemCompletionKey must not be blank"));
+        }
         return blocking(() -> {
             Map<String, String> names = Map.of(
                 "#completed", COMPLETED_ITEM_COUNT,
+                "#completedKeys", COMPLETED_ITEM_KEYS,
                 "#updated", UPDATED_AT_EPOCH_MS,
                 "#version", VERSION);
             Map<String, AttributeValue> values = Map.of(
                 ":updated", avN(nowEpochMs),
-                ":one", avN(1));
+                ":one", avN(1),
+                ":itemKey", avS(itemCompletionKey),
+                ":itemKeys", AttributeValue.builder().ss(itemCompletionKey).build());
             Optional<AwaitUnitRecord> incremented = updateBlocking(tenantId, unitId,
-                "SET #updated = :updated ADD #completed :one, #version :one",
+                "SET #updated = :updated ADD #completed :one, #version :one, #completedKeys :itemKeys",
                 names,
                 values,
-                existingNonTerminalCondition());
+                existingNonTerminalCondition()
+                    + " AND (attribute_not_exists(#completedKeys) OR NOT contains(#completedKeys, :itemKey))");
             if (incremented.isEmpty()) {
-                return getBlocking(tenantId, unitId, nowEpochMs);
+                return completeIfReady(getBlocking(tenantId, unitId, nowEpochMs), tenantId, unitId, nowEpochMs);
             }
-            AwaitUnitRecord updated = incremented.get();
-            if (!updated.dispatchComplete()
-                || updated.expectedItemCount() == null
-                || updated.completedItemCount() < updated.expectedItemCount()) {
-                return incremented;
-            }
-            Optional<AwaitUnitRecord> completed = updateBlocking(tenantId, unitId,
-                "SET #status = :status, #updated = :updated ADD #version :one",
-                Map.of("#status", STATUS, "#completed", COMPLETED_ITEM_COUNT, "#expected", EXPECTED_ITEM_COUNT,
-                    "#updated", UPDATED_AT_EPOCH_MS, "#version", VERSION),
-                Map.of(":status", avS(AwaitUnitStatus.COMPLETED.name()), ":updated", avN(nowEpochMs),
-                    ":one", avN(1)),
-                existingNonTerminalCondition() + " AND #completed >= #expected");
-            return completed.isPresent() ? completed : getBlocking(tenantId, unitId, nowEpochMs);
+            return completeIfReady(incremented, tenantId, unitId, nowEpochMs);
         });
     }
 
@@ -299,6 +287,31 @@ public class DynamoAwaitUnitStore implements AwaitUnitStore {
             return Optional.empty();
         }
         return Optional.of(record);
+    }
+
+    private Optional<AwaitUnitRecord> completeIfReady(
+        Optional<AwaitUnitRecord> current,
+        String tenantId,
+        String unitId,
+        long nowEpochMs) {
+        if (current.isEmpty()) {
+            return Optional.empty();
+        }
+        AwaitUnitRecord record = current.get();
+        if (record.status().terminal()
+            || !record.dispatchComplete()
+            || record.expectedItemCount() == null
+            || record.completedItemCount() < record.expectedItemCount()) {
+            return current;
+        }
+        Optional<AwaitUnitRecord> completed = updateBlocking(tenantId, unitId,
+            "SET #status = :status, #updated = :updated ADD #version :one",
+            Map.of("#status", STATUS, "#completed", COMPLETED_ITEM_COUNT, "#expected", EXPECTED_ITEM_COUNT,
+                "#updated", UPDATED_AT_EPOCH_MS, "#version", VERSION),
+            Map.of(":status", avS(AwaitUnitStatus.COMPLETED.name()), ":updated", avN(nowEpochMs),
+                ":one", avN(1)),
+            existingNonTerminalCondition() + " AND #completed >= #expected");
+        return completed.isPresent() ? completed : getBlocking(tenantId, unitId, nowEpochMs);
     }
 
     private Map<String, AttributeValue> toItem(AwaitUnitRecord record) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitUnitStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/store/InMemoryAwaitUnitStore.java
@@ -2,8 +2,10 @@ package org.pipelineframework.awaitable.store;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.smallrye.mutiny.Uni;
@@ -20,6 +22,7 @@ public class InMemoryAwaitUnitStore implements AwaitUnitStore {
 
     private final Object lock = new Object();
     private final Map<String, AwaitUnitRecord> unitsByScopedId = new HashMap<>();
+    private final Map<String, Set<String>> completedItemsByScopedId = new HashMap<>();
 
     @Override
     public String providerName() {
@@ -127,28 +130,49 @@ public class InMemoryAwaitUnitStore implements AwaitUnitStore {
     }
 
     @Override
-    public Uni<Optional<AwaitUnitRecord>> recordItemCompleted(String tenantId, String unitId, long nowEpochMs) {
-        return update(tenantId, unitId, nowEpochMs, current -> {
-            int completed = current.completedItemCount() + 1;
-            boolean terminal = current.dispatchComplete()
-                && current.expectedItemCount() != null
-                && completed >= current.expectedItemCount();
-            return new AwaitUnitRecord(
-                current.tenantId(),
-                current.unitId(),
-                current.executionId(),
-                current.stepId(),
-                current.stepIndex(),
-                current.cardinality(),
-                current.version() + 1,
-                terminal ? AwaitUnitStatus.COMPLETED : current.status(),
-                current.primaryInteractionId(),
-                current.expectedItemCount(),
-                completed,
-                current.dispatchComplete(),
-                current.createdAtEpochMs(),
-                nowEpochMs,
-                current.ttlEpochS());
+    public Uni<Optional<AwaitUnitRecord>> recordItemCompleted(
+        String tenantId,
+        String unitId,
+        String itemCompletionKey,
+        long nowEpochMs) {
+        if (itemCompletionKey == null || itemCompletionKey.isBlank()) {
+            return Uni.createFrom().failure(new IllegalArgumentException("itemCompletionKey must not be blank"));
+        }
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                purgeExpired(nowEpochMs);
+                String scopedId = scopedUnitId(tenantId, unitId);
+                AwaitUnitRecord current = unitsByScopedId.get(scopedId);
+                if (current == null || current.status().terminal()) {
+                    return Optional.ofNullable(current);
+                }
+                Set<String> completedItems = completedItemsByScopedId.computeIfAbsent(scopedId, ignored -> new HashSet<>());
+                if (!completedItems.add(itemCompletionKey)) {
+                    return Optional.of(current);
+                }
+                int completed = current.completedItemCount() + 1;
+                boolean terminal = current.dispatchComplete()
+                    && current.expectedItemCount() != null
+                    && completed >= current.expectedItemCount();
+                AwaitUnitRecord updated = new AwaitUnitRecord(
+                    current.tenantId(),
+                    current.unitId(),
+                    current.executionId(),
+                    current.stepId(),
+                    current.stepIndex(),
+                    current.cardinality(),
+                    current.version() + 1,
+                    terminal ? AwaitUnitStatus.COMPLETED : current.status(),
+                    current.primaryInteractionId(),
+                    current.expectedItemCount(),
+                    completed,
+                    current.dispatchComplete(),
+                    current.createdAtEpochMs(),
+                    nowEpochMs,
+                    current.ttlEpochS());
+                unitsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
         });
     }
 
@@ -220,7 +244,11 @@ public class InMemoryAwaitUnitStore implements AwaitUnitStore {
         long nowEpochS = Instant.ofEpochMilli(nowEpochMs).getEpochSecond();
         unitsByScopedId.entrySet().removeIf(entry -> {
             AwaitUnitRecord record = entry.getValue();
-            return record.ttlEpochS() > 0 && record.ttlEpochS() <= nowEpochS;
+            boolean expired = record.ttlEpochS() > 0 && record.ttlEpochS() <= nowEpochS;
+            if (expired) {
+                completedItemsByScopedId.remove(entry.getKey());
+            }
+            return expired;
         });
     }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCoordinatorCompletionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCoordinatorCompletionTest.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.awaitable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -116,6 +117,43 @@ class AwaitCoordinatorCompletionTest {
         AwaitCompletionResult duplicate = coordinator.complete(command).await().indefinitely();
 
         assertTrue(duplicate.duplicate());
+    }
+
+    @Test
+    void duplicateItemCompletionDoesNotOverCountAwaitUnit() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        AwaitCoordinator coordinator = coordinator(store);
+        AwaitCreateResult created = coordinator.createOrGetItem(
+            descriptor("AwaitPaymentProvider"),
+            "tenant-1",
+            "exec-1",
+            1,
+            "record-1",
+            java.util.Map.of("paymentRecordId", "record-1"),
+            "unit-1",
+            0,
+            null,
+            null).await().indefinitely();
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant-1",
+            created.record().interactionId(),
+            null,
+            "completion-1",
+            java.util.Map.of("status", "APPROVED"),
+            "provider",
+            11_000L);
+
+        AwaitCompletionResult first = coordinator.complete(command).await().indefinitely();
+        coordinator.recordCompletion(first.record(), 11_000L).await().indefinitely();
+        AwaitCompletionResult duplicate = coordinator.complete(command).await().indefinitely();
+        AwaitUnitRecord afterDuplicate = coordinator.recordCompletion(duplicate.record(), 12_000L).await().indefinitely();
+        AwaitUnitRecord completed = coordinator.markDispatchComplete("tenant-1", "unit-1", 1, 13_000L).await().indefinitely();
+
+        assertFalse(first.duplicate());
+        assertTrue(duplicate.duplicate());
+        assertEquals(1, afterDuplicate.completedItemCount());
+        assertEquals(1, completed.completedItemCount());
+        assertEquals(AwaitUnitStatus.COMPLETED, completed.status());
     }
 
     @Test
@@ -247,6 +285,18 @@ class AwaitCoordinatorCompletionTest {
             10_000L,
             deadlineEpochMs,
             9_999_999_999L);
+    }
+
+    private static AwaitStepDescriptor descriptor(String stepId) {
+        return new AwaitStepDescriptor(
+            stepId,
+            java.util.Map.class.getName(),
+            java.util.Map.class.getName(),
+            java.time.Duration.ofMinutes(10),
+            "interactionId",
+            "interaction-api",
+            Map.of(),
+            List.of("paymentRecordId"));
     }
 
     private static final class SimpleInstance<T> implements Instance<T> {

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitUnitStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/store/InMemoryAwaitUnitStoreTest.java
@@ -1,0 +1,51 @@
+package org.pipelineframework.awaitable.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.AwaitUnitCreateCommand;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+
+class InMemoryAwaitUnitStoreTest {
+
+    @Test
+    void duplicateItemCompletionDoesNotIncrementCompletedItemCount() {
+        InMemoryAwaitUnitStore store = new InMemoryAwaitUnitStore();
+        store.createOrGet(createCommand()).await().indefinitely();
+
+        var first = store.recordItemCompleted("tenant", "unit-1", "interaction-1", 11_000L).await().indefinitely().orElseThrow();
+        var duplicate = store.recordItemCompleted("tenant", "unit-1", "interaction-1", 12_000L).await().indefinitely().orElseThrow();
+        var dispatchComplete = store.markDispatchComplete("tenant", "unit-1", 1, 13_000L).await().indefinitely().orElseThrow();
+
+        assertEquals(1, first.completedItemCount());
+        assertEquals(1, duplicate.completedItemCount());
+        assertEquals(1, dispatchComplete.completedItemCount());
+        assertEquals(AwaitUnitStatus.COMPLETED, dispatchComplete.status());
+    }
+
+    @Test
+    void distinctItemCompletionsIncrementCompletedItemCount() {
+        InMemoryAwaitUnitStore store = new InMemoryAwaitUnitStore();
+        store.createOrGet(createCommand()).await().indefinitely();
+
+        store.recordItemCompleted("tenant", "unit-1", "interaction-1", 11_000L).await().indefinitely();
+        var second = store.recordItemCompleted("tenant", "unit-1", "interaction-2", 12_000L).await().indefinitely().orElseThrow();
+        var dispatchComplete = store.markDispatchComplete("tenant", "unit-1", 2, 13_000L).await().indefinitely().orElseThrow();
+
+        assertEquals(2, second.completedItemCount());
+        assertEquals(2, dispatchComplete.completedItemCount());
+        assertEquals(AwaitUnitStatus.COMPLETED, dispatchComplete.status());
+    }
+
+    private static AwaitUnitCreateCommand createCommand() {
+        return new AwaitUnitCreateCommand(
+            "tenant",
+            "unit-1",
+            "execution-1",
+            "AwaitPaymentProvider",
+            1,
+            "ONE_TO_ONE",
+            10_000L,
+            9_999_999_999L);
+    }
+}


### PR DESCRIPTION
## Summary
- make await item completion accounting idempotent by passing an item completion key into `AwaitUnitStore.recordItemCompleted`
- track completed item keys in the in-memory store so duplicate completion admission cannot over-count a unit
- track completed item keys in DynamoDB with a conditional string-set `ADD`, while still allowing duplicate completions to finish a ready-but-not-yet-terminal unit after a crash between increment and status transition
- add store-level and coordinator-level coverage for duplicate item completion replay

Closes #334.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=QueueAsyncCoordinatorTest,AwaitCoordinatorCompletionTest,InMemoryAwaitUnitStoreTest test`

Note: the targeted test lane still prints the existing JVM bootstrap classpath warning from Mockito/ByteBuddy; this PR does not change that warning class.
