### PR TITLE
Stop role compilation from overwriting Maven artifact files

### DIFF
--- a/examples/csv-payments/pom.xml
+++ b/examples/csv-payments/pom.xml
@@ -315,7 +315,7 @@
                             <id>compile-orchestrator-client</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -330,7 +330,7 @@
                             <id>compile-pipeline-server</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -345,7 +345,7 @@
                             <id>compile-plugin-client</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -360,7 +360,7 @@
                             <id>compile-plugin-server</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -375,7 +375,7 @@
                             <id>compile-rest-server</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>

--- a/examples/restaurant-approval/pom.xml
+++ b/examples/restaurant-approval/pom.xml
@@ -298,7 +298,7 @@
                             <id>compile-orchestrator-client</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -313,7 +313,7 @@
                             <id>compile-pipeline-server</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -328,7 +328,7 @@
                             <id>compile-plugin-client</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -343,7 +343,7 @@
                             <id>compile-plugin-server</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>
@@ -358,7 +358,7 @@
                             <id>compile-rest-server</id>
                             <phase>process-classes</phase>
                             <goals>
-                                <goal>compile</goal>
+                                <goal>testCompile</goal>
                             </goals>
                             <configuration>
                                 <proc>none</proc>


### PR DESCRIPTION
## Summary

Closes #319.

Switches generated role side-output compiler executions in the CSV Payments and Restaurant Approval parent POMs from `compile` to `testCompile` while preserving their explicit `compileSourceRoots` and `outputDirectory` settings.

These executions do not produce the module's primary artifact. They compile role-specific generated sources into `target/classes-pipeline/*`, which is then explicitly merged or packaged. Using the main `compile` goal caused Maven Compiler Plugin to repeatedly update the project artifact file pointer and emit noisy warnings such as:

```text
Overwriting artifact's file from .../target/classes to .../target/classes-pipeline/orchestrator-client
```

## Validation

- `./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -Dtest=RestaurantApprovalAwaitMonolithTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - passed
  - `Overwriting artifact's file` count: `0`
- `./examples/csv-payments/build-monolith.sh -DskipTests -Dquarkus.container-image.build=false`
  - passed
  - `Overwriting artifact's file` count: `0`
- `./mvnw -f framework/pom.xml -pl runtime clean package -DskipTests`
  - passed
  - `Overwriting artifact's file` count: `0`
- `git diff --check`
  - passed

A first CSV run without `-Dquarkus.container-image.build=false` reached the same zero artifact-warning state, then failed later while Docker/Jib was loading the generated image with `unexpected EOF`; that is unrelated to this Maven compiler warning cleanup.

Local CodeRabbit prompt-only review was attempted, but the CLI is not authenticated in this environment, so no local review feedback was produced.
