### PR TITLE
Add aggregate await materialization guards

### DIFF
--- a/docs/guide/development/orchestrator-runtime/await.md
+++ b/docs/guide/development/orchestrator-runtime/await.md
@@ -53,6 +53,15 @@ Await has the same side-effect rule as the rest of `QUEUE_ASYNC`: orchestrator s
 
 Aggregate await shapes materialize input and/or output units in the current runtime. Do not use unbounded payloads for `ONE_TO_MANY`, `MANY_TO_ONE`, or `MANY_TO_MANY` await boundaries. If replay of a materialized multi-item output fails halfway through downstream execution, TPF restarts that output unit as a whole; it does not claim exactly-once partial stream progress inside the unit.
 
+The runtime also enforces aggregate materialization guardrails:
+
+| Config key | Default | Applies to |
+| --- | --- | --- |
+| `pipeline.orchestrator.await-aggregate-max-input-items` | `10000` | materialized input units for `MANY_TO_ONE` and `MANY_TO_MANY` await steps |
+| `pipeline.orchestrator.await-aggregate-max-output-items` | `10000` | materialized output units for `ONE_TO_MANY` and `MANY_TO_MANY` await steps |
+
+Set either value to `0` only when the application has its own upstream size control and storage budget. Prefer stable business limits at the API/file/broker boundary rather than relying on these guards as the first line of defense.
+
 Transport choice changes operational responsibility. `interaction-api` requires an API consumer to query and complete pending work. `webhook` requires stable resume-token signing and callback reachability. `kafka` requires broker channel configuration, consumer health, and response-envelope monitoring.
 
 That matters for plugin-style side effects after an await boundary. A resumed queue-async execution can replay the remainder of the pipeline after a downstream retry, so once-only side-effect checkpointing is a separate concern from await durability itself.

--- a/docs/guide/evolve/await-unit-runtime/operations-and-debt.md
+++ b/docs/guide/evolve/await-unit-runtime/operations-and-debt.md
@@ -23,7 +23,7 @@ Do not use checkpoint handoff to model a human approval, webhook callback, or br
 
 1. Await requires `QUEUE_ASYNC`.
 2. External dispatch and external side effects remain at-least-once.
-3. Aggregate await units materialize input and/or output in v1, so app developers should avoid unbounded aggregate payloads.
+3. Aggregate await units materialize input and/or output in v1. Runtime item-count guards now bound materialized input and output units by default, but architects should still avoid unbounded aggregate payloads.
 4. Replay restarts a materialized output unit as a whole; there is no exactly-once partial progress inside the unit.
 5. Transport adapters have different operational obligations: `interaction-api` needs an API consumer, `webhook` needs signed token configuration, and `kafka` needs broker channels and consumer health.
 
@@ -33,4 +33,3 @@ Do not use checkpoint handoff to model a human approval, webhook callback, or br
 2. [#305](https://github.com/The-Pipeline-Framework/pipelineframework/issues/305): template generator should scaffold union DTO/mappers for REST await outputs.
 3. [#311](https://github.com/The-Pipeline-Framework/pipelineframework/issues/311): template generator should not emit confusing inactive runtime mapping variants.
 4. [#313](https://github.com/The-Pipeline-Framework/pipelineframework/issues/313): expose await unit lifecycle in replay and observability surfaces.
-5. [#314](https://github.com/The-Pipeline-Framework/pipelineframework/issues/314): add guardrails for materialized aggregate await unit sizes.

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.awaitable;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -140,11 +141,14 @@ public class AwaitCoordinator {
 
     public Uni<AwaitCompletionResult> complete(AwaitCompletionCommand command) {
         AwaitCompletionCommand normalized = normalizeCompletionCommand(command);
-        if (normalized.resumeToken() == null) {
-            return interactionStore().complete(normalized);
-        }
         return resolveForCompletion(normalized)
+            .onItem().transformToUni(record -> enforceCompletionPayloadLimitIfUnitPresent(
+                record,
+                normalized.responsePayload()))
             .onItem().transformToUni(record -> {
+                if (normalized.resumeToken() == null) {
+                    return Uni.createFrom().item(record);
+                }
                 if (record.status().terminal() && record.status() != AwaitInteractionStatus.COMPLETED) {
                     return Uni.createFrom().failure(
                         new AwaitInteractionTerminalException("Await interaction is terminal: " + record.status()));
@@ -157,6 +161,17 @@ public class AwaitCoordinator {
                     .replaceWith(record);
             })
             .onItem().transformToUni(ignored -> interactionStore().complete(normalized));
+    }
+
+    private Uni<AwaitInteractionRecord> enforceCompletionPayloadLimitIfUnitPresent(
+        AwaitInteractionRecord record,
+        Object responsePayload
+    ) {
+        return unitStore().get(record.tenantId(), record.unitId())
+            .onItem().transform(optional -> {
+                optional.ifPresent(unit -> enforceAggregateOutputLimit(unit, responsePayload));
+                return record;
+            });
     }
 
     public Uni<AwaitUnitRecord> recordCompletion(AwaitInteractionRecord record, long nowEpochMs) {
@@ -196,7 +211,7 @@ public class AwaitCoordinator {
                     .onItem().transform(optional -> optional.orElseThrow(
                         () -> new IllegalStateException("Await interaction not found for primary interaction id "
                             + unit.primaryInteractionId())))
-                    .onItem().transform(this::coerceResumePayload);
+                    .onItem().transform(record -> enforceAggregateOutputLimit(unit, coerceResumePayload(record)));
             }
             return interactionStore().findByUnit(tenantId, unitId)
                 .onItem().transform(records -> {
@@ -412,6 +427,51 @@ public class AwaitCoordinator {
                     + " for interaction " + record.interactionId(),
                 e);
         }
+    }
+
+    private Object enforceAggregateOutputLimit(AwaitUnitRecord unit, Object payload) {
+        if (!materializedOutputCardinality(unit.cardinality())) {
+            return payload;
+        }
+        int configuredLimit = orchestratorConfig == null ? 0 : orchestratorConfig.awaitAggregateMaxOutputItems();
+        if (configuredLimit <= 0 || payload == null) {
+            return payload;
+        }
+        if (payload instanceof Iterable<?> iterable) {
+            List<Object> materialized = new ArrayList<>();
+            for (Object item : iterable) {
+                if (materialized.size() == configuredLimit) {
+                    throw aggregateOutputLimitFailure(unit, configuredLimit + 1, configuredLimit);
+                }
+                materialized.add(item);
+            }
+            return List.copyOf(materialized);
+        }
+        if (payload.getClass().isArray()) {
+            int length = java.lang.reflect.Array.getLength(payload);
+            if (length > configuredLimit) {
+                throw aggregateOutputLimitFailure(unit, length, configuredLimit);
+            }
+            return payload;
+        }
+        return payload;
+    }
+
+    private static boolean materializedOutputCardinality(String cardinality) {
+        return "ONE_TO_MANY".equalsIgnoreCase(cardinality) || "MANY_TO_MANY".equalsIgnoreCase(cardinality);
+    }
+
+    private static IllegalStateException aggregateOutputLimitFailure(
+        AwaitUnitRecord unit,
+        int observedCount,
+        int configuredLimit
+    ) {
+        return new IllegalStateException(
+            "Await unit " + unit.unitId()
+                + " materialized at least " + observedCount + " output items for "
+                + unit.cardinality()
+                + ", exceeding pipeline.orchestrator.await-aggregate-max-output-items="
+                + configuredLimit + ".");
     }
 
     private String deriveCorrelationId(

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -186,10 +186,14 @@ public class AwaitCoordinator {
                     () -> new IllegalStateException("Await unit not found for failed interaction " + record.unitId())));
         }
         Uni<Optional<AwaitUnitRecord>> updated = record.itemInteraction()
-            ? unitStore().recordItemCompleted(record.tenantId(), record.unitId(), record.interactionId(), nowEpochMs)
+            ? unitStore().recordItemCompleted(record.tenantId(), record.unitId(), itemCompletionKey(record), nowEpochMs)
             : unitStore().markCompleted(record.tenantId(), record.unitId(), nowEpochMs);
         return updated.onItem().transform(optional -> optional.orElseThrow(
             () -> new IllegalStateException("Await unit not found while recording completion: " + record.unitId())));
+    }
+
+    private static String itemCompletionKey(AwaitInteractionRecord record) {
+        return record.itemIndex() == null ? record.interactionId() : "item:" + record.itemIndex();
     }
 
     public Uni<AwaitUnitRecord> markDispatchComplete(String tenantId, String unitId, int expectedItemCount, long nowEpochMs) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -257,6 +257,7 @@ public class AwaitStepSupport {
         return new AwaitExecutionContext(context.tenantId(), context.executionId(), context.currentStepIndex());
     }
 
+    @SuppressWarnings("unchecked")
     private <I, O> Multi<O> awaitOneToOneStream(
         AwaitStepDescriptor descriptor,
         Multi<I> input,
@@ -289,20 +290,28 @@ public class AwaitStepSupport {
         return dispatched
             .collect().in(() -> Boolean.TRUE, (ignored, record) -> {
             })
-            .onItem().transformToUni(ignored -> itemIndex.get() == 0
-                ? Uni.createFrom().item(Boolean.FALSE)
-                : awaitCoordinator.markDispatchComplete(
+            .onItem().transformToMulti(ignored -> {
+                if (itemIndex.get() == 0) {
+                    return Multi.createFrom().empty();
+                }
+                return awaitCoordinator.markDispatchComplete(
                     context.tenantId(),
                     unitId,
                     itemIndex.get(),
-                    System.currentTimeMillis()).replaceWith(Boolean.TRUE))
-            .onItem().transformToMulti(dispatchedAny -> Boolean.TRUE.equals(dispatchedAny)
-                ? Uni.createFrom().<O>failure(new AwaitSuspendedException(
-                    context.tenantId(),
-                    context.executionId(),
-                    unitId,
-                    stepIndex)).toMulti()
-                : Multi.createFrom().empty());
+                    System.currentTimeMillis())
+                    .onItem().transformToMulti(unit -> unit.status() == AwaitUnitStatus.COMPLETED
+                        ? awaitCoordinator.loadResumePayload(context.tenantId(), unitId)
+                            .toMulti()
+                            .onItem().transformToMultiAndConcatenate(payload ->
+                                payload instanceof Iterable
+                                    ? Multi.createFrom().<O>iterable((Iterable<O>) payload)
+                                    : Multi.createFrom().<O>item((O) payload))
+                        : Uni.createFrom().<O>failure(new AwaitSuspendedException(
+                            context.tenantId(),
+                            context.executionId(),
+                            unitId,
+                            stepIndex)).toMulti());
+            });
     }
 
     private <T> Uni<T> withAwaitExecutionContext(AwaitExecutionContext context, java.util.function.Supplier<Uni<T>> supplier) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -176,7 +176,15 @@ public class AwaitStepSupport {
 
     private <I, O> Uni<O> awaitManyToOne(AwaitStepDescriptor descriptor, Multi<I> input, AwaitExecutionContext context) {
         return input.collect().asList()
-            .onItem().transformToUni(items -> awaitOneToOne(descriptor, List.copyOf(items), context));
+            .onItem().transformToUni(items -> {
+                List<I> materialized = List.copyOf(items);
+                enforceAggregateItemLimit(
+                    "input",
+                    descriptor,
+                    materialized.size(),
+                    orchestratorConfig.awaitAggregateMaxInputItems());
+                return awaitOneToOne(descriptor, materialized, context);
+            });
     }
 
     /**
@@ -223,7 +231,13 @@ public class AwaitStepSupport {
                 if (items.isEmpty()) {
                     return Multi.createFrom().<O>empty();
                 }
-                return this.<List<I>, Object>awaitOneToOne(descriptor, List.copyOf(items), context)
+                List<I> materialized = List.copyOf(items);
+                enforceAggregateItemLimit(
+                    "input",
+                    descriptor,
+                    materialized.size(),
+                    orchestratorConfig.awaitAggregateMaxInputItems());
+                return this.<List<I>, Object>awaitOneToOne(descriptor, materialized, context)
                     .toMulti()
                     .onItem().transformToMultiAndConcatenate(result ->
                         result instanceof Iterable
@@ -310,5 +324,22 @@ public class AwaitStepSupport {
         } else {
             AwaitExecutionContextHolder.set(previous);
         }
+    }
+
+    private static void enforceAggregateItemLimit(
+        String materializedSide,
+        AwaitStepDescriptor descriptor,
+        int itemCount,
+        int configuredLimit
+    ) {
+        if (configuredLimit <= 0 || itemCount <= configuredLimit) {
+            return;
+        }
+        throw new IllegalStateException(
+            "Await step " + descriptor.stepId()
+                + " materialized " + itemCount + " " + materializedSide
+                + " items for " + descriptor.cardinality()
+                + ", exceeding pipeline.orchestrator.await-aggregate-max-" + materializedSide
+                + "-items=" + configuredLimit + ".");
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.awaitable;
 
+import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
@@ -302,10 +303,20 @@ public class AwaitStepSupport {
                     .onItem().transformToMulti(unit -> unit.status() == AwaitUnitStatus.COMPLETED
                         ? awaitCoordinator.loadResumePayload(context.tenantId(), unitId)
                             .toMulti()
-                            .onItem().transformToMultiAndConcatenate(payload ->
-                                payload instanceof Iterable
-                                    ? Multi.createFrom().<O>iterable((Iterable<O>) payload)
-                                    : Multi.createFrom().<O>item((O) payload))
+                            .onItem().transformToMultiAndConcatenate(payload -> {
+                                if (payload instanceof Iterable) {
+                                    return Multi.createFrom().<O>iterable((Iterable<O>) payload);
+                                } else if (payload != null && payload.getClass().isArray()) {
+                                    int length = Array.getLength(payload);
+                                    O[] items = (O[]) new Object[length];
+                                    for (int i = 0; i < length; i++) {
+                                        items[i] = (O) Array.get(payload, i);
+                                    }
+                                    return Multi.createFrom().<O>items(items);
+                                } else {
+                                    return Multi.createFrom().<O>item((O) payload);
+                                }
+                            })
                         : Uni.createFrom().<O>failure(new AwaitSuspendedException(
                             context.tenantId(),
                             context.executionId(),

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -2,6 +2,7 @@ package org.pipelineframework.awaitable;
 
 import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -176,16 +177,8 @@ public class AwaitStepSupport {
     }
 
     private <I, O> Uni<O> awaitManyToOne(AwaitStepDescriptor descriptor, Multi<I> input, AwaitExecutionContext context) {
-        return input.collect().asList()
-            .onItem().transformToUni(items -> {
-                List<I> materialized = List.copyOf(items);
-                enforceAggregateItemLimit(
-                    "input",
-                    descriptor,
-                    materialized.size(),
-                    orchestratorConfig.awaitAggregateMaxInputItems());
-                return awaitOneToOne(descriptor, materialized, context);
-            });
+        return materializeAggregateInput(descriptor, input)
+            .onItem().transformToUni(materialized -> awaitOneToOne(descriptor, materialized, context));
     }
 
     /**
@@ -227,17 +220,11 @@ public class AwaitStepSupport {
 
     @SuppressWarnings("unchecked")
     private <I, O> Multi<O> awaitManyToMany(AwaitStepDescriptor descriptor, Multi<I> input, AwaitExecutionContext context) {
-        return input.collect().asList()
-            .onItem().transformToMulti(items -> {
-                if (items.isEmpty()) {
+        return materializeAggregateInput(descriptor, input)
+            .onItem().transformToMulti(materialized -> {
+                if (materialized.isEmpty()) {
                     return Multi.createFrom().<O>empty();
                 }
-                List<I> materialized = List.copyOf(items);
-                enforceAggregateItemLimit(
-                    "input",
-                    descriptor,
-                    materialized.size(),
-                    orchestratorConfig.awaitAggregateMaxInputItems());
                 return this.<List<I>, Object>awaitOneToOne(descriptor, materialized, context)
                     .toMulti()
                     .onItem().transformToMultiAndConcatenate(result ->
@@ -245,6 +232,16 @@ public class AwaitStepSupport {
                             ? Multi.createFrom().<O>iterable((Iterable<O>) result)
                             : Multi.createFrom().<O>item((O) result));
             });
+    }
+
+    private <T> Uni<List<T>> materializeAggregateInput(AwaitStepDescriptor descriptor, Multi<T> input) {
+        int configuredLimit = orchestratorConfig.awaitAggregateMaxInputItems();
+        java.util.function.Supplier<List<T>> supplier = ArrayList::new;
+        java.util.function.BiConsumer<List<T>, T> accumulator = (items, item) -> {
+            items.add(item);
+            enforceAggregateItemLimit("input", descriptor, items.size(), configuredLimit);
+        };
+        return input.collect().in(supplier, accumulator).onItem().transform(List::copyOf);
     }
 
     private AwaitExecutionContext captureExecutionContext() {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
@@ -156,6 +156,28 @@ public interface PipelineOrchestratorConfig {
     Optional<String> resumeTokenSecret();
 
     /**
+     * Maximum number of items an aggregate await step may materialize from its input stream.
+     *
+     * A value of zero disables the guard.
+     *
+     * @return max materialized input items for aggregate await units
+     */
+    @WithName("await-aggregate-max-input-items")
+    @WithDefault("10000")
+    int awaitAggregateMaxInputItems();
+
+    /**
+     * Maximum number of items an aggregate await step may replay from one materialized output unit.
+     *
+     * A value of zero disables the guard.
+     *
+     * @return max materialized output items for aggregate await units
+     */
+    @WithName("await-aggregate-max-output-items")
+    @WithDefault("10000")
+    int awaitAggregateMaxOutputItems();
+
+    /**
      * DynamoDB provider configuration.
      *
      * @return dynamo provider config

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCoordinatorCompletionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCoordinatorCompletionTest.java
@@ -158,6 +158,62 @@ class AwaitCoordinatorCompletionTest {
     }
 
     @Test
+    void retryItemInteractionWithSameIndexDoesNotOverCountAwaitUnit() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        AwaitCoordinator coordinator = coordinator(store);
+        AwaitCreateResult first = coordinator.createOrGetItem(
+            descriptor("AwaitPaymentProvider"),
+            "tenant-1",
+            "exec-1",
+            1,
+            "record-1",
+            java.util.Map.of("paymentRecordId", "record-1"),
+            "unit-1",
+            0,
+            null,
+            null).await().indefinitely();
+        AwaitCreateResult retried = coordinator.createOrGetItem(
+            descriptor("AwaitPaymentProvider"),
+            "tenant-1",
+            "exec-1",
+            1,
+            "record-1-retry",
+            java.util.Map.of("paymentRecordId", "record-1-retry"),
+            "unit-1",
+            0,
+            null,
+            null).await().indefinitely();
+
+        AwaitCompletionResult firstCompleted = coordinator.complete(new AwaitCompletionCommand(
+            "tenant-1",
+            first.record().interactionId(),
+            null,
+            "completion-1",
+            java.util.Map.of("status", "APPROVED"),
+            "provider",
+            11_000L)).await().indefinitely();
+        AwaitCompletionResult retryCompleted = coordinator.complete(new AwaitCompletionCommand(
+            "tenant-1",
+            retried.record().interactionId(),
+            null,
+            "completion-2",
+            java.util.Map.of("status", "APPROVED"),
+            "provider",
+            12_000L)).await().indefinitely();
+
+        AwaitUnitRecord afterFirst = coordinator.recordCompletion(firstCompleted.record(), 11_000L).await().indefinitely();
+        AwaitUnitRecord afterRetry = coordinator.recordCompletion(retryCompleted.record(), 12_000L).await().indefinitely();
+        AwaitUnitRecord completed = coordinator.markDispatchComplete("tenant-1", "unit-1", 1, 13_000L).await().indefinitely();
+
+        assertFalse(firstCompleted.duplicate());
+        assertFalse(retryCompleted.duplicate());
+        assertEquals(1, afterFirst.completedItemCount());
+        assertEquals(1, afterRetry.completedItemCount());
+        assertEquals(1, completed.completedItemCount());
+        assertEquals(AwaitUnitStatus.COMPLETED, completed.status());
+    }
+
+    @Test
     void staleTerminalInteractionIsRejectedBeforeTokenCompletion() {
         InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
         AwaitCoordinator coordinator = coordinator(store);

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCoordinatorCompletionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCoordinatorCompletionTest.java
@@ -20,6 +20,7 @@ import org.pipelineframework.awaitable.spi.AwaitInteractionStore;
 import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
 import org.pipelineframework.awaitable.store.InMemoryAwaitInteractionStore;
 import org.pipelineframework.awaitable.store.InMemoryAwaitUnitStore;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 
 class AwaitCoordinatorCompletionTest {
 
@@ -255,12 +256,59 @@ class AwaitCoordinatorCompletionTest {
         assertEquals("approval.proto", ((DescriptorProtos.FileDescriptorProto) payload).getName());
     }
 
+    @Test
+    void completeRejectsOversizedMaterializedOutputUnit() {
+        InMemoryAwaitInteractionStore store = new InMemoryAwaitInteractionStore();
+        PipelineOrchestratorConfig config = org.mockito.Mockito.mock(PipelineOrchestratorConfig.class);
+        org.mockito.Mockito.when(config.awaitAggregateMaxOutputItems()).thenReturn(1);
+        AwaitCoordinator coordinator = coordinator(store, config);
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "BatchApproval",
+            List.class.getName(),
+            List.class.getName(),
+            "MANY_TO_MANY",
+            java.time.Duration.ofMinutes(10),
+            "interactionId",
+            "interaction-api",
+            Map.of(),
+            List.of());
+
+        AwaitCreateResult created = coordinator.createOrGet(
+            descriptor,
+            "tenant-1",
+            "exec-1",
+            1,
+            "cause-1",
+            List.of("input-a", "input-b"),
+            null,
+            null).await().indefinitely();
+        AwaitCompletionCommand completion = new AwaitCompletionCommand(
+            "tenant-1",
+            created.record().interactionId(),
+            null,
+            "completion-1",
+            List.of("output-a", "output-b"),
+            "alice",
+            11_000L);
+
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            () -> coordinator.complete(completion).await().indefinitely());
+
+        assertTrue(error.getMessage().contains("pipeline.orchestrator.await-aggregate-max-output-items=1"));
+    }
+
     private static AwaitCoordinator coordinator(InMemoryAwaitInteractionStore store) {
+        return coordinator(store, null);
+    }
+
+    private static AwaitCoordinator coordinator(InMemoryAwaitInteractionStore store, PipelineOrchestratorConfig config) {
         AwaitCoordinator coordinator = new AwaitCoordinator();
         coordinator.interactionStores = new SimpleInstance<>(List.<AwaitInteractionStore>of(store));
         coordinator.unitStores = new SimpleInstance<>(List.of(new InMemoryAwaitUnitStore()));
         coordinator.adapters = new SimpleInstance<>(List.<AwaitTransportAdapter<?>>of());
         coordinator.resumeTokenService = new AwaitResumeTokenService("secret-value-for-tests");
+        coordinator.orchestratorConfig = config;
         return coordinator;
     }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -271,6 +271,33 @@ class AwaitStepSupportTest {
             any(), any(), any(), anyInt(), any(), any(), any(), anyInt(), any(), any());
     }
 
+    @Test
+    void awaitManyToOneRejectsOversizedMaterializedInput() {
+        AwaitStepSupport support = support();
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.awaitAggregateMaxInputItems()).thenReturn(1);
+        AwaitExecutionContextHolder.set(new AwaitExecutionContext("tenant1", "exec123", 6));
+        AwaitStepDescriptor testDescriptor = new AwaitStepDescriptor(
+            "batch-review",
+            String.class.getName(),
+            String.class.getName(),
+            "MANY_TO_ONE",
+            Duration.ofMinutes(5),
+            "signedResumeToken",
+            "kafka",
+            Map.of(),
+            List.of());
+
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            () -> support.awaitManyToOne(testDescriptor, Multi.createFrom().items("first", "second"))
+                .await().indefinitely());
+
+        assertTrue(error.getMessage().contains("pipeline.orchestrator.await-aggregate-max-input-items=1"));
+        org.mockito.Mockito.verify(awaitCoordinator, never()).createOrGet(
+            any(), any(), any(), anyInt(), any(), any(), any(), any());
+    }
+
     private AwaitStepSupport support() {
         AwaitStepSupport support = new AwaitStepSupport();
         support.orchestratorConfig = orchestratorConfig;

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.pipelineframework.orchestrator.OrchestratorMode;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -212,6 +213,73 @@ class AwaitStepSupportTest {
             () -> support.awaitOneToOneStream(testDescriptor, Multi.createFrom().items("first", "second"))
                 .collect().asList()
                 .await().indefinitely());
+    }
+
+    @Test
+    void awaitOneToOneStreamContinuesWhenUnitCompletesBeforeSuspensionIsPersisted() {
+        AwaitStepSupport support = support();
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        AwaitExecutionContextHolder.set(new AwaitExecutionContext("tenant1", "exec123", 2));
+
+        AwaitStepDescriptor testDescriptor = descriptor();
+        when(awaitCoordinator.createOrGetItem(
+            org.mockito.ArgumentMatchers.eq(testDescriptor),
+            org.mockito.ArgumentMatchers.eq("tenant1"),
+            org.mockito.ArgumentMatchers.eq("exec123"),
+            org.mockito.ArgumentMatchers.eq(2),
+            any(),
+            any(),
+            any(),
+            anyInt(),
+            org.mockito.ArgumentMatchers.isNull(),
+            org.mockito.ArgumentMatchers.isNull()))
+            .thenAnswer(invocation -> {
+                Integer index = invocation.getArgument(7, Integer.class);
+                AwaitInteractionRecord record = new AwaitInteractionRecord(
+                    "tenant1", "exec123", "review", 2, String.class.getName(),
+                    "interaction-" + index, "correlation-" + index, "causation-" + index, "idem-" + index,
+                    0L, AwaitInteractionStatus.WAITING,
+                    invocation.getArgument(5), null, invocation.getArgument(6), index, null,
+                    null, null,
+                    "interaction-api", Map.of(), System.currentTimeMillis() + 300000, System.currentTimeMillis(),
+                    System.currentTimeMillis(), System.currentTimeMillis() + 86400);
+                return Uni.createFrom().item(new AwaitCreateResult(record, false));
+            });
+        when(awaitCoordinator.dispatch(org.mockito.ArgumentMatchers.eq(testDescriptor), any()))
+            .thenAnswer(invocation -> Uni.createFrom().item(invocation.getArgument(1, AwaitInteractionRecord.class)));
+        when(awaitCoordinator.markDispatchComplete(
+            org.mockito.ArgumentMatchers.eq("tenant1"),
+            org.mockito.ArgumentMatchers.anyString(),
+            anyInt(),
+            anyLong()))
+            .thenAnswer(invocation -> Uni.createFrom().item(new AwaitUnitRecord(
+                "tenant1",
+                invocation.getArgument(1, String.class),
+                "exec123",
+                testDescriptor.stepId(),
+                2,
+                testDescriptor.cardinality(),
+                1L,
+                AwaitUnitStatus.COMPLETED,
+                null,
+                2,
+                2,
+                true,
+                System.currentTimeMillis(),
+                System.currentTimeMillis(),
+                System.currentTimeMillis() + 86400)));
+        when(awaitCoordinator.loadResumePayload(
+            org.mockito.ArgumentMatchers.eq("tenant1"),
+            org.mockito.ArgumentMatchers.anyString()))
+            .thenReturn(Uni.createFrom().item(List.of("approved-first", "approved-second")));
+
+        List<String> output = support.<String, String>awaitOneToOneStream(
+                testDescriptor,
+                Multi.createFrom().items("first", "second"))
+            .collect().asList()
+            .await().indefinitely();
+
+        assertEquals(List.of("approved-first", "approved-second"), output);
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfigTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfigTest.java
@@ -44,6 +44,8 @@ class PipelineOrchestratorConfigTest {
         assertFalse(config.queueUrl().isPresent());
         assertFalse(config.dlqUrl().isPresent());
         assertFalse(config.resumeTokenSecret().isPresent());
+        assertEquals(10000, config.awaitAggregateMaxInputItems());
+        assertEquals(10000, config.awaitAggregateMaxOutputItems());
     }
 
     @ParameterizedTest(name = "{index} => {0}={1}")
@@ -172,6 +174,16 @@ class PipelineOrchestratorConfigTest {
                     assertTrue(secret.isPresent());
                     assertEquals("test-secret", secret.get());
                 }),
+            Arguments.of(
+                "pipeline.orchestrator.await-aggregate-max-input-items",
+                "500",
+                (Consumer<PipelineOrchestratorConfig>) config ->
+                    assertEquals(500, config.awaitAggregateMaxInputItems())),
+            Arguments.of(
+                "pipeline.orchestrator.await-aggregate-max-output-items",
+                "250",
+                (Consumer<PipelineOrchestratorConfig>) config ->
+                    assertEquals(250, config.awaitAggregateMaxOutputItems())),
             Arguments.of(
                 "pipeline.orchestrator.strict-startup",
                 "false",


### PR DESCRIPTION
Closes #314.

## Summary
- Adds runtime config guardrails for aggregate await materialization sizes.
- Enforces materialized input limits for `MANY_TO_ONE` and `MANY_TO_MANY` await steps before dispatch.
- Enforces materialized output limits for `ONE_TO_MANY` and `MANY_TO_MANY` await units during completion admission and resume payload loading.
- Documents the new defaults and removes #314 from the await-unit debt list.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=AwaitStepSupportTest,AwaitCoordinatorCompletionTest,PipelineOrchestratorConfigTest test`
- `npm --prefix docs run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime guardrails for aggregate await operations with two configurable limits: pipeline.orchestrator.await-aggregate-max-input-items and pipeline.orchestrator.await-aggregate-max-output-items (defaults: 10,000). Limits can be disabled by setting to 0. Oversized materialised inputs/outputs now fail with a clear error.

* **Documentation**
  * Clarified guidance on materialisation limits, applicable await cardinalities, default enforcement, and safe configuration practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->