### PR TITLE
[codex] Disambiguate deterministic ID null parts

### DIFF
--- a/examples/checkout/common/src/main/java/org/pipelineframework/tpfgo/common/util/DeterministicIds.java
+++ b/examples/checkout/common/src/main/java/org/pipelineframework/tpfgo/common/util/DeterministicIds.java
@@ -10,10 +10,15 @@ public final class DeterministicIds {
 
     public static UUID uuid(String namespace, String... parts) {
         StringBuilder seed = new StringBuilder(namespace == null ? "tpfgo" : namespace);
-        if (parts != null) {
-            for (String part : parts) {
-                seed.append('|').append(part == null ? "" : part);
+        if (parts == null) {
+            throw new NullPointerException("parts must not be null");
+        }
+        for (int index = 0; index < parts.length; index++) {
+            String part = parts[index];
+            if (part == null) {
+                throw new NullPointerException("parts[" + index + "] must not be null");
             }
+            seed.append('|').append(part);
         }
         return UUID.nameUUIDFromBytes(seed.toString().getBytes(StandardCharsets.UTF_8));
     }

--- a/examples/checkout/common/src/test/java/org/pipelineframework/tpfgo/common/util/DeterministicIdsTest.java
+++ b/examples/checkout/common/src/test/java/org/pipelineframework/tpfgo/common/util/DeterministicIdsTest.java
@@ -3,6 +3,7 @@ package org.pipelineframework.tpfgo.common.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
 
@@ -39,10 +40,11 @@ class DeterministicIdsTest {
     }
 
     @Test
-    void nullPartsTreatedAsEmptyString() {
-        UUID withNull = DeterministicIds.uuid("ns", (String) null);
-        UUID withEmpty = DeterministicIds.uuid("ns", "");
-        assertEquals(withNull, withEmpty);
+    void nullPartElementFailsFast() {
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> DeterministicIds.uuid("ns", "a", null));
+        assertEquals("parts[1] must not be null", exception.getMessage());
     }
 
     @Test
@@ -53,10 +55,11 @@ class DeterministicIdsTest {
     }
 
     @Test
-    void nullPartsArrayProducesStableUuid() {
-        UUID first = DeterministicIds.uuid("order", (String[]) null);
-        UUID second = DeterministicIds.uuid("order", (String[]) null);
-        assertEquals(first, second);
+    void nullPartsArrayFailsFast() {
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> DeterministicIds.uuid("order", (String[]) null));
+        assertEquals("parts must not be null", exception.getMessage());
     }
 
     @Test
@@ -86,7 +89,7 @@ class DeterministicIdsTest {
     void emptyPartsDistinguishFromNoArgs() {
         UUID withEmptyPart = DeterministicIds.uuid("ns", "");
         UUID noArgs = DeterministicIds.uuid("ns");
-        // May or may not be equal depending on implementation; the key property is stability
+        assertNotEquals(withEmptyPart, noArgs);
         assertEquals(withEmptyPart, DeterministicIds.uuid("ns", ""));
         assertEquals(noArgs, DeterministicIds.uuid("ns"));
     }


### PR DESCRIPTION
## Summary
- reject null deterministic ID part arrays and null part elements instead of encoding them as empty strings
- preserve the null namespace fallback and existing UUID values for non-null seed inputs
- lock empty-string parts as distinct from no parts

Closes #241

## Validation
- `./mvnw -f examples/checkout/pom.xml -pl common -Dtest=DeterministicIdsTest test`
- `./mvnw -f examples/checkout/pom.xml -pl common -Dtest='DeterministicIdsTest,GrpcMappingSupportTest,CanonicalTpfgoModelTest' test`