### PR TITLE
Fix csv-payments image build regression

### DIFF
--- a/examples/csv-payments/build-modular-observability-images.sh
+++ b/examples/csv-payments/build-modular-observability-images.sh
@@ -33,10 +33,23 @@ cp "$MODULAR_MAPPING" "$ACTIVE_MAPPING"
 cd "$ROOT_DIR"
 
 IMAGE_TAG="${CSV_E2E_OBSERVABILITY_IMAGE_TAG:-observability}"
+case "$(uname -m)" in
+  x86_64|amd64)
+    DEFAULT_IMAGE_PLATFORMS="linux/amd64"
+    ;;
+  arm64|aarch64)
+    DEFAULT_IMAGE_PLATFORMS="linux/arm64/v8"
+    ;;
+  *)
+    DEFAULT_IMAGE_PLATFORMS="linux/amd64"
+    ;;
+esac
+IMAGE_PLATFORMS="${CSV_E2E_IMAGE_PLATFORMS:-$DEFAULT_IMAGE_PLATFORMS}"
 
 ./mvnw -f examples/csv-payments/pom.xml -DskipTests clean package \
   -Dtpf.build.transport=GRPC \
   -Dquarkus.container-image.tag="${IMAGE_TAG}" \
+  -Dquarkus.container-image.platforms="${IMAGE_PLATFORMS}" \
   -Dquarkus.otel.enabled=true \
   -Dquarkus.otel.sdk.disabled=false \
   -Dquarkus.otel.metrics.enabled=false \

--- a/examples/csv-payments/build-modular-telemetry-images.sh
+++ b/examples/csv-payments/build-modular-telemetry-images.sh
@@ -35,10 +35,23 @@ cp "$MODULAR_MAPPING" "$ACTIVE_MAPPING"
 cd "$ROOT_DIR"
 
 IMAGE_TAG="${CSV_E2E_TELEMETRY_IMAGE_TAG:-otel}"
+case "$(uname -m)" in
+  x86_64|amd64)
+    DEFAULT_IMAGE_PLATFORMS="linux/amd64"
+    ;;
+  arm64|aarch64)
+    DEFAULT_IMAGE_PLATFORMS="linux/arm64/v8"
+    ;;
+  *)
+    DEFAULT_IMAGE_PLATFORMS="linux/amd64"
+    ;;
+esac
+IMAGE_PLATFORMS="${CSV_E2E_IMAGE_PLATFORMS:-$DEFAULT_IMAGE_PLATFORMS}"
 
 ./mvnw -f examples/csv-payments/pom.xml -DskipTests clean package \
   -Dtpf.build.transport=GRPC \
   -Dquarkus.container-image.tag="${IMAGE_TAG}" \
+  -Dquarkus.container-image.platforms="${IMAGE_PLATFORMS}" \
   -Dquarkus.otel.enabled=true \
   -Dquarkus.otel.sdk.disabled=false \
   -Dquarkus.otel.metrics.enabled=false \

--- a/examples/csv-payments/input-csv-file-processing-svc/pom.xml
+++ b/examples/csv-payments/input-csv-file-processing-svc/pom.xml
@@ -42,6 +42,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.pipelineframework</groupId>
+            <artifactId>pipelineframework</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.36</version>


### PR DESCRIPTION
## Summary
- Default csv-payments modular telemetry/observability image helpers to a single host platform instead of always inheriting the multi-platform project default.
- Keep intentional multi-platform image builds available through `CSV_E2E_IMAGE_PLATFORMS`.
- Add the direct runtime dependency needed by `input-csv-file-processing-svc` now that it imports the framework `BlockingIteratorPacer` API.

## CI regression
The failed job was `CSV Provider Reject Replay E2E` in run `26880808988`, job `79280103153`. It failed before tests while running `./examples/csv-payments/build-modular-telemetry-images.sh`, with Jib throwing `java.nio.channels.OverlappingFileLockException` during base image layer cache metadata writes. The project default image platforms are `linux/amd64,linux/arm64/v8`, which makes this local E2E helper do unnecessary multi-platform Jib work.

## Validation
- `bash -n examples/csv-payments/build-modular-telemetry-images.sh`
- `bash -n examples/csv-payments/build-modular-observability-images.sh`
- `git diff --check`
- `MAVEN_ARGS='-B -T 1C -V -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.parallel=none -Dfailsafe.parallel=none --no-transfer-progress -Dmaven.repo.local=/tmp/tpf-ci-m2-jib-lock' ./scripts/ci/bootstrap-local-repo-prereqs.sh framework`
- `./examples/csv-payments/build-modular-telemetry-images.sh -Dmaven.repo.local=/tmp/tpf-ci-m2-jib-lock -Dquarkus.container-image.build=false`
- `./mvnw -f examples/csv-payments/pom.xml -pl input-csv-file-processing-svc -am -Dtest='ProcessCsvPaymentsInputServiceTest,DemandPacerConfigTest' -Dsurefire.failIfNoSpecifiedTests=false -Dquarkus.container-image.build=false -Dmaven.repo.local=/tmp/tpf-ci-m2-jib-lock test`
- `./examples/csv-payments/build-modular-telemetry-images.sh -Dmaven.repo.local=/tmp/tpf-ci-m2-jib-lock`
