### PR TITLE
[codex] Scope replay viewer route background

### DIFF
--- a/docs/replay-viewer/index.md
+++ b/docs/replay-viewer/index.md
@@ -15,19 +15,12 @@ if (typeof window !== "undefined") {
 </div>
 
 <style>
-html,
-body,
-#app {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  background: #07101f;
-}
-
 .replay-viewer-route {
-  min-height: 100%;
+  min-height: 100vh;
   display: grid;
   place-items: center;
+  margin: 0;
+  background: #07101f;
   color: #f8fbff;
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
 }


### PR DESCRIPTION
## Summary
- Scope the dark replay-viewer fallback route background to `.replay-viewer-route` instead of `html, body, #app`
- Prevent the standalone replay-viewer route CSS from making the docs homepage dark in light mode

## Validation
- `npm --prefix docs run build`
- Verified built CSS no longer contains the global `html, body, #app` dark background leak


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated replay viewer styling to ensure full-height display with proper spacing and background color consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->