### PR TITLE
Support externalized module endpoint config

### DIFF
--- a/docs/guide/build/configuration/index.md
+++ b/docs/guide/build/configuration/index.md
@@ -107,8 +107,8 @@ To override routing or ports, set the following in `application.properties`:
 
 | Property                                 | Type   | Default | Description                                       |
 |------------------------------------------|--------|---------|---------------------------------------------------|
-| `pipeline.module.<module>.host`          | string | none    | Host for a module (applies to all its services).  |
-| `pipeline.module.<module>.port`          | int    | none    | Port for a module (applies to all its services).  |
+| `pipeline.module.<module>.host`          | string | none    | Host for a module; Quarkus config expressions are preserved. |
+| `pipeline.module.<module>.port`          | int or expression | none    | Port for a module; literal values are validated and Quarkus config expressions are preserved. |
 | `pipeline.module.<module>.steps`         | list   | none    | Comma/space-separated client names to assign.     |
 | `pipeline.module.<module>.aspects`       | list   | none    | Aspect names to assign (e.g. `persistence`).      |
 | `pipeline.client.base-port`              | int    | `8443`  | Base port used when assigning per-module offsets. |
@@ -125,6 +125,7 @@ About modules:
 
 Avoiding drift:
 - Keep server ports and orchestrator client ports aligned by sourcing them from the same `pipeline.module.<module>.port` or shared environment variables.
+- For deployment-specific endpoints, use Quarkus/MicroProfile config expressions such as `pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}` and `pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}`.
 - If you override a client endpoint directly, verify the corresponding server listens on the same host/port (especially when TLS is enabled).
 
 If you need to override a single client endpoint, set the Quarkus property directly:

--- a/examples/checkout/checkout-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/checkout-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/checkout-orchestrator-svc/src/test/java/org/pipelineframework/tpfgo/checkout/orchestrator/TpfgoPipelineRuntimeTopologyTest.java
+++ b/examples/checkout/checkout-orchestrator-svc/src/test/java/org/pipelineframework/tpfgo/checkout/orchestrator/TpfgoPipelineRuntimeTopologyTest.java
@@ -3,6 +3,7 @@ package org.pipelineframework.tpfgo.checkout.orchestrator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,11 +53,14 @@ class TpfgoPipelineRuntimeTopologyTest {
                 .map(clientId -> properties.getProperty(prefix + clientId + ".port"))
                 .collect(Collectors.toSet());
 
-            assertEquals(Set.of("127.0.0.1"), hosts, "Grouped runtime clients should target the shared runtime host");
-            assertEquals(Set.of("9000"), ports, "Grouped runtime clients should share the configured runtime port");
+            assertEquals(Set.of("${PIPELINE_RUNTIME_HOST:127.0.0.1}"), hosts,
+                "Grouped runtime clients should preserve the externalized runtime host");
+            assertEquals(Set.of("${PIPELINE_RUNTIME_GRPC_PORT:9000}"), ports,
+                "Grouped runtime clients should preserve the externalized runtime port");
             assertFalse(properties.stringPropertyNames().stream().anyMatch(name -> name.contains("tpfgo.checkout.order-pending.v1")),
                 "Checkpoint publication bindings should not appear in orchestrator client metadata");
             assertRuntimeMappingActive();
+            assertPipelineRuntimePortMatchesClientPort();
         }
     }
 
@@ -89,6 +93,33 @@ class TpfgoPipelineRuntimeTopologyTest {
             return parent;
         }
         fail("Could not resolve examples/checkout/config/pipeline.runtime.yaml");
+        return Path.of(".");
+    }
+
+    private static void assertPipelineRuntimePortMatchesClientPort() throws IOException {
+        Path configPath = resolveCheckoutRoot()
+            .resolve("pipeline-runtime-svc")
+            .resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("application.properties");
+        String content = Files.readString(configPath);
+        assertTrue(content.contains("quarkus.http.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}"),
+            "pipeline-runtime-svc should listen on the same externalized port used by generated clients");
+        assertTrue(content.contains("quarkus.grpc.server.use-separate-server=false"),
+            "pipeline-runtime-svc should keep gRPC bound to the HTTP listener port");
+    }
+
+    private static Path resolveCheckoutRoot() {
+        Path userDir = Path.of(System.getProperty("user.dir", ".")).normalize();
+        if (Files.exists(userDir.resolve("pipeline-runtime-svc"))) {
+            return userDir;
+        }
+        Path parent = userDir.resolve("..").normalize();
+        if (Files.exists(parent.resolve("pipeline-runtime-svc"))) {
+            return parent;
+        }
+        fail("Could not resolve examples/checkout project root");
         return Path.of(".");
     }
 }

--- a/examples/checkout/compensation-failure-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/compensation-failure-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/consumer-validation-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/consumer-validation-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/delivery-execution-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/delivery-execution-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/dispatch-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/dispatch-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/kitchen-preparation-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/kitchen-preparation-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/payment-capture-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/payment-capture-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/examples/checkout/pipeline-runtime-svc/src/main/resources/application.properties
+++ b/examples/checkout/pipeline-runtime-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.http.port=9000
+quarkus.http.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}
 quarkus.grpc.server.use-separate-server=false
 pipeline.health.enabled=false
 

--- a/examples/checkout/restaurant-acceptance-orchestrator-svc/src/main/resources/application.properties
+++ b/examples/checkout/restaurant-acceptance-orchestrator-svc/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 pipeline.orchestrator.mode=QUEUE_ASYNC
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
-pipeline.module.pipeline-runtime-svc.host=127.0.0.1
-pipeline.module.pipeline-runtime-svc.port=9000
+pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientModuleMapping.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientModuleMapping.java
@@ -113,7 +113,7 @@ public class OrchestratorClientModuleMapping {
                 switch (field) {
                     case "host" -> modules.put(moduleName, new ModuleConfig(moduleName, rawValue, existing.port()));
                     case "port" -> {
-                        Integer port = parsePort(rawValue, moduleName, env);
+                        String port = parsePortValue(rawValue, moduleName, env);
                         modules.put(moduleName, new ModuleConfig(moduleName, existing.host(), port));
                     }
                     case "steps" -> {
@@ -203,7 +203,7 @@ public class OrchestratorClientModuleMapping {
         for (int i = 0; i < moduleOrder.size(); i++) {
             String name = moduleOrder.get(i);
             ModuleConfig config = resolved.getOrDefault(name, new ModuleConfig(name));
-            int port = config.port() != null ? config.port() : basePort + i + 1;
+            String port = config.port() != null ? config.port() : String.valueOf(basePort + i + 1);
             String host = config.host() != null && !config.host().isBlank() ? config.host() : DEFAULT_HOST;
             resolved.put(name, new ModuleConfig(name, host, port));
         }
@@ -302,12 +302,17 @@ public class OrchestratorClientModuleMapping {
         return new ClientConfig(normalized, module.host(), module.port(), tlsConfigurationName);
     }
 
-    private static Integer parsePort(String value, String moduleName, ProcessingEnvironment env) {
+    private static String parsePortValue(String value, String moduleName, ProcessingEnvironment env) {
         if (value == null || value.isBlank()) {
             return null;
         }
+        String trimmed = value.trim();
+        if (isConfigExpression(trimmed)) {
+            return trimmed;
+        }
         try {
-            return Integer.parseInt(value.trim());
+            Integer.parseInt(trimmed);
+            return trimmed;
         } catch (NumberFormatException e) {
             if (env != null) {
                 env.getMessager().printMessage(javax.tools.Diagnostic.Kind.WARNING,
@@ -315,6 +320,10 @@ public class OrchestratorClientModuleMapping {
             }
             return null;
         }
+    }
+
+    private static boolean isConfigExpression(String value) {
+        return value.startsWith("${") && value.endsWith("}");
     }
 
     private static List<String> splitList(String rawValue) {
@@ -368,9 +377,9 @@ public class OrchestratorClientModuleMapping {
      *
      * @param name module name
      * @param host module host (nullable)
-     * @param port module port (nullable)
+     * @param port module port property value (nullable)
      */
-    public record ModuleConfig(String name, String host, Integer port) {
+    public record ModuleConfig(String name, String host, String port) {
         /**
          * Create a module config with only a name, leaving host and port unset.
          *
@@ -386,9 +395,9 @@ public class OrchestratorClientModuleMapping {
      *
      * @param name client name
      * @param host module host
-     * @param port module port
+     * @param port module port property value
      * @param tlsConfigurationName optional TLS configuration name
      */
-    public record ClientConfig(String name, String host, int port, String tlsConfigurationName) {
+    public record ClientConfig(String name, String host, String port, String tlsConfigurationName) {
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientPropertiesGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientPropertiesGenerator.java
@@ -395,7 +395,7 @@ public class OrchestratorClientPropertiesGenerator {
             writer.append("quarkus.grpc.clients.").append(client.name()).append(".host=")
                 .append(client.host()).append("\n");
             writer.append("quarkus.grpc.clients.").append(client.name()).append(".port=")
-                .append(String.valueOf(client.port())).append("\n");
+                .append(client.port()).append("\n");
             writer.append("quarkus.grpc.clients.").append(client.name())
                 .append(".use-quarkus-grpc-client=true\n");
             if (client.tlsConfigurationName() != null) {
@@ -447,7 +447,7 @@ public class OrchestratorClientPropertiesGenerator {
             writer.append("quarkus.grpc.clients.").append(client.name()).append(".host=")
                 .append(client.host()).append("\n");
             writer.append("quarkus.grpc.clients.").append(client.name()).append(".port=")
-                .append(String.valueOf(client.port())).append("\n");
+                .append(client.port()).append("\n");
             writer.append("quarkus.grpc.clients.").append(client.name())
                 .append(".use-quarkus-grpc-client=true\n");
             if (client.tlsConfigurationName() != null) {
@@ -512,7 +512,7 @@ public class OrchestratorClientPropertiesGenerator {
             }
             writer.append("\n# Talk to ").append(client.name()).append(" service\n");
             writer.append("quarkus.rest-client.").append(client.name()).append(".url=https://")
-                .append(client.host()).append(":").append(String.valueOf(client.port())).append("\n");
+                .append(client.host()).append(":").append(client.port()).append("\n");
             if (client.tlsConfigurationName() != null) {
                 String tlsDefault = client.tlsConfigurationName();
                 String tlsExpression = "${pipeline.client.tls-configuration-name:" + tlsDefault + "}";

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java
@@ -83,7 +83,16 @@ class OrchestratorClientGenerationTest {
         Path projectRoot = initProjectRoot();
         Path moduleDir = projectRoot.resolve("test-module");
         Path generatedSourcesDir = moduleDir.resolve("target").resolve("generated-sources").resolve("pipeline");
+        Path moduleResourcesDir = moduleDir.resolve("src").resolve("main").resolve("resources");
         Files.createDirectories(generatedSourcesDir);
+        Files.createDirectories(moduleResourcesDir);
+
+        String moduleOverrides = """
+            pipeline.module.search-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+            pipeline.module.search-svc.port=${PIPELINE_RUNTIME_PORT:9000}
+            pipeline.module.search-svc.steps=process-crawl-source
+            """;
+        Files.writeString(moduleResourcesDir.resolve("application.properties"), moduleOverrides);
 
         Files.copy(resourcePath("pipeline-search.yaml"), projectRoot.resolve("pipeline.yaml"));
 
@@ -127,6 +136,14 @@ class OrchestratorClientGenerationTest {
         Path orchestratorClientDir = generatedSourcesDir.resolve("orchestrator-client");
         assertTrue(hasGeneratedClass(orchestratorClientDir, "ProcessCrawlSourceRestClientStep"));
         assertTrue(hasGeneratedClass(orchestratorClientDir, "PersistenceRawDocumentSideEffectRestClientStep"));
+
+        JavaFileObject propertiesFile = compilation.generatedFile(
+            StandardLocation.CLASS_OUTPUT,
+            "META-INF/pipeline",
+            "orchestrator-clients.properties").orElseThrow();
+        String propertiesContent = propertiesFile.getCharContent(true).toString();
+        assertTrue(propertiesContent.contains(
+            "quarkus.rest-client.process-crawl-source.url=https://${PIPELINE_RUNTIME_HOST:127.0.0.1}:${PIPELINE_RUNTIME_PORT:9000}"));
     }
 
     @Test
@@ -200,6 +217,83 @@ class OrchestratorClientGenerationTest {
             "quarkus.grpc.clients.process-parse-document.port=8444"));
         assertTrue(propertiesContent.contains(
             "tls-configuration-name=${pipeline.client.tls-configuration-name:pipeline-client}"));
+    }
+
+    @Test
+    void preservesExternalizedModuleEndpointExpressions() throws IOException {
+        Path projectRoot = initProjectRoot();
+        Path moduleDir = projectRoot.resolve("test-module");
+        Path generatedSourcesDir = moduleDir.resolve("target").resolve("generated-sources").resolve("pipeline");
+        Path moduleResourcesDir = moduleDir.resolve("src").resolve("main").resolve("resources");
+        Files.createDirectories(generatedSourcesDir);
+        Files.createDirectories(moduleResourcesDir);
+
+        String moduleOverrides = """
+            pipeline.module.pipeline-runtime-svc.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}
+            pipeline.module.pipeline-runtime-svc.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}
+            pipeline.module.pipeline-runtime-svc.steps=process-crawl-source
+            pipeline.module.invalid-svc.port=not-a-port
+            pipeline.module.invalid-svc.steps=process-parse-document
+            """;
+        Files.writeString(moduleResourcesDir.resolve("application.properties"), moduleOverrides);
+
+        Path pipelineYaml = projectRoot.resolve("pipeline.yaml");
+        String pipelineConfig = Files.readString(resourcePath("pipeline-search.yaml"))
+            .replace("transport: \"REST\"", "transport: \"GRPC\"");
+        Files.writeString(pipelineYaml, stripAspectsSection(pipelineConfig));
+
+        Compilation compilation = Compiler.javac()
+            .withProcessors(new PipelineStepProcessor())
+            .withOptions(
+                "-Apipeline.generatedSourcesDir=" + generatedSourcesDir,
+                "-Aprotobuf.descriptor.file=" + resourcePath("descriptor_set_search.dsc"))
+            .compile(
+                JavaFileObjects.forSourceString(
+                    "org.example.OrchestratorMarker",
+                    """
+                        package org.example;
+
+                        import org.pipelineframework.annotation.PipelineOrchestrator;
+
+                        @PipelineOrchestrator
+                        public class OrchestratorMarker {
+                        }
+                        """),
+                searchServiceStub("ProcessCrawlSourceService", "CrawlRequest", "RawDocument"),
+                searchServiceStub("ProcessParseDocumentService", "RawDocument", "ParsedDocument"),
+                searchServiceStub("ProcessTokenizeContentService", "ParsedDocument", "TokenBatch"),
+                searchServiceStub("ProcessIndexDocumentService", "TokenBatch", "IndexAck"),
+                domainStub("CrawlRequest"),
+                domainStub("RawDocument"),
+                domainStub("ParsedDocument"),
+                domainStub("TokenBatch"),
+                domainStub("IndexAck"),
+                dtoStub("CrawlRequestDto"),
+                dtoStub("RawDocumentDto"),
+                dtoStub("ParsedDocumentDto"),
+                dtoStub("TokenBatchDto"),
+                dtoStub("IndexAckDto"),
+                mapperStub("CrawlRequestMapper", "CrawlRequest", "CrawlRequestDto"),
+                mapperStub("RawDocumentMapper", "RawDocument", "RawDocumentDto"),
+                mapperStub("ParsedDocumentMapper", "ParsedDocument", "ParsedDocumentDto"),
+                mapperStub("TokenBatchMapper", "TokenBatch", "TokenBatchDto"),
+                mapperStub("IndexAckMapper", "IndexAck", "IndexAckDto"));
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation).hadWarningContaining("Invalid port for module 'invalid-svc'");
+
+        JavaFileObject propertiesFile = compilation.generatedFile(
+            StandardLocation.CLASS_OUTPUT,
+            "META-INF/pipeline",
+            "orchestrator-clients.properties").orElseThrow();
+        String propertiesContent = propertiesFile.getCharContent(true).toString();
+
+        assertTrue(propertiesContent.contains(
+            "quarkus.grpc.clients.process-crawl-source.host=${PIPELINE_RUNTIME_HOST:127.0.0.1}"));
+        assertTrue(propertiesContent.contains(
+            "quarkus.grpc.clients.process-crawl-source.port=${PIPELINE_RUNTIME_GRPC_PORT:9000}"));
+        assertTrue(propertiesContent.contains(
+            "quarkus.grpc.clients.process-parse-document.port=8445"));
     }
 
     private Path initProjectRoot() throws IOException {


### PR DESCRIPTION
## Summary
- Preserve Quarkus/MicroProfile config expressions in `pipeline.module.<module>.host` and `pipeline.module.<module>.port` when generating orchestrator client properties.
- Keep literal port validation and fallback behavior for invalid non-expression values.
- Externalize the checkout pipeline-runtime module endpoint defaults through env-backed expressions.
- Document expression support for module host/port config.

Closes #242.

## Notes
This does not revive legacy connector concepts. Current code rejects top-level `connectors:` config; old connector follow-ups should be closed as obsolete or rewritten as checkpoint-publication issues separately.

## Validation
- `git diff --check`
- `./mvnw -f framework/pom.xml -pl deployment -am -Dtest=OrchestratorClientGenerationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl deployment -am -DskipTests install`
- `./mvnw -f examples/checkout/pom.xml -pl checkout-orchestrator-svc -am -Dtest=TpfgoPipelineRuntimeTopologyTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `npm --prefix docs ci`
- `npm --prefix docs run build`

The original two targeted Maven commands without `-Dsurefire.failIfNoSpecifiedTests=false` hit the standard reactor behavior where upstream modules do not contain the selected test name. The checkout test also required installing the changed framework deployment artifact locally so the example build used this branch's annotation processor instead of the previous local snapshot.
