### PR TITLE
Rename deployment transport enum

### DIFF
--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompilationContext.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompilationContext.java
@@ -17,7 +17,7 @@ import org.pipelineframework.processor.ir.PipelineAspectModel;
 import org.pipelineframework.processor.ir.PipelineOrchestratorModel;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StepDefinition;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMappingResolution;
 
@@ -73,7 +73,7 @@ public class PipelineCompilationContext {
     @Setter
     @Getter(AccessLevel.NONE)
     private boolean functionHttpBridge;
-    private TransportMode transportMode;
+    private PipelineTransport transportMode;
     private PlatformMode platformMode;
 
     @Setter
@@ -102,7 +102,7 @@ public class PipelineCompilationContext {
         this.pluginHost = false;
         this.orchestratorGenerated = false;
         this.functionHttpBridge = false;
-        this.transportMode = TransportMode.GRPC;
+        this.transportMode = PipelineTransport.GRPC;
         this.platformMode = PlatformMode.COMPUTE;
     }
 
@@ -194,7 +194,7 @@ public class PipelineCompilationContext {
      * @return true if the transport mode is GRPC, false otherwise.
      */
     public boolean isTransportModeGrpc() {
-        return transportMode == TransportMode.GRPC;
+        return transportMode == PipelineTransport.GRPC;
     }
 
     /**
@@ -203,7 +203,7 @@ public class PipelineCompilationContext {
      * @return true if the transport mode is REST, false otherwise.
      */
     public boolean isTransportModeRest() {
-        return transportMode == TransportMode.REST;
+        return transportMode == PipelineTransport.REST;
     }
 
     /**
@@ -212,15 +212,15 @@ public class PipelineCompilationContext {
      * @return `true` if the transport mode is Local, `false` otherwise
      */
     public boolean isTransportModeLocal() {
-        return transportMode == TransportMode.LOCAL;
+        return transportMode == PipelineTransport.LOCAL;
     }
 
     /**
      * Access the configured transport mode for this compilation context.
      *
-     * @return the configured TransportMode
+     * @return the configured PipelineTransport
      */
-    public TransportMode getTransportMode() {
+    public PipelineTransport getTransportMode() {
         return transportMode;
     }
 
@@ -366,10 +366,10 @@ public class PipelineCompilationContext {
     /**
      * Set the transport mode for the compilation context.
      *
-     * @param transportMode the transport mode to assign; if `null`, defaults to {@link TransportMode#GRPC}
+     * @param transportMode the transport mode to assign; if `null`, defaults to {@link PipelineTransport#GRPC}
      */
-    public void setTransportMode(TransportMode transportMode) {
-        this.transportMode = transportMode == null ? TransportMode.GRPC : transportMode;
+    public void setTransportMode(PipelineTransport transportMode) {
+        this.transportMode = transportMode == null ? PipelineTransport.GRPC : transportMode;
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineTransport.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineTransport.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 /**
  * Transport mode used for orchestrator client generation.
  */
-public enum TransportMode {
+public enum PipelineTransport {
     GRPC,
     REST,
     LOCAL;
@@ -25,12 +25,12 @@ public enum TransportMode {
     }
 
     /**
-     * Parse a string into a TransportMode when the input matches a known mode name.
+     * Parse a string into a PipelineTransport when the input matches a known mode name.
      *
      * @param raw the input string to parse; null or blank input is treated as no match
-     * @return an Optional containing the matching TransportMode for "REST", "LOCAL", or "GRPC" (case-insensitive), or Optional.empty() if the input is null, blank, or does not match
+     * @return an Optional containing the matching PipelineTransport for "REST", "LOCAL", or "GRPC" (case-insensitive), or Optional.empty() if the input is null, blank, or does not match
      */
-    public static Optional<TransportMode> fromStringOptional(String raw) {
+    public static Optional<PipelineTransport> fromStringOptional(String raw) {
         if (raw == null || raw.isBlank()) {
             return Optional.empty();
         }
@@ -48,13 +48,13 @@ public enum TransportMode {
     }
 
     /**
-     * Parse the given string into a TransportMode, using GRPC as the default when the input is null or blank.
+     * Parse the given string into a PipelineTransport, using GRPC as the default when the input is null or blank.
      *
      * @param raw the input string to parse; may be null or blank
-     * @return the corresponding TransportMode, or GRPC if {@code raw} is null or blank
+     * @return the corresponding PipelineTransport, or GRPC if {@code raw} is null or blank
      * @throws IllegalArgumentException if {@code raw} is non-blank and does not match GRPC, REST, or LOCAL
      */
-    public static TransportMode fromString(String raw) {
+    public static PipelineTransport fromString(String raw) {
         if (raw == null || raw.isBlank()) {
             return GRPC;
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ClientRoleTargetResolutionStrategy.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ClientRoleTargetResolutionStrategy.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.Objects;
 
 import org.pipelineframework.processor.ir.GenerationTarget;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Target resolution strategy for client roles.
@@ -12,7 +12,7 @@ import org.pipelineframework.processor.ir.TransportMode;
 public class ClientRoleTargetResolutionStrategy implements TargetResolutionStrategy {
 
     @Override
-    public Set<GenerationTarget> resolve(TransportMode transportMode) {
+    public Set<GenerationTarget> resolve(PipelineTransport transportMode) {
         Objects.requireNonNull(transportMode, "transportMode must not be null");
         return switch (transportMode) {
             case REST -> Set.of(GenerationTarget.REST_CLIENT_STEP);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/GrpcRequirementEvaluator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/GrpcRequirementEvaluator.java
@@ -10,7 +10,7 @@ import org.pipelineframework.config.template.PipelineTemplateConfig;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineOrchestratorModel;
 import org.pipelineframework.processor.ir.PipelineStepModel;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Evaluates whether gRPC bindings are required for the current compilation.
@@ -53,7 +53,7 @@ class GrpcRequirementEvaluator {
             if (transport == null || transport.isBlank()) {
                 return true;
             }
-            Optional<TransportMode> resolvedMode = TransportMode.fromStringOptional(transport);
+            Optional<PipelineTransport> resolvedMode = PipelineTransport.fromStringOptional(transport);
             if (resolvedMode.isEmpty()) {
                 if (messager != null) {
                     messager.printMessage(Diagnostic.Kind.WARNING,
@@ -63,7 +63,7 @@ class GrpcRequirementEvaluator {
                 // Mirror resolver behavior: treat unknown transport as GRPC (return true)
                 return true;
             }
-            return resolvedMode.get() == TransportMode.GRPC;
+            return resolvedMode.get() == PipelineTransport.GRPC;
         }
         return false;
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhase.java
@@ -25,7 +25,7 @@ import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineAspectModel;
 import org.pipelineframework.processor.ir.PipelineOrchestratorModel;
 import org.pipelineframework.processor.ir.StepDefinition;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
 import org.pipelineframework.processor.parser.StepDefinitionParser;
 
@@ -163,7 +163,7 @@ public class PipelineDiscoveryPhase implements PipelineCompilationPhase {
 
         // Determine transport and platform modes
         PipelineStepConfigLoader.StepConfig stepConfig = loadPipelineStepConfig(configPath, options, messager);
-        TransportMode transportMode = transportPlatformResolver.resolveTransport(stepConfig.transport(), messager);
+        PipelineTransport transportMode = transportPlatformResolver.resolveTransport(stepConfig.transport(), messager);
         ctx.setTransportMode(transportMode);
         PlatformMode platformMode = transportPlatformResolver.resolvePlatform(stepConfig.platform(), messager);
         ctx.setPlatformMode(platformMode);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -15,7 +15,7 @@ import org.pipelineframework.processor.ir.DeploymentRole;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.ServiceApiKind;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Resolves generation targets and client/server roles based on configuration and annotation settings.
@@ -65,8 +65,8 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      */
     @Override
     public void execute(PipelineCompilationContext ctx) throws Exception {
-        TransportMode mode = ctx.getTransportMode();
-        TransportMode transportMode = Objects.requireNonNullElse(mode, TransportMode.GRPC);
+        PipelineTransport mode = ctx.getTransportMode();
+        PipelineTransport transportMode = Objects.requireNonNullElse(mode, PipelineTransport.GRPC);
 
         // Apply transport targets and resolve client/server roles for each step model
         List<PipelineStepModel> updatedModels = new ArrayList<>();
@@ -95,7 +95,7 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      * @throws IllegalArgumentException if the deployment role is not supported
      */
     private Set<GenerationTarget> resolveTargetsForRole(
-            DeploymentRole role, TransportMode transportMode) {
+            DeploymentRole role, PipelineTransport transportMode) {
         TargetResolutionStrategy strategy = strategiesByRole.get(role);
         if (strategy == null) {
             throw new IllegalArgumentException("Unsupported deployment role: " + role);
@@ -113,7 +113,7 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      * @param transportMode the transport mode used to influence resolution (may be null if caller applies a default)
      * @return a set of GenerationTarget values applicable to the given step model
      */
-    private Set<GenerationTarget> resolveTargetsForModel(PipelineStepModel model, TransportMode transportMode) {
+    private Set<GenerationTarget> resolveTargetsForModel(PipelineStepModel model, PipelineTransport transportMode) {
         if (model.serviceClassName() != null
             && AWAIT_STEP_DESCRIPTOR_CLASS.equals(model.serviceClassName().canonicalName())) {
             return Set.of(GenerationTarget.AWAIT_CLIENT_STEP);
@@ -129,7 +129,7 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             // External adapter generation is bound later in PipelineBindingConstructionPhase.
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
-        if (transportMode == TransportMode.LOCAL
+        if (transportMode == PipelineTransport.LOCAL
             && model.sideEffect()
             && model.deploymentRole() == DeploymentRole.PLUGIN_SERVER) {
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ServerRoleTargetResolutionStrategy.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ServerRoleTargetResolutionStrategy.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.Objects;
 
 import org.pipelineframework.processor.ir.GenerationTarget;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Target resolution strategy for server roles.
@@ -12,7 +12,7 @@ import org.pipelineframework.processor.ir.TransportMode;
 public class ServerRoleTargetResolutionStrategy implements TargetResolutionStrategy {
 
     @Override
-    public Set<GenerationTarget> resolve(TransportMode transportMode) {
+    public Set<GenerationTarget> resolve(PipelineTransport transportMode) {
         Objects.requireNonNull(transportMode, "transportMode must not be null");
         return switch (transportMode) {
             case REST -> Set.of(GenerationTarget.REST_RESOURCE);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/TargetResolutionStrategy.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/TargetResolutionStrategy.java
@@ -3,7 +3,7 @@ package org.pipelineframework.processor.phase;
 import java.util.Set;
 
 import org.pipelineframework.processor.ir.GenerationTarget;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Strategy for resolving generation targets by transport mode.
@@ -17,5 +17,5 @@ public interface TargetResolutionStrategy {
      * @param transportMode transport mode to resolve against; must not be {@code null}
      * @return a non-null, unmodifiable set of {@link GenerationTarget}; empty when no targets are applicable
      */
-    Set<GenerationTarget> resolve(TransportMode transportMode);
+    Set<GenerationTarget> resolve(PipelineTransport transportMode);
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/TransportPlatformResolver.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/TransportPlatformResolver.java
@@ -5,7 +5,7 @@ import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
 
 import org.pipelineframework.config.PlatformMode;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Resolves transport and platform modes from configuration values.
@@ -20,17 +20,17 @@ class TransportPlatformResolver {
      * @param messager the messager for warning reporting, may be null
      * @return the resolved transport mode, defaults to GRPC
      */
-    TransportMode resolveTransport(String value, Messager messager) {
+    PipelineTransport resolveTransport(String value, Messager messager) {
         if (value == null || value.isBlank()) {
-            return TransportMode.GRPC;
+            return PipelineTransport.GRPC;
         }
-        Optional<TransportMode> mode = TransportMode.fromStringOptional(value);
+        Optional<PipelineTransport> mode = PipelineTransport.fromStringOptional(value);
         if (mode.isEmpty()) {
             if (messager != null) {
                 messager.printMessage(Diagnostic.Kind.WARNING,
                     "Unknown pipeline transport '" + value + "'; defaulting to GRPC.");
             }
-            return TransportMode.GRPC;
+            return PipelineTransport.GRPC;
         }
         return mode.get();
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwaitClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwaitClientStepRenderer.java
@@ -24,7 +24,7 @@ import org.pipelineframework.processor.PipelineStepProcessor;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.step.StepManyToMany;
 import org.pipelineframework.step.StepOneToOne;
 import org.pipelineframework.step.StepOneToMany;
@@ -45,7 +45,7 @@ public class AwaitClientStepRenderer {
             : model.generatedName();
         String className = baseName + "AwaitClientStep";
         PipelineConfigHints configHints = resolveConfigHints(ctx);
-        TransportMode transportMode = configHints.transportMode();
+        PipelineTransport transportMode = configHints.transportMode();
         TypeName inputType = clientStepType(model.inboundDomainType(), transportMode, configHints.basePackage());
         TypeName outputType = clientStepType(model.outboundDomainType(), transportMode, configHints.basePackage());
 
@@ -174,7 +174,7 @@ public class AwaitClientStepRenderer {
             return new PipelineConfigHints(ctx.transportMode(), ctx.pipelineBasePackage());
         }
         Map<String, String> options = ctx.processingEnv() == null ? Map.of() : ctx.processingEnv().getOptions();
-        TransportMode configuredTransport = TransportMode.fromStringOptional(
+        PipelineTransport configuredTransport = PipelineTransport.fromStringOptional(
             options == null ? null : options.get("pipeline.transport")).orElse(null);
         String basePackage = null;
         if (options != null) {
@@ -183,14 +183,14 @@ public class AwaitClientStepRenderer {
                 PipelineYamlConfig config = loadPipelineConfig(ctx, configPath);
                 if (config != null) {
                     if (configuredTransport == null) {
-                        configuredTransport = TransportMode.fromString(config.transport());
+                        configuredTransport = PipelineTransport.fromString(config.transport());
                     }
                     basePackage = config.basePackage();
                 }
             }
         }
         if (configuredTransport == null) {
-            configuredTransport = TransportMode.GRPC;
+            configuredTransport = PipelineTransport.GRPC;
         }
         return new PipelineConfigHints(configuredTransport, basePackage);
     }
@@ -209,7 +209,7 @@ public class AwaitClientStepRenderer {
         }
     }
 
-    private TypeName clientStepType(TypeName domainType, TransportMode transportMode, String pipelineBasePackage) {
+    private TypeName clientStepType(TypeName domainType, PipelineTransport transportMode, String pipelineBasePackage) {
         if (!(domainType instanceof ClassName className)) {
             return domainType;
         }
@@ -240,6 +240,6 @@ public class AwaitClientStepRenderer {
         return packageName;
     }
 
-    private record PipelineConfigHints(TransportMode transportMode, String basePackage) {
+    private record PipelineConfigHints(PipelineTransport transportMode, String basePackage) {
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/GenerationContext.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/GenerationContext.java
@@ -7,7 +7,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import com.google.protobuf.DescriptorProtos;
 import com.squareup.javapoet.ClassName;
 import org.pipelineframework.processor.ir.DeploymentRole;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 /**
  * Context for code generation operations, containing processing environment and output directory information.
@@ -24,7 +24,7 @@ import org.pipelineframework.processor.ir.TransportMode;
 public record GenerationContext(ProcessingEnvironment processingEnv, Path outputDir, DeploymentRole role,
                                 Set<String> enabledAspects, ClassName cacheKeyGenerator,
                                 DescriptorProtos.FileDescriptorSet descriptorSet,
-                                TransportMode transportMode,
+                                PipelineTransport transportMode,
                                 String pipelineBasePackage) {
     /**
      * Creates a new GenerationContext instance.

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorCliRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/OrchestratorCliRenderer.java
@@ -8,7 +8,7 @@ import com.squareup.javapoet.*;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.OrchestratorBinding;
 import org.pipelineframework.processor.ir.PipelineStepModel;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.util.GrpcJavaTypeResolver;
 
 /**
@@ -43,9 +43,9 @@ public class OrchestratorCliRenderer implements PipelineRenderer<OrchestratorBin
      */
     @Override
     public void render(OrchestratorBinding binding, GenerationContext ctx) throws IOException {
-        TransportMode transportMode = TransportMode.fromStringOptional(binding.normalizedTransport()).orElse(TransportMode.GRPC);
-        boolean restMode = transportMode == TransportMode.REST;
-        boolean localMode = transportMode == TransportMode.LOCAL;
+        PipelineTransport transportMode = PipelineTransport.fromStringOptional(binding.normalizedTransport()).orElse(PipelineTransport.GRPC);
+        boolean restMode = transportMode == PipelineTransport.REST;
+        boolean localMode = transportMode == PipelineTransport.LOCAL;
         ClassName pipelineExecutionService = ClassName.get("org.pipelineframework", "PipelineExecutionService");
         ClassName orchestratorConfig = ClassName.get("org.pipelineframework.orchestrator", "PipelineOrchestratorConfig");
         ClassName orchestratorMode = ClassName.get("org.pipelineframework.orchestrator", "OrchestratorMode");

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientPropertiesGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientPropertiesGenerator.java
@@ -18,7 +18,7 @@ import org.pipelineframework.config.pipeline.PipelineYamlStep;
 import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMappingResolution;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMappingResolver;
@@ -109,7 +109,7 @@ public class OrchestratorClientPropertiesGenerator {
      */
     private List<PipelineStepModel> filterClientModels(
         List<PipelineStepModel> models,
-        org.pipelineframework.processor.ir.TransportMode transportMode
+        org.pipelineframework.processor.ir.PipelineTransport transportMode
     ) {
         GenerationTarget target = switch (transportMode) {
             case REST -> GenerationTarget.REST_CLIENT_STEP;
@@ -423,7 +423,7 @@ public class OrchestratorClientPropertiesGenerator {
         if (config == null || config.steps() == null || config.steps().isEmpty()) {
             return;
         }
-        TransportMode mode = ctx.getTransportMode() == null ? TransportMode.GRPC : ctx.getTransportMode();
+        PipelineTransport mode = ctx.getTransportMode() == null ? PipelineTransport.GRPC : ctx.getTransportMode();
         String suffix = mode.clientStepSuffix();
         List<String> baseClassNames = orderedBaseSteps.stream()
             .map(model -> model.servicePackage() + ".pipeline."

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGenerator.java
@@ -20,7 +20,7 @@ import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.TypeMapping;
 
 /**
@@ -75,7 +75,7 @@ public class PipelineTelemetryMetadataGenerator {
         if (itemTypes == null || itemTypes.inputType() == null || itemTypes.outputType() == null) {
             return;
         }
-        TransportMode transportMode = ctx.getTransportMode();
+        PipelineTransport transportMode = ctx.getTransportMode();
         String consumer = findConsumerStep(ordered, itemTypes.inputType(), transportMode);
         String producer = findProducerStep(ordered, itemTypes.outputType(), transportMode);
         Map<String, String> stepParents = resolveStepParents(ctx, ordered);
@@ -222,7 +222,7 @@ public class PipelineTelemetryMetadataGenerator {
      * @param transportMode the transport mode to map
      * @return the GenerationTarget used for client step generation for the given transport mode
      */
-    private GenerationTarget resolveClientTarget(TransportMode transportMode) {
+    private GenerationTarget resolveClientTarget(PipelineTransport transportMode) {
         return switch (transportMode) {
             case REST -> GenerationTarget.REST_CLIENT_STEP;
             case LOCAL -> GenerationTarget.LOCAL_CLIENT_STEP;
@@ -553,7 +553,7 @@ public class PipelineTelemetryMetadataGenerator {
         PipelineStepModel model,
         PipelineYamlStep configStep,
         int index,
-        TransportMode transportMode
+        PipelineTransport transportMode
     ) {
         String service = model.generatedName();
         String logicalStep = baseLogicalStepName(service);
@@ -848,7 +848,7 @@ public class PipelineTelemetryMetadataGenerator {
     private PipelineStepModel selectBestMatch(
         List<PipelineStepModel> candidates,
         String token,
-        TransportMode transportMode
+        PipelineTransport transportMode
     ) {
         PipelineStepModel best = null;
         int bestLength = -1;
@@ -911,7 +911,7 @@ public class PipelineTelemetryMetadataGenerator {
     private String findProducerStep(
         List<PipelineStepModel> ordered,
         String itemType,
-        TransportMode transportMode
+        PipelineTransport transportMode
     ) {
         String lastMatch = null;
         for (PipelineStepModel model : ordered) {
@@ -1025,7 +1025,7 @@ public class PipelineTelemetryMetadataGenerator {
     private String findConsumerStep(
         List<PipelineStepModel> ordered,
         String itemType,
-        TransportMode transportMode) {
+        PipelineTransport transportMode) {
         for (PipelineStepModel model : ordered) {
             if (matchesType(model.inputMapping(), itemType)) {
                 return resolveClientStepClassName(model, transportMode);
@@ -1058,7 +1058,7 @@ public class PipelineTelemetryMetadataGenerator {
      * @param transportMode the transport mode whose client-step suffix is appended
      * @return the fully-qualified client step class name (package + ".pipeline." + generated name without "Service" + transport suffix)
      */
-    private String resolveClientStepClassName(PipelineStepModel model, TransportMode transportMode) {
+    private String resolveClientStepClassName(PipelineStepModel model, PipelineTransport transportMode) {
         String suffix = transportMode.clientStepSuffix();
         return model.servicePackage() + ".pipeline." +
             model.generatedName().replace("Service", "") + suffix;

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/ModelContextRoleEnricherTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/ModelContextRoleEnricherTest.java
@@ -20,7 +20,7 @@ import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineAspectModel;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.TypeMapping;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
 
@@ -46,7 +46,7 @@ class ModelContextRoleEnricherTest {
     void enrichProducesPluginAndClientModelsForColocatedPluginHost() {
         PipelineCompilationContext ctx = new PipelineCompilationContext(null, null);
         ctx.setPluginHost(true);
-        ctx.setTransportMode(TransportMode.LOCAL);
+        ctx.setTransportMode(PipelineTransport.LOCAL);
         ctx.setAspectModels(List.of());
 
         List<PipelineStepModel> result = enricher.enrich(
@@ -70,7 +70,7 @@ class ModelContextRoleEnricherTest {
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(null, roundEnv);
         ctx.setPluginHost(true);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setAspectModels(List.of(new PipelineAspectModel(
             "audit",
             AspectScope.GLOBAL,

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/ModelExtractionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/ModelExtractionPhaseTest.java
@@ -156,7 +156,7 @@ class ModelExtractionPhaseTest {
 
         context.setPipelineTemplateConfig(templateConfig);
         context.setPluginHost(true);  // Need to be a plugin host or have orchestrator to process templates
-        context.setTransportMode(org.pipelineframework.processor.ir.TransportMode.LOCAL);  // Make plugins colocated to avoid needing plugin aspects
+        context.setTransportMode(org.pipelineframework.processor.ir.PipelineTransport.LOCAL);  // Make plugins colocated to avoid needing plugin aspects
 
         phase.execute(context);
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhaseTest.java
@@ -219,7 +219,7 @@ class PipelineDiscoveryPhaseTest {
                 "com.example", "GRPC", "COMPUTE", java.util.List.of(), java.util.List.of()));
         when(configLoader.loadRuntimeMapping(moduleDir, messager)).thenReturn(null);
         when(tpResolver.resolveTransport("GRPC", messager))
-            .thenReturn(org.pipelineframework.processor.ir.TransportMode.GRPC);
+            .thenReturn(org.pipelineframework.processor.ir.PipelineTransport.GRPC);
         when(tpResolver.resolvePlatform("COMPUTE", messager))
             .thenReturn(org.pipelineframework.config.PlatformMode.COMPUTE);
         when(processingEnv.getOptions()).thenReturn(Map.of());
@@ -288,7 +288,7 @@ class PipelineDiscoveryPhaseTest {
             });
         when(configLoader.loadRuntimeMapping(moduleDir, messager)).thenReturn(null);
         when(tpResolver.resolveTransport("LOCAL", messager))
-            .thenReturn(org.pipelineframework.processor.ir.TransportMode.LOCAL);
+            .thenReturn(org.pipelineframework.processor.ir.PipelineTransport.LOCAL);
         when(tpResolver.resolvePlatform("COMPUTE", messager))
             .thenReturn(org.pipelineframework.config.PlatformMode.COMPUTE);
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhaseTest.java
@@ -26,7 +26,7 @@ import org.pipelineframework.processor.ir.ExecutionMode;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.TypeMapping;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -138,7 +138,7 @@ public class PipelineSemanticAnalysisPhaseTest {
     public void functionPlatformRequiresRestTransport() throws Exception {
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
         context.setPlatformMode(PlatformMode.FUNCTION);
-        context.setTransportMode(TransportMode.GRPC);
+        context.setTransportMode(PipelineTransport.GRPC);
         context.setStepModels(List.of(step(StreamingShape.UNARY_UNARY)));
 
         phase.execute(context);
@@ -154,7 +154,7 @@ public class PipelineSemanticAnalysisPhaseTest {
     public void functionPlatformAllowsStreamingShapes(StreamingShape shape) throws Exception {
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
         context.setPlatformMode(PlatformMode.FUNCTION);
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
         context.setStepModels(List.of(step(shape)));
 
         phase.execute(context);
@@ -166,7 +166,7 @@ public class PipelineSemanticAnalysisPhaseTest {
     public void functionPlatformAllowsUnaryRestSteps() throws Exception {
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
         context.setPlatformMode(PlatformMode.FUNCTION);
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
         context.setStepModels(List.of(step(StreamingShape.UNARY_UNARY)));
 
         phase.execute(context);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -14,7 +14,7 @@ import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.TypeMapping;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,42 +37,42 @@ class PipelineTargetResolutionPhaseTest {
 
     @Test
     void resolvesClientRoleTargetsForAllTransportModes() throws Exception {
-        assertResolvedTargets(DeploymentRole.ORCHESTRATOR_CLIENT, TransportMode.GRPC,
+        assertResolvedTargets(DeploymentRole.ORCHESTRATOR_CLIENT, PipelineTransport.GRPC,
             Set.of(GenerationTarget.CLIENT_STEP));
-        assertResolvedTargets(DeploymentRole.ORCHESTRATOR_CLIENT, TransportMode.REST,
+        assertResolvedTargets(DeploymentRole.ORCHESTRATOR_CLIENT, PipelineTransport.REST,
             Set.of(GenerationTarget.REST_CLIENT_STEP));
-        assertResolvedTargets(DeploymentRole.ORCHESTRATOR_CLIENT, TransportMode.LOCAL,
+        assertResolvedTargets(DeploymentRole.ORCHESTRATOR_CLIENT, PipelineTransport.LOCAL,
             Set.of(GenerationTarget.LOCAL_CLIENT_STEP));
 
-        assertResolvedTargets(DeploymentRole.PLUGIN_CLIENT, TransportMode.GRPC,
+        assertResolvedTargets(DeploymentRole.PLUGIN_CLIENT, PipelineTransport.GRPC,
             Set.of(GenerationTarget.CLIENT_STEP));
-        assertResolvedTargets(DeploymentRole.PLUGIN_CLIENT, TransportMode.REST,
+        assertResolvedTargets(DeploymentRole.PLUGIN_CLIENT, PipelineTransport.REST,
             Set.of(GenerationTarget.REST_CLIENT_STEP));
-        assertResolvedTargets(DeploymentRole.PLUGIN_CLIENT, TransportMode.LOCAL,
+        assertResolvedTargets(DeploymentRole.PLUGIN_CLIENT, PipelineTransport.LOCAL,
             Set.of(GenerationTarget.LOCAL_CLIENT_STEP));
     }
 
     @Test
     void resolvesServerRoleTargetsForAllTransportModes() throws Exception {
-        assertResolvedTargets(DeploymentRole.PIPELINE_SERVER, TransportMode.GRPC,
+        assertResolvedTargets(DeploymentRole.PIPELINE_SERVER, PipelineTransport.GRPC,
             Set.of(GenerationTarget.GRPC_SERVICE));
-        assertResolvedTargets(DeploymentRole.PIPELINE_SERVER, TransportMode.REST,
+        assertResolvedTargets(DeploymentRole.PIPELINE_SERVER, PipelineTransport.REST,
             Set.of(GenerationTarget.REST_RESOURCE));
-        assertResolvedTargets(DeploymentRole.PIPELINE_SERVER, TransportMode.LOCAL,
+        assertResolvedTargets(DeploymentRole.PIPELINE_SERVER, PipelineTransport.LOCAL,
             Set.of(GenerationTarget.GRPC_SERVICE_SIDE_EFFECT_ONLY));
 
-        assertResolvedTargets(DeploymentRole.PLUGIN_SERVER, TransportMode.GRPC,
+        assertResolvedTargets(DeploymentRole.PLUGIN_SERVER, PipelineTransport.GRPC,
             Set.of(GenerationTarget.GRPC_SERVICE));
-        assertResolvedTargets(DeploymentRole.PLUGIN_SERVER, TransportMode.REST,
+        assertResolvedTargets(DeploymentRole.PLUGIN_SERVER, PipelineTransport.REST,
             Set.of(GenerationTarget.REST_RESOURCE));
-        assertResolvedTargets(DeploymentRole.PLUGIN_SERVER, TransportMode.LOCAL,
+        assertResolvedTargets(DeploymentRole.PLUGIN_SERVER, PipelineTransport.LOCAL,
             Set.of(GenerationTarget.GRPC_SERVICE_SIDE_EFFECT_ONLY));
 
-        assertResolvedTargets(DeploymentRole.REST_SERVER, TransportMode.GRPC,
+        assertResolvedTargets(DeploymentRole.REST_SERVER, PipelineTransport.GRPC,
             Set.of(GenerationTarget.GRPC_SERVICE));
-        assertResolvedTargets(DeploymentRole.REST_SERVER, TransportMode.REST,
+        assertResolvedTargets(DeploymentRole.REST_SERVER, PipelineTransport.REST,
             Set.of(GenerationTarget.REST_RESOURCE));
-        assertResolvedTargets(DeploymentRole.REST_SERVER, TransportMode.LOCAL,
+        assertResolvedTargets(DeploymentRole.REST_SERVER, PipelineTransport.LOCAL,
             Set.of(GenerationTarget.GRPC_SERVICE_SIDE_EFFECT_ONLY));
     }
 
@@ -94,7 +94,7 @@ class PipelineTargetResolutionPhaseTest {
     void aggregatesResolvedTargetsAcrossModels() throws Exception {
         PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
         context.setStepModels(List.of(
             step("ServerStep", DeploymentRole.PIPELINE_SERVER),
             step("ClientStep", DeploymentRole.ORCHESTRATOR_CLIENT)));
@@ -112,7 +112,7 @@ class PipelineTargetResolutionPhaseTest {
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);
         PipelineStepModel original = step("IdentityStep", DeploymentRole.PIPELINE_SERVER);
         context.setStepModels(List.of(original));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -141,7 +141,7 @@ class PipelineTargetResolutionPhaseTest {
             .externalMapper(ClassName.get("com.example.app.mapper", "EmbeddingMapper"))
             .build();
         context.setStepModels(List.of(original));
-        context.setTransportMode(TransportMode.GRPC);
+        context.setTransportMode(PipelineTransport.GRPC);
 
         phase.execute(context);
 
@@ -160,7 +160,7 @@ class PipelineTargetResolutionPhaseTest {
             .delegateService(ClassName.get("com.example.lib", "EmbeddingService"))
             .build();
         context.setStepModels(List.of(delegated));
-        context.setTransportMode(TransportMode.GRPC);
+        context.setTransportMode(PipelineTransport.GRPC);
 
         phase.execute(context);
 
@@ -183,7 +183,7 @@ class PipelineTargetResolutionPhaseTest {
                 new PipelineTemplateRemoteTarget(null, "tpf.remote-operators.charge-card.url")))
             .build();
         context.setStepModels(List.of(remote));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -208,7 +208,7 @@ class PipelineTargetResolutionPhaseTest {
                 new PipelineTemplateRemoteTarget("https://operator.example/process", null)))
             .build();
         context.setStepModels(List.of(remote));
-        context.setTransportMode(TransportMode.GRPC);
+        context.setTransportMode(PipelineTransport.GRPC);
 
         phase.execute(context);
 
@@ -230,7 +230,7 @@ class PipelineTargetResolutionPhaseTest {
             .serviceApiKind(ServiceApiKind.BLOCKING)
             .build();
         context.setStepModels(List.of(blocking));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -249,7 +249,7 @@ class PipelineTargetResolutionPhaseTest {
             .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
             .build();
         context.setStepModels(List.of(blocking));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -269,7 +269,7 @@ class PipelineTargetResolutionPhaseTest {
             .delegateService(ClassName.get("com.external.lib", "ExternalService"))
             .build();
         context.setStepModels(List.of(blocking));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -290,7 +290,7 @@ class PipelineTargetResolutionPhaseTest {
                 new PipelineTemplateRemoteTarget("https://operator.example/process", null)))
             .build();
         context.setStepModels(List.of(blocking));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -308,7 +308,7 @@ class PipelineTargetResolutionPhaseTest {
             .serviceApiKind(ServiceApiKind.REACTIVE)
             .build();
         context.setStepModels(List.of(reactive));
-        context.setTransportMode(TransportMode.REST);
+        context.setTransportMode(PipelineTransport.REST);
 
         phase.execute(context);
 
@@ -327,7 +327,7 @@ class PipelineTargetResolutionPhaseTest {
             .delegateService(ClassName.get("com.external.lib", "ExternalIteratorService"))
             .build();
         context.setStepModels(List.of(blocking));
-        context.setTransportMode(TransportMode.GRPC);
+        context.setTransportMode(PipelineTransport.GRPC);
 
         phase.execute(context);
 
@@ -338,7 +338,7 @@ class PipelineTargetResolutionPhaseTest {
 
     private void assertResolvedTargets(
             DeploymentRole role,
-            TransportMode transportMode,
+            PipelineTransport transportMode,
             Set<GenerationTarget> expectedTargets) throws Exception {
         PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/TemplateExpansionOrchestratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/TemplateExpansionOrchestratorTest.java
@@ -79,7 +79,7 @@ class TemplateExpansionOrchestratorTest {
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
         ctx.setPluginHost(true);
         // For local transport mode, plugins are colocated
-        ctx.setTransportMode(org.pipelineframework.processor.ir.TransportMode.LOCAL);
+        ctx.setTransportMode(org.pipelineframework.processor.ir.PipelineTransport.LOCAL);
         
         List<PipelineStepModel> baseModels = List.of(TestModelFactory.createTestModel("TestService"));
         
@@ -112,7 +112,7 @@ class TemplateExpansionOrchestratorTest {
         ctx.setPluginHost(true);
         
         // Test with monolith layout
-        ctx.setTransportMode(org.pipelineframework.processor.ir.TransportMode.GRPC);
+        ctx.setTransportMode(org.pipelineframework.processor.ir.PipelineTransport.GRPC);
         // Without monolith mapping, this should behave differently than with monolith
         
         List<PipelineStepModel> baseModels = List.of(TestModelFactory.createTestModel("TestService"));

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/TransportPlatformResolverTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/TransportPlatformResolverTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.pipelineframework.config.PlatformMode;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,38 +46,38 @@ class TransportPlatformResolverTest {
 
     @Test
     void resolveTransport_grpc() {
-        assertEquals(TransportMode.GRPC, resolver.resolveTransport("GRPC", messager));
+        assertEquals(PipelineTransport.GRPC, resolver.resolveTransport("GRPC", messager));
     }
 
     @Test
     void resolveTransport_rest() {
-        assertEquals(TransportMode.REST, resolver.resolveTransport("REST", messager));
+        assertEquals(PipelineTransport.REST, resolver.resolveTransport("REST", messager));
     }
 
     @Test
     void resolveTransport_local() {
-        assertEquals(TransportMode.LOCAL, resolver.resolveTransport("LOCAL", messager));
+        assertEquals(PipelineTransport.LOCAL, resolver.resolveTransport("LOCAL", messager));
     }
 
     @Test
     void resolveTransport_null_defaultsToGrpc() {
-        assertEquals(TransportMode.GRPC, resolver.resolveTransport(null, messager));
+        assertEquals(PipelineTransport.GRPC, resolver.resolveTransport(null, messager));
     }
 
     @Test
     void resolveTransport_blank_defaultsToGrpc() {
-        assertEquals(TransportMode.GRPC, resolver.resolveTransport("  ", messager));
+        assertEquals(PipelineTransport.GRPC, resolver.resolveTransport("  ", messager));
     }
 
     @Test
     void resolveTransport_unknown_warnsAndDefaultsToGrpc() {
-        assertEquals(TransportMode.GRPC, resolver.resolveTransport("UNKNOWN", messager));
+        assertEquals(PipelineTransport.GRPC, resolver.resolveTransport("UNKNOWN", messager));
         verify(messager).printMessage(eq(Diagnostic.Kind.WARNING), contains("Unknown pipeline transport"));
     }
 
     @Test
     void resolveTransport_nullMessager_noException() {
-        assertEquals(TransportMode.GRPC, resolver.resolveTransport("INVALID", null));
+        assertEquals(PipelineTransport.GRPC, resolver.resolveTransport("INVALID", null));
     }
 
     // --- Platform ---
@@ -115,9 +115,9 @@ class TransportPlatformResolverTest {
 
     @Test
     void resolveTransport_caseInsensitive() {
-        assertEquals(TransportMode.GRPC, resolver.resolveTransport("grpc", messager));
-        assertEquals(TransportMode.REST, resolver.resolveTransport("rest", messager));
-        assertEquals(TransportMode.LOCAL, resolver.resolveTransport("local", messager));
+        assertEquals(PipelineTransport.GRPC, resolver.resolveTransport("grpc", messager));
+        assertEquals(PipelineTransport.REST, resolver.resolveTransport("rest", messager));
+        assertEquals(PipelineTransport.LOCAL, resolver.resolveTransport("local", messager));
     }
 
     @Test

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineOrderMetadataGeneratorTest.java
@@ -28,7 +28,7 @@ import org.pipelineframework.processor.ir.ExecutionMode;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.TypeMapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,7 +73,7 @@ class PipelineOrderMetadataGeneratorTest {
         RoundEnvironment roundEnv = mock(RoundEnvironment.class);
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setOrchestratorGenerated(true);
         ctx.setModuleDir(moduleDir);
 
@@ -139,7 +139,7 @@ class PipelineOrderMetadataGeneratorTest {
         RoundEnvironment roundEnv = mock(RoundEnvironment.class);
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setOrchestratorGenerated(false);
         ctx.setModuleDir(moduleDir);
 
@@ -192,7 +192,7 @@ class PipelineOrderMetadataGeneratorTest {
         RoundEnvironment roundEnv = mock(RoundEnvironment.class);
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setOrchestratorGenerated(true);
         ctx.setModuleDir(moduleDir);
 
@@ -243,7 +243,7 @@ class PipelineOrderMetadataGeneratorTest {
         RoundEnvironment roundEnv = mock(RoundEnvironment.class);
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setOrchestratorGenerated(true);
         ctx.setModuleDir(moduleDir);
         ctx.setStepModels(List.of());  // no models
@@ -287,7 +287,7 @@ class PipelineOrderMetadataGeneratorTest {
         RoundEnvironment roundEnv = mock(RoundEnvironment.class);
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setOrchestratorGenerated(true);
         ctx.setModuleDir(moduleDir);
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelinePlatformMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelinePlatformMetadataGeneratorTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.pipelineframework.config.PlatformMode;
 import org.pipelineframework.processor.PipelineCompilationContext;
-import org.pipelineframework.processor.ir.TransportMode;
+import org.pipelineframework.processor.ir.PipelineTransport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -40,7 +40,7 @@ class PipelinePlatformMetadataGeneratorTest {
 
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
         ctx.setPlatformMode(PlatformMode.FUNCTION);
-        ctx.setTransportMode(TransportMode.REST);
+        ctx.setTransportMode(PipelineTransport.REST);
         ctx.setModuleName("orchestrator-svc");
         ctx.setPluginHost(false);
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGeneratorTest.java
@@ -274,7 +274,7 @@ class PipelineTelemetryMetadataGeneratorTest {
         RoundEnvironment roundEnv = mock(RoundEnvironment.class);
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
         ctx.setOrchestratorGenerated(true);
-        ctx.setTransportMode(TransportMode.GRPC);
+        ctx.setTransportMode(PipelineTransport.GRPC);
         ctx.setModuleDir(tempDir);
         return ctx;
     }


### PR DESCRIPTION
## Summary
- Rename deployment IR `TransportMode` to `PipelineTransport` to disambiguate pipeline generation transport from checkpoint handoff target kinds.
- Update compiler phases, renderers, metadata generators, and deployment tests to use the new type name.
- Keep the external `pipeline.transport` config key and GRPC/REST/LOCAL values unchanged.

Closes #233

## Validation
- `git diff --check`
- `./mvnw -f framework/pom.xml -pl deployment -am test`
- `./mvnw -f framework/pom.xml -pl runtime -am test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal transport mode handling for improved type consistency and standardization across the framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->