### PR TITLE
[codex] Fix await completion-before-waiting resume race

### DIFF
--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -2454,10 +2454,17 @@ abstract class AbstractCsvPaymentsEndToEnd {
                 "Expected await item completion event to include unit id.");
         assertTrue(attributes.containsKey("tpf.await.interaction_id"),
                 "Expected await item completion event to include interaction id.");
-        assertTrue(attributes.containsKey("tpf.await.expected_item_count"),
-                "Expected await item completion event to include expected item count.");
         assertTrue(attributes.containsKey("tpf.await.completed_item_count"),
                 "Expected await item completion event to include completed item count.");
+        assertTrue(
+                replayDocument.events().stream()
+                        .filter(event -> AWAIT_UNIT_ITEM_COMPLETED.equals(event.event())
+                                || AWAIT_UNIT_DISPATCH_COMPLETE.equals(event.event())
+                                || AWAIT_UNIT_COMPLETED.equals(event.event()))
+                        .map(PipelineExecutionEvent::attributes)
+                        .anyMatch(eventAttributes -> eventAttributes != null
+                                && eventAttributes.containsKey("tpf.await.expected_item_count")),
+                "Expected await lifecycle events to include expected item count once dispatch size is known.");
     }
 
     private void assertReplayEvent(PipelineReplayDocument replayDocument, String eventName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -35,6 +35,7 @@ import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitCoordinator;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.awaitable.AwaitSuspendedException;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
 import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
 import org.pipelineframework.telemetry.PipelineTelemetry;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
@@ -367,8 +368,8 @@ class QueueAsyncCoordinator {
         .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
             .onItem().transformToUni(validated -> {
               return awaitCoordinator.recordCompletion(validated.record(), normalized.nowEpochMs())
-                  .onItem().transformToUni(unit -> unit.status() == org.pipelineframework.awaitable.AwaitUnitStatus.COMPLETED
-                      ? resumeAwaitExecution(validated, unit.unitId(), normalized.nowEpochMs())
+                  .onItem().transformToUni(unit -> unit.status() == AwaitUnitStatus.COMPLETED
+                      ? releaseAwaitResume(validated.record(), unit.unitId(), normalized.nowEpochMs()).replaceWith(validated)
                       : Uni.createFrom().item(validated));
             }));
   }
@@ -391,6 +392,7 @@ class QueueAsyncCoordinator {
       ExecutionRecord<Object, Object> record,
       AwaitSuspendedException suspended,
       String transitionKey) {
+    long nowEpochMs = System.currentTimeMillis();
     return executionStateStore.markWaitingExternal(
             record.tenantId(),
             record.executionId(),
@@ -398,7 +400,7 @@ class QueueAsyncCoordinator {
             transitionKey,
             suspended.unitId(),
             suspended.stepIndex(),
-            System.currentTimeMillis())
+            nowEpochMs)
         .onItem().transformToUni(updated -> {
           if (updated.isPresent()) {
             LOG.infof(
@@ -420,7 +422,7 @@ class QueueAsyncCoordinator {
                 null,
                 null,
                 null));
-            return Uni.createFrom().voidItem();
+            return releaseAlreadyCompletedAwaitUnit(record, suspended, nowEpochMs);
           }
           return Uni.createFrom().failure(new IllegalStateException(
               "Failed to persist WAITING_EXTERNAL state for execution "
@@ -494,16 +496,62 @@ class QueueAsyncCoordinator {
     return items.getFirst();
   }
 
-  private Uni<AwaitCompletionResult> resumeAwaitExecution(
-      AwaitCompletionResult result,
+  private Uni<Void> releaseAlreadyCompletedAwaitUnit(
+      ExecutionRecord<Object, Object> record,
+      AwaitSuspendedException suspended,
+      long nowEpochMs) {
+    return awaitCoordinator.getUnit(record.tenantId(), suspended.unitId())
+        .onItem().transformToUni(unit -> {
+          if (unit == null || unit.status() != AwaitUnitStatus.COMPLETED) {
+            return Uni.createFrom().voidItem();
+          }
+          return releaseAwaitResume(
+              record.tenantId(),
+              record.executionId(),
+              unit.unitId(),
+              unit.stepId(),
+              suspended.stepIndex(),
+              null,
+              null,
+              null,
+              null,
+              nowEpochMs);
+        });
+  }
+
+  private Uni<Void> releaseAwaitResume(
+      AwaitInteractionRecord record,
       String awaitUnitId,
       long nowEpochMs) {
-    AwaitInteractionRecord record = result.record();
+    return releaseAwaitResume(
+        record.tenantId(),
+        record.executionId(),
+        awaitUnitId,
+        record.stepId(),
+        record.stepIndex(),
+        record.interactionId(),
+        record.correlationId(),
+        record.transportType(),
+        record.itemIndex(),
+        nowEpochMs);
+  }
+
+  private Uni<Void> releaseAwaitResume(
+      String tenantId,
+      String executionId,
+      String awaitUnitId,
+      String stepId,
+      int stepIndex,
+      String interactionId,
+      String correlationId,
+      String transportType,
+      Integer itemIndex,
+      long nowEpochMs) {
     return executionStateStore.markAwaitCompleted(
-            record.tenantId(),
-            record.executionId(),
+            tenantId,
+            executionId,
             awaitUnitId,
-            record.stepIndex() + 1,
+            stepIndex + 1,
             nowEpochMs)
         .onItem().transformToUni(updated -> {
           if (updated.isPresent()) {
@@ -514,24 +562,29 @@ class QueueAsyncCoordinator {
                 updated.get().currentStepIndex());
             recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
                 AwaitReplayLifecycleEvent.RESUME_RELEASED,
-                record.executionId(),
+                executionId,
                 awaitUnitId,
-                record.stepId(),
-                record.stepIndex(),
+                stepId,
+                stepIndex,
                 updated.get().status().name(),
-                record.interactionId(),
-                record.correlationId(),
-                record.transportType(),
-                record.itemIndex(),
+                interactionId,
+                correlationId,
+                transportType,
+                itemIndex,
                 null,
                 null,
                 null));
             return workDispatcher.enqueueNow(new ExecutionWorkItem(
                     updated.get().tenantId(),
                     updated.get().executionId()))
-                .replaceWith(result);
+                .replaceWithVoid();
           }
-          return Uni.createFrom().item(result);
+          LOG.debugf(
+              "Await resume release for execution %s awaitUnitId=%s at stepIndex=%d produced no state update; treating as idempotent no-op",
+              executionId,
+              awaitUnitId,
+              stepIndex);
+          return Uni.createFrom().voidItem();
         });
   }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -43,6 +43,8 @@ import org.pipelineframework.awaitable.AwaitSuspendedException;
 import org.pipelineframework.awaitable.AwaitUnitRecord;
 import org.pipelineframework.awaitable.AwaitUnitStatus;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
+import org.pipelineframework.telemetry.PipelineTelemetry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -82,6 +84,9 @@ class QueueAsyncCoordinatorTest {
     private CheckpointPublicationService checkpointPublicationService;
 
     @Mock
+    private PipelineTelemetry telemetry;
+
+    @Mock
     private Instance<ExecutionStateStore> executionStateStores;
 
     @Mock
@@ -107,6 +112,7 @@ class QueueAsyncCoordinatorTest {
         coordinator.workDispatcher = workDispatcher;
         coordinator.deadLetterPublisher = deadLetterPublisher;
         coordinator.awaitCoordinator = awaitCoordinator;
+        coordinator.telemetry = telemetry;
         coordinator.checkpointPublicationService = checkpointPublicationService;
         coordinator.executionStateStores = executionStateStores;
         coordinator.workDispatchers = workDispatchers;
@@ -281,6 +287,8 @@ class QueueAsyncCoordinatorTest {
                 org.mockito.ArgumentMatchers.eq(0),
                 org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+        when(awaitCoordinator.getUnit("tenant-1", "unit-1"))
+            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.WAITING_EXTERNAL, 1, 0, false, null)));
 
         coordinator.processExecutionWorkItem(
                 new ExecutionWorkItem("tenant-1", "exec-await"),
@@ -299,6 +307,106 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.eq("unit-1"),
             org.mockito.ArgumentMatchers.eq(0),
             org.mockito.ArgumentMatchers.anyLong());
+        verify(executionStateStore, never()).markAwaitCompleted(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyInt(),
+            org.mockito.ArgumentMatchers.anyLong());
+        verify(workDispatcher, never()).enqueueNow(any());
+    }
+
+    @Test
+    void processExecutionWorkItemReleasesResumeWhenAwaitUnitCompletedBeforeWaitingPersists() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+        ExecutionRecord<Object, Object> claimed = createRecord("tenant-1", "exec-await", "key-await");
+        ExecutionRecord<Object, Object> waiting = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-await",
+            "key-await",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.WAITING_EXTERNAL,
+            1L,
+            2,
+            0,
+            null,
+            0L,
+            Long.MAX_VALUE,
+            "exec-await:0:0",
+            "input",
+            "unit-1",
+            null,
+            null,
+            null,
+            1L,
+            2L,
+            99999999L);
+        ExecutionRecord<Object, Object> resumed = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-await",
+            "key-await",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.QUEUED,
+            2L,
+            3,
+            0,
+            null,
+            0L,
+            3L,
+            "exec-await:0:0",
+            "input",
+            "unit-1",
+            null,
+            null,
+            null,
+            1L,
+            3L,
+            99999999L);
+        when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+        when(executionStateStore.markWaitingExternal(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-await"),
+                org.mockito.ArgumentMatchers.eq(0L),
+                org.mockito.ArgumentMatchers.eq("exec-await:0:0"),
+                org.mockito.ArgumentMatchers.eq("unit-1"),
+                org.mockito.ArgumentMatchers.eq(2),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(awaitCoordinator.getUnit("tenant-1", "unit-1"))
+            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, 10, 10, true, null)));
+        when(executionStateStore.markAwaitCompleted(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-await"),
+                org.mockito.ArgumentMatchers.eq("unit-1"),
+                org.mockito.ArgumentMatchers.eq(3),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(resumed)));
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+        coordinator.processExecutionWorkItem(
+                new ExecutionWorkItem("tenant-1", "exec-await"),
+                record -> Multi.createFrom().failure(new AwaitSuspendedException(
+                    "tenant-1",
+                    "exec-await",
+                    "unit-1",
+                    2)))
+            .await().indefinitely();
+
+        verify(executionStateStore).markAwaitCompleted(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-await"),
+            org.mockito.ArgumentMatchers.eq("unit-1"),
+            org.mockito.ArgumentMatchers.eq(3),
+            org.mockito.ArgumentMatchers.anyLong());
+        verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-await"));
+        ArgumentCaptor<AwaitReplayLifecycleEvent> lifecycleCaptor =
+            ArgumentCaptor.forClass(AwaitReplayLifecycleEvent.class);
+        verify(telemetry, org.mockito.Mockito.times(2)).recordAwaitLifecycle(lifecycleCaptor.capture());
+        assertEquals(
+            List.of(AwaitReplayLifecycleEvent.EXECUTION_WAITING, AwaitReplayLifecycleEvent.RESUME_RELEASED),
+            lifecycleCaptor.getAllValues().stream().map(AwaitReplayLifecycleEvent::eventName).toList());
     }
 
     @Test
@@ -317,6 +425,8 @@ class QueueAsyncCoordinatorTest {
                 org.mockito.ArgumentMatchers.eq(0),
                 org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+        when(awaitCoordinator.getUnit("tenant-1", "unit-1"))
+            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.WAITING_EXTERNAL, 1, 0, false, null)));
 
         coordinator.processExecutionWorkItem(
                 new ExecutionWorkItem("tenant-1", "exec-await"),


### PR DESCRIPTION
## Summary

Fixes the await resume race where all await-unit completions can arrive before the execution is persisted as `WAITING_EXTERNAL`.

Previously, the normal completion path attempted `markAwaitCompleted(...)` while the execution was not waiting yet. That returned empty, and once `markWaitingExternal(...)` later succeeded there was no second release check, leaving the run waiting forever with no `await_resume_released` event.

## Changes

- After `markWaitingExternal(...)` succeeds, `QueueAsyncCoordinator` now checks the await unit state.
- If the unit is already `COMPLETED`, it releases resume immediately through the same helper used by the normal completion path:
  - `markAwaitCompleted(..., nextStepIndex = awaitStepIndex + 1)`
  - emit `await_resume_released`
  - enqueue the execution work item
- Keeps the existing completion-after-waiting path intact.
- Adds a deterministic `QueueAsyncCoordinatorTest` for completion-before-waiting.
- Tightens CSV replay coverage so expected await counts are asserted once dispatch size is known, without requiring early item-completion events to invent expected counts before dispatch completes.

## Validation

- `./mvnw -f /Users/mari/tpf4-await-race/framework/pom.xml -pl runtime -am -Dtest=QueueAsyncCoordinatorTest,AwaitCoordinatorCompletionTest,AwaitStepSupportTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f /Users/mari/tpf4-await-race/framework/pom.xml -pl runtime -am -DskipTests install`
- `./examples/csv-payments/build-modular-telemetry-images.sh`
- `./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -am -Dcsv.e2e.telemetry.enabled=true -Dquarkus.otel.traces.sampler.arg=1 -Dcsv.e2e.reader-demand-pacer.rows-per-period=20 -Dcsv.e2e.reader-demand-pacer.millis-period=1000 -Dcsv.e2e.input.file=examples/csv-payments/input-csv-file-processing-svc/csv/payments_1k.csv -Dcsv.e2e.pipeline.wait.seconds=1800 -Dcsv.e2e.orchestrator.wait.seconds=1800 -Dtest=CsvPaymentsEndToEndIT#fullPipelineWorks -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
- Local CodeRabbit review against `origin/main` completed; two trivial findings fixed, one defensive follow-up fixed.

## 1K replay evidence

The clean-branch 1K replay completed and contained:

- `status: completed`
- `await_interaction_dispatched: 1000`
- `await_unit_dispatch_complete: 1`
- `await_execution_waiting: 1`
- `await_unit_item_completed: 1000`
- `await_unit_completed: 1`
- `await_resume_released: 1`
- direct events for `ProcessFolder`, `ProcessCsvPaymentsInput`, `AwaitPaymentProvider`, `ProcessPaymentStatus`, and `ProcessCsvPaymentsOutputFile`

The reproduced ordering was the race case: unit completion happened before waiting persisted, followed by immediate resume release after waiting persisted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of await unit completion handling in asynchronous operations
  * Enhanced event tracking across await lifecycle transitions

* **Tests**
  * Strengthened validation of replay events for await-related scenarios
  * Added comprehensive telemetry tracking to async coordination tests
  * Improved edge case coverage for await suspension and resumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->