### PR TITLE
[codex] Fix itemized ONE_TO_ONE await continuations

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -124,6 +124,7 @@ const mainSidebar = [
         collapsed: true,
         items: [
             {text: 'Orchestrator Runtime Modes', link: '/guide/development/orchestrator-runtime/'},
+            {text: 'Await Boundaries', link: '/guide/operations/await-boundaries'},
             {text: 'Error Handling & DLQ', link: '/guide/operations/error-handling'},
             {text: 'Queue-Async Crash Semantics', link: '/guide/operations/error-handling#queue-async-crash-matrix'},
             {text: 'In-flight Probe', link: '/guide/operations/in-flight-probe'},
@@ -185,7 +186,7 @@ const mainSidebar = [
                     {text: 'Model', link: '/guide/evolve/await-unit-runtime/'},
                     {text: 'Sequences', link: '/guide/evolve/await-unit-runtime/sequences'},
                     {text: 'Patterns', link: '/guide/evolve/await-unit-runtime/patterns'},
-                    {text: 'Operations And Debt', link: '/guide/evolve/await-unit-runtime/operations-and-debt'}
+                    {text: 'Limitations And Debt', link: '/guide/evolve/await-unit-runtime/operations-and-debt'}
                 ]
             },
             {

--- a/docs/guide/development/orchestrator-runtime/await.md
+++ b/docs/guide/development/orchestrator-runtime/await.md
@@ -2,7 +2,7 @@
 
 Await steps suspend `QUEUE_ASYNC` execution at an external boundary. TPF persists the interaction, dispatches through the configured adapter, and resumes the owning execution after a correlated completion is admitted.
 
-Internally, await is backed by durable await units. For implementation diagrams and the state model, see [Await Unit Runtime](/guide/evolve/await-unit-runtime/).
+For production operation, see [Await Boundary Operations](/guide/operations/await-boundaries). Internally, await is backed by durable await units; for implementation diagrams and the state model, see [Await Unit Runtime](/guide/evolve/await-unit-runtime/).
 
 ## Supported Shapes
 
@@ -47,6 +47,8 @@ Await and checkpoint handoff both cross a process boundary, but they have differ
 
 Use await for human approvals, webhook callbacks, and brokered provider decisions that must resume the same execution. Use checkpoint handoff when the receiving workflow has separate ownership, scaling, or operational responsibility.
 
+For a deeper checkpoint handoff lifecycle guide, see [Checkpoint Handoff](/guide/development/orchestrator-runtime/checkpoint-handoff).
+
 ## Application Design Notes
 
 Await has the same side-effect rule as the rest of `QUEUE_ASYNC`: orchestrator state transitions are guarded, but external dispatch and external side effects are at-least-once. Use stable business idempotency keys at the external boundary.
@@ -62,7 +64,7 @@ The runtime also enforces aggregate materialization guardrails:
 
 Set either value to `0` only when the application has its own upstream size control and storage budget. Prefer stable business limits at the API/file/broker boundary rather than relying on these guards as the first line of defense.
 
-Transport choice changes operational responsibility. `interaction-api` requires an API consumer to query and complete pending work. `webhook` requires stable resume-token signing and callback reachability. `kafka` requires broker channel configuration, consumer health, and response-envelope monitoring.
+Transport choice changes operational responsibility. `interaction-api` requires an API consumer to query and complete pending work. `webhook` requires stable resume-token signing and callback reachability. `kafka` requires broker channel configuration, consumer health, and response-envelope monitoring. The operational checklist is covered in [Await Boundary Operations](/guide/operations/await-boundaries).
 
 That matters for plugin-style side effects after an await boundary. A resumed queue-async execution can replay the remainder of the pipeline after a downstream retry, so once-only side-effect checkpointing is a separate concern from await durability itself.
 

--- a/docs/guide/evolve/await-unit-runtime/index.md
+++ b/docs/guide/evolve/await-unit-runtime/index.md
@@ -9,7 +9,7 @@ This guide is implementation-facing. Application-facing usage lives in [Await Bo
 1. [Model](/guide/evolve/await-unit-runtime/) explains the durable records and cardinality semantics.
 2. [Sequences](/guide/evolve/await-unit-runtime/sequences) shows unary, stream, aggregate, timeout, and resume flows.
 3. [Patterns](/guide/evolve/await-unit-runtime/patterns) explains the architectural patterns and why the unit model fixed the design.
-4. [Operations And Debt](/guide/evolve/await-unit-runtime/operations-and-debt) covers checkpoint handoff, limitations, and tracked follow-up work.
+4. [Limitations And Debt](/guide/evolve/await-unit-runtime/operations-and-debt) tracks implementation limitations and follow-up work.
 
 ## Core Model
 
@@ -58,21 +58,88 @@ classDiagram
       transportType
     }
 
+    class PipelineExecutionService
+    class PipelineRunner
+    class QueueAsyncCoordinator
+    class AwaitStepSupport
     class AwaitCoordinator
     class AwaitUnitStore
     class AwaitInteractionStore
     class AwaitTransportAdapter
-    class QueueAsyncCoordinator
+    class ExecutionStateStore
 
     ExecutionRecord --> AwaitUnitRecord : awaitUnitId
     AwaitUnitRecord "1" --> "1..n" AwaitInteractionRecord : owns
+    PipelineExecutionService --> PipelineRunner : run / resume steps
+    PipelineRunner --> AwaitStepSupport : execute generated await step
+    AwaitStepSupport --> AwaitCoordinator : create / dispatch unit
+    PipelineExecutionService --> QueueAsyncCoordinator : async execution lifecycle
     QueueAsyncCoordinator --> AwaitCoordinator : complete / resume
+    QueueAsyncCoordinator --> ExecutionStateStore : wait / resume execution
     AwaitCoordinator --> AwaitUnitStore
     AwaitCoordinator --> AwaitInteractionStore
     AwaitCoordinator --> AwaitTransportAdapter : dispatch
 ```
 
 `AwaitUnitRecord` is the source of truth for completion of the authored await boundary. `AwaitInteractionRecord` is the transport-facing projection. That distinction prevents execution state, dispatch strategy, and step cardinality from collapsing into one ambiguous record.
+
+## CSV Payments Applied Model
+
+`csv-payments` applies this model to a Kafka-backed payment-provider boundary:
+
+1. `Process Csv Payments Input` expands an input file into a stream of `PaymentRecord` items.
+2. `Await Payment Provider` is authored as `kind: await` with `cardinality: ONE_TO_ONE`.
+3. Because the await step receives a stream, TPF creates one owning await unit with one item interaction per `PaymentRecord`.
+4. The Kafka adapter publishes requests to `csv-payments.payment.requests`; the mock provider publishes completions to `csv-payments.payment.results`.
+5. Completed item outputs are `PaymentStatus` records. The runtime can continue per-item work through `Process Payment Status`, then release the parent execution at the next aggregate boundary.
+
+```mermaid
+classDiagram
+    class CsvExecutionRecord {
+      executionId
+      currentStepIndex = Await Payment Provider
+      status = WAITING_EXTERNAL
+      awaitUnitId = csv payment unit
+    }
+
+    class CsvAwaitUnitRecord {
+      stepId = Await Payment Provider
+      cardinality = ONE_TO_ONE
+      expectedItemCount = payment records
+      completedItemCount = provider completions
+      dispatchComplete
+      status
+    }
+
+    class PaymentInteraction0 {
+      itemIndex = 0
+      requestPayload = PaymentRecord
+      responsePayload = PaymentStatus
+      transportType = kafka
+      correlationId
+    }
+
+    class PaymentInteraction1 {
+      itemIndex = 1
+      requestPayload = PaymentRecord
+      responsePayload = PaymentStatus
+      transportType = kafka
+      correlationId
+    }
+
+    class KafkaTopics {
+      request = csv-payments.payment.requests
+      response = csv-payments.payment.results
+    }
+
+    CsvExecutionRecord --> CsvAwaitUnitRecord : awaitUnitId
+    CsvAwaitUnitRecord "1" --> "0..n" PaymentInteraction0 : owns ordered item
+    CsvAwaitUnitRecord "1" --> "0..n" PaymentInteraction1 : owns ordered item
+    PaymentInteraction0 --> KafkaTopics : dispatch / complete
+    PaymentInteraction1 --> KafkaTopics : dispatch / complete
+```
+
+The important detail is that CSV does not model the provider as a pipeline step. The provider is an external actor reached through the await transport. The pipeline resumes from admitted `PaymentStatus` completions.
 
 ## Cardinality As Unit Shape
 

--- a/docs/guide/evolve/await-unit-runtime/operations-and-debt.md
+++ b/docs/guide/evolve/await-unit-runtime/operations-and-debt.md
@@ -1,23 +1,8 @@
-# Await Unit Operations And Debt
+# Await Unit Limitations And Debt
 
-This page covers runtime boundaries, operational limitations, and tracked follow-up work for the await unit model.
+This implementation-facing page tracks limitations and follow-up work for the await unit model.
 
-## Await Versus Checkpoint Handoff
-
-Await and checkpoint handoff both cross a process boundary, but they solve different problems.
-
-| Concern | Await unit | Checkpoint handoff |
-| --- | --- | --- |
-| Ownership | one execution parks and later resumes | source pipeline publishes; target pipeline owns its own execution |
-| Boundary | mid-pipeline external wait | terminal or named publication boundary |
-| Resume | same execution continues from `awaitUnitId` | downstream execution starts/admits work independently |
-| State of record | await unit + interaction stores | execution state + checkpoint publication/admission |
-| DLQ responsibility | owning execution remains responsible | downstream orchestrator owns retry/DLQ after admission |
-| Use when | external result belongs to the same business flow | another pipeline should own the next lifecycle |
-
-Do not use await to simulate a second pipeline. If the receiving workflow has separate ownership, lifecycle, scaling, or DLQ responsibility, use checkpoint handoff.
-
-Do not use checkpoint handoff to model a human approval, webhook callback, or brokered provider decision that must resume the same execution. That is an await unit.
+Application-facing guidance lives in [Await Boundaries](/guide/development/orchestrator-runtime/await). Operational guidance lives in [Await Boundary Operations](/guide/operations/await-boundaries).
 
 ## Limitations
 
@@ -26,9 +11,3 @@ Do not use checkpoint handoff to model a human approval, webhook callback, or br
 3. Aggregate await units materialize input and/or output in v1. Runtime item-count guards now bound materialized input and output units by default, but architects should still avoid unbounded aggregate payloads.
 4. Replay restarts a materialized output unit as a whole; there is no exactly-once partial progress inside the unit.
 5. Transport adapters have different operational obligations: `interaction-api` needs an API consumer, `webhook` needs signed token configuration, and `kafka` needs broker channels and consumer health.
-
-## Tracked Debt
-
-1. [#304](https://github.com/The-Pipeline-Framework/pipelineframework/issues/304): generated common modules should not trigger `com.google.protobuf` split-package warnings.
-2. [#305](https://github.com/The-Pipeline-Framework/pipelineframework/issues/305): template generator should scaffold union DTO/mappers for REST await outputs.
-3. [#311](https://github.com/The-Pipeline-Framework/pipelineframework/issues/311): template generator should not emit confusing inactive runtime mapping variants.

--- a/docs/guide/evolve/await-unit-runtime/sequences.md
+++ b/docs/guide/evolve/await-unit-runtime/sequences.md
@@ -58,6 +58,56 @@ sequenceDiagram
 
 Completion may arrive out of order. Replay preserves input order by reading completed item interactions by `itemIndex`.
 
+## CSV Payments Itemized Await
+
+This is the concrete `csv-payments` shape. `Await Payment Provider` owns the Kafka boundary, but `Process Payment Status` can run per completed item. The parent execution only waits for the next aggregate boundary, `Process Csv Payments Output File`.
+
+```mermaid
+sequenceDiagram
+    participant Input as Process Csv Payments Input
+    participant Runner as PipelineRunner
+    participant Await as Await Payment Provider
+    participant AwaitCoord as AwaitCoordinator
+    participant Kafka as Kafka broker
+    participant Provider as payments-processing-svc
+    participant Exec as PipelineExecutionService
+    participant Queue as QueueAsyncCoordinator
+    participant Status as Process Payment Status
+    participant Output as Process Csv Payments Output File
+
+    Input-->>Runner: PaymentRecord item 0
+    Runner->>Await: execute item 0
+    Await->>AwaitCoord: create item interaction(itemIndex=0)
+    AwaitCoord->>Kafka: publish request envelope
+    Kafka->>Provider: deliver payment request
+
+    Input-->>Runner: PaymentRecord item 1
+    Runner->>Await: execute item 1
+    Await->>AwaitCoord: create item interaction(itemIndex=1)
+    AwaitCoord->>Kafka: publish request envelope
+    Kafka->>Provider: deliver payment request
+
+    Await-->>Queue: suspend parent execution(awaitUnitId)
+    Queue->>Queue: mark WAITING_EXTERNAL
+
+    Provider-->>Kafka: PaymentStatus item 0
+    Kafka-->>Exec: complete by correlationId
+    Exec->>Queue: complete await interaction
+    Queue->>Status: continue item 0
+    Status-->>Queue: PaymentOutput item 0
+
+    Provider-->>Kafka: PaymentStatus item 1
+    Kafka-->>Exec: complete by correlationId
+    Exec->>Queue: complete await interaction
+    Queue->>Status: continue item 1
+    Status-->>Queue: PaymentOutput item 1
+
+    Queue->>Queue: all item continuations collected in itemIndex order
+    Queue->>Output: resume parent at aggregate boundary
+```
+
+The model is itemized until the next aggregate step. If an authored downstream step is `MANY_TO_ONE` or `MANY_TO_MANY`, the parent execution resumes there with the collected ordered item outputs.
+
 ## Aggregate Unit
 
 `ONE_TO_MANY`, `MANY_TO_ONE`, and `MANY_TO_MANY` are aggregate interaction units. The runtime materializes the relevant side of the boundary so replay has one stable unit to restart.

--- a/docs/guide/operations/await-boundaries.md
+++ b/docs/guide/operations/await-boundaries.md
@@ -1,0 +1,90 @@
+# Await Boundary Operations
+
+Await boundaries are operationally different from ordinary remote calls. A `kind: await` step parks a `QUEUE_ASYNC` execution, dispatches work to an external actor, and resumes only after a correlated completion is admitted.
+
+Use this page with [Await Boundaries](/guide/development/orchestrator-runtime/await) for application design and [Replay & Live Topology](/guide/operations/observability/replay) for replay inspection.
+
+## Runtime Requirements
+
+Await requires `QUEUE_ASYNC`. The owning execution must be stored before it can wait on an external result.
+
+At minimum:
+
+```properties
+pipeline.orchestrator.mode=QUEUE_ASYNC
+pipeline.orchestrator.resume-token-secret=${PIPELINE_ORCHESTRATOR_RESUME_TOKEN_SECRET}
+```
+
+For crash-surviving environments, use durable queue-async providers:
+
+```properties
+pipeline.orchestrator.state-provider=dynamo
+pipeline.orchestrator.dispatcher-provider=sqs
+pipeline.orchestrator.dlq-provider=sqs
+```
+
+The state transition that parks or resumes the execution is guarded by the orchestrator store. External dispatch and external side effects remain at-least-once.
+
+## Transport Responsibilities
+
+| Transport | Operational responsibility |
+| --- | --- |
+| `interaction-api` | A UI or client must list pending interactions and call the generated completion API. |
+| `webhook` | Configure a stable resume-token secret, reachable callback URLs, and partner retry/idempotency handling. |
+| `kafka` | Configure request and response channels, monitor broker/consumer health, and keep correlation ids stable. |
+
+Kafka await uses framework-owned request and response envelopes. The external provider is not a pipeline step; it is the actor that completes the await interaction.
+
+## Idempotency And Completion
+
+Await protects TPF-owned execution state, not external business effects.
+
+Design each external boundary with:
+
+1. stable business idempotency keys,
+2. duplicate-safe provider requests,
+3. duplicate-safe completion admission,
+4. durable or queryable business records where the external effect matters.
+
+Late or duplicate completions can be dropped when the target interaction is already terminal, stale, or otherwise not admissible. Monitor:
+
+- `tpf.await.completion.dropped.total`
+
+## Replay And Tracing
+
+Replay and trace events expose the lifecycle of the await unit:
+
+- `await_interaction_dispatched`
+- `await_unit_dispatch_complete`
+- `await_execution_waiting`
+- `await_unit_item_completed`
+- `await_unit_completed`
+- `await_resume_released`
+- `await_unit_terminal`
+
+Use these events to separate runtime behavior from viewer interpretation. For example, in `csv-payments`, `Await Payment Provider` is `ONE_TO_ONE` over a stream, so item completions should appear as provider responses are admitted. The replay viewer should show those real lifecycle events rather than inventing smoothed timing.
+
+## Aggregate Limits
+
+`ONE_TO_ONE` over a stream is itemized. Aggregate await shapes materialize input and/or output units in the current runtime:
+
+| Config key | Default | Applies to |
+| --- | --- | --- |
+| `pipeline.orchestrator.await-aggregate-max-input-items` | `10000` | materialized input units for `MANY_TO_ONE` and `MANY_TO_MANY` await steps |
+| `pipeline.orchestrator.await-aggregate-max-output-items` | `10000` | materialized output units for `ONE_TO_MANY` and `MANY_TO_MANY` await steps |
+
+Do not use unbounded aggregate await payloads. If replay of a materialized output unit fails halfway through downstream execution, TPF restarts that output unit as a whole.
+
+## Await Versus Checkpoint Handoff
+
+Await and checkpoint handoff both cross a process boundary, but they assign ownership differently.
+
+| Concern | Await | Checkpoint handoff |
+| --- | --- | --- |
+| Execution ownership | one execution parks and later resumes | one pipeline publishes and another pipeline admits independent work |
+| Boundary | mid-pipeline external wait | terminal or named publication boundary |
+| Completion | correlated interaction completion | downstream checkpoint admission |
+| Retry and DLQ | owning execution remains responsible | downstream orchestrator owns retry and DLQ after admission |
+| Use when | the external result belongs to the same business flow | another pipeline should own the next lifecycle |
+
+Use await for human approvals, webhook callbacks, and brokered provider decisions that must resume the same execution. Use checkpoint handoff when the receiving workflow has separate ownership, scaling, or operational responsibility.

--- a/docs/guide/operations/observability/replay.md
+++ b/docs/guide/operations/observability/replay.md
@@ -87,7 +87,7 @@ TPF emits:
 
 Replay JSON is written from the same runtime semantics by the framework replay exporter.
 
-Await boundaries park the owning `QUEUE_ASYNC` execution on a durable await unit and resume from that unit after completion admission. Replay events include await unit ids, execution ids, interaction ids, step ids, unit status, and expected/completed item counts where the runtime knows them. For the implementation model, see [Await Unit Runtime](/guide/evolve/await-unit-runtime/).
+Await boundaries park the owning `QUEUE_ASYNC` execution on a durable await unit and resume from that unit after completion admission. Replay events include await unit ids, execution ids, interaction ids, step ids, unit status, and expected/completed item counts where the runtime knows them. For operations, see [Await Boundary Operations](/guide/operations/await-boundaries); for the implementation model, see [Await Unit Runtime](/guide/evolve/await-unit-runtime/).
 
 ## Replay exporter configuration
 

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -2436,15 +2436,26 @@ abstract class AbstractCsvPaymentsEndToEnd {
                         "store".equals(transition.relationKind())),
                 "Expected store transitions in merged replay topology.");
         assertReplayLifecycleEvents(replayDocument);
+        assertItemizedAwaitContinuationsStartBeforeUnitCompletes(replayDocument);
     }
 
     private void assertReplayLifecycleEvents(PipelineReplayDocument replayDocument) {
         assertReplayEvent(replayDocument, AWAIT_INTERACTION_DISPATCHED);
         assertReplayEvent(replayDocument, AWAIT_UNIT_DISPATCH_COMPLETE);
-        assertReplayEvent(replayDocument, AWAIT_EXECUTION_WAITING);
         assertReplayEvent(replayDocument, AWAIT_UNIT_ITEM_COMPLETED);
-        assertReplayEvent(replayDocument, AWAIT_UNIT_COMPLETED);
-        assertReplayEvent(replayDocument, AWAIT_RESUME_RELEASED);
+        boolean executionWaited = replayDocument.events().stream()
+                .anyMatch(event -> AWAIT_EXECUTION_WAITING.equals(event.event()));
+        if (executionWaited) {
+            assertReplayEvent(replayDocument, AWAIT_RESUME_RELEASED);
+        }
+        assertTrue(
+                replayDocument.events().stream()
+                        .filter(event -> AWAIT_UNIT_COMPLETED.equals(event.event())
+                                || AWAIT_UNIT_DISPATCH_COMPLETE.equals(event.event()))
+                        .map(PipelineExecutionEvent::attributes)
+                        .anyMatch(eventAttributes -> eventAttributes != null
+                                && "COMPLETED".equals(eventAttributes.get("tpf.await.status"))),
+                "Expected await lifecycle events to show unit completion.");
         PipelineExecutionEvent itemCompleted = replayDocument.events().stream()
                 .filter(event -> AWAIT_UNIT_ITEM_COMPLETED.equals(event.event()))
                 .findFirst()
@@ -2465,6 +2476,23 @@ abstract class AbstractCsvPaymentsEndToEnd {
                         .anyMatch(eventAttributes -> eventAttributes != null
                                 && eventAttributes.containsKey("tpf.await.expected_item_count")),
                 "Expected await lifecycle events to include expected item count once dispatch size is known.");
+    }
+
+    private void assertItemizedAwaitContinuationsStartBeforeUnitCompletes(PipelineReplayDocument replayDocument) {
+        Comparator<PipelineExecutionEvent> playbackOrder = Comparator
+                .comparingDouble(AbstractCsvPaymentsEndToEnd::playbackTimeForEvent)
+                .thenComparingLong(event -> event.sequence() == null ? Long.MAX_VALUE : event.sequence());
+        PipelineExecutionEvent firstPaymentStatusEvent = replayDocument.events().stream()
+                .filter(event -> "ProcessPaymentStatus".equals(event.step()))
+                .min(playbackOrder)
+                .orElseThrow(() -> new AssertionError("Expected ProcessPaymentStatus replay events."));
+        PipelineExecutionEvent awaitUnitCompletedEvent = replayDocument.events().stream()
+                .filter(event -> AWAIT_UNIT_COMPLETED.equals(event.event()))
+                .min(playbackOrder)
+                .orElseThrow(() -> new AssertionError("Expected await_unit_completed replay events."));
+        assertTrue(
+                playbackOrder.compare(firstPaymentStatusEvent, awaitUnitCompletedEvent) < 0,
+                "Expected ONE_TO_ONE await item continuations to reach ProcessPaymentStatus before the full await unit completes.");
     }
 
     private void assertReplayEvent(PipelineReplayDocument replayDocument, String eventName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitItemContinuationHandler.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitItemContinuationHandler.java
@@ -1,0 +1,24 @@
+package org.pipelineframework;
+
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+
+interface AwaitItemContinuationHandler {
+
+    Uni<Void> continueAwaitItem(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        int nextStepIndex,
+        Optional<ExecutionRecord<Object, Object>> parent,
+        long nowEpochMs);
+
+    Uni<Void> releaseAwaitParentIfReady(
+        ExecutionRecord<Object, Object> parent,
+        AwaitUnitRecord unit,
+        int nextStepIndex,
+        long nowEpochMs);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -39,11 +39,17 @@ import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitExecutionContext;
 import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitPayloadSupport;
 import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+import org.pipelineframework.step.StepManyToMany;
+import org.pipelineframework.step.functional.ManyToOne;
 
 /**
  * Service responsible for executing pipeline logic.
@@ -62,6 +68,9 @@ public class PipelineExecutionService {
   /** Runner responsible for executing pipeline steps. */
   @Inject
   protected PipelineRunner pipelineRunner;
+
+  @Inject
+  PipelineStepOrderer stepOrderer;
 
   /** Health check service to verify dependent services. */
   @Inject
@@ -214,7 +223,45 @@ public class PipelineExecutionService {
    * Completes a durable await interaction and schedules owning execution continuation.
    */
   public Uni<AwaitCompletionResult> completeAwaitInteraction(AwaitCompletionCommand command) {
-    return queueAsyncCoordinator.completeAwait(command);
+    return queueAsyncCoordinator.completeAwait(command, new AwaitItemContinuationHandler() {
+      @Override
+      public Uni<Void> continueAwaitItem(
+          AwaitInteractionRecord record,
+          AwaitUnitRecord unit,
+          int nextStepIndex,
+          java.util.Optional<ExecutionRecord<Object, Object>> parent,
+          long nowEpochMs) {
+        if (parent.isEmpty()) {
+          return Uni.createFrom().voidItem();
+        }
+        List<Object> steps = loadStepsForExecution();
+        List<Object> orderedSteps = stepOrderer.orderSteps(steps);
+        int aggregateStepIndex = firstAggregateStepIndex(orderedSteps, nextStepIndex);
+        Object awaitPayload = coerceAwaitItemPayload(record);
+        ExecutionInputSnapshot continuationInput = new ExecutionInputSnapshot(ExecutionInputShape.UNI, awaitPayload);
+        return executePipelineSegment(
+                Uni.createFrom().item(awaitPayload),
+                steps,
+                nextStepIndex,
+                aggregateStepIndex)
+            .onItem().transformToUni(outputs -> queueAsyncCoordinator.recordAwaitItemContinuation(
+                record,
+                unit,
+                aggregateStepIndex,
+                continuationInput,
+                outputs,
+                nowEpochMs));
+      }
+
+      @Override
+      public Uni<Void> releaseAwaitParentIfReady(
+          ExecutionRecord<Object, Object> parent,
+          AwaitUnitRecord unit,
+          int nextStepIndex,
+          long nowEpochMs) {
+        return releaseItemizedAwaitParentIfReady(parent, unit, nextStepIndex, nowEpochMs);
+      }
+    });
   }
 
   /**
@@ -248,7 +295,29 @@ public class PipelineExecutionService {
    * Processes one execution work item and advances lifecycle state.
    */
   public Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem) {
-    return queueAsyncCoordinator.processExecutionWorkItem(workItem, this::executePipelineStreamingFromRecord);
+    return queueAsyncCoordinator.processExecutionWorkItem(
+        workItem,
+        this::executePipelineStreamingFromRecord,
+        new AwaitItemContinuationHandler() {
+          @Override
+          public Uni<Void> continueAwaitItem(
+              AwaitInteractionRecord record,
+              AwaitUnitRecord unit,
+              int nextStepIndex,
+              java.util.Optional<ExecutionRecord<Object, Object>> parent,
+              long nowEpochMs) {
+            return Uni.createFrom().voidItem();
+          }
+
+          @Override
+          public Uni<Void> releaseAwaitParentIfReady(
+              ExecutionRecord<Object, Object> parent,
+              AwaitUnitRecord unit,
+              int nextStepIndex,
+              long nowEpochMs) {
+            return releaseItemizedAwaitParentIfReady(parent, unit, nextStepIndex, nowEpochMs);
+          }
+        });
   }
 
   /**
@@ -316,7 +385,7 @@ public class PipelineExecutionService {
 
   private Multi<?> executePipelineStreamingFromRecord(ExecutionRecord<Object, Object> record) {
     return Multi.createFrom().deferred(() -> {
-      Uni<Object> sourcePayload = record.currentStepIndex() > 0
+      Uni<Object> sourcePayload = record.awaitUnitId() != null
           ? awaitCoordinator.loadResumePayload(record.tenantId(), record.awaitUnitId())
           : Uni.createFrom().item(record.inputPayload());
       return sourcePayload.onItem().transformToMulti(payload -> {
@@ -357,12 +426,24 @@ public class PipelineExecutionService {
   }
 
   private Object executePipelineStreamingInternalFromStep(Object input, int startStepIndex) {
-    StopWatch watch = new StopWatch();
     List<Object> steps = loadStepsForExecution();
     if (steps == null) {
       return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
     }
-    PipelineRunner.ExecutionResult executionResult = pipelineRunner.runFromStepWithContext(input, steps, startStepIndex);
+    return executePipelineStreamingInternalFromStep(input, steps, startStepIndex, steps.size());
+  }
+
+  private Object executePipelineStreamingInternalFromStep(
+      Object input,
+      List<Object> steps,
+      int startStepIndex,
+      int stopBeforeStepIndex) {
+    StopWatch watch = new StopWatch();
+    if (steps == null) {
+      return Multi.createFrom().failure(new IllegalStateException("Pipeline steps could not be loaded."));
+    }
+    PipelineRunner.ExecutionResult executionResult =
+        pipelineRunner.runFromStepUntilWithContext(input, steps, startStepIndex, stopBeforeStepIndex);
     Object result = executionResult.result();
     if (result instanceof Multi<?> multi) {
       return executionHooks.attachMultiHooks(multi, watch, executionResult.telemetryContext());
@@ -377,6 +458,70 @@ public class PipelineExecutionService {
             startStepIndex,
             resultType)));
     return executionHooks.attachMultiHooks(failed, watch, executionResult.telemetryContext());
+  }
+
+  private Uni<List<?>> executePipelineSegment(Object input, List<Object> steps, int startStepIndex, int stopBeforeStepIndex) {
+    Object result = executePipelineStreamingInternalFromStep(input, steps, startStepIndex, stopBeforeStepIndex);
+    if (result instanceof Multi<?> multi) {
+      return multi.collect().asList().onItem().transform(list -> (List<?>) list);
+    }
+    if (result instanceof Uni<?> uni) {
+      return uni.toMulti().collect().asList().onItem().transform(list -> (List<?>) list);
+    }
+    return Uni.createFrom().failure(new IllegalStateException("Pipeline segment returned unsupported result"));
+  }
+
+  private static int firstAggregateStepIndex(List<Object> steps, int startStepIndex) {
+    if (steps == null) {
+      return startStepIndex;
+    }
+    for (int index = Math.max(0, startStepIndex); index < steps.size(); index++) {
+      Object step = steps.get(index);
+      if (step instanceof ManyToOne<?, ?> || step instanceof StepManyToMany<?, ?>) {
+        return index;
+      }
+    }
+    return steps.size();
+  }
+
+  private Object coerceAwaitItemPayload(AwaitInteractionRecord record) {
+    try {
+      ClassLoader loader = Thread.currentThread().getContextClassLoader();
+      if (loader == null) {
+        loader = AwaitPayloadSupport.class.getClassLoader();
+      }
+      Class<?> outputType = AwaitPayloadSupport.resolvePayloadClass(
+          record.outputType(),
+          loader);
+      return AwaitPayloadSupport.coercePayload(record.responsePayload(), outputType);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "Failed resolving await output type " + record.outputType()
+              + " for interaction " + record.interactionId(),
+          e);
+    }
+  }
+
+  private Uni<Void> releaseItemizedAwaitParentIfReady(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int nextStepIndex,
+      long nowEpochMs) {
+    List<Object> steps = loadStepsForExecution();
+    if (steps == null) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Failed loading pipeline steps for await itemized parent release executionId="
+              + parent.executionId()
+              + ", awaitUnitId="
+              + unit.unitId()));
+    }
+    List<Object> orderedSteps = stepOrderer.orderSteps(steps);
+    int aggregateStepIndex = firstAggregateStepIndex(orderedSteps, nextStepIndex);
+    return queueAsyncCoordinator.releaseItemizedAwaitParentIfReady(
+        parent,
+        unit,
+        aggregateStepIndex,
+        nowEpochMs);
   }
 
   private void restoreAwaitContext(AwaitExecutionContext previous) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
@@ -112,6 +112,14 @@ public class PipelineRunner implements AutoCloseable {
     }
 
     public ExecutionResult runFromStepWithContext(Object input, List<Object> steps, int startStepIndex) {
+        return runFromStepUntilWithContext(input, steps, startStepIndex, steps == null ? 0 : steps.size());
+    }
+
+    public ExecutionResult runFromStepUntilWithContext(
+        Object input,
+        List<Object> steps,
+        int startStepIndex,
+        int stopBeforeStepIndex) {
         Objects.requireNonNull(steps, "Steps list must not be null");
         if (!(input instanceof Uni<?> || input instanceof Multi<?>)) {
             throw new IllegalArgumentException(MessageFormat.format(
@@ -122,6 +130,9 @@ public class PipelineRunner implements AutoCloseable {
         List<Object> orderedSteps = stepOrderer.orderSteps(steps);
         if (startStepIndex < 0 || startStepIndex > orderedSteps.size()) {
             throw new IllegalArgumentException("startStepIndex is out of range: " + startStepIndex);
+        }
+        if (stopBeforeStepIndex < startStepIndex || stopBeforeStepIndex > orderedSteps.size()) {
+            throw new IllegalArgumentException("stopBeforeStepIndex is out of range: " + stopBeforeStepIndex);
         }
 
         Object current = input;
@@ -134,7 +145,7 @@ public class PipelineRunner implements AutoCloseable {
         PipelineContext contextSnapshot = PipelineContextHolder.get();
         CacheReadSupport cacheReadSupport = cacheSupportFactory.buildCacheReadSupport();
         AwaitExecutionContext awaitContext = AwaitExecutionContextHolder.get();
-        for (int index = startStepIndex; index < orderedSteps.size(); index++) {
+        for (int index = startStepIndex; index < stopBeforeStepIndex; index++) {
             Object step = orderedSteps.get(index);
             if (step == null) {
                 logger.warn("Warning: Found null step in configuration, skipping...");

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -41,6 +41,8 @@ import org.pipelineframework.telemetry.PipelineTelemetry;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
 import org.pipelineframework.orchestrator.DeadLetterPublisher;
 import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.ExecutionResultShape;
 import org.pipelineframework.orchestrator.ExecutionResultShapeResolver;
@@ -61,6 +63,30 @@ import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
 class QueueAsyncCoordinator {
 
   private static final Logger LOG = Logger.getLogger(QueueAsyncCoordinator.class);
+  private static final int AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS = 3;
+  private static final long AWAIT_ITEM_CONTINUATION_RETRY_BASE_MS = 100L;
+  private static final String ONE_TO_ONE_CARDINALITY = "ONE_TO_ONE";
+  private static final AwaitItemContinuationHandler NOOP_ITEM_CONTINUATION_HANDLER =
+      new AwaitItemContinuationHandler() {
+        @Override
+        public Uni<Void> continueAwaitItem(
+            AwaitInteractionRecord record,
+            org.pipelineframework.awaitable.AwaitUnitRecord unit,
+            int nextStepIndex,
+            Optional<ExecutionRecord<Object, Object>> parent,
+            long nowEpochMs) {
+          return Uni.createFrom().voidItem();
+        }
+
+        @Override
+        public Uni<Void> releaseAwaitParentIfReady(
+            ExecutionRecord<Object, Object> parent,
+            org.pipelineframework.awaitable.AwaitUnitRecord unit,
+            int nextStepIndex,
+            long nowEpochMs) {
+          return Uni.createFrom().voidItem();
+        }
+      };
 
   @Inject
   PipelineOrchestratorConfig orchestratorConfig;
@@ -268,6 +294,13 @@ class QueueAsyncCoordinator {
   }
 
   Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming) {
+    return processExecutionWorkItem(workItem, executeStreaming, NOOP_ITEM_CONTINUATION_HANDLER);
+  }
+
+  Uni<Void> processExecutionWorkItem(
+      ExecutionWorkItem workItem,
+      Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming,
+      AwaitItemContinuationHandler itemContinuationHandler) {
     if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
       return Uni.createFrom().voidItem();
     }
@@ -305,7 +338,11 @@ class QueueAsyncCoordinator {
                       System.currentTimeMillis()))
               .onItem().transformToUni(updated -> Uni.createFrom().voidItem())
               .onFailure(this::containsAwaitSuspension).recoverWithUni(
-                  failure -> markWaitingExternal(record, extractAwaitSuspension(failure), transitionKey))
+                  failure -> markWaitingExternal(
+                      record,
+                      extractAwaitSuspension(failure),
+                      transitionKey,
+                      itemContinuationHandler))
               .onFailure().recoverWithUni(
                   failure -> executionFailureHandler.handleExecutionFailure(
                       record,
@@ -345,6 +382,12 @@ class QueueAsyncCoordinator {
   }
 
   Uni<AwaitCompletionResult> completeAwait(AwaitCompletionCommand command) {
+    return completeAwait(command, NOOP_ITEM_CONTINUATION_HANDLER);
+  }
+
+  Uni<AwaitCompletionResult> completeAwait(
+      AwaitCompletionCommand command,
+      AwaitItemContinuationHandler itemContinuationHandler) {
     if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
       return Uni.createFrom().failure(new IllegalStateException(
           "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
@@ -368,10 +411,123 @@ class QueueAsyncCoordinator {
         .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
             .onItem().transformToUni(validated -> {
               return awaitCoordinator.recordCompletion(validated.record(), normalized.nowEpochMs())
-                  .onItem().transformToUni(unit -> unit.status() == AwaitUnitStatus.COMPLETED
-                      ? releaseAwaitResume(validated.record(), unit.unitId(), normalized.nowEpochMs()).replaceWith(validated)
-                      : Uni.createFrom().item(validated));
+                  .onItem().transformToUni(unit -> {
+                    if (usesItemContinuations(validated.record(), unit)) {
+                      dispatchAwaitItemContinuation(
+                          validated.record(),
+                          unit,
+                          itemContinuationHandler,
+                          normalized.nowEpochMs());
+                      return Uni.createFrom().item(validated);
+                    }
+                    return unit.status() == AwaitUnitStatus.COMPLETED
+                        ? releaseAwaitResume(validated.record(), unit.unitId(), normalized.nowEpochMs()).replaceWith(validated)
+                        : Uni.createFrom().item(validated);
+                  });
             }));
+  }
+
+  private void dispatchAwaitItemContinuation(
+      AwaitInteractionRecord record,
+      org.pipelineframework.awaitable.AwaitUnitRecord unit,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    if (itemContinuationHandler == NOOP_ITEM_CONTINUATION_HANDLER) {
+      return;
+    }
+    dispatchAwaitItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, 1);
+  }
+
+  private void dispatchAwaitItemContinuationAttempt(
+      AwaitInteractionRecord record,
+      org.pipelineframework.awaitable.AwaitUnitRecord unit,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs,
+      int attempt) {
+    Infrastructure.getDefaultExecutor().execute(() ->
+        executionStateStore
+            .getExecution(record.tenantId(), record.executionId())
+            .onItem().transformToUni(parent -> itemContinuationHandler.continueAwaitItem(
+                record,
+                unit,
+                record.stepIndex() + 1,
+                parent,
+                nowEpochMs))
+            .subscribe().with(
+                ignored -> {
+                },
+                failure -> {
+                  if (attempt < AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS) {
+                    long retryDelayMs = awaitItemContinuationRetryDelayMs(attempt);
+                    LOG.warnf(
+                        failure,
+                        "Retrying await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s attempt=%d delayMs=%d",
+                        record.tenantId(),
+                        record.executionId(),
+                        record.unitId(),
+                        record.interactionId(),
+                        record.itemIndex(),
+                        attempt + 1,
+                        retryDelayMs);
+                    queueSweepExecutor.schedule(
+                        () -> dispatchAwaitItemContinuationAttempt(
+                            record,
+                            unit,
+                            itemContinuationHandler,
+                            nowEpochMs,
+                            attempt + 1),
+                        retryDelayMs,
+                        TimeUnit.MILLISECONDS);
+                    return;
+                  }
+                  markAwaitItemContinuationFailed(record, failure, attempt);
+                }));
+  }
+
+  private static long awaitItemContinuationRetryDelayMs(int attempt) {
+    int boundedAttempt = Math.max(1, Math.min(attempt, AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS));
+    return AWAIT_ITEM_CONTINUATION_RETRY_BASE_MS << (boundedAttempt - 1);
+  }
+
+  private void markAwaitItemContinuationFailed(
+      AwaitInteractionRecord record,
+      Throwable failure,
+      int attempt) {
+    long nowEpochMs = System.currentTimeMillis();
+    executionStateStore.getExecution(record.tenantId(), record.executionId())
+        .onItem().transformToUni(parent -> {
+          if (parent.isEmpty() || parent.get().status().terminal()) {
+            return Uni.createFrom().item(Optional.<ExecutionRecord<Object, Object>>empty());
+          }
+          ExecutionRecord<Object, Object> parentRecord = parent.get();
+          return executionStateStore.markTerminalFailure(
+              parentRecord.tenantId(),
+              parentRecord.executionId(),
+              parentRecord.version(),
+              ExecutionStatus.FAILED,
+              "await-item-continuation-failed:" + record.unitId() + ":" + record.itemIndex(),
+              "AWAIT_ITEM_CONTINUATION_FAILED",
+              "Await item continuation failed after " + attempt + " attempts: " + failure.getMessage(),
+              nowEpochMs);
+        })
+        .subscribe().with(
+            ignored -> LOG.errorf(
+                failure,
+                "Failed processing await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s after %d attempts; marked parent failed when still active",
+                record.tenantId(),
+                record.executionId(),
+                record.unitId(),
+                record.interactionId(),
+                record.itemIndex(),
+                attempt),
+            persistenceFailure -> LOG.errorf(
+                persistenceFailure,
+                "Failed marking parent execution failed after await item continuation failure tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s",
+                record.tenantId(),
+                record.executionId(),
+                record.unitId(),
+                record.interactionId(),
+                record.itemIndex()));
   }
 
   Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
@@ -391,7 +547,8 @@ class QueueAsyncCoordinator {
   private Uni<Void> markWaitingExternal(
       ExecutionRecord<Object, Object> record,
       AwaitSuspendedException suspended,
-      String transitionKey) {
+      String transitionKey,
+      AwaitItemContinuationHandler itemContinuationHandler) {
     long nowEpochMs = System.currentTimeMillis();
     return executionStateStore.markWaitingExternal(
             record.tenantId(),
@@ -422,7 +579,7 @@ class QueueAsyncCoordinator {
                 null,
                 null,
                 null));
-            return releaseAlreadyCompletedAwaitUnit(record, suspended, nowEpochMs);
+            return releaseAlreadyCompletedAwaitUnit(record, suspended, nowEpochMs, itemContinuationHandler);
           }
           return Uni.createFrom().failure(new IllegalStateException(
               "Failed to persist WAITING_EXTERNAL state for execution "
@@ -499,11 +656,19 @@ class QueueAsyncCoordinator {
   private Uni<Void> releaseAlreadyCompletedAwaitUnit(
       ExecutionRecord<Object, Object> record,
       AwaitSuspendedException suspended,
-      long nowEpochMs) {
+      long nowEpochMs,
+      AwaitItemContinuationHandler itemContinuationHandler) {
     return awaitCoordinator.getUnit(record.tenantId(), suspended.unitId())
         .onItem().transformToUni(unit -> {
           if (unit == null || unit.status() != AwaitUnitStatus.COMPLETED) {
             return Uni.createFrom().voidItem();
+          }
+          if (usesItemContinuations(unit)) {
+            return itemContinuationHandler.releaseAwaitParentIfReady(
+                record,
+                unit,
+                suspended.stepIndex() + 1,
+                nowEpochMs);
           }
           return releaseAwaitResume(
               record.tenantId(),
@@ -517,6 +682,157 @@ class QueueAsyncCoordinator {
               null,
               nowEpochMs);
         });
+  }
+
+  Uni<Void> recordAwaitItemContinuation(
+      AwaitInteractionRecord interaction,
+      org.pipelineframework.awaitable.AwaitUnitRecord unit,
+      int aggregateStepIndex,
+      ExecutionInputSnapshot continuationInput,
+      List<?> segmentOutputs,
+      long nowEpochMs) {
+    if (!usesItemContinuations(interaction, unit)) {
+      return Uni.createFrom().voidItem();
+    }
+    if (interaction.itemIndex() == null) {
+      return Uni.createFrom().failure(new IllegalArgumentException("Itemized await continuation requires itemIndex"));
+    }
+    if (continuationInput == null) {
+      return Uni.createFrom().failure(new IllegalArgumentException(
+          "Itemized await continuation requires normalized continuation input"));
+    }
+    ExecutionInputSnapshot normalizedInput = copyInputSnapshot(continuationInput);
+    return executionStateStore.getExecution(interaction.tenantId(), interaction.executionId())
+        .onItem().transformToUni(parent -> {
+          if (parent.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          ExecutionRecord<Object, Object> parentRecord = parent.get();
+          String childKey = awaitItemContinuationKey(parentRecord, unit, interaction.itemIndex());
+          return executionStateStore.getExecutionByKey(interaction.tenantId(), childKey)
+              .onItem().transformToUni(existing -> {
+                if (existing.isPresent() && existing.get().status() == ExecutionStatus.SUCCEEDED) {
+                  return releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs);
+                }
+                long ttl = parentRecord.ttlEpochS();
+                ExecutionCreateCommand create = new ExecutionCreateCommand(
+                    interaction.tenantId(),
+                    childKey,
+                    normalizedInput,
+                    ExecutionResultShape.MATERIALIZED_MULTI,
+                    nowEpochMs,
+                    ttl);
+                return executionStateStore.createOrGetExecution(create)
+                    .onItem().transformToUni(created -> {
+                      ExecutionRecord<Object, Object> child = created.record();
+                      if (created.duplicate() && child.status() == ExecutionStatus.SUCCEEDED) {
+                        return releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs);
+                      }
+                      String transitionKey = "await-item-continuation:" + unit.unitId() + ":" + interaction.itemIndex();
+                      return executionStateStore.markSucceeded(
+                              child.tenantId(),
+                              child.executionId(),
+                              child.version(),
+                              transitionKey,
+                              List.copyOf(segmentOutputs == null ? List.of() : segmentOutputs),
+                              nowEpochMs)
+                          .onItem().transformToUni(ignored ->
+                              releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
+                    });
+              });
+        });
+  }
+
+  private static ExecutionInputSnapshot copyInputSnapshot(ExecutionInputSnapshot snapshot) {
+    Object payload = snapshot.payload();
+    if (payload instanceof List<?> list) {
+      payload = List.copyOf(list);
+    }
+    return new ExecutionInputSnapshot(snapshot.shape(), payload);
+  }
+
+  Uni<Void> releaseItemizedAwaitParentIfReady(
+      ExecutionRecord<Object, Object> parent,
+      org.pipelineframework.awaitable.AwaitUnitRecord unit,
+      int aggregateStepIndex,
+      long nowEpochMs) {
+    if (parent == null || unit == null || !usesItemContinuations(unit)
+        || !unit.dispatchComplete() || unit.expectedItemCount() == null) {
+      return Uni.createFrom().voidItem();
+    }
+    List<Uni<Optional<ExecutionRecord<Object, Object>>>> lookups = new ArrayList<>();
+    for (int index = 0; index < unit.expectedItemCount(); index++) {
+      lookups.add(executionStateStore.getExecutionByKey(parent.tenantId(), awaitItemContinuationKey(parent, unit, index)));
+    }
+    return Uni.join().all(lookups).andCollectFailures()
+        .onItem().transformToUni(children -> {
+          List<Object> orderedOutputs = new ArrayList<>();
+          for (Object childObject : children) {
+            @SuppressWarnings("unchecked")
+            Optional<ExecutionRecord<Object, Object>> child = (Optional<ExecutionRecord<Object, Object>>) childObject;
+            if (child.isEmpty() || child.get().status() != ExecutionStatus.SUCCEEDED) {
+              return Uni.createFrom().voidItem();
+            }
+            Object payload = child.get().resultPayload();
+            if (payload instanceof Iterable<?> iterable) {
+              iterable.forEach(orderedOutputs::add);
+            } else if (payload != null) {
+              orderedOutputs.add(payload);
+            }
+          }
+          Object resumePayload = new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(orderedOutputs));
+          return executionStateStore.markAwaitItemContinuationsCompleted(
+                  parent.tenantId(),
+                  parent.executionId(),
+                  unit.unitId(),
+                  aggregateStepIndex,
+                  resumePayload,
+                  nowEpochMs)
+              .onItem().transformToUni(updated -> {
+                if (updated.isEmpty()) {
+                  return Uni.createFrom().voidItem();
+                }
+                recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
+                    AwaitReplayLifecycleEvent.RESUME_RELEASED,
+                    parent.executionId(),
+                    unit.unitId(),
+                    unit.stepId(),
+                    unit.stepIndex(),
+                    updated.get().status().name(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    unit.expectedItemCount(),
+                    unit.completedItemCount(),
+                    unit.dispatchComplete()));
+                return workDispatcher.enqueueNow(new ExecutionWorkItem(
+                        updated.get().tenantId(),
+                        updated.get().executionId()))
+                    .replaceWithVoid();
+              });
+        });
+  }
+
+  private static boolean usesItemContinuations(
+      AwaitInteractionRecord record,
+      org.pipelineframework.awaitable.AwaitUnitRecord unit) {
+    return record != null
+        && record.itemInteraction()
+        && usesItemContinuations(unit);
+  }
+
+  private static boolean usesItemContinuations(org.pipelineframework.awaitable.AwaitUnitRecord unit) {
+    return unit != null
+        && unit.primaryInteractionId() == null
+        && ONE_TO_ONE_CARDINALITY.equalsIgnoreCase(unit.cardinality());
+  }
+
+  private static String awaitItemContinuationKey(
+      ExecutionRecord<Object, Object> parent,
+      org.pipelineframework.awaitable.AwaitUnitRecord unit,
+      int itemIndex) {
+    return parent.executionKey() + ":await-item:" + unit.unitId() + ":" + itemIndex;
   }
 
   private Uni<Void> releaseAwaitResume(

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/DynamoExecutionStateStore.java
@@ -145,6 +145,14 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
     }
 
     @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> getExecutionByKey(String tenantId, String executionKey) {
+        return blocking(() -> findExistingByScopedExecutionKey(
+            tenantId,
+            scopedExecutionKey(tenantId, executionKey),
+            System.currentTimeMillis()));
+    }
+
+    @Override
     public Uni<Optional<ExecutionRecord<Object, Object>>> claimLease(
         String tenantId,
         String executionId,
@@ -466,6 +474,28 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
             nowEpochMs));
     }
 
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitItemContinuationsCompleted(
+        String tenantId,
+        String executionId,
+        String awaitUnitId,
+        int nextStepIndex,
+        Object inputPayload,
+        long nowEpochMs
+    ) {
+        if (awaitUnitId == null || awaitUnitId.isBlank()) {
+            return Uni.createFrom().failure(new IllegalArgumentException(
+                "awaitUnitId must not be blank when releasing await item continuations"));
+        }
+        return blocking(() -> markAwaitItemContinuationsCompletedBlocking(
+            tenantId,
+            executionId,
+            awaitUnitId,
+            nextStepIndex,
+            inputPayload,
+            nowEpochMs));
+    }
+
     private Optional<ExecutionRecord<Object, Object>> markWaitingExternalBlocking(
         String tenantId,
         String executionId,
@@ -563,7 +593,71 @@ public class DynamoExecutionStateStore implements ExecutionStateStore {
                     "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
             .updateExpression(
                 "SET #status = :queued, #version = #version + :one, #step = :step, #nextDue = :now, " +
-                    "#leaseExpires = :zero, #updated = :now " +
+                    "#awaitUnit = :awaitUnit, #leaseExpires = :zero, #updated = :now " +
+                    "REMOVE #result, #errorCode, #errorMessage, #leaseOwner")
+            .expressionAttributeNames(names)
+            .expressionAttributeValues(values)
+            .returnValues(ReturnValue.ALL_NEW)
+            .build();
+        try {
+            Map<String, AttributeValue> attributes = dynamoClient().updateItem(request).attributes();
+            if (attributes == null || attributes.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(toRecord(attributes));
+        } catch (ConditionalCheckFailedException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<ExecutionRecord<Object, Object>> markAwaitItemContinuationsCompletedBlocking(
+        String tenantId,
+        String executionId,
+        String awaitUnitId,
+        int nextStepIndex,
+        Object inputPayload,
+        long nowEpochMs
+    ) {
+        Map<String, String> names = Map.ofEntries(
+            Map.entry("#status", STATUS),
+            Map.entry("#version", VERSION),
+            Map.entry("#step", CURRENT_STEP_INDEX),
+            Map.entry("#nextDue", NEXT_DUE_EPOCH_MS),
+            Map.entry("#awaitUnit", AWAIT_UNIT_ID),
+            Map.entry("#inputPayload", INPUT_PAYLOAD_JSON),
+            Map.entry("#inputShape", INPUT_SHAPE),
+            Map.entry("#result", RESULT_PAYLOAD_JSON),
+            Map.entry("#errorCode", ERROR_CODE),
+            Map.entry("#errorMessage", ERROR_MESSAGE),
+            Map.entry("#leaseOwner", LEASE_OWNER),
+            Map.entry("#leaseExpires", LEASE_EXPIRES_EPOCH_MS),
+            Map.entry("#updated", UPDATED_AT_EPOCH_MS),
+            Map.entry("#ttl", TTL_EPOCH_S));
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":queued", avS(ExecutionStatus.QUEUED.name()));
+        values.put(":waitingExternal", avS(ExecutionStatus.WAITING_EXTERNAL.name()));
+        values.put(":step", avN(nextStepIndex));
+        values.put(":awaitUnit", avS(awaitUnitId));
+        values.put(":inputPayload", avS(toJson(inputPayload instanceof ExecutionInputSnapshot snapshot
+            ? snapshot.payload()
+            : inputPayload)));
+        values.put(":inputShape", avS(inputPayload instanceof ExecutionInputSnapshot snapshot
+            ? snapshot.shape().name()
+            : ExecutionInputShape.RAW.name()));
+        values.put(":zero", avN(0));
+        values.put(":now", avN(nowEpochMs));
+        values.put(":one", avN(1));
+        values.put(":nowSec", avN(Instant.ofEpochMilli(nowEpochMs).getEpochSecond()));
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+            .tableName(executionTable())
+            .key(executionPrimaryKey(tenantId, executionId))
+            .conditionExpression(
+                "#status = :waitingExternal AND #awaitUnit = :awaitUnit " +
+                    "AND (attribute_not_exists(#ttl) OR #ttl > :nowSec)")
+            .updateExpression(
+                "SET #status = :queued, #version = #version + :one, #step = :step, #nextDue = :now, " +
+                    "#inputPayload = :inputPayload, #inputShape = :inputShape, #leaseExpires = :zero, #updated = :now " +
                     "REMOVE #result, #errorCode, #errorMessage, #leaseOwner, #awaitUnit")
             .expressionAttributeNames(names)
             .expressionAttributeValues(values)

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionStateStore.java
@@ -61,6 +61,15 @@ public interface ExecutionStateStore {
     Uni<Optional<ExecutionRecord<Object, Object>>> getExecution(String tenantId, String executionId);
 
     /**
+     * Fetches one execution by tenant and idempotency execution key.
+     *
+     * @param tenantId tenant identifier
+     * @param executionKey execution key
+     * @return execution record when available
+     */
+    Uni<Optional<ExecutionRecord<Object, Object>>> getExecutionByKey(String tenantId, String executionKey);
+
+    /**
      * Claims the lease and marks execution RUNNING.
      *
      * @param tenantId tenant identifier
@@ -108,16 +117,14 @@ public interface ExecutionStateStore {
      * @param nowEpochMs transition timestamp
      * @return updated waiting execution when the transition wins optimistic concurrency, otherwise empty
      */
-    default Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+    Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
         String tenantId,
         String executionId,
         long expectedVersion,
         String transitionKey,
         String awaitUnitId,
         int awaitStepIndex,
-        long nowEpochMs) {
-        return Uni.createFrom().failure(new UnsupportedOperationException("markWaitingExternal is not implemented"));
-    }
+        long nowEpochMs);
 
     /**
      * Stores a completed await payload and makes the execution due for continuation.
@@ -134,14 +141,40 @@ public interface ExecutionStateStore {
      * @param nowEpochMs transition timestamp
      * @return updated queued execution when completion is accepted, otherwise empty
      */
-    default Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+    Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
         String tenantId,
         String executionId,
         String awaitUnitId,
         int nextStepIndex,
-        long nowEpochMs) {
-        return Uni.createFrom().failure(new UnsupportedOperationException("markAwaitCompleted is not implemented"));
-    }
+        long nowEpochMs);
+
+    /**
+     * Replaces a waiting execution's input with itemized continuation output and queues the parent
+     * at {@code nextStepIndex}.
+     *
+     * <p>{@code markAwaitItemContinuationsCompleted} is an idempotent release operation for
+     * itemized await continuations. Implementations should match the execution by
+     * {@link ExecutionStatus#WAITING_EXTERNAL} plus the provided {@code awaitUnitId}, not by an
+     * expected version, because duplicate or racing completion checks may safely retry this
+     * transition. When accepted, {@code inputPayload} becomes the replacement input for the
+     * resumed aggregate step and {@code nowEpochMs} is the transition timestamp.</p>
+     *
+     * @param tenantId tenant identifier
+     * @param executionId execution identifier
+     * @param awaitUnitId durable await unit id used to match the waiting execution
+     * @param nextStepIndex next pipeline step index to execute
+     * @param inputPayload replacement input payload for the resumed step
+     * @param nowEpochMs transition timestamp
+     * @return updated queued execution when completion is accepted, otherwise {@link Optional#empty()};
+     *         empty results are safe to retry or treat as an already-lost idempotency race
+     */
+    Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitItemContinuationsCompleted(
+        String tenantId,
+        String executionId,
+        String awaitUnitId,
+        int nextStepIndex,
+        Object inputPayload,
+        long nowEpochMs);
 
     /**
      * Schedules a retry if expected version matches.

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStore.java
@@ -93,6 +93,20 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
     }
 
     @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> getExecutionByKey(String tenantId, String executionKey) {
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                long nowEpochMs = System.currentTimeMillis();
+                String executionId = executionIdByScopedKey.get(scopedExecutionKey(tenantId, executionKey));
+                if (executionId == null) {
+                    return Optional.empty();
+                }
+                return Optional.ofNullable(getActiveRecord(scopedExecutionId(tenantId, executionId), nowEpochMs));
+            }
+        });
+    }
+
+    @Override
     public Uni<Optional<ExecutionRecord<Object, Object>>> claimLease(
         String tenantId,
         String executionId,
@@ -265,6 +279,70 @@ public class InMemoryExecutionStateStore implements ExecutionStateStore {
                 return Optional.of(updated);
             }
         });
+    }
+
+    @Override
+    public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitItemContinuationsCompleted(
+        String tenantId,
+        String executionId,
+        String awaitUnitId,
+        int nextStepIndex,
+        Object inputPayload,
+        long nowEpochMs) {
+        if (awaitUnitId == null || awaitUnitId.isBlank()) {
+            return Uni.createFrom().failure(new IllegalArgumentException(
+                "awaitUnitId must not be blank when releasing await item continuations"));
+        }
+        return Uni.createFrom().item(() -> {
+            synchronized (lock) {
+                String scopedId = scopedExecutionId(tenantId, executionId);
+                ExecutionRecord<Object, Object> current = getActiveRecord(scopedId, nowEpochMs);
+                if (current == null || current.status() != ExecutionStatus.WAITING_EXTERNAL) {
+                    return Optional.empty();
+                }
+                if (!Objects.equals(current.awaitUnitId(), awaitUnitId)) {
+                    return Optional.empty();
+                }
+                ExecutionInputSnapshot normalizedInput = normalizeExecutionInputPayload(inputPayload);
+                ExecutionRecord<Object, Object> updated = new ExecutionRecord<>(
+                    current.tenantId(),
+                    current.executionId(),
+                    current.executionKey(),
+                    current.resultShape(),
+                    ExecutionStatus.QUEUED,
+                    current.version() + 1,
+                    nextStepIndex,
+                    current.attempt(),
+                    null,
+                    0L,
+                    nowEpochMs,
+                    current.lastTransitionKey(),
+                    normalizedInput,
+                    null,
+                    null,
+                    null,
+                    null,
+                    current.createdAtEpochMs(),
+                    nowEpochMs,
+                    current.ttlEpochS());
+                executionsByScopedId.put(scopedId, updated);
+                return Optional.of(updated);
+            }
+        });
+    }
+
+    private static ExecutionInputSnapshot normalizeExecutionInputPayload(Object inputPayload) {
+        if (inputPayload instanceof ExecutionInputSnapshot snapshot) {
+            return new ExecutionInputSnapshot(snapshot.shape(), copySnapshotPayload(snapshot.payload()));
+        }
+        return new ExecutionInputSnapshot(ExecutionInputShape.RAW, copySnapshotPayload(inputPayload));
+    }
+
+    private static Object copySnapshotPayload(Object payload) {
+        if (payload instanceof List<?> list) {
+            return List.copyOf(list);
+        }
+        return payload;
     }
 
     @Override

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
@@ -75,11 +75,17 @@ class PipelineExecutionServiceTest {
     @Test
     void processExecutionWorkItemDelegatesToCoordinator() {
         ExecutionWorkItem item = new ExecutionWorkItem("tenant-1", "exec-4");
-        when(queueAsyncCoordinator.processExecutionWorkItem(eq(item), org.mockito.ArgumentMatchers.any()))
+        when(queueAsyncCoordinator.processExecutionWorkItem(
+                eq(item),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()))
             .thenReturn(Uni.createFrom().voidItem());
 
         service.processExecutionWorkItem(item).await().indefinitely();
 
-        verify(queueAsyncCoordinator).processExecutionWorkItem(eq(item), org.mockito.ArgumentMatchers.any());
+        verify(queueAsyncCoordinator).processExecutionWorkItem(
+            eq(item),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -27,6 +27,7 @@ import org.pipelineframework.orchestrator.ExecutionStateStore;
 import org.pipelineframework.orchestrator.ExecutionStatus;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.EventWorkDispatcher;
+import org.pipelineframework.orchestrator.InMemoryExecutionStateStore;
 import org.pipelineframework.orchestrator.LoggingDeadLetterPublisher;
 import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
 import org.pipelineframework.orchestrator.OrchestratorMode;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -375,7 +377,7 @@ class QueueAsyncCoordinatorTest {
                 org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
         when(awaitCoordinator.getUnit("tenant-1", "unit-1"))
-            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, 10, 10, true, null)));
+            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, 10, 10, true, "interaction-1")));
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-await"),
@@ -822,9 +824,94 @@ class QueueAsyncCoordinatorTest {
     }
 
     @Test
+    void completeAwaitMarksParentFailedWhenItemContinuationKeepsFailing() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        AwaitInteractionRecord completed = itemAwaitRecord(0, AwaitInteractionStatus.COMPLETED, "approved");
+        AwaitCompletionCommand command = new AwaitCompletionCommand(
+            "tenant-1",
+            completed.interactionId(),
+            null,
+            null,
+            java.util.Map.of("value", "approved"),
+            "user-1",
+            System.currentTimeMillis());
+        AwaitUnitRecord unit = awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, 1, 1, true, null);
+        ExecutionRecord<Object, Object> waiting = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            ExecutionStatus.WAITING_EXTERNAL,
+            7L,
+            2,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            "unit-1",
+            null,
+            null,
+            null,
+            1L,
+            1L,
+            99999999L);
+        AwaitItemContinuationHandler failingHandler = new AwaitItemContinuationHandler() {
+            @Override
+            public Uni<Void> continueAwaitItem(
+                AwaitInteractionRecord record,
+                AwaitUnitRecord unit,
+                int nextStepIndex,
+                Optional<ExecutionRecord<Object, Object>> parent,
+                long nowEpochMs) {
+                return Uni.createFrom().failure(new IllegalStateException("segment failed"));
+            }
+
+            @Override
+            public Uni<Void> releaseAwaitParentIfReady(
+                ExecutionRecord<Object, Object> parent,
+                AwaitUnitRecord unit,
+                int nextStepIndex,
+                long nowEpochMs) {
+                return Uni.createFrom().voidItem();
+            }
+        };
+        when(awaitCoordinator.complete(command))
+            .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(completed, false)));
+        when(awaitCoordinator.recordCompletion(org.mockito.ArgumentMatchers.eq(completed), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(unit));
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(executionStateStore.markTerminalFailure(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-1"),
+                org.mockito.ArgumentMatchers.eq(7L),
+                org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+                org.mockito.ArgumentMatchers.eq("await-item-continuation-failed:unit-1:0"),
+                org.mockito.ArgumentMatchers.eq("AWAIT_ITEM_CONTINUATION_FAILED"),
+                org.mockito.ArgumentMatchers.contains("segment failed"),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+
+        coordinator.completeAwait(command, failingHandler).await().indefinitely();
+
+        verify(executionStateStore, timeout(1000)).markTerminalFailure(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-1"),
+            org.mockito.ArgumentMatchers.eq(7L),
+            org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+            org.mockito.ArgumentMatchers.eq("await-item-continuation-failed:unit-1:0"),
+            org.mockito.ArgumentMatchers.eq("AWAIT_ITEM_CONTINUATION_FAILED"),
+            org.mockito.ArgumentMatchers.contains("segment failed"),
+            org.mockito.ArgumentMatchers.anyLong());
+        verify(workDispatcher, never()).enqueueNow(any());
+    }
+
+    @Test
     void completeAwaitResumesCompletedItemUnitAndEnqueuesExecution() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        AwaitInteractionRecord second = itemAwaitRecord(1, AwaitInteractionStatus.COMPLETED, "review");
+        AwaitInteractionRecord second = awaitRecord();
         AwaitCompletionCommand command = new AwaitCompletionCommand(
             "tenant-1",
             second.interactionId(),
@@ -836,7 +923,7 @@ class QueueAsyncCoordinatorTest {
         when(awaitCoordinator.complete(command))
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(second, false)));
         when(awaitCoordinator.recordCompletion(org.mockito.ArgumentMatchers.eq(second), org.mockito.ArgumentMatchers.anyLong()))
-            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, 2, 2, true, null)));
+            .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, null, 0, false, "interaction-1")));
         ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
@@ -856,6 +943,72 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.eq(3),
             org.mockito.ArgumentMatchers.anyLong());
         verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+    }
+
+    @Test
+    void recordAwaitItemContinuationStoresChildrenAndReleasesParentAtAggregateBoundaryInOrder() {
+        InMemoryExecutionStateStore store = new InMemoryExecutionStateStore();
+        coordinator.executionStateStore = store;
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+        long now = System.currentTimeMillis();
+        CreateExecutionResult parent = store.createOrGetExecution(new org.pipelineframework.orchestrator.ExecutionCreateCommand(
+                "tenant-1",
+                "parent-key",
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input"),
+                ExecutionResultShape.MATERIALIZED_MULTI,
+                now,
+                now + 100000))
+            .await().indefinitely();
+        store.markWaitingExternal(
+                "tenant-1",
+                parent.record().executionId(),
+                parent.record().version(),
+                "transition",
+                "unit-1",
+                2,
+                now)
+            .await().indefinitely();
+        AwaitUnitRecord unit = awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, 2, 2, true, null);
+
+        coordinator.recordAwaitItemContinuation(
+                itemAwaitRecord(parent.record().executionId(), 1, AwaitInteractionStatus.COMPLETED, "second"),
+                unit,
+                4,
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "second-normalized"),
+                List.of("out-1"),
+                now)
+            .await().indefinitely();
+        verify(workDispatcher, never()).enqueueNow(any());
+
+        coordinator.recordAwaitItemContinuation(
+                itemAwaitRecord(parent.record().executionId(), 0, AwaitInteractionStatus.COMPLETED, "first"),
+                unit,
+                4,
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "first-normalized"),
+                List.of("out-0"),
+                now)
+            .await().indefinitely();
+
+        ExecutionRecord<Object, Object> resumed = store.getExecution("tenant-1", parent.record().executionId())
+            .await().indefinitely()
+            .orElseThrow();
+        assertEquals(ExecutionStatus.QUEUED, resumed.status());
+        assertEquals(4, resumed.currentStepIndex());
+        assertNull(resumed.awaitUnitId());
+        assertInstanceOf(ExecutionInputSnapshot.class, resumed.inputPayload());
+        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) resumed.inputPayload();
+        assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
+        assertEquals(List.of("out-0", "out-1"), snapshot.payload());
+        ExecutionRecord<Object, Object> firstChild = store.getExecutionByKey(
+                "tenant-1",
+                "parent-key:await-item:unit-1:0")
+            .await().indefinitely()
+            .orElseThrow();
+        assertInstanceOf(ExecutionInputSnapshot.class, firstChild.inputPayload());
+        ExecutionInputSnapshot firstChildInput = (ExecutionInputSnapshot) firstChild.inputPayload();
+        assertEquals(ExecutionInputShape.UNI, firstChildInput.shape());
+        assertEquals("first-normalized", firstChildInput.payload());
+        verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", parent.record().executionId()));
     }
 
     @Test
@@ -1032,9 +1185,17 @@ class QueueAsyncCoordinatorTest {
         int itemIndex,
         AwaitInteractionStatus status,
         String decision) {
+        return itemAwaitRecord("exec-1", itemIndex, status, decision);
+    }
+
+    private AwaitInteractionRecord itemAwaitRecord(
+        String executionId,
+        int itemIndex,
+        AwaitInteractionStatus status,
+        String decision) {
         return new AwaitInteractionRecord(
             "tenant-1",
-            "exec-1",
+            executionId,
             "AwaitPaymentProvider",
             2,
             Decision.class.getName(),

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/ExecutionStateStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/ExecutionStateStoreTest.java
@@ -25,52 +25,10 @@ class ExecutionStateStoreTest {
 
     @Test
     void customProviderNameOverridesDefault() {
-        ExecutionStateStore store = new ExecutionStateStore() {
+        ExecutionStateStore store = new TestExecutionStateStore() {
             @Override
             public String providerName() {
                 return "redis";
-            }
-
-            @Override
-            public Uni<CreateExecutionResult> createOrGetExecution(ExecutionCreateCommand command) {
-                return Uni.createFrom().nullItem();
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> getExecution(String tenantId, String executionId) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> claimLease(
-                String tenantId, String executionId, String leaseOwner, long nowEpochMs, long leaseMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> markSucceeded(
-                String tenantId, String executionId, long expectedVersion, String transitionKey,
-                Object resultPayload, long nowEpochMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> scheduleRetry(
-                String tenantId, String executionId, long expectedVersion, int nextAttempt,
-                long nextDueEpochMs, String transitionKey, String errorCode, String errorMessage, long nowEpochMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> markTerminalFailure(
-                String tenantId, String executionId, long expectedVersion, ExecutionStatus finalStatus,
-                String transitionKey, String errorCode, String errorMessage, long nowEpochMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<List<ExecutionRecord<Object, Object>>> findDueExecutions(long nowEpochMs, int limit) {
-                return Uni.createFrom().item(List.of());
             }
         };
 
@@ -79,52 +37,10 @@ class ExecutionStateStoreTest {
 
     @Test
     void customPriorityOverridesDefault() {
-        ExecutionStateStore store = new ExecutionStateStore() {
+        ExecutionStateStore store = new TestExecutionStateStore() {
             @Override
             public int priority() {
                 return 50;
-            }
-
-            @Override
-            public Uni<CreateExecutionResult> createOrGetExecution(ExecutionCreateCommand command) {
-                return Uni.createFrom().nullItem();
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> getExecution(String tenantId, String executionId) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> claimLease(
-                String tenantId, String executionId, String leaseOwner, long nowEpochMs, long leaseMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> markSucceeded(
-                String tenantId, String executionId, long expectedVersion, String transitionKey,
-                Object resultPayload, long nowEpochMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> scheduleRetry(
-                String tenantId, String executionId, long expectedVersion, int nextAttempt,
-                long nextDueEpochMs, String transitionKey, String errorCode, String errorMessage, long nowEpochMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<Optional<ExecutionRecord<Object, Object>>> markTerminalFailure(
-                String tenantId, String executionId, long expectedVersion, ExecutionStatus finalStatus,
-                String transitionKey, String errorCode, String errorMessage, long nowEpochMs) {
-                return Uni.createFrom().item(Optional.empty());
-            }
-
-            @Override
-            public Uni<List<ExecutionRecord<Object, Object>>> findDueExecutions(long nowEpochMs, int limit) {
-                return Uni.createFrom().item(List.of());
             }
         };
 
@@ -147,8 +63,12 @@ class ExecutionStateStoreTest {
 
         assertNotNull(store.createOrGetExecution(command));
         assertNotNull(store.getExecution("tenant1", "exec1"));
+        assertNotNull(store.getExecutionByKey("tenant1", "key1"));
         assertNotNull(store.claimLease("tenant1", "exec1", "worker1", now, 30000L));
         assertNotNull(store.markSucceeded("tenant1", "exec1", 1L, "key1", "result", now));
+        assertNotNull(store.markWaitingExternal("tenant1", "exec1", 1L, "key1", "unit1", 1, now));
+        assertNotNull(store.markAwaitCompleted("tenant1", "exec1", "unit1", 2, now));
+        assertNotNull(store.markAwaitItemContinuationsCompleted("tenant1", "exec1", "unit1", 2, "input", now));
         assertNotNull(store.scheduleRetry("tenant1", "exec1", 1L, 2, now + 5000, "key1", "Error", "msg", now));
         assertNotNull(store.markTerminalFailure("tenant1", "exec1", 1L, ExecutionStatus.FAILED, "key1", "Error", "msg", now));
         assertNotNull(store.findDueExecutions(now, 10));
@@ -166,6 +86,11 @@ class ExecutionStateStoreTest {
         }
 
         @Override
+        public Uni<Optional<ExecutionRecord<Object, Object>>> getExecutionByKey(String tenantId, String executionKey) {
+            return Uni.createFrom().item(Optional.of(createTestRecord()));
+        }
+
+        @Override
         public Uni<Optional<ExecutionRecord<Object, Object>>> claimLease(
             String tenantId, String executionId, String leaseOwner, long nowEpochMs, long leaseMs) {
             return Uni.createFrom().item(Optional.of(createTestRecord()));
@@ -175,6 +100,26 @@ class ExecutionStateStoreTest {
         public Uni<Optional<ExecutionRecord<Object, Object>>> markSucceeded(
             String tenantId, String executionId, long expectedVersion, String transitionKey,
             Object resultPayload, long nowEpochMs) {
+            return Uni.createFrom().item(Optional.of(createTestRecord()));
+        }
+
+        @Override
+        public Uni<Optional<ExecutionRecord<Object, Object>>> markWaitingExternal(
+            String tenantId, String executionId, long expectedVersion, String transitionKey,
+            String awaitUnitId, int awaitStepIndex, long nowEpochMs) {
+            return Uni.createFrom().item(Optional.of(createTestRecord()));
+        }
+
+        @Override
+        public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitCompleted(
+            String tenantId, String executionId, String awaitUnitId, int nextStepIndex, long nowEpochMs) {
+            return Uni.createFrom().item(Optional.of(createTestRecord()));
+        }
+
+        @Override
+        public Uni<Optional<ExecutionRecord<Object, Object>>> markAwaitItemContinuationsCompleted(
+            String tenantId, String executionId, String awaitUnitId, int nextStepIndex,
+            Object inputPayload, long nowEpochMs) {
             return Uni.createFrom().item(Optional.of(createTestRecord()));
         }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/InMemoryExecutionStateStoreTest.java
@@ -170,6 +170,50 @@ class InMemoryExecutionStateStoreTest {
     }
 
     @Test
+    void itemizedAwaitReleaseStoresSnapshotValueCopy() {
+        InMemoryExecutionStateStore store = new InMemoryExecutionStateStore();
+        long now = System.currentTimeMillis();
+        CreateExecutionResult created = store.createOrGetExecution(
+                new ExecutionCreateCommand(
+                    "tenant-a",
+                    "key-itemized-release",
+                    "payload",
+                    ExecutionResultShape.MATERIALIZED_MULTI,
+                    now,
+                    now / 1000 + 60))
+            .await().indefinitely();
+        Optional<ExecutionRecord<Object, Object>> waiting = store.markWaitingExternal(
+                "tenant-a",
+                created.record().executionId(),
+                created.record().version(),
+                "transition-await",
+                "unit-1",
+                5,
+                now + 1)
+            .await().indefinitely();
+        assertTrue(waiting.isPresent());
+        ExecutionInputSnapshot resumeInput = new ExecutionInputSnapshot(
+            ExecutionInputShape.MULTI,
+            new java.util.ArrayList<>(List.of("a", "b")));
+
+        Optional<ExecutionRecord<Object, Object>> queued = store.markAwaitItemContinuationsCompleted(
+                "tenant-a",
+                created.record().executionId(),
+                "unit-1",
+                6,
+                resumeInput,
+                now + 2)
+            .await().indefinitely();
+
+        assertTrue(queued.isPresent());
+        ExecutionInputSnapshot stored = assertInstanceOf(ExecutionInputSnapshot.class, queued.get().inputPayload());
+        assertNotSame(resumeInput, stored);
+        assertEquals(ExecutionInputShape.MULTI, stored.shape());
+        assertEquals(List.of("a", "b"), stored.payload());
+        assertNotSame(resumeInput.payload(), stored.payload());
+    }
+
+    @Test
     void dueSweepReturnsEmptyWhenLimitIsNonPositive() {
         InMemoryExecutionStateStore store = new InMemoryExecutionStateStore();
         long now = System.currentTimeMillis();


### PR DESCRIPTION
## Summary

Fixes the CSV await barrier by treating `ONE_TO_ONE` await over a `Multi` as itemized await work instead of one aggregate await unit release.

Key behavior changes:
- `AwaitStreamOneToOneStep` completions now continue item-by-item after Kafka/provider completion.
- Completed await items run downstream per-item steps immediately, then stop at the next aggregate step.
- The parent execution resumes at the aggregate step only after all item continuations are durably recorded and ordered by item index.
- Aggregate await cardinalities keep barrier semantics.
- Failed async item continuations are bounded-retried, then mark the parent execution failed instead of leaving it `WAITING_EXTERNAL`.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime -am -Dtest=QueueAsyncCoordinatorTest,ExecutionStateStoreTest,AwaitStepSupportTest,AwaitCoordinatorCompletionTest,PipelineReplayExecutionTest,ExecutionReplayTrackerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -am -DskipTests test-compile`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipTests install`
- `./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -am -Dcsv.e2e.telemetry.enabled=true -Dquarkus.otel.traces.sampler.arg=1 -Dcsv.e2e.reader-demand-pacer.rows-per-period=20 -Dcsv.e2e.reader-demand-pacer.millis-period=1000 -Dcsv.e2e.input.file=examples/csv-payments/input-csv-file-processing-svc/csv/payments_1k.csv -Dcsv.e2e.pipeline.wait.seconds=1800 -Dcsv.e2e.orchestrator.wait.seconds=1800 -Dtest=CsvPaymentsEndToEndIT#fullPipelineWorks -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

CSV replay proof from the passing 1K telemetry run:

```json
{
  "events": 12020,
  "counts": {
    "await_interaction_dispatched": 1000,
    "await_unit_item_completed": 1000,
    "await_unit_completed": 1,
    "await_resume_released": 1
  },
  "firstStatus": 2.38873675,
  "unitComplete": 50.371422,
  "statusBeforeUnitComplete": true
}
```

## CodeRabbit local review

Ran local CodeRabbit against exact base commit `74789d60` from the fresh `origin/main` worktree.

Addressed findings:
- strict store support for itemized await continuation operations
- classloader fallback for await payload coercion
- no stranded parent on item-continuation failure
- bounded scheduled retry before terminal failure
- deterministic CSV replay ordering assertion
- null-safe itemized parent release guard
- queue coordinator regression tests for child continuation ordering and failure behavior



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Itemized await continuations with exponential-backoff retry and ordered per-item resumption
  * Bounded pipeline execution (run a subset of steps)
  * Execution lookup by idempotency/execution key

* **Bug Fixes**
  * Resume payload selection now correctly uses await-unit presence
  * Parent release logic improved for itemized continuations
  * Stored resume snapshots are copied to avoid shared mutable payloads

* **Tests**
  * Updated await lifecycle assertions and added tests for itemized continuation flows and failure paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->