### PR TITLE
[codex] Improve Mermaid diagram readability on docs site

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -282,6 +282,34 @@ export default withMermaid(
     title: 'The Pipeline Framework',
     description: 'A framework for building reactive pipeline processing systems',
     lang: 'en-GB',
+    mermaid: {
+      fontFamily: 'Red Hat Text, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+      fontSize: 16,
+      flowchart: {
+        useMaxWidth: false,
+        htmlLabels: true
+      },
+      class: {
+        useMaxWidth: false,
+        htmlLabels: true
+      },
+      sequence: {
+        useMaxWidth: false,
+        actorFontSize: 17,
+        messageFontSize: 16,
+        noteFontSize: 16,
+        actorFontFamily: 'Red Hat Text, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+        messageFontFamily: 'Red Hat Text, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+        noteFontFamily: 'Red Hat Text, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif'
+      },
+      themeVariables: {
+        fontFamily: 'Red Hat Text, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+        fontSize: '16px',
+        primaryTextColor: '#1f2937',
+        secondaryTextColor: '#374151',
+        lineColor: '#64748b'
+      }
+    },
     
     // Base URL for the site (can be changed for different deployments)
     base: '/',

--- a/docs/.vitepress/theme/components/MermaidDiagramEnhancer.vue
+++ b/docs/.vitepress/theme/components/MermaidDiagramEnhancer.vue
@@ -1,0 +1,144 @@
+<!--
+  Copyright (c) 2023-2025 Mariano Barcia
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script setup>
+import {nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {useRoute} from 'vitepress'
+
+const route = useRoute()
+const activeSvg = ref('')
+const activeTitle = ref('Diagram')
+let mutationObserver
+let enhanceTimer
+let lastFocusedElement
+
+function diagramTitleFor(stage) {
+  let cursor = stage.previousElementSibling
+  while (cursor) {
+    if (/^H[1-6]$/.test(cursor.tagName)) {
+      return cursor.textContent?.trim() || 'Diagram'
+    }
+    cursor = cursor.previousElementSibling
+  }
+  return 'Diagram'
+}
+
+function openDiagram(stage) {
+  const svg = stage.querySelector('svg')
+  if (!svg) {
+    return
+  }
+  lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  activeTitle.value = diagramTitleFor(stage)
+  activeSvg.value = svg.outerHTML
+  document.documentElement.classList.add('tpf-mermaid-lightbox-open')
+  nextTick(() => {
+    document.querySelector('.tpf-mermaid-lightbox__close')?.focus()
+  })
+}
+
+function closeDiagram() {
+  activeSvg.value = ''
+  document.documentElement.classList.remove('tpf-mermaid-lightbox-open')
+  lastFocusedElement?.focus?.()
+}
+
+function handleStageKeydown(event, stage) {
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return
+  }
+  event.preventDefault()
+  openDiagram(stage)
+}
+
+function enhanceDiagram(stage) {
+  if (!stage.querySelector('svg')) {
+    return
+  }
+  stage.querySelector(':scope > .tpf-mermaid-expand')?.remove()
+  if (stage.dataset.tpfMermaidEnhanced !== 'true') {
+    stage.addEventListener('click', () => openDiagram(stage))
+    stage.addEventListener('keydown', (event) => handleStageKeydown(event, stage))
+  }
+  stage.dataset.tpfMermaidEnhanced = 'true'
+  stage.classList.add('tpf-mermaid-stage')
+  stage.tabIndex = 0
+  stage.setAttribute('role', 'button')
+  stage.setAttribute('aria-label', `Expand ${diagramTitleFor(stage)} diagram`)
+  stage.title = 'Expand diagram'
+}
+
+function enhanceDiagrams() {
+  clearTimeout(enhanceTimer)
+  enhanceTimer = window.setTimeout(() => {
+    document.querySelectorAll('.vp-doc .mermaid').forEach(enhanceDiagram)
+  }, 80)
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape' && activeSvg.value) {
+    closeDiagram()
+  }
+}
+
+onMounted(() => {
+  enhanceDiagrams()
+  mutationObserver = new MutationObserver(enhanceDiagrams)
+  mutationObserver.observe(document.body, {childList: true, subtree: true})
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(enhanceTimer)
+  mutationObserver?.disconnect()
+  document.removeEventListener('keydown', handleKeydown)
+  document.documentElement.classList.remove('tpf-mermaid-lightbox-open')
+})
+
+watch(
+  () => route.path,
+  () => nextTick(enhanceDiagrams)
+)
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="activeSvg"
+      class="tpf-mermaid-lightbox"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="`${activeTitle} expanded diagram`"
+      @click.self="closeDiagram"
+    >
+      <div class="tpf-mermaid-lightbox__panel">
+        <div class="tpf-mermaid-lightbox__header">
+          <p>{{ activeTitle }}</p>
+          <button
+            type="button"
+            class="tpf-mermaid-lightbox__close"
+            title="Close diagram"
+            aria-label="Close diagram"
+            @click="closeDiagram"
+          >
+            Close
+          </button>
+        </div>
+        <div class="tpf-mermaid-lightbox__stage" v-html="activeSvg"></div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -626,6 +626,61 @@ kbd {
   }
 }
 
+@media (max-width: 640px), (max-width: 1279px) and (pointer: coarse) {
+  html,
+  body,
+  #app,
+  .Layout,
+  .VPApp,
+  .VPContent,
+  .VPDoc,
+  .VPDoc .container,
+  .VPDoc .content,
+  .VPDoc .content-container,
+  .vp-doc {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  html,
+  body,
+  #app,
+  .Layout,
+  .VPApp,
+  .VPContent,
+  .VPDoc {
+    overflow-x: hidden !important;
+  }
+
+  .VPDoc {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+
+  .VPDoc .container,
+  .VPDoc .content,
+  .VPDoc .content-container {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .VPDoc.has-aside .content-container {
+    max-width: 100% !important;
+  }
+
+  .vp-doc {
+    overflow-wrap: anywhere;
+  }
+
+  .vp-doc div[class*='language-'],
+  .vp-doc table {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}
+
 /* Sidebar */
 .VPSidebar {
   padding-top: 1.5rem;

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -18,11 +18,13 @@
 import DefaultTheme from 'vitepress/theme'
 import {h} from 'vue'
 import './custom.css'
+import './mermaid.css'
 import Callout from './components/Callout.vue'
 import FeaturedArticles from './components/FeaturedArticles.vue'
 import HeroSection from './components/HeroSection.vue'
 import VersionBadge from './components/VersionBadge.vue'
 import LatestReleases from './components/LatestReleases.vue'
+import MermaidDiagramEnhancer from './components/MermaidDiagramEnhancer.vue'
 
 function installReplayViewerHardNavigation() {
   if (typeof window === 'undefined' || window.__tpfReplayViewerHardNavInstalled) {
@@ -57,9 +59,12 @@ function installReplayViewerHardNavigation() {
 export default {
   ...DefaultTheme,
   Layout() {
-    return h(DefaultTheme.Layout, null, {
-      'doc-before': () => h(VersionBadge)
-    })
+    return h('div', [
+      h(DefaultTheme.Layout, null, {
+        'doc-before': () => h(VersionBadge)
+      }),
+      h(MermaidDiagramEnhancer)
+    ])
   },
   enhanceApp({ app }) {
     // Register custom components

--- a/docs/.vitepress/theme/mermaid.css
+++ b/docs/.vitepress/theme/mermaid.css
@@ -15,12 +15,212 @@
  */
 
 /* Mermaid diagram styles */
-.mermaid {
+.vp-doc .mermaid {
+  box-sizing: border-box;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  margin: 1.35rem 0;
+  padding: 1rem;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
   text-align: center;
-  margin: 1rem 0;
+  cursor: zoom-in;
+  touch-action: manipulation;
 }
 
-.mermaid svg {
+.vp-doc .mermaid svg {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
   max-width: 100%;
   height: auto;
+  min-width: 0;
+  margin: 0 auto;
+  vertical-align: middle;
+}
+
+.vp-doc .mermaid text,
+.vp-doc .mermaid .label,
+.vp-doc .mermaid .messageText,
+.vp-doc .mermaid .actor {
+  font-family: var(--vp-font-family-base);
+}
+
+.vp-doc .mermaid:hover,
+.vp-doc .mermaid:focus-visible {
+  border-color: var(--vp-c-brand);
+  outline: none;
+}
+
+.tpf-mermaid-lightbox-open body {
+  overflow: hidden !important;
+}
+
+.tpf-mermaid-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
+  background: rgb(15 23 42 / 68%);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
+
+.tpf-mermaid-lightbox__panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: min(96vw, 1680px);
+  height: min(92vh, 1040px);
+  overflow: hidden;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 16px;
+  background: var(--vp-c-bg);
+  box-shadow: 0 28px 80px rgb(2 6 23 / 35%);
+}
+
+.tpf-mermaid-lightbox__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.tpf-mermaid-lightbox__header p {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-display);
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tpf-mermaid-lightbox__close {
+  flex: 0 0 auto;
+  min-height: 34px;
+  padding: 0 0.8rem;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 999px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-base);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.tpf-mermaid-lightbox__close:hover,
+.tpf-mermaid-lightbox__close:focus-visible {
+  border-color: var(--vp-c-brand);
+  color: var(--vp-c-brand);
+}
+
+.tpf-mermaid-lightbox__stage {
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding: clamp(1rem, 2vw, 1.75rem);
+  background: var(--vp-c-bg-soft);
+  overscroll-behavior: contain;
+}
+
+.tpf-mermaid-lightbox__stage svg {
+  display: block;
+  width: auto;
+  min-width: 0;
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
+.tpf-mermaid-lightbox__stage text,
+.tpf-mermaid-lightbox__stage .label,
+.tpf-mermaid-lightbox__stage .messageText,
+.tpf-mermaid-lightbox__stage .actor {
+  font-family: var(--vp-font-family-base);
+}
+
+.dark .vp-doc .mermaid {
+  background: var(--vp-c-bg-alt);
+}
+
+.dark .tpf-mermaid-lightbox {
+  background: rgb(2 6 23 / 78%);
+}
+
+@media (max-width: 640px), (max-width: 1279px) and (pointer: coarse) {
+  .vp-doc .mermaid {
+    margin: 1rem 0;
+    padding: 0.65rem;
+    border-radius: 10px;
+  }
+
+  .vp-doc .mermaid svg {
+    min-width: 0;
+  }
+
+  .tpf-mermaid-lightbox {
+    padding: 0;
+  }
+
+  .tpf-mermaid-lightbox__panel {
+    width: 100dvw;
+    height: 100dvh;
+    border-radius: 0;
+  }
+
+  .tpf-mermaid-lightbox__header {
+    padding: 0.45rem 0.6rem;
+  }
+
+  .tpf-mermaid-lightbox__header p {
+    font-size: 0.9rem;
+  }
+
+  .tpf-mermaid-lightbox__close {
+    min-height: 30px;
+    padding: 0 0.65rem;
+  }
+
+  .tpf-mermaid-lightbox__stage {
+    overflow: hidden;
+    padding: 0.25rem;
+    scrollbar-width: none;
+  }
+
+  .tpf-mermaid-lightbox__stage::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tpf-mermaid-lightbox__stage svg {
+    width: auto;
+    height: auto;
+    min-width: 0;
+    max-width: 100%;
+    max-height: 100%;
+  }
+}
+
+@media (min-width: 901px) and (hover: hover) and (pointer: fine) {
+  .tpf-mermaid-lightbox__stage {
+    display: block;
+    overflow: auto;
+  }
+
+  .tpf-mermaid-lightbox__stage svg {
+    min-width: min(1400px, 160vw);
+    max-width: none;
+    max-height: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add a VitePress Mermaid diagram enhancer so rendered diagrams can be opened in a fullscreen lightbox
- make diagrams clickable/tappable instead of relying on a separate expand button
- improve Mermaid sequence/class/flowchart rendering defaults
- tighten mobile/touch docs layout so content and diagrams fit the viewport, including landscape

## Validation
- npm --prefix docs run build
- git diff --check

## Scope
This PR is site-wide docs UX only. Await-runtime guide content is being kept with PR #368.