### PR TITLE
[codex] Sync replay viewer public app

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "docs/**"
+      - "tools/replay-viewer/**"
       - "tools/homepage-replay-video/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
@@ -46,3 +47,4 @@ jobs:
             docs/public/home/replay-proof.mp4 \
             docs/public/home/replay-proof-poster.jpg
           npm --prefix docs run build
+          git diff --exit-code -- docs/public/replay-viewer-app

--- a/docs/public/replay-viewer-app/README.md
+++ b/docs/public/replay-viewer-app/README.md
@@ -21,8 +21,8 @@ So the viewer only needs one file at import time.
 - primary pipeline steps
 - plugin nodes
 - transition edges
-- replay metadata in a strip below the player
-- player chrome over the viewport for transport, scrubber, inline speed radios, and utility icons
+- replay metadata in the info modal
+- hover/tap player chrome over the viewport for transport, scrubber, replay title, inline speed radios, and utility icons
 - a persistent shell link back to the replay docs page outside the player chrome
 - modal source and info surfaces opened from the bottom-right utility icons
 - semantic effects for:

--- a/docs/public/replay-viewer-app/app.js
+++ b/docs/public/replay-viewer-app/app.js
@@ -6,6 +6,7 @@ const viewport = document.querySelector(".viewport");
 const playerSurface = document.getElementById("playerSurface");
 const playerChrome = document.getElementById("playerChrome");
 const backToDocsLink = document.getElementById("backToDocsLink");
+const loadReplayButton = document.getElementById("loadReplayButton");
 const playPauseButton = document.getElementById("playPauseButton");
 const stopButton = document.getElementById("stopButton");
 const restartButton = document.getElementById("restartButton");
@@ -14,6 +15,12 @@ const stepButton = document.getElementById("stepButton");
 const infoButton = document.getElementById("infoButton");
 const infoModal = document.getElementById("infoModal");
 const infoCloseButton = document.getElementById("infoCloseButton");
+const sourceModal = document.getElementById("sourceModal");
+const sourceCloseButton = document.getElementById("sourceCloseButton");
+const sourceCancelButton = document.getElementById("sourceCancelButton");
+const sourceModalTitle = document.getElementById("sourceModalTitle");
+const sourceModalDescription = document.getElementById("sourceModalDescription");
+const sourceModalStatus = document.getElementById("sourceModalStatus");
 const fullscreenButton = document.getElementById("fullscreenButton");
 const datasetSelect = document.getElementById("datasetSelect");
 const sourceApplyButton = document.getElementById("sourceApplyButton");
@@ -22,12 +29,14 @@ const customReplayInputWrap = document.getElementById("customReplayInputWrap");
 const replayFileInput = document.getElementById("replayFileInput");
 const speedInputs = [...document.querySelectorAll('input[name="speed"]')];
 const timelineSlider = document.getElementById("timelineSlider");
-const datasetName = document.getElementById("datasetName");
-const pipelineName = document.getElementById("pipelineName");
-const durationText = document.getElementById("durationText");
-const topologyText = document.getElementById("topologyText");
+const playerTitle = document.getElementById("playerTitle");
 const playbackText = document.getElementById("playbackText");
-const eventCountText = document.getElementById("eventCountText");
+const summaryDatasetName = document.getElementById("summaryDatasetName");
+const summaryPipelineName = document.getElementById("summaryPipelineName");
+const summaryDurationText = document.getElementById("summaryDurationText");
+const summaryTopologyText = document.getElementById("summaryTopologyText");
+const summaryEventCountText = document.getElementById("summaryEventCountText");
+const rejectLegendItems = [...document.querySelectorAll('[data-support-kind="reject"]')];
 const loadProgress = document.getElementById("loadProgress");
 const loadProgressFill = document.getElementById("loadProgressFill");
 const loadProgressText = document.getElementById("loadProgressText");
@@ -40,10 +49,15 @@ const BASE_LABEL_HEIGHT = 0.8;
 const SUPPORT_LABEL_HEIGHT = 0.5;
 const LABEL_OFFSET_Y = 1.12;
 const COUNTER_LABEL_HEIGHT = 0.44;
+const PRESSURE_RING_START_ANGLE = (Math.PI * 5) / 4;
+const PRESSURE_RING_SWEEP_ANGLE = -(Math.PI * 3) / 2;
 const PRIMARY_ROW_Y = 2.45;
 const BRANCH_ROW_OFFSET_Y = 2.05;
 const EMPTY_REPLAY_SOURCE_KEY = "none";
 const DEFAULT_REPLAY_SOURCE_KEY = EMPTY_REPLAY_SOURCE_KEY;
+const FIRST_VISIT_AUTOLOAD_SOURCE_KEY = "csv-payments";
+const FIRST_VISIT_AUTOLOAD_STORAGE_KEY = "tpf-replay-viewer-first-visit-autoloaded:v1";
+const COMPLETION_PROMPT_DELAY_MS = 3000;
 const LAYOUT_STORAGE_PREFIX = "tpf-replay-viewer-layout";
 const BUILT_IN_REPLAYS = new Map(BUILT_IN_REPLAYS_CONFIG.map((entry) => [entry.key, { label: entry.label, path: entry.path }]));
 const EFFECT_PRESETS = {
@@ -108,7 +122,7 @@ const END_DRAIN_SECONDS = Math.max(
         return [];
       })
 );
-const CHROME_HIDE_DELAY_MS = 1800;
+const CHROME_HIDE_DELAY_MS = 2000;
 
 const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -137,6 +151,7 @@ const automaticNodePositions = new Map();
 const nodeLabelSprites = new Map();
 const nodeValueSprites = new Map();
 const nodeIconSprites = new Map();
+const nodePressureRings = new Map();
 const edgeLines = new Map();
 const particles = new Map();
 const pulseEffects = [];
@@ -183,6 +198,7 @@ const AWAIT_ATTR = {
 let fallbackAwaitDisplayStep = null;
 let activeAnimationPolicy = emptyAnimationPolicy();
 let replayHasAwaitLifecycleEvents = false;
+let replayBackpressureCapacity = null;
 
 let replayDocument = normalizeReplayDocument(validateReplayDocument({ topology: { steps: [], transitions: [] }, events: [], durationMs: 0, pipeline: "loading" }));
 let replayDurationSeconds = 0.1;
@@ -206,6 +222,8 @@ let dragState = null;
 let suppressNextCanvasClick = false;
 let prefersTapChrome = window.matchMedia("(hover: none), (pointer: coarse)").matches;
 let loadProgressHideTimeout = null;
+let completionPromptTimeout = null;
+let completionPromptShownForPlayback = false;
 
 function resolveReplayDocsHref() {
   const replayDocsPath = "/guide/operations/observability/replay";
@@ -250,7 +268,8 @@ function updateSourceApplyButton() {
   }
   const nextSourceKey = datasetSelect.value;
   const hasPendingCustomReplay = nextSourceKey === "custom" && Boolean(replayFileInput.files?.length);
-  sourceApplyButton.disabled = nextSourceKey === EMPTY_REPLAY_SOURCE_KEY
+  sourceApplyButton.disabled = isLoadingReplay
+    || nextSourceKey === EMPTY_REPLAY_SOURCE_KEY
     || (nextSourceKey === "custom" && !hasPendingCustomReplay);
 }
 
@@ -678,6 +697,12 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
+function setSourceModalStatus(text) {
+  if (sourceModalStatus) {
+    sourceModalStatus.textContent = text;
+  }
+}
+
 function setLoadProgress(visible, ratio = 0, text = "Loading replay...") {
   isLoadingReplay = visible;
   if (loadProgressHideTimeout) {
@@ -687,11 +712,13 @@ function setLoadProgress(visible, ratio = 0, text = "Loading replay...") {
   loadProgress.hidden = !visible;
   loadProgressFill.style.width = `${Math.round(clamp(ratio, 0, 1) * 100)}%`;
   loadProgressText.textContent = text;
+  setSourceModalStatus(text);
   if (visible) {
     revealPlayerChrome(true);
   } else if (!isAnyModalOpen()) {
     scheduleChromeHide();
   }
+  updateSourceApplyButton();
 }
 
 function finishLoadProgress(text = "Replay loaded") {
@@ -702,6 +729,7 @@ function finishLoadProgress(text = "Replay loaded") {
   loadProgress.hidden = false;
   loadProgressFill.style.width = "100%";
   loadProgressText.textContent = text;
+  setSourceModalStatus(text);
   loadProgressHideTimeout = window.setTimeout(() => {
     loadProgress.hidden = true;
     loadProgressHideTimeout = null;
@@ -709,6 +737,7 @@ function finishLoadProgress(text = "Replay loaded") {
       scheduleChromeHide();
     }
   }, 1100);
+  updateSourceApplyButton();
 }
 
 function nextAnimationFrame() {
@@ -983,6 +1012,11 @@ function clearScene() {
     removeAndDispose(sprite);
   }
   nodeValueSprites.clear();
+  for (const ring of nodePressureRings.values()) {
+    removeAndDispose(ring.track);
+    removeAndDispose(ring.arc);
+  }
+  nodePressureRings.clear();
   for (const sprite of nodeIconSprites.values()) {
     removeAndDispose(sprite);
   }
@@ -1053,10 +1087,6 @@ function setPlayerChromeVisible(visible) {
 
 function scheduleChromeHide(delayMs = CHROME_HIDE_DELAY_MS) {
   cancelChromeHide();
-  if (!prefersTapChrome) {
-    setPlayerChromeVisible(true);
-    return;
-  }
   if (isAnyModalOpen() || isScrubbingTimeline || isLoadingReplay) {
     setPlayerChromeVisible(true);
     return;
@@ -1066,24 +1096,80 @@ function scheduleChromeHide(delayMs = CHROME_HIDE_DELAY_MS) {
       setPlayerChromeVisible(true);
       return;
     }
-    if (prefersTapChrome && !isPlaying) {
-      return;
-    }
     setPlayerChromeVisible(false);
   }, delayMs);
 }
 
 function revealPlayerChrome(sticky = false) {
   setPlayerChromeVisible(true);
-  if (!prefersTapChrome) {
+  if (sticky || isAnyModalOpen() || isScrubbingTimeline || isLoadingReplay) {
     cancelChromeHide();
     return;
   }
-  if (!sticky) {
-    scheduleChromeHide();
-  } else {
-    cancelChromeHide();
+  scheduleChromeHide();
+}
+
+function setSourceModalMode(mode = "load") {
+  if (!sourceModalTitle || !sourceModalDescription) {
+    return;
   }
+  if (mode === "completion") {
+    sourceModalTitle.textContent = "Replay finished";
+    sourceModalDescription.textContent = "Load another built-in capture or try your own replay JSON.";
+    setSourceModalStatus("Choose what to inspect next.");
+    return;
+  }
+  sourceModalTitle.textContent = "Load replay";
+  sourceModalDescription.textContent = "Choose a captured built-in replay or upload a replay JSON. The viewer plays real event timing, counters, and topology without synthetic flows.";
+  if (isLoadingReplay) {
+    setSourceModalStatus(loadProgressText.textContent);
+  } else if (activeReplaySourceKey === EMPTY_REPLAY_SOURCE_KEY) {
+    setSourceModalStatus("CSV Payments will load automatically on your first visit.");
+  } else {
+    setSourceModalStatus("Choose a different replay or upload a custom JSON file.");
+  }
+}
+
+function openSourceModal(mode = "load") {
+  setSourceModalMode(mode);
+  openModalElement("source", sourceModal);
+}
+
+function cancelCompletionPrompt() {
+  if (completionPromptTimeout != null) {
+    window.clearTimeout(completionPromptTimeout);
+    completionPromptTimeout = null;
+  }
+}
+
+function resetCompletionPromptForPlayback() {
+  cancelCompletionPrompt();
+  completionPromptShownForPlayback = false;
+}
+
+function scheduleCompletionPrompt() {
+  if (
+    completionPromptShownForPlayback ||
+    replayDocument.events.length === 0 ||
+    isLoadingReplay ||
+    isAnyModalOpen()
+  ) {
+    return;
+  }
+  completionPromptShownForPlayback = true;
+  cancelCompletionPrompt();
+  completionPromptTimeout = window.setTimeout(() => {
+    completionPromptTimeout = null;
+    if (
+      isPlaying ||
+      isLoadingReplay ||
+      isAnyModalOpen() ||
+      currentTimeSeconds < replayDurationSeconds
+    ) {
+      return;
+    }
+    openSourceModal("completion");
+  }, COMPLETION_PROMPT_DELAY_MS);
 }
 
 function openModalElement(name, element) {
@@ -1168,6 +1254,26 @@ function renderRunParameters(runParameters) {
   }
 }
 
+function runParameterValue(runParameters, key) {
+  for (const section of runParameters?.sections ?? []) {
+    for (const entry of section?.entries ?? []) {
+      if (entry?.key === key) {
+        return entry.value ?? null;
+      }
+    }
+  }
+  return null;
+}
+
+function numericRunParameter(runParameters, key) {
+  const value = runParameterValue(runParameters, key);
+  if (value == null || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
 function renderAwaitUnitSummary() {
   const units = awaitUnitSummaries(replayDocument.events);
   if (units.length === 0) {
@@ -1243,8 +1349,19 @@ function awaitUnitSummaries(events) {
     });
 }
 
+function updateLegendForReplay(document) {
+  const hasReject = (document.topology?.steps ?? []).some((step) => step.pluginKind === "reject")
+    || (document.events ?? []).some((event) => event.event === "reject");
+  for (const item of rejectLegendItems) {
+    item.hidden = !hasReject;
+  }
+}
+
 function reportViewerIssue(message) {
-  eventCountText.textContent = `Status: ${message}`;
+  loadProgress.hidden = false;
+  loadProgressFill.style.width = "100%";
+  loadProgressText.textContent = `Status: ${message}`;
+  setSourceModalStatus(`Status: ${message}`);
   if (runtimeStatus) {
     runtimeStatus.textContent = message;
   }
@@ -1273,9 +1390,11 @@ function loadReplay(document, label, sourceKey = activeReplaySourceKey) {
   replayDocument = normalizeReplayDocument(validateReplayDocument(document));
   activeLayoutStorageKey = replayLayoutStorageKey(replayDocument);
   replayDurationSeconds = computeReplayDurationSeconds(replayDocument);
+  replayBackpressureCapacity = numericRunParameter(replayDocument.runParameters, "pipeline.defaults.backpressure-buffer-capacity");
   currentTimeSeconds = 0;
   isPlaying = false;
   isFinishingEffects = false;
+  resetCompletionPromptForPlayback();
   fallbackAwaitDisplayStep = replayDocument.fallbackAwaitDisplayStep ?? null;
   replayHasAwaitLifecycleEvents = replayDocument.hasAwaitLifecycleEvents === true;
   for (const [rawStepName, displayStepName] of Object.entries(replayDocument.displayAliases ?? {})) {
@@ -1330,14 +1449,16 @@ function loadReplay(document, label, sourceKey = activeReplaySourceKey) {
   datasetSelect.value = sourceKey;
   setCustomReplayVisibility(sourceKey === "custom");
   updateSourceApplyButton();
-  datasetName.textContent = label;
-  pipelineName.textContent = `Pipeline: ${replayDocument.pipeline}`;
-  durationText.textContent = `Duration: ${replayDurationSeconds.toFixed(2)}s`;
-  topologyText.textContent = `Topology: ${replayDocument.topology.steps.length} nodes / ${replayDocument.topology.transitions.length} edges`;
-  eventCountText.textContent = `Events: ${replayDocument.events.length}`;
+  playerTitle.textContent = label;
+  summaryDatasetName.textContent = label;
+  summaryPipelineName.textContent = replayDocument.pipeline;
+  summaryDurationText.textContent = `${replayDurationSeconds.toFixed(2)}s`;
+  summaryTopologyText.textContent = `${replayDocument.topology.steps.length} nodes / ${replayDocument.topology.transitions.length} edges`;
+  summaryEventCountText.textContent = String(replayDocument.events.length);
+  updateLegendForReplay(replayDocument);
   renderRunParameters(replayDocument.runParameters);
   resetPlaybackState();
-  revealPlayerChrome(true);
+  revealPlayerChrome();
   updateUi();
 }
 
@@ -1371,6 +1492,83 @@ async function loadBuiltInReplay(datasetKey) {
     throw new Error(`${dataset.label} could not be rendered: ${error.message}`);
   }
   finishLoadProgress(`${dataset.label} loaded`);
+}
+
+async function applySelectedReplaySource({ closeOnSuccess = true } = {}) {
+  if (isLoadingReplay) {
+    return false;
+  }
+  cancelCompletionPrompt();
+  const nextSource = datasetSelect.value;
+  if (nextSource === EMPTY_REPLAY_SOURCE_KEY) {
+    return false;
+  }
+  try {
+    if (nextSource === "custom") {
+      const [file] = replayFileInput.files || [];
+      if (!file) {
+        return false;
+      }
+      isPlaying = false;
+      setLoadProgress(true, 0, `Loading ${file.name}...`);
+      updateUi();
+      await nextAnimationFrame();
+      const text = await readReplayFile(file);
+      setLoadProgress(true, 1, `Parsing ${file.name}...`);
+      await nextAnimationFrame();
+      const parsed = JSON.parse(text);
+      loadReplay(parsed, file.name, "custom");
+      finishLoadProgress(`${file.name} loaded`);
+    } else {
+      await loadBuiltInReplay(nextSource);
+    }
+    resetCompletionPromptForPlayback();
+    if (closeOnSuccess && openModal === "source") {
+      closeModalElement("source", sourceModal);
+    }
+    scheduleChromeHide();
+    updateUi();
+    return true;
+  } catch (error) {
+    setLoadProgress(false);
+    reportViewerIssue(`failed to load replay (${error.message})`);
+    setSourceModalStatus(`Could not load replay: ${error.message}`);
+    playPauseButton.disabled = false;
+    restartButton.disabled = false;
+    stepBackButton.disabled = false;
+    stepButton.disabled = false;
+    return false;
+  }
+}
+
+async function loadFirstVisitReplayAfterPaint() {
+  if (DEFAULT_REPLAY_SOURCE_KEY !== EMPTY_REPLAY_SOURCE_KEY) {
+    return;
+  }
+  try {
+    if (localStorage.getItem(FIRST_VISIT_AUTOLOAD_STORAGE_KEY)) {
+      return;
+    }
+  } catch (_error) {
+    // Keep the first-run experience useful when storage is unavailable.
+  }
+  await nextAnimationFrame();
+  await nextAnimationFrame();
+  await new Promise((resolve) => window.setTimeout(resolve, 2000));
+  if (isLoadingReplay || replayDocument.events.length > 0 || isAnyModalOpen()) {
+    return;
+  }
+  try {
+    await loadBuiltInReplay(FIRST_VISIT_AUTOLOAD_SOURCE_KEY);
+    try {
+      localStorage.setItem(FIRST_VISIT_AUTOLOAD_STORAGE_KEY, "true");
+    } catch (_error) {
+      // Private browsing or locked-down storage should not block the loaded replay.
+    }
+  } catch (error) {
+    setLoadProgress(false);
+    reportViewerIssue(`failed to load first-visit replay (${error.message})`);
+  }
 }
 
 function readReplayFile(file) {
@@ -1550,6 +1748,9 @@ function registerNode(step, position) {
   scene.add(mesh);
   nodeMeshes.set(step.step, mesh);
   nodePositions.set(step.step, position.clone());
+  if (!isSideEffect) {
+    registerPressureRing(step, position);
+  }
   if (!isSideEffect || isNamedSupportActor(step)) {
     const sprite = buildStepLabelSprite(step.step);
     const labelOffset = isSideEffect ? LABEL_OFFSET_Y - 0.08 : LABEL_OFFSET_Y;
@@ -1560,16 +1761,7 @@ function registerNode(step, position) {
     nodeLabelSprites.set(step.step, sprite);
   }
   if (!isSideEffect) {
-    const valueSprite = buildTextSprite("0|0", {
-      fontSize: 28,
-      fontWeight: 700,
-      fillStyle: "#f8fbff",
-      paddingX: 12,
-      paddingY: 8,
-      backgroundStyle: "rgba(7, 16, 31, 0.0)",
-      borderStyle: null,
-      height: COUNTER_LABEL_HEIGHT
-    });
+    const valueSprite = buildThroughputCounterSprite("—|—");
     valueSprite.position.copy(position);
     scene.add(valueSprite);
     nodeValueSprites.set(step.step, valueSprite);
@@ -1618,6 +1810,7 @@ function updateNodeDecorations(stepName) {
       : new THREE.Vector3(0, 0, 0);
     value.position.copy(position).add(valueOffset);
   }
+  updatePressureRingPosition(stepName, position);
   const icon = nodeIconSprites.get(stepName);
   if (icon) {
     icon.position.copy(position);
@@ -1692,6 +1885,127 @@ function buildStepLabelSprite(stepName) {
 function buildPluginIconSprite(step) {
   const iconKind = resolveDisplayIconKind(step);
   return buildIconSprite(iconKind, iconKind === "reject" ? 0.54 : 0.72);
+}
+
+function buildThroughputCounterSprite(text) {
+  return buildTextSprite(text, {
+    fontSize: 28,
+    fontWeight: 700,
+    fillStyle: "#f8fbff",
+    paddingX: 12,
+    paddingY: 8,
+    backgroundStyle: "rgba(7, 16, 31, 0.0)",
+    borderStyle: null,
+    height: COUNTER_LABEL_HEIGHT
+  });
+}
+
+function replaceThroughputCounterSprite(sprite, text) {
+  replaceSpriteText(sprite, text, sprite.userData.options ?? {
+    fontSize: 28,
+    fontWeight: 700,
+    fillStyle: "#f8fbff",
+    paddingX: 12,
+    paddingY: 8,
+    backgroundStyle: "rgba(7, 16, 31, 0.0)",
+    borderStyle: null,
+    height: COUNTER_LABEL_HEIGHT
+  });
+  sprite.userData.text = text;
+}
+
+function registerPressureRing(step, position) {
+  const radius = BASE_NODE_RADIUS + 0.14;
+  const width = 0.065;
+  const trackGeometry = new THREE.RingGeometry(
+    radius,
+    radius + width,
+    80,
+    1,
+    PRESSURE_RING_START_ANGLE,
+    PRESSURE_RING_SWEEP_ANGLE
+  );
+  const trackMaterial = new THREE.MeshBasicMaterial({
+    color: 0x8da2c9,
+    transparent: true,
+    opacity: 0.22,
+    side: THREE.DoubleSide,
+    depthTest: false
+  });
+  const track = new THREE.Mesh(trackGeometry, trackMaterial);
+  track.position.copy(position).setZ(0.05);
+  track.renderOrder = 8;
+  scene.add(track);
+
+  const arcMaterial = new THREE.MeshBasicMaterial({
+    color: 0x8bffa5,
+    transparent: true,
+    opacity: 0,
+    side: THREE.DoubleSide,
+    depthTest: false
+  });
+  const arc = new THREE.Mesh(
+    new THREE.RingGeometry(radius, radius + width, 80, 1, PRESSURE_RING_START_ANGLE, -0.001),
+    arcMaterial
+  );
+  arc.position.copy(position).setZ(0.06);
+  arc.renderOrder = 9;
+  scene.add(arc);
+
+  nodePressureRings.set(step.step, {
+    track,
+    arc,
+    radius,
+    width,
+    ratio: null
+  });
+}
+
+function updatePressureRingPosition(stepName, position) {
+  const ring = nodePressureRings.get(stepName);
+  if (!ring) {
+    return;
+  }
+  ring.track.position.copy(position).setZ(0.05);
+  ring.arc.position.copy(position).setZ(0.06);
+}
+
+function updatePressureRing(stepName, pressureRatio) {
+  const ring = nodePressureRings.get(stepName);
+  if (!ring) {
+    return;
+  }
+  const normalizedRatio = Number.isFinite(pressureRatio) ? clamp(pressureRatio, 0, 1) : null;
+  if (ring.ratio === normalizedRatio) {
+    return;
+  }
+  ring.ratio = normalizedRatio;
+  ring.arc.geometry.dispose();
+  const thetaLength = normalizedRatio == null || normalizedRatio <= 0
+    ? -0.001
+    : PRESSURE_RING_SWEEP_ANGLE * normalizedRatio;
+  ring.arc.geometry = new THREE.RingGeometry(
+    ring.radius,
+    ring.radius + ring.width,
+    80,
+    1,
+    PRESSURE_RING_START_ANGLE,
+    thetaLength
+  );
+  ring.arc.material.opacity = normalizedRatio == null || normalizedRatio <= 0 ? 0 : 0.96;
+  if (normalizedRatio != null) {
+    ring.arc.material.color.setHex(pressureColorForRatio(normalizedRatio));
+  }
+}
+
+function pressureColorForRatio(ratio) {
+  if (ratio >= 0.8) {
+    return 0xff7c8f;
+  }
+  if (ratio >= 0.45) {
+    return 0xffd166;
+  }
+  return 0x8bffa5;
 }
 
 function buildTextSprite(text, options = {}) {
@@ -2043,7 +2357,8 @@ function fitCameraToTopology(steps) {
   const width = Math.max(1, maxX - minX);
   const height = Math.max(1, maxY - minY);
   const centerX = (minX + maxX) / 2;
-  const centerY = (minY + maxY) / 2 + height * 0.16;
+  const verticalBias = camera.aspect < 0.9 ? -0.08 : 0.08;
+  const centerY = (minY + maxY) / 2 + height * verticalBias;
   const halfFovRadians = THREE.MathUtils.degToRad(camera.fov / 2);
   const fitHeightDistance = height * 0.5 / Math.tan(halfFovRadians);
   const fitWidthDistance = width * 0.5 / (Math.tan(halfFovRadians) * camera.aspect);
@@ -2286,15 +2601,37 @@ function resolveEventKey(event) {
 
 function stateForStep(stepName) {
   if (!runtimeStepState.has(stepName)) {
-    runtimeStepState.set(stepName, { inflight: 0, processed: 0, rejects: 0, known: false });
+    runtimeStepState.set(stepName, {
+      received: 0,
+      sent: 0,
+      inFlight: 0,
+      rejects: 0,
+      known: false,
+      receivedKnown: true,
+      sentKnown: true,
+      peakPressure: 0,
+      peakInFlight: 0,
+      activeInputKeys: new Set()
+    });
   }
   return runtimeStepState.get(stepName);
 }
 
-function countedItemCount(event) {
+function inputItemKeys(event) {
+  if (Array.isArray(event?.parentItemIds) && event.parentItemIds.length > 0) {
+    return event.parentItemIds.map((itemId) => String(itemId));
+  }
+  return event?.itemId ? [String(event.itemId)] : [];
+}
+
+function inputItemCount(event) {
   if (Array.isArray(event?.parentItemIds) && event.parentItemIds.length > 0) {
     return event.parentItemIds.length;
   }
+  return event?.itemId ? 1 : 0;
+}
+
+function outputItemCount(event) {
   return event?.itemId ? 1 : 0;
 }
 
@@ -2315,16 +2652,159 @@ function displayStateForStep(stepName) {
   }
   return {
     state: directState,
-    unknown: !directEventSteps.has(stepName)
+    unknown: !directState.known
   };
+}
+
+function markCounterEvidence(state, itemCount) {
+  if (itemCount > 0) {
+    state.known = true;
+    state.receivedKnown = true;
+    state.sentKnown = true;
+  }
+}
+
+function formatCounterValue(value, known = true) {
+  return known ? `${value}` : "—";
+}
+
+function recordReceived(state, itemCount) {
+  markCounterEvidence(state, itemCount);
+  if (itemCount > 0) {
+    state.received += itemCount;
+  }
+}
+
+function recordSent(state, itemCount) {
+  markCounterEvidence(state, itemCount);
+  if (itemCount > 0) {
+    state.sent += itemCount;
+  }
+}
+
+function recordInFlight(state, itemKeys, fallbackCount = 0) {
+  if (itemKeys.length > 0) {
+    let added = 0;
+    for (const itemKey of itemKeys) {
+      if (!state.activeInputKeys.has(itemKey)) {
+        state.activeInputKeys.add(itemKey);
+        added += 1;
+      }
+    }
+    if (added > 0) {
+      state.inFlight += added;
+      updatePeakPressure(state);
+    }
+    return;
+  }
+  if (fallbackCount > 0) {
+    state.inFlight += fallbackCount;
+    updatePeakPressure(state);
+  }
+}
+
+function releaseInFlight(state, itemKeys, fallbackCount = 0) {
+  if (itemKeys.length > 0) {
+    let released = 0;
+    for (const itemKey of itemKeys) {
+      if (state.activeInputKeys.delete(itemKey)) {
+        released += 1;
+      }
+    }
+    if (released > 0) {
+      state.inFlight = Math.max(0, state.inFlight - released);
+    }
+    return;
+  }
+  if (fallbackCount > 0) {
+    state.inFlight = Math.max(0, state.inFlight - fallbackCount);
+  }
+}
+
+function setInFlight(state, itemCount) {
+  state.inFlight = Math.max(0, itemCount);
+  state.peakInFlight = Math.max(state.peakInFlight ?? 0, state.inFlight);
+  state.peakPressure = Math.max(state.peakPressure ?? 0, state.inFlight);
+}
+
+function isCountedThroughputStep(stepName) {
+  const step = resolveStepDefinition(stepName);
+  return Boolean(step) && !step.sideEffect && step.pluginKind !== "reject";
+}
+
+function hasPrimaryInboundTransition(stepName) {
+  return (replayDocument.topology?.transitions ?? []).some((transition) =>
+    transition.to === stepName
+      && (transition.relationKind ?? "primary") === "primary"
+      && isCountedThroughputStep(transition.from)
+  );
+}
+
+function shouldCountStartAsReceived(event) {
+  if (!event?.step || !isCountedThroughputStep(event.step)) {
+    return false;
+  }
+  if (!hasPrimaryInboundTransition(event.step)) {
+    return true;
+  }
+  return stepHasRenderRole(event.from, "await");
+}
+
+function updatePeakPressure(state) {
+  state.peakInFlight = Math.max(state.peakInFlight ?? 0, state.inFlight ?? 0);
+  state.peakPressure = Math.max(state.peakPressure ?? 0, state.inFlight ?? 0);
+}
+
+function pressureForState(state) {
+  if (!state?.receivedKnown || !state?.sentKnown) {
+    return null;
+  }
+  return Math.max(0, state.inFlight ?? 0);
+}
+
+function pressureRatioForState(state) {
+  const pressure = pressureForState(state);
+  if (pressure == null) {
+    return null;
+  }
+  const capacity = replayBackpressureCapacity ?? state.peakInFlight ?? state.peakPressure;
+  if (!Number.isFinite(capacity) || capacity <= 0) {
+    return pressure > 0 ? 1 : 0;
+  }
+  return clamp(pressure / capacity, 0, 1);
+}
+
+function pressureCapacityForState(state) {
+  const pressure = pressureForState(state);
+  if (pressure == null) {
+    return null;
+  }
+  const capacity = replayBackpressureCapacity ?? state.peakInFlight ?? state.peakPressure;
+  return Number.isFinite(capacity) && capacity > 0 ? capacity : null;
+}
+
+function tooltipForStep(stepName) {
+  const step = resolveStepDefinition(stepName);
+  if (!step) {
+    return "";
+  }
+  const display = displayStateForStep(stepName);
+  const state = display.state;
+  const label = normalizeStepLabel(stepName);
+  if (step.pluginKind === "reject") {
+    return `${label}: rejected ${state.rejects}`;
+  }
+  if (display.unknown) {
+    return `${label}: received/sent counters unknown for this replay.`;
+  }
+  const pressure = pressureForState(state) ?? 0;
+  const capacity = pressureCapacityForState(state);
+  const capacityText = capacity == null ? "observed peak" : `${capacity} capacity`;
+  return `${label}: received ${formatCounterValue(state.received, state.receivedKnown)}, sent ${formatCounterValue(state.sent, state.sentKnown)}, queued pressure ${pressure} (${capacityText}).`;
 }
 
 function rejectStepNameFor(stepName) {
   return `Rejects ${stepName}`;
-}
-
-function stepCardinality(stepName) {
-  return resolveStepDefinition(stepName)?.cardinality?.toLowerCase() ?? null;
 }
 
 function recordReplayCounters(rawEvent) {
@@ -2337,46 +2817,41 @@ function recordReplayCounters(rawEvent) {
     return;
   }
   const state = stateForStep(event.step);
-  const itemCount = countedItemCount(rawEvent);
-  const cardinality = stepCardinality(event.step);
+  const inputCount = inputItemCount(rawEvent);
+  const inputKeys = inputItemKeys(rawEvent);
+  const outputCount = outputItemCount(rawEvent);
   if (isAwaitResumableError(rawEvent)) {
-    if (itemCount > 0) {
-      state.inflight = Math.max(0, state.inflight - itemCount);
-      state.processed += itemCount;
+    return;
+  }
+  if (event.event === "start") {
+    if (shouldCountStartAsReceived(event)) {
+      recordReceived(state, inputCount);
+    }
+    releaseInFlight(state, inputKeys, inputCount);
+    return;
+  }
+  if (event.event === "emit") {
+    recordSent(state, outputCount);
+    if (event.to && isCountedThroughputStep(event.to)) {
+      const targetState = stateForStep(event.to);
+      recordReceived(targetState, outputCount);
+      recordInFlight(targetState, rawEvent?.itemId ? [String(rawEvent.itemId)] : [], outputCount);
     }
     return;
   }
-  if (event.event === "emit" && event.to && stepHasRenderRole(event.to, "await")) {
-    stateForStep(event.to).inflight += itemCount;
-  }
-  if (event.event === "start" && event.from && stepHasRenderRole(event.from, "await")) {
-    const awaitState = stateForStep(event.from);
-    awaitState.inflight = Math.max(0, awaitState.inflight - itemCount);
-    awaitState.processed += itemCount;
-  }
-  if (event.event === "start") {
-    state.inflight += itemCount;
-    return;
-  }
-  if (event.event === "emit" && cardinality === "one-to-many" && event.from === event.step) {
-    state.processed += itemCount;
+  if (event.event === "success" || event.event === "error") {
+    releaseInFlight(state, inputKeys, inputCount);
     return;
   }
   if (event.event === "cache_hit") {
-    state.processed += itemCount;
     return;
   }
   if (event.event === "reject") {
     const rejectStepName = event.to || rejectStepNameFor(event.step);
     const rejectState = stateForStep(rejectStepName);
-    rejectState.rejects += itemCount;
+    markCounterEvidence(rejectState, inputCount);
+    rejectState.rejects += inputCount;
     return;
-  }
-  if (event.event === "success" || event.event === "error") {
-    state.inflight = Math.max(0, state.inflight - itemCount);
-    if (event.event === "success" && cardinality !== "one-to-many") {
-      state.processed += itemCount;
-    }
   }
 }
 
@@ -2387,13 +2862,33 @@ function recordAwaitLifecycleCounters(rawEvent, event) {
   }
   const expected = awaitLifecycleNumber(rawEvent, AWAIT_ATTR.expectedItemCount);
   const completed = awaitLifecycleNumber(rawEvent, AWAIT_ATTR.completedItemCount);
-  if (expected == null || completed == null) {
+  if (expected == null && completed == null) {
     return;
   }
   const state = stateForStep(awaitStepName);
-  state.inflight = Math.max(0, expected - completed);
-  state.processed = completed;
   state.known = true;
+  state.receivedKnown = true;
+  state.sentKnown = true;
+  if (rawEvent.event === "await_interaction_dispatched") {
+    if (expected != null) {
+      state.received = Math.max(state.received, expected);
+      setInFlight(state, Math.max(0, expected - state.sent));
+    }
+    return;
+  }
+  if (completed != null) {
+    state.sent = completed;
+    state.sentKnown = true;
+  } else {
+    state.sentKnown = false;
+  }
+  if (expected != null) {
+    state.received = Math.max(state.received, expected);
+    state.receivedKnown = true;
+  }
+  const receivedBaseline = expected ?? Math.max(state.received, completed ?? 0);
+  const completedBaseline = completed ?? state.sent;
+  setInFlight(state, Math.max(0, receivedBaseline - completedBaseline));
 }
 
 function spawnSupportTransit(fromStep, toStep, startTime, color, duration = 0.36, size = 0.085) {
@@ -2552,7 +3047,7 @@ function processEvent(rawEvent) {
   }
   const outputResumeEdge = event?.step ? activeAnimationPolicy.outputResumeByTargetStep.get(event.step) : null;
   if (rawEvent.event === "start" && outputResumeEdge && event.from === outputResumeEdge.from) {
-    animateOutputResume(outputResumeEdge, rawEvent.startTime, countedItemCount(rawEvent) > 1);
+    animateOutputResume(outputResumeEdge, rawEvent.startTime, inputItemCount(rawEvent) > 1);
   }
   const displayTargets = resolveDisplayTargets(event);
   if (isAwaitResumableError(rawEvent)) {
@@ -2828,29 +3323,26 @@ function updateNodes(timeSeconds) {
       ? `${state.rejects}`
       : display.unknown
         ? "—|—"
-        : `${state.inflight}|${state.processed}`;
+        : `${formatCounterValue(state.received, state.receivedKnown)}|${formatCounterValue(state.sent, state.sentKnown)}`;
+    const pressureRatio = step?.pluginKind === "reject" || display.unknown ? null : pressureRatioForState(state);
     if (sprite.userData.text !== expectedText) {
-      replaceSpriteText(sprite, expectedText, step?.pluginKind === "reject" ? {
-        fontSize: 26,
-        fontWeight: 700,
-        fillStyle: "#f8fbff",
-        paddingX: 6,
-        paddingY: 4,
-        backgroundStyle: "rgba(7, 16, 31, 0.0)",
-        borderStyle: null,
-        height: 0.22
-      } : {
-        fontSize: 28,
-        fontWeight: 700,
-        fillStyle: "#f8fbff",
-        paddingX: 12,
-        paddingY: 8,
-        backgroundStyle: "rgba(7, 16, 31, 0.0)",
-        borderStyle: null,
-        height: COUNTER_LABEL_HEIGHT
-      });
+      if (step?.pluginKind === "reject") {
+        replaceSpriteText(sprite, expectedText, {
+          fontSize: 26,
+          fontWeight: 700,
+          fillStyle: "#f8fbff",
+          paddingX: 6,
+          paddingY: 4,
+          backgroundStyle: "rgba(7, 16, 31, 0.0)",
+          borderStyle: null,
+          height: 0.22
+        });
+      } else {
+        replaceThroughputCounterSprite(sprite, expectedText);
+      }
       sprite.userData.text = expectedText;
     }
+    updatePressureRing(stepName, pressureRatio);
   }
 }
 
@@ -2959,6 +3451,7 @@ function updateHoveredStep(clientX, clientY) {
   const intersections = raycaster.intersectObjects([...nodeMeshes.values()], false);
   hoveredStepName = intersections[0]?.object?.userData?.step?.step ?? null;
   renderer.domElement.style.cursor = hoveredStepName ? "grab" : "default";
+  renderer.domElement.title = hoveredStepName ? tooltipForStep(hoveredStepName) : "";
 }
 
 function worldPointForPointer(clientX, clientY) {
@@ -3029,7 +3522,7 @@ function endNodeDrag(event) {
   suppressNextCanvasClick = moved;
   try {
     renderer.domElement.releasePointerCapture(event.pointerId);
-  } catch {
+  } catch (_error) {
     // Pointer capture may already be gone after browser-level cancellation.
   }
   renderer.domElement.style.cursor = hoveredStepName ? "grab" : "default";
@@ -3074,6 +3567,7 @@ function tick(now) {
       isPlaying = false;
       isFinishingEffects = false;
       currentTimeSeconds = replayDurationSeconds;
+      scheduleCompletionPrompt();
     }
     updateUi();
     renderer.render(scene, camera);
@@ -3087,24 +3581,34 @@ function tick(now) {
 }
 
 playPauseButton.addEventListener("click", () => {
-  if (isLoadingReplay) {
-    return;
+  try {
+    if (isLoadingReplay) {
+      return;
+    }
+    cancelCompletionPrompt();
+    revealPlayerChrome();
+    const shouldStart = !isPlaying;
+    if (shouldStart && currentTimeSeconds >= replayDurationSeconds) {
+      rebuildPlaybackTo(0);
+      completionPromptShownForPlayback = false;
+    }
+    previousAnimationFrame = performance.now();
+    isFinishingEffects = false;
+    isPlaying = shouldStart;
+    scheduleChromeHide();
+    updateUi();
+  } catch (error) {
+    reportRuntimeError("playback could not start", error);
   }
-  revealPlayerChrome(true);
-  if (!isPlaying && currentTimeSeconds >= replayDurationSeconds) {
-    rebuildPlaybackTo(0);
-  }
-  if (!isPlaying && nextEventCursor === 0 && replayDocument.events.length > 0) {
-    rebuildPlaybackToCursor(1);
-  }
-  previousAnimationFrame = performance.now();
-  isFinishingEffects = false;
-  isPlaying = !isPlaying;
-  scheduleChromeHide();
-  updateUi();
+});
+
+loadReplayButton.addEventListener("click", () => {
+  cancelCompletionPrompt();
+  openSourceModal("load");
 });
 
 restartButton.addEventListener("click", () => {
+  resetCompletionPromptForPlayback();
   revealPlayerChrome(true);
   restartPlayback();
   scheduleChromeHide();
@@ -3114,18 +3618,18 @@ stopButton.addEventListener("click", () => {
   if (isLoadingReplay) {
     return;
   }
+  resetCompletionPromptForPlayback();
   revealPlayerChrome(true);
   isPlaying = false;
   restartPlayback();
-  if (!prefersTapChrome) {
-    scheduleChromeHide();
-  }
+  scheduleChromeHide();
 });
 
 stepBackButton.addEventListener("click", () => {
   if (isLoadingReplay) {
     return;
   }
+  resetCompletionPromptForPlayback();
   revealPlayerChrome(true);
   stepBackwardOneEvent();
   scheduleChromeHide();
@@ -3135,12 +3639,14 @@ stepButton.addEventListener("click", () => {
   if (isLoadingReplay) {
     return;
   }
+  resetCompletionPromptForPlayback();
   revealPlayerChrome(true);
   stepForwardOneEvent();
   scheduleChromeHide();
 });
 
 timelineSlider.addEventListener("input", () => {
+  resetCompletionPromptForPlayback();
   revealPlayerChrome(true);
   isScrubbingTimeline = true;
   const nextTime = (Number(timelineSlider.value) / 10000) * replayDurationSeconds;
@@ -3150,6 +3656,7 @@ timelineSlider.addEventListener("input", () => {
 });
 
 timelineSlider.addEventListener("pointerdown", () => {
+  cancelCompletionPrompt();
   revealPlayerChrome(true);
   isScrubbingTimeline = true;
 });
@@ -3197,43 +3704,16 @@ infoCloseButton.addEventListener("click", () => {
   closeModalElement("info", infoModal);
 });
 
+sourceCloseButton.addEventListener("click", () => {
+  closeModalElement("source", sourceModal);
+});
+
+sourceCancelButton.addEventListener("click", () => {
+  closeModalElement("source", sourceModal);
+});
+
 sourceApplyButton.addEventListener("click", async () => {
-  if (isLoadingReplay) {
-    return;
-  }
-  const nextSource = datasetSelect.value;
-  if (nextSource === EMPTY_REPLAY_SOURCE_KEY) {
-    return;
-  }
-  try {
-    if (nextSource === "custom") {
-      const [file] = replayFileInput.files || [];
-      if (!file) {
-        return;
-      }
-      isPlaying = false;
-      setLoadProgress(true, 0, `Loading ${file.name}...`);
-      updateUi();
-      await nextAnimationFrame();
-      const text = await readReplayFile(file);
-      setLoadProgress(true, 1, `Parsing ${file.name}...`);
-      await nextAnimationFrame();
-      const parsed = JSON.parse(text);
-      loadReplay(parsed, file.name, "custom");
-      finishLoadProgress(`${file.name} loaded`);
-    } else {
-      await loadBuiltInReplay(nextSource);
-    }
-    scheduleChromeHide();
-    updateUi();
-  } catch (error) {
-    setLoadProgress(false);
-    reportViewerIssue(`failed to load replay (${error.message})`);
-    playPauseButton.disabled = false;
-    restartButton.disabled = false;
-    stepBackButton.disabled = false;
-    stepButton.disabled = false;
-  }
+  await applySelectedReplaySource();
 });
 
 fullscreenButton.addEventListener("click", async () => {
@@ -3295,6 +3775,7 @@ renderer.domElement.addEventListener("click", (event) => {
   }
   if (!prefersTapChrome) {
     revealPlayerChrome();
+    event.preventDefault();
     return;
   }
   if (playerChrome.dataset.visible === "true") {
@@ -3309,23 +3790,24 @@ if (resetLayoutButton) {
   resetLayoutButton.addEventListener("click", () => {
     resetCurrentLayout();
     revealPlayerChrome(true);
+    scheduleChromeHide();
     updateUi();
   });
 }
 
 playerChrome.addEventListener("pointermove", () => {
-  revealPlayerChrome(true);
+  revealPlayerChrome();
 });
 
 playerChrome.addEventListener("pointerleave", () => {
-  if (prefersTapChrome && !isAnyModalOpen()) {
-    scheduleChromeHide(900);
+  if (!isAnyModalOpen()) {
+    scheduleChromeHide();
   }
 });
 
 playerChrome.addEventListener("click", (event) => {
   event.stopPropagation();
-  revealPlayerChrome(true);
+  revealPlayerChrome();
 });
 
 window.addEventListener("resize", () => {
@@ -3335,21 +3817,23 @@ window.addEventListener("resize", () => {
   fitCameraToTopology(replayDocument.topology.steps);
   updateLabels();
   prefersTapChrome = window.matchMedia("(hover: none), (pointer: coarse)").matches;
-  setPlayerChromeVisible(true);
-  if (prefersTapChrome && !isAnyModalOpen() && !isLoadingReplay) {
-    scheduleChromeHide();
-  } else {
+  if (isAnyModalOpen() || isLoadingReplay || isScrubbingTimeline) {
+    setPlayerChromeVisible(true);
     cancelChromeHide();
+  } else if (playerChrome.dataset.visible === "true") {
+    scheduleChromeHide();
   }
 });
 
-for (const modal of [infoModal]) {
+for (const modal of [infoModal, sourceModal]) {
   modal.addEventListener("click", (event) => {
     const closeTarget = event.target.closest("[data-close-modal]");
     if (closeTarget) {
       const name = closeTarget.getAttribute("data-close-modal");
       if (name === "info") {
         closeModalElement("info", infoModal);
+      } else if (name === "source") {
+        closeModalElement("source", sourceModal);
       }
     }
   });
@@ -3359,6 +3843,8 @@ document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") {
     if (openModal === "info") {
       closeModalElement("info", infoModal);
+    } else if (openModal === "source") {
+      closeModalElement("source", sourceModal);
     }
   }
 });
@@ -3375,9 +3861,19 @@ window.addEventListener("pageshow", () => {
     infoModal.hidden = true;
     infoModal.setAttribute("aria-hidden", "true");
   }
+  if (!sourceModal.hidden) {
+    sourceModal.hidden = true;
+    sourceModal.setAttribute("aria-hidden", "true");
+  }
   openModal = null;
+  cancelCompletionPrompt();
   syncStagedReplaySourceToActive();
-  revealPlayerChrome(prefersTapChrome || isLoadingReplay);
+  if (isLoadingReplay || isScrubbingTimeline) {
+    revealPlayerChrome(true);
+  } else {
+    setPlayerChromeVisible(false);
+    cancelChromeHide();
+  }
 });
 
 window.addEventListener("error", (event) => {
@@ -3408,7 +3904,7 @@ if (backToDocsLink) {
     window.location.assign(backToDocsLink.href);
   });
 }
-setPlayerChromeVisible(true);
+setPlayerChromeVisible(false);
 updateUi();
 requestAnimationFrame(tick);
 // Intentionally starts empty so large built-in datasets load only after an explicit picker selection.
@@ -3417,4 +3913,6 @@ if (DEFAULT_REPLAY_SOURCE_KEY !== EMPTY_REPLAY_SOURCE_KEY) {
     setLoadProgress(false);
     reportViewerIssue(`failed to load built-in dataset (${error.message})`);
   });
+} else {
+  loadFirstVisitReplayAfterPaint();
 }

--- a/docs/public/replay-viewer-app/app.js
+++ b/docs/public/replay-viewer-app/app.js
@@ -2,6 +2,7 @@ import * as THREE from "./vendor/three.module.min.js";
 import { BUILT_IN_REPLAYS_CONFIG } from "./built-in-replays.js";
 
 const mount = document.getElementById("threeMount");
+const appShell = document.querySelector(".app-shell");
 const viewport = document.querySelector(".viewport");
 const playerSurface = document.getElementById("playerSurface");
 const playerChrome = document.getElementById("playerChrome");
@@ -217,6 +218,7 @@ let activeLayoutStorageKey = null;
 let chromeHideTimeout = null;
 let fatalRenderErrorLatched = false;
 let openModal = null;
+let modalReturnFocusElement = null;
 let isScrubbingTimeline = false;
 let dragState = null;
 let suppressNextCanvasClick = false;
@@ -1181,10 +1183,25 @@ function openModalElement(name, element) {
   if (name === "source") {
     syncStagedReplaySourceToActive();
   }
+  if (!openModal) {
+    modalReturnFocusElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  }
   openModal = name;
+  if (appShell) {
+    appShell.inert = true;
+  }
   element.hidden = false;
   element.setAttribute("aria-hidden", "false");
   revealPlayerChrome(true);
+  window.requestAnimationFrame(() => {
+    if (openModal !== name || element.hidden) {
+      return;
+    }
+    const focusTarget = name === "source"
+      ? (datasetSelect ?? sourceCloseButton)
+      : infoCloseButton;
+    focusTarget?.focus({ preventScroll: true });
+  });
 }
 
 function closeModalElement(name, element) {
@@ -1197,7 +1214,14 @@ function closeModalElement(name, element) {
   openModal = null;
   element.hidden = true;
   element.setAttribute("aria-hidden", "true");
+  if (appShell) {
+    appShell.inert = false;
+  }
   revealPlayerChrome(!prefersTapChrome);
+  if (modalReturnFocusElement?.isConnected) {
+    modalReturnFocusElement.focus({ preventScroll: true });
+  }
+  modalReturnFocusElement = null;
 }
 
 function clearElement(element) {
@@ -1363,6 +1387,7 @@ function updateLegendForReplay(document) {
 }
 
 function reportViewerIssue(message) {
+  revealPlayerChrome(true);
   loadProgress.hidden = false;
   loadProgressFill.style.width = "100%";
   loadProgressText.textContent = `Status: ${message}`;
@@ -2833,6 +2858,11 @@ function recordReplayCounters(rawEvent) {
       recordReceived(state, inputCount);
     }
     releaseInFlight(state, inputKeys, inputCount);
+    if (!replayHasAwaitLifecycleEvents && stepHasRenderRole(event.from, "await")) {
+      const awaitState = stateForStep(event.from);
+      recordSent(awaitState, inputCount);
+      releaseInFlight(awaitState, inputKeys, inputCount);
+    }
     return;
   }
   if (event.event === "emit") {
@@ -3877,6 +3907,10 @@ window.addEventListener("pageshow", () => {
     sourceModal.setAttribute("aria-hidden", "true");
   }
   openModal = null;
+  modalReturnFocusElement = null;
+  if (appShell) {
+    appShell.inert = false;
+  }
   cancelCompletionPrompt();
   syncStagedReplaySourceToActive();
   if (isLoadingReplay || isScrubbingTimeline) {

--- a/docs/public/replay-viewer-app/app.js
+++ b/docs/public/replay-viewer-app/app.js
@@ -1083,6 +1083,11 @@ function cancelChromeHide() {
 
 function setPlayerChromeVisible(visible) {
   playerChrome.dataset.visible = visible ? "true" : "false";
+  playerChrome.setAttribute("aria-hidden", visible ? "false" : "true");
+  playerChrome.inert = !visible;
+  if (!visible && playerChrome.contains(document.activeElement)) {
+    document.activeElement.blur();
+  }
 }
 
 function scheduleChromeHide(delayMs = CHROME_HIDE_DELAY_MS) {
@@ -3808,6 +3813,12 @@ playerChrome.addEventListener("pointerleave", () => {
 playerChrome.addEventListener("click", (event) => {
   event.stopPropagation();
   revealPlayerChrome();
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Tab" && !isAnyModalOpen()) {
+    revealPlayerChrome();
+  }
 });
 
 window.addEventListener("resize", () => {

--- a/docs/public/replay-viewer-app/index.html
+++ b/docs/public/replay-viewer-app/index.html
@@ -23,8 +23,11 @@
                   <div id="playbackText" class="playback-time">0.00s / 0.10s</div>
                 </div>
 
+                <div id="playerTitle" class="player-title">Replay viewer ready</div>
+
                 <div class="player-controls-bar">
                   <div class="player-controls-transport">
+                    <button id="loadReplayButton" class="icon-button icon-button--transport" type="button" aria-haspopup="dialog" aria-controls="sourceModal" aria-label="Load replay" title="Load replay">⏏</button>
                     <button id="playPauseButton" class="icon-button icon-button--transport" type="button" aria-label="Play replay" title="Play replay">▶</button>
                     <button id="stopButton" class="icon-button icon-button--transport" type="button" aria-label="Stop replay" title="Stop replay">⏹</button>
                     <button id="restartButton" class="icon-button icon-button--transport" type="button" aria-label="Restart replay" title="Restart replay">↺</button>
@@ -40,6 +43,7 @@
                   </div>
 
                   <div class="player-controls-utility">
+                    <button id="resetLayoutButton" class="icon-button" type="button" aria-label="Reset layout" title="Reset layout" disabled>⌖</button>
                     <button id="infoButton" class="icon-button" type="button" aria-haspopup="dialog" aria-controls="infoModal" aria-label="Replay info" title="Replay info">ⓘ</button>
                     <button id="fullscreenButton" class="icon-button" type="button" aria-label="Full screen" title="Full screen">⛶</button>
                   </div>
@@ -55,39 +59,45 @@
               </div>
             </div>
           </section>
-
-          <section class="metadata-strip" aria-label="Replay metadata">
-            <div class="metadata-heading">
-              <div id="datasetName" class="headline">Replay viewer ready</div>
-              <div class="source-controls" aria-label="Replay source controls">
-                <label class="source-control">
-                  <span>Replay source</span>
-                  <select id="datasetSelect" aria-label="Select replay source">
-                    <option value="none" selected>Choose replay...</option>
-                    <option value="csv-payments">CSV Payments built-in</option>
-                    <option value="search-warm-cache">Search built-in pre-warm</option>
-                    <option value="search-cache-hit">Search built-in</option>
-                    <option value="custom">Custom replay</option>
-                  </select>
-                </label>
-                <label id="customReplayInputWrap" class="source-control source-control--file" hidden aria-hidden="true">
-                  <span>Replay JSON</span>
-                  <span class="file-input-button">Choose file</span>
-                  <input id="replayFileInput" type="file" accept="application/json,.json" />
-                </label>
-                <button id="sourceApplyButton" class="source-action" type="button">Load</button>
-                <button id="resetLayoutButton" class="source-action source-action--secondary" type="button" disabled>Reset layout</button>
-              </div>
-            </div>
-            <div class="metadata-lines">
-              <div id="pipelineName" class="meta-line">Choose a replay to begin.</div>
-              <div id="durationText" class="meta-line"></div>
-              <div id="topologyText" class="meta-line"></div>
-              <div id="eventCountText" class="meta-line"></div>
-            </div>
-          </section>
         </section>
       </main>
+    </div>
+
+    <div id="sourceModal" class="info-modal" hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="sourceModalTitle">
+      <div class="info-modal-backdrop" data-close-modal="source"></div>
+      <div class="info-modal-panel info-modal-panel--compact source-modal-panel">
+        <div class="info-modal-header">
+          <div>
+            <h2 id="sourceModalTitle">Load replay</h2>
+            <p id="sourceModalDescription" class="modal-description">Choose a captured built-in replay or upload a replay JSON. The viewer plays real event timing, counters, and topology without synthetic flows.</p>
+          </div>
+          <button id="sourceCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close load replay" title="Close load replay">✕</button>
+        </div>
+        <div class="info-modal-body info-modal-body--compact source-modal-body">
+          <div class="source-controls source-controls--modal" aria-label="Replay source controls">
+            <label class="source-control">
+              <span>Replay source</span>
+              <select id="datasetSelect" aria-label="Select replay source">
+                <option value="none" selected>Choose replay...</option>
+                <option value="csv-payments">CSV Payments built-in</option>
+                <option value="search-warm-cache">Search built-in pre-warm</option>
+                <option value="search-cache-hit">Search built-in</option>
+                <option value="custom">Custom replay</option>
+              </select>
+            </label>
+            <label id="customReplayInputWrap" class="source-control source-control--file" hidden aria-hidden="true">
+              <span>Replay JSON</span>
+              <span class="file-input-button">Choose file</span>
+              <input id="replayFileInput" type="file" accept="application/json,.json" />
+            </label>
+            <div id="sourceModalStatus" class="source-modal-status" role="status" aria-live="polite">CSV Payments will load automatically on your first visit.</div>
+            <div class="source-modal-actions">
+              <button id="sourceApplyButton" class="source-action" type="button">Load</button>
+              <button id="sourceCancelButton" class="source-action source-action--secondary" type="button">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div id="infoModal" class="info-modal" hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="infoModalTitle">
@@ -98,6 +108,31 @@
           <button id="infoCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close replay info" title="Close replay info">✕</button>
         </div>
         <div class="info-modal-body">
+          <section class="info-section info-section--replay-summary">
+            <h3>Replay summary</h3>
+            <div class="replay-summary">
+              <div class="replay-summary-entry">
+                <span>Dataset</span>
+                <strong id="summaryDatasetName">Replay viewer ready</strong>
+              </div>
+              <div class="replay-summary-entry">
+                <span>Pipeline</span>
+                <strong id="summaryPipelineName">Choose a replay to begin.</strong>
+              </div>
+              <div class="replay-summary-entry">
+                <span>Duration</span>
+                <strong id="summaryDurationText">-</strong>
+              </div>
+              <div class="replay-summary-entry">
+                <span>Topology</span>
+                <strong id="summaryTopologyText">-</strong>
+              </div>
+              <div class="replay-summary-entry">
+                <span>Events</span>
+                <strong id="summaryEventCountText">-</strong>
+              </div>
+            </div>
+          </section>
           <section class="info-section info-section--run-parameters">
             <h3>Run parameters</h3>
             <div id="runParametersContent" class="run-parameters"></div>
@@ -105,14 +140,55 @@
           <section class="info-section info-section--aux">
             <div class="info-section-legend">
               <h3>Legend</h3>
+              <h4>Throughput counters</h4>
+              <div class="legend-list">
+                <div class="legend-item legend-item--throughput">
+                  <span class="legend-counter-sample" aria-hidden="true">
+                    <span class="legend-pressure-ring"></span>
+                    <span class="legend-counter-text">1000|1</span>
+                  </span>
+                  <span>received | sent; ring shows queued pressure waiting at the node</span>
+                </div>
+              </div>
+              <h4>Event motion</h4>
               <div class="legend-list">
                 <div class="legend-item"><span class="legend-swatch legend-swatch--start"></span><span>start / success transit</span></div>
                 <div class="legend-item"><span class="legend-swatch legend-swatch--emit"></span><span>emit / fan-out</span></div>
                 <div class="legend-item"><span class="legend-swatch legend-swatch--emit"></span><span>cache hit</span></div>
                 <div class="legend-item"><span class="legend-swatch legend-swatch--retry"></span><span>retry loop</span></div>
                 <div class="legend-item"><span class="legend-swatch legend-swatch--error"></span><span>error burst</span></div>
-                <div class="legend-item"><span class="legend-swatch legend-swatch--branch"></span><span>DB node</span></div>
-                <div class="legend-item"><span class="legend-swatch legend-swatch--branch legend-swatch--cache"></span><span>Cache node</span></div>
+                <div class="legend-item"><span class="legend-swatch legend-swatch--branch"></span><span>DB/store transit</span></div>
+              </div>
+              <h4>Support actors</h4>
+              <div class="legend-list legend-list--support">
+                <div class="legend-item">
+                  <span class="legend-actor legend-actor--store" aria-hidden="true"><span class="legend-icon legend-icon--database"></span></span>
+                  <span>DB/store side-effect actor</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-actor legend-actor--cache" aria-hidden="true"><span class="legend-icon legend-icon--cache"></span></span>
+                  <span>Cache read/write actor</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-actor legend-actor--cache-invalidate" aria-hidden="true"><span class="legend-icon legend-icon--cache"></span><span class="legend-actor-badge">!</span></span>
+                  <span>Cache invalidate: one cache scope</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-actor legend-actor--cache-invalidate-all" aria-hidden="true"><span class="legend-icon legend-icon--cache"></span><span class="legend-actor-badge">×</span></span>
+                  <span>Cache invalidate all: broader cache scope</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-actor legend-actor--broker" aria-hidden="true"><span class="legend-icon legend-icon--broker"></span></span>
+                  <span>Broker support actor</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-actor legend-actor--provider" aria-hidden="true"><span class="legend-icon legend-icon--provider"></span></span>
+                  <span>External provider actor</span>
+                </div>
+                <div class="legend-item" data-support-kind="reject" hidden>
+                  <span class="legend-actor legend-actor--reject" aria-hidden="true"><span class="legend-icon legend-icon--reject"></span></span>
+                  <span>Reject queue actor</span>
+                </div>
               </div>
             </div>
           </section>

--- a/docs/public/replay-viewer-app/style.css
+++ b/docs/public/replay-viewer-app/style.css
@@ -170,6 +170,17 @@ button:disabled {
   margin: 0;
 }
 
+.player-title {
+  min-width: 0;
+  color: #f8fbff;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .playback-time {
   min-width: 118px;
   text-align: right;
@@ -243,35 +254,6 @@ button:disabled {
   color: #8da2c9;
 }
 
-.metadata-strip {
-  position: absolute;
-  z-index: 7;
-  top: 12px;
-  left: 12px;
-  right: 12px;
-  display: grid;
-  grid-template-columns: minmax(280px, 1.2fr) minmax(260px, 0.8fr);
-  gap: 12px 20px;
-  align-items: center;
-  padding: 10px 12px;
-  border: 1px solid rgb(148 163 184 / 14%);
-  border-radius: 12px;
-  background: rgb(7 16 31 / 52%);
-  backdrop-filter: blur(10px);
-  pointer-events: none;
-}
-
-.metadata-heading {
-  display: grid;
-  gap: 10px;
-}
-
-.headline {
-  font-size: 20px;
-  font-weight: 700;
-  color: #f8fbff;
-}
-
 .source-controls {
   display: flex;
   flex-wrap: wrap;
@@ -343,19 +325,6 @@ button:disabled {
   cursor: pointer;
 }
 
-.metadata-lines {
-  display: grid;
-  gap: 5px 16px;
-  justify-items: start;
-  pointer-events: none;
-}
-
-.meta-line {
-  font-size: 13px;
-  line-height: 1.32;
-  color: #a8b9dc;
-}
-
 .info-modal {
   position: fixed;
   inset: 0;
@@ -406,6 +375,14 @@ button:disabled {
   color: #f8fbff;
 }
 
+.modal-description {
+  margin: 6px 0 0;
+  max-width: 58ch;
+  color: #a8b9dc;
+  font-size: 13px;
+  line-height: 1.48;
+}
+
 .icon-button--close {
   width: 38px;
   height: 38px;
@@ -414,7 +391,7 @@ button:disabled {
 
 .info-modal-body {
   display: grid;
-  grid-template-columns: minmax(0, 1.7fr) minmax(240px, 0.9fr);
+  grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1.45fr) minmax(250px, 0.95fr);
   gap: 0;
   min-height: 0;
 }
@@ -422,6 +399,14 @@ button:disabled {
 .info-modal-body--compact {
   grid-template-columns: 1fr;
   padding: 18px 20px;
+}
+
+.source-modal-panel {
+  width: min(560px, calc(100vw - 48px));
+}
+
+.source-modal-body {
+  gap: 14px;
 }
 
 .modal-field {
@@ -457,12 +442,42 @@ button:disabled {
   width: fit-content;
 }
 
+.source-controls--modal {
+  display: grid;
+  gap: 14px;
+  align-items: stretch;
+}
+
+.source-controls--modal .source-control,
+.source-controls--modal .source-control select,
+.source-controls--modal .file-input-button {
+  width: 100%;
+}
+
+.source-modal-status {
+  min-height: 20px;
+  color: #8da2c9;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.source-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
 .info-section {
   padding: 18px 20px;
 }
 
+.info-section--replay-summary,
 .info-section--run-parameters {
   border-right: 1px solid rgb(148 163 184 / 12%);
+}
+
+.info-section--replay-summary,
+.info-section--run-parameters {
   min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -481,6 +496,35 @@ button:disabled {
   gap: 14px 18px;
   overflow: auto;
   padding-right: 4px;
+}
+
+.replay-summary {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.replay-summary-entry {
+  display: grid;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgb(148 163 184 / 10%);
+}
+
+.replay-summary-entry span {
+  color: #7890bd;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.replay-summary-entry strong {
+  color: #f8fbff;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .run-parameters-empty {
@@ -578,10 +622,63 @@ button:disabled {
   gap: 7px;
 }
 
+.legend-list + h4 {
+  margin-top: 18px;
+}
+
+.info-section-legend h4 {
+  margin: 12px 0 9px;
+  color: #dbe4ff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .legend-item {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.legend-item--throughput {
+  align-items: center;
+}
+
+.legend-counter-sample {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.legend-counter-text {
+  position: relative;
+  z-index: 1;
+  color: #f8fbff;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  text-align: center;
+  text-shadow: 0 0 8px rgb(7 16 31 / 80%);
+}
+
+.legend-pressure-ring {
+  position: absolute;
+  inset: 3px;
+  border-radius: 999px;
+  background:
+    conic-gradient(from 225deg, #ffd166 0deg 200deg, rgb(148 163 184 / 24%) 200deg 270deg, transparent 270deg 360deg);
+  box-shadow: 0 0 12px rgb(255 209 102 / 32%);
+}
+
+.legend-pressure-ring::after {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border-radius: inherit;
+  background: #07101f;
 }
 
 .legend-swatch {
@@ -621,15 +718,230 @@ button:disabled {
   box-shadow: 0 0 12px rgb(139 255 165 / 40%);
 }
 
-@media (max-width: 1024px) {
-  .metadata-strip {
-    grid-template-columns: 1fr;
-  }
+.legend-list--support {
+  gap: 9px;
+}
 
+.legend-actor {
+  position: relative;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #caa6ff;
+  box-shadow: 0 0 16px rgb(202 166 255 / 34%);
+}
+
+.legend-actor--store {
+  background: #67b2f3;
+  box-shadow: 0 0 16px rgb(103 178 243 / 34%);
+}
+
+.legend-actor--cache {
+  background: #8bffa5;
+  box-shadow: 0 0 16px rgb(139 255 165 / 34%);
+}
+
+.legend-actor--cache-invalidate {
+  background: #ffd166;
+  box-shadow: 0 0 16px rgb(255 209 102 / 34%);
+}
+
+.legend-actor--cache-invalidate-all {
+  background: #ff9f68;
+  box-shadow: 0 0 16px rgb(255 159 104 / 34%);
+}
+
+.legend-actor--broker {
+  background: #8f7aea;
+  box-shadow: 0 0 16px rgb(143 122 234 / 34%);
+}
+
+.legend-actor--provider {
+  background: #b08cff;
+  box-shadow: 0 0 16px rgb(176 140 255 / 34%);
+}
+
+.legend-actor--reject {
+  background: #ff7c8f;
+  box-shadow: 0 0 16px rgb(255 124 143 / 34%);
+}
+
+.legend-icon,
+.legend-icon::before,
+.legend-icon::after {
+  box-sizing: border-box;
+}
+
+.legend-icon {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+}
+
+.legend-icon--database {
+  width: 15px;
+  height: 16px;
+  border: 2px solid #f8fbff;
+  border-top: 0;
+  border-radius: 0 0 7px 7px;
+}
+
+.legend-icon--database::before,
+.legend-icon--database::after {
+  content: "";
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  height: 7px;
+  border: 2px solid #f8fbff;
+  border-radius: 999px;
+}
+
+.legend-icon--database::before {
+  top: -4px;
+}
+
+.legend-icon--database::after {
+  top: 5px;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.legend-icon--cache::before,
+.legend-icon--cache::after,
+.legend-icon--broker::before,
+.legend-icon--broker::after {
+  content: "";
+  position: absolute;
+  border: 2px solid #f8fbff;
+}
+
+.legend-icon--cache,
+.legend-icon--cache::before,
+.legend-icon--cache::after {
+  border: 2px solid #f8fbff;
+  border-radius: 6px;
+}
+
+.legend-icon--cache {
+  width: 16px;
+  height: 7px;
+  transform: translateY(-5px);
+}
+
+.legend-icon--cache::before {
+  left: -4px;
+  top: 6px;
+  width: 20px;
+  height: 7px;
+}
+
+.legend-icon--cache::after {
+  left: -7px;
+  top: 12px;
+  width: 26px;
+  height: 7px;
+}
+
+.legend-icon--broker,
+.legend-icon--broker::before,
+.legend-icon--broker::after {
+  border: 2px solid #f8fbff;
+  border-radius: 4px;
+}
+
+.legend-icon--broker {
+  width: 5px;
+  height: 17px;
+}
+
+.legend-icon--broker::before {
+  left: -8px;
+  top: 3px;
+  width: 5px;
+  height: 14px;
+}
+
+.legend-icon--broker::after {
+  right: -8px;
+  top: -3px;
+  width: 5px;
+  height: 20px;
+}
+
+.legend-icon--provider {
+  width: 15px;
+  height: 16px;
+  border: 2px solid #f8fbff;
+  border-radius: 5px;
+}
+
+.legend-icon--provider::before,
+.legend-icon--provider::after {
+  content: "";
+  position: absolute;
+  right: -7px;
+  width: 6px;
+  border-top: 2px solid #f8fbff;
+}
+
+.legend-icon--provider::before {
+  top: 4px;
+}
+
+.legend-icon--provider::after {
+  top: 10px;
+}
+
+.legend-icon--reject {
+  width: 18px;
+  height: 13px;
+  border: 2px solid #f8fbff;
+  border-radius: 5px;
+}
+
+.legend-icon--reject::before {
+  content: "";
+  position: absolute;
+  left: 3px;
+  right: 3px;
+  bottom: -8px;
+  height: 8px;
+  border: 2px solid #f8fbff;
+  border-top: 0;
+  transform: skewX(-18deg);
+}
+
+.legend-actor-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 17px;
+  height: 17px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #ffdf8f;
+  border-radius: 999px;
+  background: rgb(7 16 31 / 84%);
+  color: #ffdf8f;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+@media (max-width: 1024px) {
   .info-modal-body {
     grid-template-columns: 1fr;
   }
 
+  .info-section--replay-summary,
   .info-section--run-parameters {
     border-right: 0;
     border-bottom: 1px solid rgb(148 163 184 / 12%);
@@ -638,59 +950,99 @@ button:disabled {
 
 @media (max-width: 820px) {
   .viewer-page {
-    padding: 12px;
+    padding: 8px;
+    min-height: 100dvh;
   }
 
   .viewer-shell-bar {
     justify-content: flex-start;
   }
 
+  .shell-link {
+    min-height: 34px;
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+
+  .viewport {
+    border-radius: 10px;
+  }
+
   .three-mount {
-    min-height: 540px;
-    height: min(68vh, 720px);
+    min-height: 0;
+    height: calc(100dvh - 58px);
   }
 
   .player-controls {
-    left: 12px;
-    right: 12px;
-    bottom: 10px;
-    padding: 10px;
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    gap: 5px;
+    padding: 6px;
     max-width: none;
+    border-radius: 10px;
   }
 
   .player-controls-scrubber {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 8px;
   }
 
+  .player-title {
+    font-size: 12px;
+  }
+
   .playback-time {
-    min-width: 0;
-    text-align: left;
+    min-width: 84px;
+    text-align: right;
+    font-size: 11px;
   }
 
   .player-controls-bar {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
+    align-items: center;
+    gap: 8px;
   }
 
   .player-controls-transport,
   .player-controls-utility {
-    justify-content: center;
-    flex-wrap: wrap;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    min-width: 0;
+    gap: 5px;
+  }
+
+  .player-controls-transport {
+    overflow-x: auto;
+    padding-bottom: 2px;
+    scrollbar-width: none;
+  }
+
+  .player-controls-transport::-webkit-scrollbar {
+    display: none;
+  }
+
+  .icon-button,
+  .icon-button--transport {
+    flex: 0 0 auto;
+    width: 34px;
+    height: 34px;
+    font-size: 15px;
   }
 
   .speed-group--inline {
-    justify-content: center;
+    flex: 0 0 auto;
+    justify-content: flex-start;
     margin-left: 0;
     padding-left: 0;
     border-left: 0;
-    width: 100%;
+    width: auto;
+    gap: 5px;
   }
 
-  .metadata-strip {
-    grid-template-columns: 1fr;
-    gap: 8px;
+  .speed-group label {
+    min-height: 28px;
+    padding: 0 6px;
+    font-size: 11px;
   }
 
   .source-controls {
@@ -702,6 +1054,10 @@ button:disabled {
   .source-action,
   .file-input-button {
     width: 100%;
+  }
+
+  .source-modal-actions {
+    flex-direction: column;
   }
 
   .info-modal-panel,

--- a/tools/replay-viewer/app.js
+++ b/tools/replay-viewer/app.js
@@ -2,6 +2,7 @@ import * as THREE from "./vendor/three.module.min.js";
 import { BUILT_IN_REPLAYS_CONFIG } from "./built-in-replays.js";
 
 const mount = document.getElementById("threeMount");
+const appShell = document.querySelector(".app-shell");
 const viewport = document.querySelector(".viewport");
 const playerSurface = document.getElementById("playerSurface");
 const playerChrome = document.getElementById("playerChrome");
@@ -217,6 +218,7 @@ let activeLayoutStorageKey = null;
 let chromeHideTimeout = null;
 let fatalRenderErrorLatched = false;
 let openModal = null;
+let modalReturnFocusElement = null;
 let isScrubbingTimeline = false;
 let dragState = null;
 let suppressNextCanvasClick = false;
@@ -1181,10 +1183,25 @@ function openModalElement(name, element) {
   if (name === "source") {
     syncStagedReplaySourceToActive();
   }
+  if (!openModal) {
+    modalReturnFocusElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  }
   openModal = name;
+  if (appShell) {
+    appShell.inert = true;
+  }
   element.hidden = false;
   element.setAttribute("aria-hidden", "false");
   revealPlayerChrome(true);
+  window.requestAnimationFrame(() => {
+    if (openModal !== name || element.hidden) {
+      return;
+    }
+    const focusTarget = name === "source"
+      ? (datasetSelect ?? sourceCloseButton)
+      : infoCloseButton;
+    focusTarget?.focus({ preventScroll: true });
+  });
 }
 
 function closeModalElement(name, element) {
@@ -1197,7 +1214,14 @@ function closeModalElement(name, element) {
   openModal = null;
   element.hidden = true;
   element.setAttribute("aria-hidden", "true");
+  if (appShell) {
+    appShell.inert = false;
+  }
   revealPlayerChrome(!prefersTapChrome);
+  if (modalReturnFocusElement?.isConnected) {
+    modalReturnFocusElement.focus({ preventScroll: true });
+  }
+  modalReturnFocusElement = null;
 }
 
 function clearElement(element) {
@@ -1363,6 +1387,7 @@ function updateLegendForReplay(document) {
 }
 
 function reportViewerIssue(message) {
+  revealPlayerChrome(true);
   loadProgress.hidden = false;
   loadProgressFill.style.width = "100%";
   loadProgressText.textContent = `Status: ${message}`;
@@ -2833,6 +2858,11 @@ function recordReplayCounters(rawEvent) {
       recordReceived(state, inputCount);
     }
     releaseInFlight(state, inputKeys, inputCount);
+    if (!replayHasAwaitLifecycleEvents && stepHasRenderRole(event.from, "await")) {
+      const awaitState = stateForStep(event.from);
+      recordSent(awaitState, inputCount);
+      releaseInFlight(awaitState, inputKeys, inputCount);
+    }
     return;
   }
   if (event.event === "emit") {
@@ -3877,6 +3907,10 @@ window.addEventListener("pageshow", () => {
     sourceModal.setAttribute("aria-hidden", "true");
   }
   openModal = null;
+  modalReturnFocusElement = null;
+  if (appShell) {
+    appShell.inert = false;
+  }
   cancelCompletionPrompt();
   syncStagedReplaySourceToActive();
   if (isLoadingReplay || isScrubbingTimeline) {

--- a/tools/replay-viewer/app.js
+++ b/tools/replay-viewer/app.js
@@ -1083,6 +1083,11 @@ function cancelChromeHide() {
 
 function setPlayerChromeVisible(visible) {
   playerChrome.dataset.visible = visible ? "true" : "false";
+  playerChrome.setAttribute("aria-hidden", visible ? "false" : "true");
+  playerChrome.inert = !visible;
+  if (!visible && playerChrome.contains(document.activeElement)) {
+    document.activeElement.blur();
+  }
 }
 
 function scheduleChromeHide(delayMs = CHROME_HIDE_DELAY_MS) {
@@ -3808,6 +3813,12 @@ playerChrome.addEventListener("pointerleave", () => {
 playerChrome.addEventListener("click", (event) => {
   event.stopPropagation();
   revealPlayerChrome();
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Tab" && !isAnyModalOpen()) {
+    revealPlayerChrome();
+  }
 });
 
 window.addEventListener("resize", () => {


### PR DESCRIPTION
## Summary
- syncs `docs/public/replay-viewer-app/*` from the canonical `tools/replay-viewer/*` source so the Cloudflare Pages deployment serves the latest replay viewer UI
- adds `tools/replay-viewer/**` to the docs workflow path filter
- adds a docs workflow guard that fails if `npm --prefix docs run build` changes `docs/public/replay-viewer-app`

## Root cause
PR #371 intentionally excluded the generated public app copy to reduce review payload size. That was wrong for the current Pages deployment path: production serves the committed `docs/public/replay-viewer-app` assets, so the public copy must be committed or the deployed standalone app stays stale.

## Validation
- `node --check docs/public/replay-viewer-app/app.js`
- `git diff --check`
- `npm --prefix docs run build`
- `git diff --exit-code -- docs/public/replay-viewer-app`

## Production check before fix
`https://9ce8f41c.pipelineframework.pages.dev/replay-viewer-app/` served the stale metadata-strip viewer even though `tools/replay-viewer/*` on `origin/main` had the load modal and pressure-ring changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated modal for replay file selection and source management
  * Introduced player title display in transport controls
  * Added reset layout button to player utilities
  * Expanded info modal with new replay summary section
  * Enhanced legend with throughput visualization and pressure metrics
  * Implemented auto-load on first visit

* **Documentation**
  * Updated replay viewer documentation with interface clarifications

* **Chores**
  * Updated documentation build workflow triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->