### PR TITLE
[codex] Use consistent replay viewer control icons

### DIFF
--- a/docs/public/replay-viewer-app/app.js
+++ b/docs/public/replay-viewer-app/app.js
@@ -3421,7 +3421,9 @@ function updateUi() {
   const ratio = replayDurationSeconds <= 0 ? 0 : playbackSeconds / replayDurationSeconds;
   timelineSlider.value = `${Math.round(ratio * 10000)}`;
   playbackText.textContent = `${playbackSeconds.toFixed(2)}s / ${replayDurationSeconds.toFixed(2)}s`;
-  playPauseButton.textContent = isPlaying ? "⏸" : "▶";
+  playPauseButton.dataset.playing = isPlaying ? "true" : "false";
+  playPauseButton.setAttribute("aria-label", isPlaying ? "Pause replay" : "Play replay");
+  playPauseButton.title = isPlaying ? "Pause replay" : "Play replay";
   stopButton.disabled = isLoadingReplay || (nextEventCursor === 0 && currentTimeSeconds <= 0);
   stepBackButton.disabled = isLoadingReplay || nextEventCursor <= 0;
   stepButton.disabled = isLoadingReplay || nextEventCursor >= replayDocument.events.length;
@@ -3764,9 +3766,10 @@ fullscreenButton.addEventListener("click", async () => {
 });
 
 document.addEventListener("fullscreenchange", () => {
-  fullscreenButton.textContent = document.fullscreenElement === playerSurface
-    ? "🡼"
-    : "⛶";
+  const isFullscreen = document.fullscreenElement === playerSurface;
+  fullscreenButton.dataset.fullscreen = isFullscreen ? "true" : "false";
+  fullscreenButton.setAttribute("aria-label", isFullscreen ? "Exit full screen" : "Full screen");
+  fullscreenButton.title = isFullscreen ? "Exit full screen" : "Full screen";
 });
 
 renderer.domElement.addEventListener("pointermove", (event) => {

--- a/docs/public/replay-viewer-app/index.html
+++ b/docs/public/replay-viewer-app/index.html
@@ -27,12 +27,45 @@
 
                 <div class="player-controls-bar">
                   <div class="player-controls-transport">
-                    <button id="loadReplayButton" class="icon-button icon-button--transport" type="button" aria-haspopup="dialog" aria-controls="sourceModal" aria-label="Load replay" title="Load replay">⏏</button>
-                    <button id="playPauseButton" class="icon-button icon-button--transport" type="button" aria-label="Play replay" title="Play replay">▶</button>
-                    <button id="stopButton" class="icon-button icon-button--transport" type="button" aria-label="Stop replay" title="Stop replay">⏹</button>
-                    <button id="restartButton" class="icon-button icon-button--transport" type="button" aria-label="Restart replay" title="Restart replay">↺</button>
-                    <button id="stepBackButton" class="icon-button icon-button--transport" type="button" aria-label="Step to previous event" title="Step to previous event">⏮</button>
-                    <button id="stepButton" class="icon-button icon-button--transport" type="button" aria-label="Step to next event" title="Step to next event">⏭</button>
+                    <button id="loadReplayButton" class="icon-button icon-button--transport" type="button" aria-haspopup="dialog" aria-controls="sourceModal" aria-label="Load replay" title="Load replay">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 4l6 8H6l6-8z" />
+                        <path d="M6 17h12" />
+                      </svg>
+                    </button>
+                    <button id="playPauseButton" class="icon-button icon-button--transport" type="button" aria-label="Play replay" title="Play replay" data-playing="false">
+                      <svg class="control-icon control-icon--play" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8 5v14l11-7-11-7z" />
+                      </svg>
+                      <svg class="control-icon control-icon--pause" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8 5v14" />
+                        <path d="M16 5v14" />
+                      </svg>
+                    </button>
+                    <button id="stopButton" class="icon-button icon-button--transport" type="button" aria-label="Stop replay" title="Stop replay">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M7 7h10v10H7z" />
+                      </svg>
+                    </button>
+                    <button id="restartButton" class="icon-button icon-button--transport" type="button" aria-label="Restart replay" title="Restart replay">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M7 7h6a5 5 0 1 1-4.4 7.4" />
+                        <path d="M7 7V3" />
+                        <path d="M7 7h4" />
+                      </svg>
+                    </button>
+                    <button id="stepBackButton" class="icon-button icon-button--transport" type="button" aria-label="Step to previous event" title="Step to previous event">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M6 5v14" />
+                        <path d="M18 6l-9 6 9 6V6z" />
+                      </svg>
+                    </button>
+                    <button id="stepButton" class="icon-button icon-button--transport" type="button" aria-label="Step to next event" title="Step to next event">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M18 5v14" />
+                        <path d="M6 6l9 6-9 6V6z" />
+                      </svg>
+                    </button>
                     <fieldset class="speed-group speed-group--inline" aria-label="Replay speed">
                       <label><input type="radio" name="speed" value="0.25" /> 0.25x</label>
                       <label><input type="radio" name="speed" value="0.5" checked /> 0.5x</label>
@@ -43,9 +76,36 @@
                   </div>
 
                   <div class="player-controls-utility">
-                    <button id="resetLayoutButton" class="icon-button" type="button" aria-label="Reset layout" title="Reset layout" disabled>⌖</button>
-                    <button id="infoButton" class="icon-button" type="button" aria-haspopup="dialog" aria-controls="infoModal" aria-label="Replay info" title="Replay info">ⓘ</button>
-                    <button id="fullscreenButton" class="icon-button" type="button" aria-label="Full screen" title="Full screen">⛶</button>
+                    <button id="resetLayoutButton" class="icon-button" type="button" aria-label="Reset layout" title="Reset layout" disabled>
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 4v4" />
+                        <path d="M12 16v4" />
+                        <path d="M4 12h4" />
+                        <path d="M16 12h4" />
+                        <circle cx="12" cy="12" r="4" />
+                      </svg>
+                    </button>
+                    <button id="infoButton" class="icon-button" type="button" aria-haspopup="dialog" aria-controls="infoModal" aria-label="Replay info" title="Replay info">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <circle cx="12" cy="12" r="8" />
+                        <path d="M12 11v5" />
+                        <path d="M12 8h.01" />
+                      </svg>
+                    </button>
+                    <button id="fullscreenButton" class="icon-button" type="button" aria-label="Full screen" title="Full screen" data-fullscreen="false">
+                      <svg class="control-icon control-icon--enter-fullscreen" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8 4H4v4" />
+                        <path d="M16 4h4v4" />
+                        <path d="M20 16v4h-4" />
+                        <path d="M8 20H4v-4" />
+                      </svg>
+                      <svg class="control-icon control-icon--exit-fullscreen" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M9 4v5H4" />
+                        <path d="M15 4v5h5" />
+                        <path d="M20 15h-5v5" />
+                        <path d="M4 15h5v5" />
+                      </svg>
+                    </button>
                   </div>
                 </div>
 
@@ -71,7 +131,12 @@
             <h2 id="sourceModalTitle">Load replay</h2>
             <p id="sourceModalDescription" class="modal-description">Choose a captured built-in replay or upload a replay JSON. The viewer plays real event timing, counters, and topology without synthetic flows.</p>
           </div>
-          <button id="sourceCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close load replay" title="Close load replay">✕</button>
+          <button id="sourceCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close load replay" title="Close load replay">
+            <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 6l12 12" />
+              <path d="M18 6L6 18" />
+            </svg>
+          </button>
         </div>
         <div class="info-modal-body info-modal-body--compact source-modal-body">
           <div class="source-controls source-controls--modal" aria-label="Replay source controls">
@@ -105,7 +170,12 @@
       <div class="info-modal-panel">
         <div class="info-modal-header">
           <h2 id="infoModalTitle">Replay info</h2>
-          <button id="infoCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close replay info" title="Close replay info">✕</button>
+          <button id="infoCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close replay info" title="Close replay info">
+            <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 6l12 12" />
+              <path d="M18 6L6 18" />
+            </svg>
+          </button>
         </div>
         <div class="info-modal-body">
           <section class="info-section info-section--replay-summary">

--- a/docs/public/replay-viewer-app/style.css
+++ b/docs/public/replay-viewer-app/style.css
@@ -218,10 +218,51 @@ button:disabled {
   border-radius: 999px;
 }
 
+.control-icon {
+  width: 20px;
+  height: 20px;
+  display: block;
+  color: currentColor;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.icon-button--transport .control-icon {
+  width: 21px;
+  height: 21px;
+}
+
+#loadReplayButton .control-icon path:first-child,
+#playPauseButton .control-icon--play path,
+#stopButton .control-icon path,
+#stepBackButton .control-icon path:last-child,
+#stepButton .control-icon path:last-child {
+  fill: currentColor;
+  stroke: none;
+}
+
+#playPauseButton .control-icon--pause,
+#fullscreenButton .control-icon--exit-fullscreen {
+  display: none;
+}
+
+#playPauseButton[data-playing="true"] .control-icon--play,
+#fullscreenButton[data-fullscreen="true"] .control-icon--enter-fullscreen {
+  display: none;
+}
+
+#playPauseButton[data-playing="true"] .control-icon--pause,
+#fullscreenButton[data-fullscreen="true"] .control-icon--exit-fullscreen {
+  display: block;
+}
+
 .icon-button--transport {
   width: 44px;
   height: 44px;
-  font-size: 20px;
 }
 
 .load-progress {
@@ -1026,7 +1067,12 @@ button:disabled {
     flex: 0 0 auto;
     width: 34px;
     height: 34px;
-    font-size: 15px;
+  }
+
+  .control-icon,
+  .icon-button--transport .control-icon {
+    width: 17px;
+    height: 17px;
   }
 
   .speed-group--inline {

--- a/tools/replay-viewer/app.js
+++ b/tools/replay-viewer/app.js
@@ -3421,7 +3421,9 @@ function updateUi() {
   const ratio = replayDurationSeconds <= 0 ? 0 : playbackSeconds / replayDurationSeconds;
   timelineSlider.value = `${Math.round(ratio * 10000)}`;
   playbackText.textContent = `${playbackSeconds.toFixed(2)}s / ${replayDurationSeconds.toFixed(2)}s`;
-  playPauseButton.textContent = isPlaying ? "⏸" : "▶";
+  playPauseButton.dataset.playing = isPlaying ? "true" : "false";
+  playPauseButton.setAttribute("aria-label", isPlaying ? "Pause replay" : "Play replay");
+  playPauseButton.title = isPlaying ? "Pause replay" : "Play replay";
   stopButton.disabled = isLoadingReplay || (nextEventCursor === 0 && currentTimeSeconds <= 0);
   stepBackButton.disabled = isLoadingReplay || nextEventCursor <= 0;
   stepButton.disabled = isLoadingReplay || nextEventCursor >= replayDocument.events.length;
@@ -3764,9 +3766,10 @@ fullscreenButton.addEventListener("click", async () => {
 });
 
 document.addEventListener("fullscreenchange", () => {
-  fullscreenButton.textContent = document.fullscreenElement === playerSurface
-    ? "🡼"
-    : "⛶";
+  const isFullscreen = document.fullscreenElement === playerSurface;
+  fullscreenButton.dataset.fullscreen = isFullscreen ? "true" : "false";
+  fullscreenButton.setAttribute("aria-label", isFullscreen ? "Exit full screen" : "Full screen");
+  fullscreenButton.title = isFullscreen ? "Exit full screen" : "Full screen";
 });
 
 renderer.domElement.addEventListener("pointermove", (event) => {

--- a/tools/replay-viewer/index.html
+++ b/tools/replay-viewer/index.html
@@ -27,12 +27,45 @@
 
                 <div class="player-controls-bar">
                   <div class="player-controls-transport">
-                    <button id="loadReplayButton" class="icon-button icon-button--transport" type="button" aria-haspopup="dialog" aria-controls="sourceModal" aria-label="Load replay" title="Load replay">⏏</button>
-                    <button id="playPauseButton" class="icon-button icon-button--transport" type="button" aria-label="Play replay" title="Play replay">▶</button>
-                    <button id="stopButton" class="icon-button icon-button--transport" type="button" aria-label="Stop replay" title="Stop replay">⏹</button>
-                    <button id="restartButton" class="icon-button icon-button--transport" type="button" aria-label="Restart replay" title="Restart replay">↺</button>
-                    <button id="stepBackButton" class="icon-button icon-button--transport" type="button" aria-label="Step to previous event" title="Step to previous event">⏮</button>
-                    <button id="stepButton" class="icon-button icon-button--transport" type="button" aria-label="Step to next event" title="Step to next event">⏭</button>
+                    <button id="loadReplayButton" class="icon-button icon-button--transport" type="button" aria-haspopup="dialog" aria-controls="sourceModal" aria-label="Load replay" title="Load replay">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 4l6 8H6l6-8z" />
+                        <path d="M6 17h12" />
+                      </svg>
+                    </button>
+                    <button id="playPauseButton" class="icon-button icon-button--transport" type="button" aria-label="Play replay" title="Play replay" data-playing="false">
+                      <svg class="control-icon control-icon--play" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8 5v14l11-7-11-7z" />
+                      </svg>
+                      <svg class="control-icon control-icon--pause" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8 5v14" />
+                        <path d="M16 5v14" />
+                      </svg>
+                    </button>
+                    <button id="stopButton" class="icon-button icon-button--transport" type="button" aria-label="Stop replay" title="Stop replay">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M7 7h10v10H7z" />
+                      </svg>
+                    </button>
+                    <button id="restartButton" class="icon-button icon-button--transport" type="button" aria-label="Restart replay" title="Restart replay">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M7 7h6a5 5 0 1 1-4.4 7.4" />
+                        <path d="M7 7V3" />
+                        <path d="M7 7h4" />
+                      </svg>
+                    </button>
+                    <button id="stepBackButton" class="icon-button icon-button--transport" type="button" aria-label="Step to previous event" title="Step to previous event">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M6 5v14" />
+                        <path d="M18 6l-9 6 9 6V6z" />
+                      </svg>
+                    </button>
+                    <button id="stepButton" class="icon-button icon-button--transport" type="button" aria-label="Step to next event" title="Step to next event">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M18 5v14" />
+                        <path d="M6 6l9 6-9 6V6z" />
+                      </svg>
+                    </button>
                     <fieldset class="speed-group speed-group--inline" aria-label="Replay speed">
                       <label><input type="radio" name="speed" value="0.25" /> 0.25x</label>
                       <label><input type="radio" name="speed" value="0.5" checked /> 0.5x</label>
@@ -43,9 +76,36 @@
                   </div>
 
                   <div class="player-controls-utility">
-                    <button id="resetLayoutButton" class="icon-button" type="button" aria-label="Reset layout" title="Reset layout" disabled>⌖</button>
-                    <button id="infoButton" class="icon-button" type="button" aria-haspopup="dialog" aria-controls="infoModal" aria-label="Replay info" title="Replay info">ⓘ</button>
-                    <button id="fullscreenButton" class="icon-button" type="button" aria-label="Full screen" title="Full screen">⛶</button>
+                    <button id="resetLayoutButton" class="icon-button" type="button" aria-label="Reset layout" title="Reset layout" disabled>
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 4v4" />
+                        <path d="M12 16v4" />
+                        <path d="M4 12h4" />
+                        <path d="M16 12h4" />
+                        <circle cx="12" cy="12" r="4" />
+                      </svg>
+                    </button>
+                    <button id="infoButton" class="icon-button" type="button" aria-haspopup="dialog" aria-controls="infoModal" aria-label="Replay info" title="Replay info">
+                      <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <circle cx="12" cy="12" r="8" />
+                        <path d="M12 11v5" />
+                        <path d="M12 8h.01" />
+                      </svg>
+                    </button>
+                    <button id="fullscreenButton" class="icon-button" type="button" aria-label="Full screen" title="Full screen" data-fullscreen="false">
+                      <svg class="control-icon control-icon--enter-fullscreen" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8 4H4v4" />
+                        <path d="M16 4h4v4" />
+                        <path d="M20 16v4h-4" />
+                        <path d="M8 20H4v-4" />
+                      </svg>
+                      <svg class="control-icon control-icon--exit-fullscreen" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M9 4v5H4" />
+                        <path d="M15 4v5h5" />
+                        <path d="M20 15h-5v5" />
+                        <path d="M4 15h5v5" />
+                      </svg>
+                    </button>
                   </div>
                 </div>
 
@@ -71,7 +131,12 @@
             <h2 id="sourceModalTitle">Load replay</h2>
             <p id="sourceModalDescription" class="modal-description">Choose a captured built-in replay or upload a replay JSON. The viewer plays real event timing, counters, and topology without synthetic flows.</p>
           </div>
-          <button id="sourceCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close load replay" title="Close load replay">✕</button>
+          <button id="sourceCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close load replay" title="Close load replay">
+            <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 6l12 12" />
+              <path d="M18 6L6 18" />
+            </svg>
+          </button>
         </div>
         <div class="info-modal-body info-modal-body--compact source-modal-body">
           <div class="source-controls source-controls--modal" aria-label="Replay source controls">
@@ -105,7 +170,12 @@
       <div class="info-modal-panel">
         <div class="info-modal-header">
           <h2 id="infoModalTitle">Replay info</h2>
-          <button id="infoCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close replay info" title="Close replay info">✕</button>
+          <button id="infoCloseButton" class="icon-button icon-button--close" type="button" aria-label="Close replay info" title="Close replay info">
+            <svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 6l12 12" />
+              <path d="M18 6L6 18" />
+            </svg>
+          </button>
         </div>
         <div class="info-modal-body">
           <section class="info-section info-section--replay-summary">

--- a/tools/replay-viewer/style.css
+++ b/tools/replay-viewer/style.css
@@ -218,10 +218,51 @@ button:disabled {
   border-radius: 999px;
 }
 
+.control-icon {
+  width: 20px;
+  height: 20px;
+  display: block;
+  color: currentColor;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.icon-button--transport .control-icon {
+  width: 21px;
+  height: 21px;
+}
+
+#loadReplayButton .control-icon path:first-child,
+#playPauseButton .control-icon--play path,
+#stopButton .control-icon path,
+#stepBackButton .control-icon path:last-child,
+#stepButton .control-icon path:last-child {
+  fill: currentColor;
+  stroke: none;
+}
+
+#playPauseButton .control-icon--pause,
+#fullscreenButton .control-icon--exit-fullscreen {
+  display: none;
+}
+
+#playPauseButton[data-playing="true"] .control-icon--play,
+#fullscreenButton[data-fullscreen="true"] .control-icon--enter-fullscreen {
+  display: none;
+}
+
+#playPauseButton[data-playing="true"] .control-icon--pause,
+#fullscreenButton[data-fullscreen="true"] .control-icon--exit-fullscreen {
+  display: block;
+}
+
 .icon-button--transport {
   width: 44px;
   height: 44px;
-  font-size: 20px;
 }
 
 .load-progress {
@@ -1026,7 +1067,12 @@ button:disabled {
     flex: 0 0 auto;
     width: 34px;
     height: 34px;
-    font-size: 15px;
+  }
+
+  .control-icon,
+  .icon-button--transport .control-icon {
+    width: 17px;
+    height: 17px;
   }
 
   .speed-group--inline {


### PR DESCRIPTION
## Summary
- Replace font-dependent Unicode playback/control glyphs with consistent inline SVG icons
- Toggle play/pause and fullscreen visual state via data attributes instead of mutating button text
- Sync the generated public replay viewer app copy

## Validation
- node --check tools/replay-viewer/app.js
- node --check docs/public/replay-viewer-app/app.js
- git diff --check
- npm --prefix docs run build

## Notes
- This PR intentionally does not regenerate Search replay datasets. Current Search captures have peak queued pressure of 4 with capacity 128, so the ring is truthful but visually subtle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced emoji and glyph icons with inline SVG graphics in replay viewer controls.
  * Updated icon sizing and styling for improved visual consistency across buttons.
  * Enhanced responsive behavior for mobile screens.

* **Accessibility**
  * Improved button semantics with aria-labels and title attributes for better screen reader support.
  * Enhanced state indication for play/pause and fullscreen controls using semantic attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->