### PR TITLE
chore: stabilize tests and clarify mcp bridge publish auth

### DIFF
--- a/docs/guide/evolve/publishing.md
+++ b/docs/guide/evolve/publishing.md
@@ -37,6 +37,7 @@ The GitHub Actions workflow automatically:
 - [settings.xml Configuration](#local-settingsxml-configuration)
 - [GitHub Actions Workflow](#github-actions-workflow)
 - [Safe Release Process](#safe-release-process)
+- [Coordinated tpf-mcp-bridge Release](#coordinated-tpf-mcp-bridge-release)
 - [Troubleshooting](#troubleshooting)
 
 ## Overview
@@ -287,13 +288,48 @@ git tag tpf-mcp-bridge-vX.Y.Z
 git push origin tpf-mcp-bridge-vX.Y.Z
 ```
 
+Pushing that tag triggers the bridge repository's `.github/workflows/publish.yml`
+workflow. The workflow verifies that the tag name matches the root npm
+`package.json` version, runs the bridge and vendored generator tests, runs
+`npm pack --dry-run`, then publishes `@pipelineframework/tpf-mcp-bridge` to npm.
+
+The bridge publish workflow uses npm trusted publishing rather than a long-lived
+`NPM_TOKEN`. The npm package must have a trusted publisher configured for:
+
+- package: `@pipelineframework/tpf-mcp-bridge`
+- repository: `The-Pipeline-Framework/tpf-mcp-bridge`
+- workflow file: `.github/workflows/publish.yml`
+
+The workflow must retain `permissions: id-token: write` and use an npm version
+that supports trusted publishing. The current bridge workflow uses Node 24 with
+`actions/setup-node@v6` and checks for npm `>= 11.5.1`, matching npm's trusted
+publishing requirements. If `npm publish` fails with a misleading `404 Not Found`
+for an existing package, treat that as an npm authentication/trusted-publisher
+configuration problem before assuming the package is missing.
+
 Before tagging the bridge:
 
 1. Sync `template-generator-node/src/pipeline-template-schema.json` from the matching released framework deployment artifact.
 2. Update generator templates that embed framework parent or dependency versions so generated projects target the released TPF version.
 3. Bump the root npm package version and keep `package-lock.json` aligned.
 4. Run `npm test`, `npm --prefix template-generator-node test`, and `npm pack --dry-run`.
-5. Note the compatible TPF release in the bridge release notes, for example `compatible with TPF v26.5.2`.
+5. For generator changes that affect generated Java, generated POMs, runtime layout, REST await outputs, mapper contracts, or framework version alignment, run the generated-scaffold compile smoke against the matching framework tag. Generate inside a framework tag worktree under `examples/<smoke-name>` so the scaffold root POM's `<relativePath>../../pom.xml</relativePath>` resolves to `pipeline-framework-root`; then run:
+
+   ```bash
+   ./mvnw -f examples/<smoke-name>/pom.xml -DskipTests compile
+   ```
+
+6. Note the compatible TPF release in the bridge release notes, for example `compatible with TPF v26.5.2`.
+
+After the workflow completes:
+
+```bash
+npm view @pipelineframework/tpf-mcp-bridge version --registry=https://registry.npmjs.org
+```
+
+Confirm the returned version matches the bridge package version. If a publish
+fails after the tag exists, keep the tag immutable in normal release practice:
+fix the workflow or package metadata, then publish a new patch version and tag.
 
 ## Important Publishing Details (Central Validation)
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepArtifactGenerationServiceTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepArtifactGenerationServiceTest.java
@@ -40,7 +40,7 @@ import org.pipelineframework.processor.util.RoleMetadataGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -152,10 +152,9 @@ class StepArtifactGenerationServiceTest {
         ArgumentCaptor<GrpcBinding> bindingCaptor = ArgumentCaptor.forClass(GrpcBinding.class);
         ArgumentCaptor<GenerationContext> contextCaptor = ArgumentCaptor.forClass(GenerationContext.class);
         verify(renderer).render(bindingCaptor.capture(), contextCaptor.capture());
-        Object serviceDescriptor = bindingCaptor.getValue().serviceDescriptor();
-        assertNotNull(serviceDescriptor);
-        assertTrue(serviceDescriptor instanceof Descriptors.ServiceDescriptor);
-        assertEquals("ChargeCard", ((Descriptors.ServiceDescriptor) serviceDescriptor).getName());
+        assertEquals(
+            "ChargeCard",
+            assertInstanceOf(Descriptors.ServiceDescriptor.class, bindingCaptor.getValue().serviceDescriptor()).getName());
         assertEquals(DeploymentRole.PIPELINE_SERVER, contextCaptor.getValue().role());
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/TemplateModelBuilderTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/TemplateModelBuilderTest.java
@@ -58,6 +58,15 @@ class TemplateModelBuilderTest {
     }
 
     @Test
+    void pipelineTemplateConfig_whitespaceBasePackage_throwsException() {
+        PipelineTemplateStep step = step("Process Data", "Input", "Output");
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineTemplateConfig("app", "  ", "GRPC", List.of(step), null));
+        assertEquals("basePackage must not be blank", ex.getMessage());
+    }
+
+    @Test
     void buildModels_validStep_buildsModel() {
         PipelineTemplateStep step = step("Process Data", "InputDto", "OutputDto");
         PipelineTemplateConfig config = new PipelineTemplateConfig("app", "com.example", "GRPC", List.of(step), null);

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineCacheSupportFactoryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineCacheSupportFactoryTest.java
@@ -18,6 +18,7 @@ package org.pipelineframework;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.Duration;
 
 import io.smallrye.mutiny.Uni;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ class PipelineCacheSupportFactoryTest {
 
         assertNotNull(support);
         Uni<Optional<Object>> readUni = support.reader().get("v1:key");
-        Optional<Object> cached = readUni.await().indefinitely();
+        Optional<Object> cached = readUni.await().atMost(Duration.ofSeconds(5));
         Object actual = cached.orElseThrow();
         assertEquals("cached-high", actual);
         assertEquals(CachePolicy.REQUIRE_CACHE, support.resolvePolicy(null));

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineParallelismPolicyResolverTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineParallelismPolicyResolverTest.java
@@ -26,6 +26,7 @@ import org.pipelineframework.parallelism.ThreadSafety;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PipelineParallelismPolicyResolverTest {
@@ -84,14 +85,16 @@ class PipelineParallelismPolicyResolverTest {
 
     @Test
     void strictAdvisedOrderingFollowsCurrentBehavior() {
-        assertFalse(resolver.shouldParallelize(
-            new StrictAdvisedAnnotationStep(),
-            ParallelismPolicy.AUTO,
-            PipelineParallelismPolicyResolver.StepParallelismType.ONE_TO_MANY));
-        assertTrue(resolver.shouldParallelize(
-            new StrictAdvisedAnnotationStep(),
-            ParallelismPolicy.PARALLEL,
-            PipelineParallelismPolicyResolver.StepParallelismType.ONE_TO_MANY));
+        assertAll(
+            "strict-advised ordering behavior",
+            () -> assertFalse(resolver.shouldParallelize(
+                new StrictAdvisedAnnotationStep(),
+                ParallelismPolicy.AUTO,
+                PipelineParallelismPolicyResolver.StepParallelismType.ONE_TO_MANY)),
+            () -> assertTrue(resolver.shouldParallelize(
+                new StrictAdvisedAnnotationStep(),
+                ParallelismPolicy.PARALLEL,
+                PipelineParallelismPolicyResolver.StepParallelismType.ONE_TO_MANY)));
     }
 
     static class RelaxedSafeHints implements ParallelismHints {

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
@@ -83,7 +83,8 @@ class PipelineStepExecutorTest {
             null);
 
         List<String> values = ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5));
-        assertTrue(values.containsAll(Set.of("a-future", "b-future")));
+        values.sort(String::compareTo);
+        assertEquals(List.of("a-future", "b-future"), values);
     }
 
     @Test
@@ -97,7 +98,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().indefinitely());
+        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -149,7 +150,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals("a,b", ((Uni<String>) result).await().indefinitely());
+        assertEquals("a,b", ((Uni<String>) result).await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -161,7 +162,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals(List.of("x-mapped"), ((Multi<String>) result).collect().asList().await().indefinitely());
+        assertEquals(List.of("x-mapped"), ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -170,7 +171,7 @@ class PipelineStepExecutorTest {
             new BlockingSuffixOneToOneStep("-blocking"),
             Uni.createFrom().item("x"));
 
-        assertEquals("x-blocking", ((Uni<String>) result).await().indefinitely());
+        assertEquals("x-blocking", ((Uni<String>) result).await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -184,7 +185,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().indefinitely());
+        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -198,7 +199,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().indefinitely());
+        assertEquals(List.of("x-1", "x-2"), ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -210,7 +211,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals("a,b", ((Uni<String>) result).await().indefinitely());
+        assertEquals("a,b", ((Uni<String>) result).await().atMost(Duration.ofSeconds(5)));
     }
 
     @Test
@@ -222,7 +223,7 @@ class PipelineStepExecutorTest {
             null,
             null);
 
-        assertEquals(List.of("a-mapped", "b-mapped"), ((Multi<String>) result).collect().asList().await().indefinitely());
+        assertEquals(List.of("a-mapped", "b-mapped"), ((Multi<String>) result).collect().asList().await().atMost(Duration.ofSeconds(5)));
     }
 
     static final class SuffixOneToOneStep extends ConfigurableStep implements StepOneToOne<String, String> {

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepOrdererTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepOrdererTest.java
@@ -53,9 +53,11 @@ class PipelineStepOrdererTest {
         TestSteps.TestStepOneToMany stepA = new TestSteps.TestStepOneToMany();
         TestSteps.TestStepManyToMany stepC = new TestSteps.TestStepManyToMany();
 
-        List<Object> ordered = orderer.applyConfiguredOrder(
-            List.of(stepB, stepA, stepC),
-            List.of(stepA.getClass().getName(), stepB.getClass().getName(), stepC.getClass().getName()));
+        List<Object> ordered = withContextClassLoader(
+            tempDir,
+            () -> orderer.applyConfiguredOrder(
+                List.of(stepB, stepA, stepC),
+                List.of(stepA.getClass().getName(), stepB.getClass().getName(), stepC.getClass().getName())));
 
         assertEquals(List.of(stepA, stepB, stepC), ordered);
     }
@@ -65,9 +67,11 @@ class PipelineStepOrdererTest {
         TestSteps.TestStepOneToOneProcessed stepB = new TestSteps.TestStepOneToOneProcessed();
         TestSteps.TestStepOneToMany stepA = new TestSteps.TestStepOneToMany();
 
-        List<Object> ordered = orderer.applyConfiguredOrder(
-            List.of(stepB, stepA),
-            List.of(stepB.getClass().getName()));
+        List<Object> ordered = withContextClassLoader(
+            tempDir,
+            () -> orderer.applyConfiguredOrder(
+                List.of(stepB, stepA),
+                List.of(stepB.getClass().getName())));
 
         assertEquals(List.of(stepB, stepA), ordered);
     }
@@ -77,9 +81,11 @@ class PipelineStepOrdererTest {
         TestSteps.TestStepOneToOneProcessed first = new TestSteps.TestStepOneToOneProcessed();
         TestSteps.TestStepOneToOneProcessed second = new TestSteps.TestStepOneToOneProcessed();
 
-        List<Object> ordered = orderer.applyConfiguredOrder(
-            List.of(first, second),
-            List.of(first.getClass().getName(), second.getClass().getName()));
+        List<Object> ordered = withContextClassLoader(
+            tempDir,
+            () -> orderer.applyConfiguredOrder(
+                List.of(first, second),
+                List.of(first.getClass().getName(), second.getClass().getName())));
 
         assertEquals(List.of(first, second), ordered);
     }

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineIdlCompatibilityCheckerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineIdlCompatibilityCheckerTest.java
@@ -236,6 +236,15 @@ class PipelineIdlCompatibilityCheckerTest {
         List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
 
         assertTrue(errors.isEmpty(), "Expected deprecation metadata to remain compatible, got: " + errors);
+    }
+
+    @Test
+    void compatibilityResultListIsImmutable() {
+        PipelineIdlSnapshot baseline = snapshot(List.of(simpleField(1, "paymentId", "uuid")));
+        PipelineIdlSnapshot current = snapshot(List.of(field(1, "paymentId", "uuid", null, null, null, false, false, true, "string")));
+
+        List<String> errors = new PipelineIdlCompatibilityChecker().compare(baseline, current);
+        assertTrue(errors.isEmpty(), "Expected deprecation metadata to remain compatible, got: " + errors);
         assertThrows(UnsupportedOperationException.class, () -> errors.add("mutate"));
     }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/SqsWorkPollerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/SqsWorkPollerTest.java
@@ -140,7 +140,7 @@ class SqsWorkPollerTest {
     }
 
     @Test
-    void pollOnceProcessesMultipleMessagesAndDeletesOnlyHandledOnes() {
+    void pollOnceProcessesValidAndMalformedMessagesAndDeletesHandledAndMalformed() {
         SqsClient client = mock(SqsClient.class);
         PipelineExecutionService pipelineExecutionService = mock(PipelineExecutionService.class);
         Message first = validMessage("receipt-4", "exec-4");


### PR DESCRIPTION
## Scope\n- This PR keeps all production behavior unchanged and updates a small set of tests for stronger determinism and clearer assertions.\n- Adds robust guidance in [docs/guide/evolve/publishing.md](docs/guide/evolve/publishing.md) for tpf-mcp-bridge npm trusted-publishing failures and required checks.\n\n## Out of scope\n- No framework runtime or bridge code changes\n- No workflow file changes\n- No additional example changes\n\n## Validation\n- ./mvnw -f framework/pom.xml -pl runtime -Dtest='PipelineCacheSupportFactoryTest,PipelineStepExecutorTest,PipelineParallelismPolicyResolverTest,PipelineStepOrdererTest,PipelineIdlCompatibilityCheckerTest,SqsWorkPollerTest' test\n- ./mvnw -f framework/pom.xml -pl deployment -Dtest='StepArtifactGenerationServiceTest,TemplateModelBuilderTest' test\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded publishing guide with comprehensive bridge release workflow details, including trigger conditions, validation steps, pre-tag checklist, and post-publish verification procedures.

* **Tests**
  * Improved test reliability with bounded waits instead of indefinite timeouts.
  * Added validation test for empty basePackage strings.
  * Added immutability verification for compatibility check results.
  * Enhanced assertion grouping and test execution context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->