### PR TITLE
refactor: cache support wiring and policy cleanup

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineCacheReadSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineCacheReadSupport.java
@@ -19,6 +19,7 @@ package org.pipelineframework;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.pipelineframework.cache.CacheKeyStrategy;
 import org.pipelineframework.cache.CachePolicy;
@@ -45,29 +46,33 @@ class PipelineCacheReadSupport {
         if (item == null) {
             return Optional.empty();
         }
-        // Key resolution is target-aware first: if any strategy supports the requested target type,
-        // only those strategies participate and an all-empty result means an explicit no-match.
-        // If no strategy supports the target type, fall back to the full strategy list.
-        boolean foundSupporting = false;
         if (targetType != null) {
-            for (CacheKeyStrategy strategy : strategies) {
-                if (!strategy.supportsTarget(targetType)) {
-                    continue;
-                }
-                foundSupporting = true;
-                Optional<String> resolved = strategy.resolveKey(item, context);
-                if (resolved.isPresent()) {
-                    String key = resolved.get();
-                    if (!key.isBlank()) {
-                        return Optional.of(key.trim());
-                    }
-                }
+            Predicate<CacheKeyStrategy> supportsTarget = strategy -> strategy.supportsTarget(targetType);
+            Optional<String> targetKey = resolveWithFilter(item, context, supportsTarget);
+            if (targetKey.isPresent()) {
+                return targetKey;
             }
+            boolean foundSupporting = strategies.stream().anyMatch(supportsTarget::test);
             if (foundSupporting) {
                 return Optional.empty();
             }
         }
+        return resolveWithFilter(item, context, strategy -> true);
+    }
+
+    CachePolicy resolvePolicy(PipelineContext context) {
+        String policy = defaultPolicy;
+        if (context != null && context.cachePolicy() != null) {
+            policy = context.cachePolicy();
+        }
+        return CachePolicy.fromConfig(policy);
+    }
+
+    private Optional<String> resolveWithFilter(Object item, PipelineContext context, Predicate<CacheKeyStrategy> strategyFilter) {
         for (CacheKeyStrategy strategy : strategies) {
+            if (!strategyFilter.test(strategy)) {
+                continue;
+            }
             Optional<String> resolved = strategy.resolveKey(item, context);
             if (resolved.isPresent()) {
                 String key = resolved.get();
@@ -77,11 +82,6 @@ class PipelineCacheReadSupport {
             }
         }
         return Optional.empty();
-    }
-
-    CachePolicy resolvePolicy(PipelineContext context) {
-        String policy = context != null ? context.cachePolicy() : defaultPolicy;
-        return CachePolicy.fromConfig(policy);
     }
 
     boolean shouldRead(CachePolicy policy) {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineCacheSupportFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineCacheSupportFactory.java
@@ -32,45 +32,60 @@ class PipelineCacheSupportFactory {
 
     private static final Logger logger = Logger.getLogger(PipelineCacheSupportFactory.class);
 
-    @Inject
-    Instance<CacheKeyStrategy> cacheKeyStrategies;
+    private final Instance<CacheKeyStrategy> cacheKeyStrategies;
+    private final Instance<PipelineCacheReader> cacheReaders;
+    private final String cachePolicyDefault;
 
     @Inject
-    Instance<PipelineCacheReader> cacheReaders;
-
-    @ConfigProperty(name = "pipeline.cache.policy", defaultValue = "prefer-cache")
-    String cachePolicyDefault;
+    PipelineCacheSupportFactory(
+        Instance<CacheKeyStrategy> cacheKeyStrategies,
+        Instance<PipelineCacheReader> cacheReaders,
+        @ConfigProperty(name = "pipeline.cache.policy", defaultValue = "prefer-cache") String cachePolicyDefault) {
+        this.cacheKeyStrategies = cacheKeyStrategies;
+        this.cacheReaders = cacheReaders;
+        this.cachePolicyDefault = cachePolicyDefault;
+    }
 
     PipelineRunner.CacheReadSupport buildCacheReadSupport() {
-        if (cacheReaders == null || cacheReaders.isUnsatisfied()) {
+        if (cacheReaders.isUnsatisfied()) {
             return null;
         }
         List<PipelineCacheReader> readers = cacheReaders.stream()
             .sorted(Comparator.comparingInt(PipelineCacheReader::priority).reversed()
-                .thenComparing(cacheReader -> cacheReader.getClass().getName()))
+                .thenComparing(this::beanTypeName))
             .toList();
-        if (readers.isEmpty() || cacheKeyStrategies == null || cacheKeyStrategies.isUnsatisfied()) {
+        if (readers.isEmpty() || cacheKeyStrategies.isUnsatisfied()) {
             return null;
         }
         if (readers.size() > 1) {
             String readerNames = String.join(
                 ", ",
                 readers.stream()
-                    .map(cacheReader -> cacheReader.getClass().getName() + "(priority=" + cacheReader.priority() + ")")
+                    .map(cacheReader -> beanTypeName(cacheReader) + "(priority=" + cacheReader.priority() + ")")
                     .toList());
             logger.warnf(
                 "Multiple PipelineCacheReader beans found (%s). Using %s based on priority ordering.",
                 readerNames,
-                readers.get(0).getClass().getName());
+                beanTypeName(readers.get(0)));
         }
         PipelineCacheReader reader = readers.get(0);
         List<CacheKeyStrategy> ordered = cacheKeyStrategies.stream()
             .sorted(Comparator.comparingInt(CacheKeyStrategy::priority).reversed()
-                .thenComparing(strategy -> strategy.getClass().getName()))
+                .thenComparing(this::beanTypeName))
             .toList();
         if (ordered.isEmpty()) {
             return null;
         }
         return new PipelineRunner.CacheReadSupport(reader, ordered, cachePolicyDefault);
+    }
+
+    private String beanTypeName(Object bean) {
+        String beanClassName = bean.getClass().getName();
+        Class<?> beanClass = bean.getClass();
+        if (beanClass.getSuperclass() != null
+            && (beanClassName.contains("_Subclass") || beanClassName.contains("$$") || beanClassName.contains("_ClientProxy"))) {
+            return beanClass.getSuperclass().getName();
+        }
+        return beanClassName;
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineCacheSupportFactoryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineCacheSupportFactoryTest.java
@@ -34,30 +34,32 @@ class PipelineCacheSupportFactoryTest {
 
     @Test
     void returnsNullWhenNoReadersPresent() {
-        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory();
-        factory.cacheReaders = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of());
-        factory.cacheKeyStrategies = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.FixedKeyStrategy()));
+        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory(
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.FixedKeyStrategy())),
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of()),
+            "prefer-cache");
 
         assertNull(factory.buildCacheReadSupport());
     }
 
     @Test
     void returnsNullWhenNoStrategiesPresent() {
-        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory();
-        factory.cacheReaders = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.HighPriorityReader()));
-        factory.cacheKeyStrategies = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of());
+        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory(
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of()),
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.HighPriorityReader())),
+            "prefer-cache");
 
         assertNull(factory.buildCacheReadSupport());
     }
 
     @Test
     void selectsHighestPriorityReaderAndPreservesPolicyWiring() {
-        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory();
-        factory.cacheReaders = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(
+        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory(
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.FixedKeyStrategy())),
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(
             new PipelineRunnerCacheReadTest.LowPriorityReader(),
-            new PipelineRunnerCacheReadTest.HighPriorityReader()));
-        factory.cacheKeyStrategies = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.FixedKeyStrategy()));
-        factory.cachePolicyDefault = "require-cache";
+            new PipelineRunnerCacheReadTest.HighPriorityReader())),
+            "require-cache");
 
         PipelineRunner.CacheReadSupport support = factory.buildCacheReadSupport();
 
@@ -71,18 +73,30 @@ class PipelineCacheSupportFactoryTest {
 
     @Test
     void tiesCacheKeyStrategiesByClassNameDeterministically() {
-        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory();
-        factory.cacheReaders = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.HighPriorityReader()));
-        // Equal-priority strategies are ordered by class name, so AStrategy wins over ZStrategy.
-        factory.cacheKeyStrategies = new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(
-            new ZStrategy(),
-            new AStrategy()));
-        factory.cachePolicyDefault = "prefer-cache";
+        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory(
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(
+                new ZStrategy(),
+                new AStrategy())),
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.HighPriorityReader())),
+            "prefer-cache");
 
         PipelineRunner.CacheReadSupport support = factory.buildCacheReadSupport();
 
         assertNotNull(support);
         assertEquals("a", support.resolveKey("input", null).orElseThrow());
+    }
+
+    @Test
+    void resolvesPolicyFromContextWhenContextPolicyIsNullFallsBackToDefault() {
+        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory(
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.FixedKeyStrategy())),
+            new PipelineRunnerCacheReadTest.SimpleInstance<>(List.of(new PipelineRunnerCacheReadTest.HighPriorityReader())),
+            "cache-only");
+
+        PipelineRunner.CacheReadSupport support = factory.buildCacheReadSupport();
+
+        assertNotNull(support);
+        assertEquals(CachePolicy.CACHE_ONLY, support.resolvePolicy(new PipelineContext(null, null, null)));
     }
 
     static final class AStrategy implements CacheKeyStrategy {

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineRunnerCacheReadTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineRunnerCacheReadTest.java
@@ -1,6 +1,7 @@
 package org.pipelineframework;
 
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -293,12 +294,10 @@ class PipelineRunnerCacheReadTest {
 
     @Test
     void selectsHighestPriorityCacheReader() {
-        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory();
-        factory.cacheReaders = new SimpleInstance<>(List.of(
-            new LowPriorityReader(),
-            new HighPriorityReader()));
-        factory.cacheKeyStrategies = new SimpleInstance<>(List.of(new FixedKeyStrategy()));
-        factory.cachePolicyDefault = "prefer-cache";
+        PipelineCacheSupportFactory factory = new PipelineCacheSupportFactory(
+            new SimpleInstance<>(List.<CacheKeyStrategy>of(new FixedKeyStrategy())),
+            new SimpleInstance<>(List.<PipelineCacheReader>of(new LowPriorityReader(), new HighPriorityReader())),
+            "prefer-cache");
         PipelineRunner.CacheReadSupport support = factory.buildCacheReadSupport();
 
         CountingStep step = new CountingStep();
@@ -314,7 +313,7 @@ class PipelineRunnerCacheReadTest {
             support,
             context);
 
-        String value = ((Uni<String>) result).await().indefinitely();
+        String value = ((Uni<String>) result).await().atMost(Duration.ofSeconds(5));
         assertEquals("cached-high", value);
         assertEquals(0, step.calls.get());
     }


### PR DESCRIPTION
## Scope
- Implement cache support cleanup for issue #217 without changing pipeline execution behavior.
- Switch `PipelineCacheSupportFactory` to constructor injection and keep collaborator wiring deterministic.
- Make cache key-resolution in `PipelineCacheReadSupport` shared and explicit.
- Make null `cachePolicy` context values resolve to the default policy explicitly.
- Keep behavior unchanged while tightening test coverage and lifecycle handling for cache status cleanup.

## Out of scope
- No execution model, transport, or step ordering changes.
- No broader cache architecture redesign.

## Validation
- `./mvnw -q -f framework/pom.xml -pl runtime -Dtest=PipelineCacheSupportFactoryTest,PipelineRunnerCacheReadTest test`
