### PR TITLE
Add self-host incident demo and contract release docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -198,6 +198,7 @@ const mainSidebar = [
                     {text: 'Worker Protocols', link: '/guide/evolve/durable-coordinator/worker-protocols'},
                     {text: 'Step-Aware Invocation Runtime', link: '/guide/evolve/durable-coordinator/boundary-invocation-model'},
                     {text: 'Bundle Contract', link: '/guide/evolve/durable-coordinator/bundle-contract'},
+                    {text: 'Pipeline Contract And Release Model', link: '/guide/evolve/durable-coordinator/pipeline-contract-release-model'},
                     {text: 'Local APIs', link: '/guide/evolve/durable-coordinator/local-apis'},
                     {text: 'Self-Hosted Deployment', link: '/guide/evolve/durable-coordinator/self-hosted-deployment'},
                     {text: 'Self-Hosted Milestone', link: '/guide/evolve/durable-coordinator/self-hosted-milestone'}

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -199,6 +199,7 @@ const mainSidebar = [
                     {text: 'Step-Aware Invocation Runtime', link: '/guide/evolve/durable-coordinator/boundary-invocation-model'},
                     {text: 'Bundle Contract', link: '/guide/evolve/durable-coordinator/bundle-contract'},
                     {text: 'Local APIs', link: '/guide/evolve/durable-coordinator/local-apis'},
+                    {text: 'Self-Hosted Deployment', link: '/guide/evolve/durable-coordinator/self-hosted-deployment'},
                     {text: 'Self-Hosted Milestone', link: '/guide/evolve/durable-coordinator/self-hosted-milestone'}
                 ]
             },

--- a/docs/guide/evolve/durable-coordinator/bundle-contract.md
+++ b/docs/guide/evolve/durable-coordinator/bundle-contract.md
@@ -1,8 +1,8 @@
 # Bundle Contract
 
-A pipeline bundle is best understood as a versioned orchestration contract: pipeline intent, step graph, type ids, codecs, mapper metadata, await metadata, runtime mapping, and compatibility identity.
+The current durable coordinator uses `META-INF/pipeline/bundle-manifest.json` as its v1 identity artifact. It is enough to validate local executable artifacts, pin executions, and reject workers that host the wrong `pipelineId + bundleVersionId`.
 
-An executable bundle is one implementation form of that contract: the contract plus step code/runtime packaged as a JAR, image, or deployable artifact. Current local JAR registration proves the executable-bundle path for local/dev and self-host experiments; it is not the only intended product model.
+The target concept is broader: a pipeline contract plus a release descriptor. See [Pipeline Contract And Release Model](/guide/evolve/durable-coordinator/pipeline-contract-release-model) for the design direction covering container images, native binaries, functions, local files, external endpoints, and independently deployed step artifacts.
 
 ## Manifest
 
@@ -12,9 +12,9 @@ Manifest v1 records pipeline id, bundle version id, bundle hash, runtime metadat
 
 Workers validate command envelope identity before decoding payloads or executing business code. A command targeting another `pipelineId` or `bundleVersionId` returns a failed transition result.
 
-## Registry And Pinning
+## Current Registry And Pinning
 
-The local executable-bundle path has two public pieces:
+The local executable-artifact path has two runtime pieces:
 
 1. `PipelineBundleRegistry` stores bundle records and the active bundle pointer for each tenant and pipeline.
 2. `PipelineBundleArtifactStore` copies validated executable JARs into a coordinator-owned content-addressed store and verifies size/checksum/manifest integrity.
@@ -27,4 +27,4 @@ Existing executions, retries, await resumes, and result reads stay pinned to the
 
 Workers must already host matching code. The coordinator does not load registered artifacts into a worker runtime.
 
-Future contract-only and hybrid execution should allow independently deployed services or functions to implement the same contract without requiring every path to be an executable JAR.
+Future release registration should allow independently deployed services or functions to satisfy the same pipeline contract without requiring every path to be a registered executable JAR.

--- a/docs/guide/evolve/durable-coordinator/index.md
+++ b/docs/guide/evolve/durable-coordinator/index.md
@@ -1,6 +1,6 @@
 # Durable Coordinator
 
-The durable coordinator is the public, self-hostable control-plane boundary for `QUEUE_ASYNC` execution.
+The durable coordinator is the self-hostable control-plane boundary for `QUEUE_ASYNC` execution.
 
 It owns execution state, leases, retry/DLQ, await units, bundle identity, worker dispatch, and status/result APIs. Step code still runs in workers: local in-process workers, REST workers, gRPC workers, or SQS request/reply workers.
 
@@ -14,6 +14,7 @@ This section is implementation-facing. Application usage remains in [Orchestrato
 | Await state | `AwaitUnitRecord` plus pending/completion interaction records |
 | Worker boundary | portable command/result envelopes over local, REST, gRPC, or SQS |
 | Bundle identity | generated `META-INF/pipeline/bundle-manifest.json` and strict worker identity validation |
+| Contract/release direction | target model separates pipeline contract, release descriptor, artifact descriptors, and deployment plans |
 | Self-host path | batteries-included local coordinator using the restaurant approval example |
 
 ```mermaid
@@ -42,13 +43,14 @@ sequenceDiagram
 
 1. [Worker Protocols](/guide/evolve/durable-coordinator/worker-protocols) explains local, REST, gRPC, and SQS transition workers.
 2. [Step-Aware Invocation Runtime](/guide/evolve/durable-coordinator/boundary-invocation-model) explains the shared invocation seam used by pipeline steps and transition workers.
-3. [Bundle Contract](/guide/evolve/durable-coordinator/bundle-contract) explains manifest identity, activation, pinning, and worker availability.
-4. [Local APIs](/guide/evolve/durable-coordinator/local-apis) documents the current default-disabled control-plane and admin APIs.
-5. [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment) gives the production-ish self-host topology, configuration, and operator runbooks.
-6. [Self-Hosted Milestone](/guide/evolve/durable-coordinator/self-hosted-milestone) tracks what remains before the public self-host path is credible.
+3. [Bundle Contract](/guide/evolve/durable-coordinator/bundle-contract) explains the current manifest identity, activation, pinning, and worker availability path.
+4. [Pipeline Contract And Release Model](/guide/evolve/durable-coordinator/pipeline-contract-release-model) describes the target model for contracts, releases, artifacts, deployment plans, and drift detection.
+5. [Local APIs](/guide/evolve/durable-coordinator/local-apis) documents the current default-disabled control-plane and admin APIs.
+6. [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment) gives the production-ish self-host topology, configuration, and operator runbooks.
+7. [Self-Hosted Milestone](/guide/evolve/durable-coordinator/self-hosted-milestone) tracks what remains after the current self-host proof.
 
 ## Limits
 
 The current coordinator path does not dynamically load registered JAR code. Workers must already host matching pipeline code and validate `pipelineId + bundleVersionId`.
 
-The current file-backed bundle registry is single-coordinator oriented. Multi-instance registry coordination, built-in DLQ replay, and worker lifecycle remain follow-up public substrate work.
+The current file-backed bundle registry is single-coordinator oriented. Multi-instance registry coordination, built-in DLQ replay, and worker lifecycle remain follow-up runtime substrate work.

--- a/docs/guide/evolve/durable-coordinator/index.md
+++ b/docs/guide/evolve/durable-coordinator/index.md
@@ -44,10 +44,11 @@ sequenceDiagram
 2. [Step-Aware Invocation Runtime](/guide/evolve/durable-coordinator/boundary-invocation-model) explains the shared invocation seam used by pipeline steps and transition workers.
 3. [Bundle Contract](/guide/evolve/durable-coordinator/bundle-contract) explains manifest identity, activation, pinning, and worker availability.
 4. [Local APIs](/guide/evolve/durable-coordinator/local-apis) documents the current default-disabled control-plane and admin APIs.
-5. [Self-Hosted Milestone](/guide/evolve/durable-coordinator/self-hosted-milestone) tracks what remains before the public self-host path is credible.
+5. [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment) gives the production-ish self-host topology, configuration, and operator runbooks.
+6. [Self-Hosted Milestone](/guide/evolve/durable-coordinator/self-hosted-milestone) tracks what remains before the public self-host path is credible.
 
 ## Limits
 
 The current coordinator path does not dynamically load registered JAR code. Workers must already host matching pipeline code and validate `pipelineId + bundleVersionId`.
 
-The current file-backed bundle registry is single-coordinator oriented. Multi-instance registry coordination, worker lifecycle, upgrade/drain policy, and production deployment recipes remain follow-up public substrate work.
+The current file-backed bundle registry is single-coordinator oriented. Multi-instance registry coordination, built-in DLQ replay, and worker lifecycle remain follow-up public substrate work.

--- a/docs/guide/evolve/durable-coordinator/local-apis.md
+++ b/docs/guide/evolve/durable-coordinator/local-apis.md
@@ -2,7 +2,7 @@
 
 The runtime includes default-disabled local/dev APIs that prove coordinator ownership of submission, status/result lookup, await query/completion, bundle activation, and worker dispatch.
 
-They are internal runtime groundwork and self-host reference surfaces, not a public hosted service API.
+They are internal runtime groundwork and self-host reference surfaces, not a general hosted-service API.
 
 ## Control Plane
 

--- a/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
+++ b/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
@@ -131,6 +131,6 @@ CNAB, Open Application Model, Serverless Workflow, and CDEvents are useful refer
 
 ## Relationship To Current Bundle Manifest
 
-`META-INF/pipeline/bundle-manifest.json` is the current v1 implementation artifact. It gives the coordinator and worker enough identity to validate portable transition envelopes and pin executions.
+`META-INF/pipeline/bundle-manifest.json` is the current v1 identity artifact. It gives the coordinator and worker enough identity to validate portable transition envelopes and pin executions.
 
 The next runtime step should not delete that path. It should introduce release registration beside the existing local executable artifact registration, then map the current bundle manifest into the new contract/release vocabulary.

--- a/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
+++ b/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
@@ -1,0 +1,136 @@
+# Pipeline Contract And Release Model
+
+The durable coordinator needs a versioned thing to execute, but that thing should not be a JAR. A JAR is one artifact form. The strategic unit is a pipeline contract, and each deployable version is a release that pins the artifacts satisfying that contract.
+
+This page describes the target model. Current runtime code still uses `META-INF/pipeline/bundle-manifest.json` and local executable JAR registration as the first implementation form.
+
+## Core Terms
+
+| Term | Meaning |
+| --- | --- |
+| Pipeline contract | Generated semantic contract derived from YAML plus compiled metadata: graph, step ids, cardinalities, type ids, mapper and boundary metadata, await metadata, and compatibility identity. |
+| Release descriptor | Build-produced descriptor that selects one deployable version of a pipeline contract and pins exact artifacts by digest or immutable reference. |
+| Artifact descriptor | A concrete runtime artifact that satisfies part or all of the release: local file, JAR, native binary, container image, function package, or external endpoint. |
+| Deployment plan | Platform-specific actioning layer: Helm, Kustomize, ECS task definitions, Terraform, Lambda aliases, Azure Functions configuration, or local scripts. |
+| Activation | Coordinator decision that new executions should use a specific release. |
+| Pinning | Execution record stores the contract/release identity it started with; retries, awaits, and resumes keep that identity. |
+
+## Contract Descriptor
+
+`pipeline-contract.json` should be the generated semantic description of the pipeline, independent of where the code is deployed.
+
+It should include:
+
+1. pipeline id and contract version,
+2. ordered graph and step ids,
+3. authored step names and kinds,
+4. cardinality for each step,
+5. input and output type ids,
+6. mapper, boundary, and transport metadata needed for compatibility checks,
+7. await correlation and transport metadata,
+8. inter-pipeline handoff contracts when a pipeline publishes or consumes another pipeline boundary,
+9. compatibility hash over canonical contract content.
+
+The contract is produced from both YAML and code-derived compiler metadata. A YAML-only hash is not enough, because step types, mapper bindings, generated codecs, and await/boundary metadata can change without a visually large YAML diff.
+
+## Release Descriptor
+
+`pipeline-release.json` should be emitted by a build or release process after artifacts are built and addressable.
+
+It should include:
+
+1. pipeline id,
+2. contract version,
+3. release version,
+4. artifact descriptors for the coordinator-facing worker or individual steps,
+5. expected worker capability identities,
+6. deployment target metadata when known,
+7. artifact digests and optional provenance, SBOM, and signature references.
+
+Example:
+
+```json
+{
+  "schemaVersion": 1,
+  "pipelineId": "payments.csv",
+  "contractVersion": "sha256:contractabc",
+  "releaseVersion": "2026.06.07.1",
+  "artifacts": [
+    {
+      "artifactId": "payment-provider-worker",
+      "kind": "container-image",
+      "scope": "step",
+      "stepIds": ["await-payment-provider"],
+      "uri": "oci://123456789012.dkr.ecr.eu-west-1.amazonaws.com/payment-provider@sha256:image222",
+      "digest": "sha256:image222",
+      "runtime": "jvm",
+      "capabilities": ["transition-worker", "step:await-payment-provider"]
+    }
+  ]
+}
+```
+
+The coordinator should validate and activate releases. It should not become the deployment engine. Platform-specific tools deploy the artifacts, then the coordinator verifies that workers report matching contract/release capability before accepting work.
+
+## Artifact Kinds
+
+The release model should support these artifact kinds:
+
+| Kind | Example | Typical use |
+| --- | --- | --- |
+| `local-file` | `/var/lib/tpf/artifacts/worker.jar` | Local/self-host pilots and air-gapped installs. |
+| `jar` | `file:///opt/tpf/restaurant-worker.jar` or Maven coordinates plus checksum | JVM worker process. |
+| `native-binary` | `/opt/tpf/workers/payment-worker` | Quarkus native worker. |
+| `container-image` | `oci://ecr.example/payments/worker@sha256:...` | Kubernetes, ECS, and production container platforms. |
+| `lambda-zip` | `s3://bucket/payment-worker.zip#sha256:...` | AWS Lambda zip deployment. |
+| `lambda-image` | `oci://ecr.example/payment-lambda@sha256:...` | AWS Lambda container image. |
+| `external-endpoint` | `https://payments.internal/step` | Pre-existing service that satisfies a step contract. |
+
+Local artifacts are valid, but they still need a digest. Production releases should prefer immutable references such as OCI digests, S3 object version plus checksum, Maven coordinate plus checksum, or a signed local manifest in air-gapped deployments.
+
+## Ownership Models
+
+The model must not assume one repo, one team, or one artifact.
+
+### One Team Owns The Pipeline
+
+One repository and build can emit the contract, release descriptor, and all artifacts. Activation promotes a single release version.
+
+### Several Teams Own Steps
+
+The central pipeline contract defines required step interfaces and graph position. Each team publishes an artifact that satisfies one or more step contracts. The release descriptor is the integration point that pins the exact artifacts used together.
+
+### Teams Own Chained Pipelines
+
+Each pipeline owns its own contract and release lifecycle. Handoff boundaries become explicit contracts between pipelines, so upstream output compatibility and downstream input compatibility can be checked before activation.
+
+## Drift Detection
+
+The release model should make drift visible at several levels:
+
+| Drift type | Detection target |
+| --- | --- |
+| Contract drift | YAML graph, step order, cardinality, type ids, mapper metadata, await metadata, or boundary metadata changed. |
+| Code drift | A running worker artifact digest differs from the artifact pinned in the release descriptor. |
+| Deployment drift | The active release expects endpoints/images/functions that are not deployed or reachable. |
+| Runtime drift | Worker capability reports a different pipeline id, contract version, release version, or artifact digest. |
+
+The current worker capability check already proves the start of runtime drift detection through `pipelineId + bundleVersionId`. The target model should extend that to contract version, release version, and artifact identity.
+
+## Standards To Reuse
+
+TPF should define only the pipeline-specific contract and release semantics. The surrounding supply-chain model should reuse common standards and conventions:
+
+1. [OCI Image and Distribution specifications](https://opencontainers.org/) for container image and generic artifact addressing.
+2. [SLSA](https://slsa.dev/) and [in-toto](https://in-toto.io/) for build provenance.
+3. [SPDX](https://spdx.dev/) or [CycloneDX](https://cyclonedx.org/) for SBOMs.
+4. [Sigstore/cosign](https://docs.sigstore.dev/cosign/) for signing.
+5. Helm, Kustomize, Terraform, ECS task definitions, Lambda aliases, and cloud-native deployment tools for platform actioning.
+
+CNAB, Open Application Model, Serverless Workflow, and CDEvents are useful references, but they should not replace TPF's typed compiled pipeline contract.
+
+## Relationship To Current Bundle Manifest
+
+`META-INF/pipeline/bundle-manifest.json` is the current v1 implementation artifact. It gives the coordinator and worker enough identity to validate portable transition envelopes and pin executions.
+
+The next runtime step should not delete that path. It should introduce release registration beside the existing local executable artifact registration, then map the current bundle manifest into the new contract/release vocabulary.

--- a/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
@@ -1,0 +1,189 @@
+# Self-Hosted Deployment Recipe
+
+This page describes the current production-ish self-host shape for the durable coordinator. It is not a deployment stack or a managed service contract. It is a recipe for operators who want to run the coordinator with durable stores, explicit worker boundaries, and known manual procedures.
+
+The runnable starting point remains `examples/restaurant-approval/self-host`. That example proves the same control-plane, bundle, await, result, and failure/DLQ paths in one local process.
+
+## Deployment Shapes
+
+### One Process
+
+Use this shape for local adoption and demos.
+
+One packaged application process enables:
+
+1. generic control-plane API,
+2. bundle admin API,
+3. file bundle registry and artifact store,
+4. local in-process transition worker,
+5. memory/event/log providers by default.
+
+This is the fastest way to prove the model, but it is not crash-surviving HA. If the process dies, in-memory execution state is gone.
+
+### Coordinator And Worker Processes
+
+Use this shape when you want a real control-plane/data-plane boundary.
+
+The coordinator process enables the control-plane and admin APIs, owns execution/await state, and selects a remote transition worker through configured REST or gRPC target properties. Worker processes host the same pipeline bundle code and expose the default-disabled worker endpoint or service.
+
+REST worker selection example:
+
+```properties
+pipeline.orchestrator.worker.rest.base-url=http://restaurant-worker:8181
+pipeline.orchestrator.worker.rest.shared-secret-ref=env:TPF_WORKER_SECRET
+```
+
+Worker process example:
+
+```properties
+pipeline.orchestrator.worker.rest.server-enabled=true
+pipeline.orchestrator.worker.rest.shared-secret-ref=env:TPF_WORKER_SECRET
+```
+
+gRPC follows the same model with `pipeline.orchestrator.worker.grpc.endpoint`, `grpc.server-enabled`, and the matching shared secret or secret ref.
+
+### Durable Coordinator Baseline
+
+Use this shape for production-style recovery tests and self-host pilots.
+
+The coordinator persists execution and await state in DynamoDB-style tables, dispatches work through SQS-style queues, and publishes terminal execution failures to a durable DLQ. Workers can still be local, REST, gRPC, or SQS request/reply workers, but a separated REST or gRPC worker is the clearer operational boundary.
+
+Minimum coordinator configuration:
+
+```properties
+pipeline.orchestrator.mode=QUEUE_ASYNC
+pipeline.orchestrator.strict-startup=true
+pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
+pipeline.orchestrator.execution-ttl-days=7
+pipeline.orchestrator.lease-ms=30000
+pipeline.orchestrator.max-retries=3
+pipeline.orchestrator.retry-delay=PT10S
+pipeline.orchestrator.retry-multiplier=2.0
+pipeline.orchestrator.sweep-interval=PT30S
+pipeline.orchestrator.sweep-limit=100
+
+pipeline.orchestrator.state-provider=dynamo
+pipeline.orchestrator.dispatcher-provider=sqs
+pipeline.orchestrator.dlq-provider=sqs
+pipeline.orchestrator.queue-url=https://sqs.eu-west-1.amazonaws.com/123456789012/tpf-work
+pipeline.orchestrator.dlq-url=https://sqs.eu-west-1.amazonaws.com/123456789012/tpf-execution-dlq
+
+pipeline.orchestrator.dynamo.execution-table=tpf_execution
+pipeline.orchestrator.dynamo.execution-key-table=tpf_execution_key
+pipeline.orchestrator.dynamo.await-interaction-table=tpf_await_interaction
+pipeline.orchestrator.dynamo.await-interaction-key-table=tpf_await_interaction_key
+pipeline.orchestrator.dynamo.region=eu-west-1
+pipeline.orchestrator.sqs.region=eu-west-1
+
+pipeline.orchestrator.control-plane.enabled=true
+pipeline.orchestrator.control-plane.admin-token-ref=env:TPF_CONTROL_PLANE_TOKEN
+pipeline.orchestrator.admin.enabled=true
+pipeline.orchestrator.admin.admin-token-ref=env:TPF_ADMIN_TOKEN
+
+pipeline.orchestrator.bundles.registry.provider=file
+pipeline.orchestrator.bundles.storage.root=/var/lib/tpf/bundles
+```
+
+The await interaction table must provide these ALL-projected GSIs:
+
+1. `await-interaction-by-unit`,
+2. `await-interaction-pending-by-tenant`,
+3. `await-interaction-pending-by-assignee`,
+4. `await-interaction-pending-by-group`,
+5. `await-interaction-pending-by-step`,
+6. `await-interaction-pending-by-deadline`.
+
+SQS request/reply worker protocol has one additional v1 constraint: `pipeline.orchestrator.worker.sqs.response-queue-url` must be dedicated per coordinator instance or shard. Shared response queues can route a worker response to the wrong process because response demultiplexing is not implemented.
+
+## Startup Checklist
+
+Before accepting work:
+
+1. Build the pipeline artifact and confirm it contains `META-INF/pipeline/bundle-manifest.json`.
+2. Start durable substrates first: execution tables, await tables and indexes, work queue, DLQ queue, and any worker protocol queues.
+3. Start worker processes with the matching pipeline code and worker protocol secret.
+4. Start the coordinator with `strict-startup=true`.
+5. Register the local executable artifact JAR through the bundle admin API.
+6. Activate the bundle version for the tenant and pipeline.
+7. Submit one canary execution and verify status, pending await interaction, completion, and result.
+
+The current coordinator does not dynamically load registered JAR code. Bundle registration validates and stores a local executable artifact, but workers must already host matching code. Worker availability checks verify `pipelineId + bundleVersionId` before hosted execution submission. The target contract/release model is described in [Pipeline Contract And Release Model](/guide/evolve/durable-coordinator/pipeline-contract-release-model).
+
+## Operator Runbooks
+
+### Register And Activate
+
+1. Register the generated artifact with `POST /tpf/admin/tenants/{tenantId}/pipelines/{pipelineId}/bundles/register`.
+2. Read the returned `bundleVersionId`.
+3. Activate with `POST /tpf/admin/tenants/{tenantId}/pipelines/{pipelineId}/bundles/{bundleVersionId}/activate`.
+4. Confirm `GET /active` returns the expected bundle id and hash.
+5. Keep workers for that bundle running before submitting executions.
+
+Activation affects new executions only. Existing executions remain pinned to the bundle id stored on their execution record.
+
+### Submit And Complete Await
+
+1. Submit through `POST /tpf/control-plane/tenants/{tenantId}/executions`.
+2. Poll `GET /executions/{executionId}`.
+3. If the execution parks on await, query `GET /interactions/pending`.
+4. Complete with `POST /interactions/complete`.
+5. Poll terminal status and then read `GET /executions/{executionId}/result`.
+
+The restaurant self-host client demonstrates this flow through `run-self-hosted-demo.sh --ci`.
+
+### Incident Triage
+
+Use the restaurant incident demo as the current failure-visibility proof:
+
+```bash
+./examples/restaurant-approval/self-host/run-self-hosted-incident.sh --ci
+```
+
+For real incidents:
+
+1. Check execution status and read `errorCode`, `errorMessage`, `attempt`, and `stepIndex`.
+2. Confirm whether the execution is retrying, failed, or terminally DLQ'd.
+3. Inspect coordinator logs or the configured execution DLQ for the matching execution id.
+4. Confirm downstream idempotency before any manual re-drive.
+5. Re-submit or re-drive through an application-owned procedure with stable business idempotency keys.
+
+There is no built-in generic DLQ replay endpoint yet. The DLQ proves durable failure publication; replay ownership remains application/operator-owned.
+
+### Manual Upgrade And Drain
+
+The current safe upgrade procedure is conservative:
+
+1. Deploy workers that host the new bundle version.
+2. Register and activate the new bundle.
+3. Submit canary executions and verify worker availability and results.
+4. Leave old workers running until executions pinned to the old bundle drain.
+5. Stop old workers only after status queries show no active executions for the old bundle.
+
+There is no worker lifecycle registry yet. Operators must track healthy, stale, draining, and unavailable worker states outside the framework for now.
+
+## What To Monitor
+
+At minimum:
+
+1. work queue depth and oldest message age,
+2. execution status distribution: running, waiting external, retrying, failed, DLQ,
+3. lease takeover and sweeper activity,
+4. await pending count and oldest pending deadline,
+5. DLQ publication count and repeated failure fingerprints,
+6. worker protocol latency and transport failures,
+7. bundle activation events and active bundle id per tenant/pipeline.
+
+For metric names and observability surfaces, use the operations guides for [Metrics](/guide/operations/observability/metrics), [Replay & Live Topology](/guide/operations/observability/replay), and the [Operator Playbook](/guide/operations/operators-playbook).
+
+## Current Limits
+
+This recipe intentionally does not include:
+
+1. Kubernetes manifests or Docker Compose files,
+2. dynamic JAR loading in the coordinator,
+3. multi-instance HA bundle registry metadata,
+4. built-in generic DLQ replay,
+5. worker registration, heartbeat, or drain state,
+6. production tenancy, RBAC, or org/principal management.
+
+The file-backed bundle registry is suitable for local/dev and single-coordinator self-host pilots. A serious multi-coordinator deployment still needs a durable registry metadata store before the file registry can be considered HA-ready.

--- a/docs/guide/evolve/durable-coordinator/self-hosted-milestone.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-milestone.md
@@ -1,6 +1,6 @@
 # Self-Hosted Milestone
 
-The near-term adoption goal is a public, self-hosted durable coordinator path that users can run and inspect without private code.
+The near-term adoption goal is a self-hosted durable coordinator path that users can run, inspect, and operate directly.
 
 The first reference is `examples/restaurant-approval/self-host`, which runs one batteries-included coordinator process from the packaged `monolith-svc` artifact. It uses the local in-process transition worker by default so users can exercise hosted-style submission, bundle activation, await completion, and result inspection without starting a second service.
 
@@ -25,7 +25,7 @@ The first reference is `examples/restaurant-approval/self-host`, which runs one 
 | Gap | Why it matters |
 | --- | --- |
 | Built-in DLQ replay | current self-host incident flow shows status, terminal error details, and DLQ publication, but re-drive remains application-owned |
-| Contract/bundle correction | the long-term concept is a pipeline contract, with executable artifacts as one implementation form |
+| Contract/release model | the long-term concept is a pipeline contract and release descriptor, with executable JAR registration as the current local implementation form |
 | Worker lifecycle | healthy, stale, draining, and unavailable states should be added only when self-host workflows require them |
 
-Until this milestone is credible, durable coordinator semantics, worker protocols, bundle/contract identity, and function-platform parity primitives should remain public and self-hostable.
+The `COMPUTE` self-host path is now credible for local adoption and operator walkthroughs. The main remaining design gap is the contract/release model that can describe container images, native binaries, function artifacts, local files, external endpoints, and independently deployed step artifacts without making JAR registration the conceptual unit.

--- a/docs/guide/evolve/durable-coordinator/self-hosted-milestone.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-milestone.md
@@ -15,15 +15,16 @@ The first reference is `examples/restaurant-approval/self-host`, which runs one 
 | Worker availability check before submit | present |
 | Await pending query and completion | present |
 | Accepted/declined terminal results | present |
+| Failure/DLQ incident walkthrough | present in `restaurant-approval/self-host` |
+| Operator walkthrough | present in `restaurant-approval/self-host` |
+| Production-ish deployment recipe | present in [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment) |
 | Kafka await over stream | covered separately by `csv-payments` |
 
 ## Remaining Gap
 
 | Gap | Why it matters |
 | --- | --- |
-| Operator walkthrough | users need a step-by-step runbook for status, await, result, logs, replay, and DLQ |
-| Replay/DLQ incident demo | durable orchestration needs visible recovery paths, not only happy paths |
-| Production-ish deployment recipe | self-host users need coordinator, worker, store, queue, secret, and artifact layout guidance |
+| Built-in DLQ replay | current self-host incident flow shows status, terminal error details, and DLQ publication, but re-drive remains application-owned |
 | Contract/bundle correction | the long-term concept is a pipeline contract, with executable artifacts as one implementation form |
 | Worker lifecycle | healthy, stale, draining, and unavailable states should be added only when self-host workflows require them |
 

--- a/examples/restaurant-approval/self-host/README.md
+++ b/examples/restaurant-approval/self-host/README.md
@@ -16,11 +16,25 @@ From the repository root:
 
 The script packages `monolith-svc`, starts the coordinator, registers and activates the generated bundle JAR, submits accepted and declined orders through `/tpf/control-plane/...`, completes the await interaction, and verifies terminal results.
 
+The demo client submits the generated REST input DTO as a `RAW` generic control-plane payload. That matches the current executable-bundle runtime shape: the active step order is made of generated REST client steps, while the bundle manifest still records domain contract types. The strategic model is a pipeline contract; this local JAR bundle path is the current implementation form.
+
 By default it first installs the current `framework` SNAPSHOT so the example build uses the runtime code from this checkout. For faster reruns after the local SNAPSHOT is current:
 
 ```bash
 TPF_SKIP_FRAMEWORK_INSTALL=true ./examples/restaurant-approval/self-host/run-self-hosted-demo.sh --ci
 ```
+
+## Incident Demo
+
+Run the failure-visibility path:
+
+```bash
+./examples/restaurant-approval/self-host/run-self-hosted-incident.sh --ci
+```
+
+This starts the same one-process coordinator, registers and activates the bundle, submits an order, waits for the restaurant approval await interaction, and then completes that interaction with a deliberately invalid but API-valid restaurant decision. The resumed execution fails through the normal queue-async path, publishes through the log DLQ provider, and prints an operator triage summary.
+
+The incident script sets `TPF_ORCHESTRATOR_MAX_RETRIES=0` by default so the failure reaches the terminal path immediately. Override that variable if you want to observe retry state first.
 
 ## Local Defaults
 
@@ -69,15 +83,78 @@ python3 examples/restaurant-approval/self-host/demo-client.py run-flows \
   --control-plane-token restaurant-control-plane-admin-token
 ```
 
+Inspect a known execution:
+
+```bash
+python3 examples/restaurant-approval/self-host/demo-client.py status \
+  --base-url http://localhost:8081 \
+  --tenant-id restaurant-demo \
+  --execution-id <execution-id> \
+  --control-plane-token restaurant-control-plane-admin-token
+```
+
+List pending await interactions:
+
+```bash
+python3 examples/restaurant-approval/self-host/demo-client.py pending \
+  --base-url http://localhost:8081 \
+  --tenant-id restaurant-demo \
+  --await-step-id ProcessAwaitRestaurantDecisionService \
+  --control-plane-token restaurant-control-plane-admin-token
+```
+
+Read a terminal result:
+
+```bash
+python3 examples/restaurant-approval/self-host/demo-client.py result \
+  --base-url http://localhost:8081 \
+  --tenant-id restaurant-demo \
+  --execution-id <execution-id> \
+  --control-plane-token restaurant-control-plane-admin-token
+```
+
+Run the incident flow against an already-started coordinator:
+
+```bash
+python3 examples/restaurant-approval/self-host/demo-client.py run-incident \
+  --base-url http://localhost:8081 \
+  --tenant-id restaurant-demo \
+  --pipeline-id org.pipelineframework.restaurantapproval \
+  --await-step-id ProcessAwaitRestaurantDecisionService \
+  --control-plane-token restaurant-control-plane-admin-token \
+  --log-file examples/restaurant-approval/monolith-svc/target/tpf-self-host/logs/coordinator.log
+```
+
 Logs are written under `examples/restaurant-approval/monolith-svc/target/tpf-self-host/logs`.
+
+## Operator Walkthrough
+
+For a normal await flow:
+
+1. Submit through `/tpf/control-plane/tenants/{tenantId}/executions`.
+2. Poll `/tpf/control-plane/tenants/{tenantId}/executions/{executionId}` until `WAITING_EXTERNAL`.
+3. Query `/tpf/control-plane/tenants/{tenantId}/interactions/pending` with the await step id.
+4. Complete the interaction through `/tpf/control-plane/tenants/{tenantId}/interactions/complete`.
+5. Poll status until `SUCCEEDED`, then read `/result`.
+
+For the incident flow:
+
+1. Submit and wait for `WAITING_EXTERNAL`.
+2. Complete the await interaction with the deliberately invalid decision payload.
+3. Poll status until `FAILED`.
+4. Inspect `errorCode`, `errorMessage`, `attempt`, and `stepIndex` from the status response.
+5. Inspect `coordinator.log` for `Execution moved to DLQ` and the matching execution id.
+
+Current recovery boundary: this self-host reference exposes status, terminal error details, and DLQ publication evidence. It does not provide a built-in generic DLQ replay endpoint yet. Correct the business input or downstream dependency, then re-submit/re-drive through an application-owned procedure with stable idempotency keys.
 
 ## What This Proves
 
 1. A coordinator process can submit and inspect executions without using generated `/pipeline/*` app routes.
 2. Bundle registration, activation, artifact storage, execution pinning, and worker availability checks are exercised.
 3. Local transition execution works without configuring a remote worker target.
+4. Await suspension and completion happen through the hosted control-plane API.
+5. Terminal failure and DLQ publication are visible in the self-host operator flow.
 
 To prove the REST worker protocol separately, start `start-worker.sh`, configure `pipeline.orchestrator.worker.rest.base-url` and `pipeline.orchestrator.worker.rest.shared-secret` on a coordinator process, and run the same control-plane client. The automated split-process IT covers that protocol path.
-4. Await suspension and completion happen through the hosted control-plane API.
 
 This is not a managed service, dynamic JAR loading, worker fleet lifecycle, or production tenancy. It is the public self-host adoption path for the current runtime seams.

--- a/examples/restaurant-approval/self-host/README.md
+++ b/examples/restaurant-approval/self-host/README.md
@@ -51,6 +51,8 @@ The incident script sets `TPF_ORCHESTRATOR_MAX_RETRIES=0` by default so the fail
 
 These defaults are local/dev only. Real self-host deployments should use secret references, durable stores, and explicit operational runbooks.
 
+For the production-ish topology, durable provider choices, secret refs, and manual upgrade/drain procedure, see [Self-Hosted Deployment](/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md).
+
 ## Manual Flow
 
 Package the app:

--- a/examples/restaurant-approval/self-host/README.md
+++ b/examples/restaurant-approval/self-host/README.md
@@ -51,7 +51,7 @@ The incident script sets `TPF_ORCHESTRATOR_MAX_RETRIES=0` by default so the fail
 
 These defaults are local/dev only. Real self-host deployments should use secret references, durable stores, and explicit operational runbooks.
 
-For the production-ish topology, durable provider choices, secret refs, and manual upgrade/drain procedure, see [Self-Hosted Deployment](/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md).
+For the production-ish topology, durable provider choices, secret refs, and manual upgrade/drain procedure, see [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment).
 
 ## Manual Flow
 

--- a/examples/restaurant-approval/self-host/demo-client.py
+++ b/examples/restaurant-approval/self-host/demo-client.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 PAYLOAD_ENCODING = "application/tpf-transition+json"
-ORDER_TYPE = "org.pipelineframework.restaurantapproval.common.domain.PlaceRestaurantOrderRequest"
+ORDER_TYPE = "org.pipelineframework.restaurantapproval.common.dto.PlaceRestaurantOrderRequestDto"
 
 
 def request(method, url, token=None, body=None, timeout=10):
@@ -143,7 +143,7 @@ def submit_order(args, customer_name, restaurant_name):
     }
     body = {
         "pipelineId": args.pipeline_id,
-        "inputShape": "UNI",
+        "inputShape": "RAW",
         "inputPayload": encoded_payload(order, ORDER_TYPE),
         "idempotencyKey": f"order-{request_id}",
         "outputStreaming": False,
@@ -158,7 +158,8 @@ def submit_order(args, customer_name, restaurant_name):
     return result["executionId"]
 
 
-def wait_status(args, execution_id, target_status, timeout_seconds=30):
+def wait_status(args, execution_id, target_status, timeout_seconds=None):
+    timeout_seconds = timeout_seconds or getattr(args, "timeout_seconds", 30)
     deadline = time.time() + timeout_seconds
     last = None
     url = f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/executions/{execution_id}"
@@ -174,7 +175,21 @@ def wait_status(args, execution_id, target_status, timeout_seconds=30):
     raise RuntimeError(f"Execution {execution_id} did not reach {target_status}; last={last}")
 
 
-def pending_interaction(args, execution_id, timeout_seconds=30):
+def wait_terminal_failure(args, execution_id, timeout_seconds=30):
+    deadline = time.time() + timeout_seconds
+    last = None
+    url = f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/executions/{execution_id}"
+    while time.time() < deadline:
+        last = request("GET", url, token=auth(args))
+        if last["status"] in {"FAILED", "DLQ"}:
+            print(f"Execution {execution_id} reached terminal failure: {json.dumps(last, sort_keys=True)}")
+            return last
+        time.sleep(0.2)
+    raise RuntimeError(f"Execution {execution_id} did not fail terminally; last={last}")
+
+
+def pending_interaction(args, execution_id, timeout_seconds=None):
+    timeout_seconds = timeout_seconds or getattr(args, "timeout_seconds", 30)
     deadline = time.time() + timeout_seconds
     url = (
         f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/interactions/pending"
@@ -189,6 +204,38 @@ def pending_interaction(args, execution_id, timeout_seconds=30):
                 return interaction
         time.sleep(0.2)
     raise RuntimeError(f"No pending interaction found for execution {execution_id}")
+
+
+def query_pending(args):
+    url = (
+        f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/interactions/pending"
+        f"?stepId={args.await_step_id}"
+    )
+    interactions = request("GET", url, token=auth(args))
+    if args.execution_id:
+        interactions = [
+            interaction for interaction in interactions
+            if interaction.get("executionId") == args.execution_id
+        ]
+    print(json.dumps(interactions, indent=2, sort_keys=True))
+
+
+def inspect_status(args):
+    status = request(
+        "GET",
+        f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/executions/{args.execution_id}",
+        token=auth(args),
+    )
+    print(json.dumps(status, indent=2, sort_keys=True))
+
+
+def inspect_result(args):
+    result = request(
+        "GET",
+        f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/executions/{args.execution_id}/result",
+        token=auth(args),
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
 
 
 def complete(args, interaction, decision):
@@ -226,6 +273,30 @@ def complete(args, interaction, decision):
     print(f"Completed interaction {completed['interactionId']} as {decision}")
 
 
+def complete_invalid_decision(args, interaction):
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    decision_payload = {
+        "accepted": {
+            "orderId": "not-a-uuid",
+            "decidedAt": now,
+            "note": "This completion is intentionally invalid for the incident demo.",
+        }
+    }
+    body = {
+        "interactionId": interaction["interactionId"],
+        "idempotencyKey": f"complete-invalid-{interaction['interactionId']}",
+        "responsePayload": encoded_payload(decision_payload, "java.util.Map"),
+        "actor": "restaurant-self-host-incident-demo",
+    }
+    completed = request(
+        "POST",
+        f"{args.base_url}/tpf/control-plane/tenants/{args.tenant_id}/interactions/complete",
+        token=auth(args),
+        body=body,
+    )
+    print(f"Completed interaction {completed['interactionId']} with an intentionally invalid decision payload")
+
+
 def result_payload(args, execution_id):
     result = request(
         "GET",
@@ -253,6 +324,44 @@ def run_one(args, decision, customer_name, restaurant_name, expected_outcome):
 def run_flows(args):
     run_one(args, "accepted", "Ada Lovelace", "Cafe TPF", "APPROVED")
     run_one(args, "declined", "Grace Hopper", "Bistro Queue", "DECLINED")
+
+
+def wait_log_contains(log_file, execution_id, timeout_seconds=20):
+    if not log_file:
+        return
+    path = Path(log_file)
+    deadline = time.time() + timeout_seconds
+    needle = "Execution moved to DLQ"
+    while time.time() < deadline:
+        if path.exists():
+            contents = path.read_text(errors="replace")
+            if needle in contents and execution_id in contents:
+                print(f"Observed DLQ publication in {path}: {needle} / execution={execution_id}")
+                return
+        time.sleep(0.2)
+    raise RuntimeError(f"Did not observe DLQ log line for execution {execution_id} in {path}")
+
+
+def run_incident(args):
+    execution_id = submit_order(args, "Katherine Johnson", "Faulty Kitchen")
+    wait_status(args, execution_id, "WAITING_EXTERNAL")
+    interaction = pending_interaction(args, execution_id)
+    complete_invalid_decision(args, interaction)
+    terminal = wait_terminal_failure(args, execution_id)
+    if terminal.get("errorCode") in {None, ""}:
+        raise RuntimeError(f"Expected terminal failure to include errorCode; got {terminal}")
+    if terminal.get("errorMessage") in {None, ""}:
+        raise RuntimeError(f"Expected terminal failure to include errorMessage; got {terminal}")
+    wait_log_contains(args.log_file, execution_id)
+    print("Incident triage summary:")
+    print(json.dumps({
+        "executionId": execution_id,
+        "status": terminal.get("status"),
+        "attempt": terminal.get("attempt"),
+        "errorCode": terminal.get("errorCode"),
+        "errorMessage": terminal.get("errorMessage"),
+        "operatorAction": "Inspect the failure and re-submit corrected business input; built-in DLQ replay is not provided yet.",
+    }, indent=2, sort_keys=True))
 
 
 def main():
@@ -285,6 +394,38 @@ def main():
     flows.add_argument("--await-step-id", required=True)
     flows.add_argument("--control-plane-token", required=True)
     flows.set_defaults(func=run_flows)
+
+    status = sub.add_parser("status")
+    status.add_argument("--base-url", required=True)
+    status.add_argument("--tenant-id", required=True)
+    status.add_argument("--control-plane-token", required=True)
+    status.add_argument("--execution-id", required=True)
+    status.set_defaults(func=inspect_status)
+
+    pending = sub.add_parser("pending")
+    pending.add_argument("--base-url", required=True)
+    pending.add_argument("--tenant-id", required=True)
+    pending.add_argument("--await-step-id", required=True)
+    pending.add_argument("--control-plane-token", required=True)
+    pending.add_argument("--execution-id")
+    pending.set_defaults(func=query_pending)
+
+    result = sub.add_parser("result")
+    result.add_argument("--base-url", required=True)
+    result.add_argument("--tenant-id", required=True)
+    result.add_argument("--control-plane-token", required=True)
+    result.add_argument("--execution-id", required=True)
+    result.set_defaults(func=inspect_result)
+
+    incident = sub.add_parser("run-incident")
+    incident.add_argument("--base-url", required=True)
+    incident.add_argument("--tenant-id", required=True)
+    incident.add_argument("--pipeline-id", required=True)
+    incident.add_argument("--await-step-id", required=True)
+    incident.add_argument("--control-plane-token", required=True)
+    incident.add_argument("--log-file")
+    incident.add_argument("--timeout-seconds", type=int, default=90)
+    incident.set_defaults(func=run_incident)
 
     args = parser.parse_args()
     try:

--- a/examples/restaurant-approval/self-host/run-self-hosted-incident.sh
+++ b/examples/restaurant-approval/self-host/run-self-hosted-incident.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${EXAMPLE_DIR}/../.." && pwd)"
+MONOLITH_DIR="${EXAMPLE_DIR}/monolith-svc"
+
+TPF_TENANT_ID="${TPF_TENANT_ID:-restaurant-demo}"
+TPF_PIPELINE_ID="${TPF_PIPELINE_ID:-org.pipelineframework.restaurantapproval}"
+TPF_AWAIT_STEP_ID="${TPF_AWAIT_STEP_ID:-ProcessAwaitRestaurantDecisionService}"
+TPF_COORDINATOR_PORT="${TPF_COORDINATOR_PORT:-8081}"
+TPF_CONTROL_PLANE_TOKEN="${TPF_CONTROL_PLANE_TOKEN:-restaurant-control-plane-admin-token}"
+TPF_ADMIN_TOKEN="${TPF_ADMIN_TOKEN:-restaurant-control-plane-admin-token}"
+TPF_RUN_DIR="${TPF_RUN_DIR:-${MONOLITH_DIR}/target/tpf-self-host-incident}"
+TPF_LOG_DIR="${TPF_LOG_DIR:-${TPF_RUN_DIR}/logs}"
+TPF_PID_DIR="${TPF_PID_DIR:-${TPF_RUN_DIR}/pids}"
+TPF_SKIP_FRAMEWORK_INSTALL="${TPF_SKIP_FRAMEWORK_INSTALL:-false}"
+TPF_ORCHESTRATOR_MAX_RETRIES="${TPF_ORCHESTRATOR_MAX_RETRIES:-0}"
+TPF_ORCHESTRATOR_RETRY_DELAY="${TPF_ORCHESTRATOR_RETRY_DELAY:-PT1S}"
+
+CI_MODE=false
+if [[ "${1:-}" == "--ci" ]]; then
+  CI_MODE=true
+fi
+
+cleanup() {
+  if [[ -f "${TPF_PID_DIR}/coordinator.pid" ]]; then
+    pid="$(cat "${TPF_PID_DIR}/coordinator.pid")"
+    if kill -0 "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+      for _ in {1..50}; do
+        if ! kill -0 "${pid}" >/dev/null 2>&1; then
+          break
+        fi
+        sleep 0.1
+      done
+      if kill -0 "${pid}" >/dev/null 2>&1; then
+        kill -9 "${pid}" >/dev/null 2>&1 || true
+      fi
+    fi
+    rm -f "${TPF_PID_DIR}/coordinator.pid"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "${CI_MODE}" == "true" ]]; then
+  rm -rf "${TPF_RUN_DIR}"
+fi
+
+mkdir -p "${TPF_LOG_DIR}" "${TPF_PID_DIR}"
+rm -f "${TPF_PID_DIR}/coordinator.pid"
+
+if [[ "${TPF_SKIP_FRAMEWORK_INSTALL}" != "true" ]]; then
+  echo "Installing current framework SNAPSHOT for the example build..."
+  "${REPO_ROOT}/mvnw" -f "${REPO_ROOT}/framework/pom.xml" -pl runtime,deployment -am -DskipTests install
+fi
+
+echo "Packaging restaurant-approval monolith..."
+"${REPO_ROOT}/mvnw" -f "${EXAMPLE_DIR}/pom.xml" -pl monolith-svc -am -DskipTests package
+
+echo "Starting batteries-included coordinator for incident demo..."
+export TPF_RUN_DIR
+export TPF_LOG_DIR
+export TPF_PID_DIR
+export TPF_TENANT_ID
+export TPF_PIPELINE_ID
+export TPF_AWAIT_STEP_ID
+export TPF_COORDINATOR_PORT
+export TPF_CONTROL_PLANE_TOKEN
+export TPF_ADMIN_TOKEN
+export TPF_ORCHESTRATOR_MAX_RETRIES
+export TPF_ORCHESTRATOR_RETRY_DELAY
+"${SCRIPT_DIR}/start-coordinator.sh"
+
+python3 "${SCRIPT_DIR}/demo-client.py" wait-health --base-url "http://localhost:${TPF_COORDINATOR_PORT}" --name coordinator
+
+"${SCRIPT_DIR}/register-and-activate-bundle.sh"
+
+python3 "${SCRIPT_DIR}/demo-client.py" run-incident \
+  --base-url "http://localhost:${TPF_COORDINATOR_PORT}" \
+  --tenant-id "${TPF_TENANT_ID}" \
+  --pipeline-id "${TPF_PIPELINE_ID}" \
+  --await-step-id "${TPF_AWAIT_STEP_ID}" \
+  --control-plane-token "${TPF_CONTROL_PLANE_TOKEN}" \
+  --log-file "${TPF_LOG_DIR}/coordinator.log"
+
+if [[ "${CI_MODE}" == "true" ]]; then
+  echo "Self-hosted coordinator incident demo completed in CI mode."
+else
+  echo "Self-hosted coordinator incident demo completed."
+  echo "Log:"
+  echo "  ${TPF_LOG_DIR}/coordinator.log"
+fi

--- a/examples/restaurant-approval/self-host/run-self-hosted-incident.sh
+++ b/examples/restaurant-approval/self-host/run-self-hosted-incident.sh
@@ -16,6 +16,8 @@ TPF_RUN_DIR="${TPF_RUN_DIR:-${MONOLITH_DIR}/target/tpf-self-host-incident}"
 TPF_LOG_DIR="${TPF_LOG_DIR:-${TPF_RUN_DIR}/logs}"
 TPF_PID_DIR="${TPF_PID_DIR:-${TPF_RUN_DIR}/pids}"
 TPF_SKIP_FRAMEWORK_INSTALL="${TPF_SKIP_FRAMEWORK_INSTALL:-false}"
+# Incident runs default to zero retries, unlike start-coordinator.sh's default of 3,
+# so CI reaches terminal failure/DLQ immediately. Override to observe retry state.
 TPF_ORCHESTRATOR_MAX_RETRIES="${TPF_ORCHESTRATOR_MAX_RETRIES:-0}"
 TPF_ORCHESTRATOR_RETRY_DELAY="${TPF_ORCHESTRATOR_RETRY_DELAY:-PT1S}"
 

--- a/examples/restaurant-approval/self-host/start-coordinator.sh
+++ b/examples/restaurant-approval/self-host/start-coordinator.sh
@@ -12,6 +12,8 @@ TPF_RUN_DIR="${TPF_RUN_DIR:-${MONOLITH_DIR}/target/tpf-self-host}"
 TPF_BUNDLE_STORE_ROOT="${TPF_BUNDLE_STORE_ROOT:-${TPF_RUN_DIR}/bundles}"
 TPF_LOG_DIR="${TPF_LOG_DIR:-${TPF_RUN_DIR}/logs}"
 TPF_PID_DIR="${TPF_PID_DIR:-${TPF_RUN_DIR}/pids}"
+TPF_ORCHESTRATOR_MAX_RETRIES="${TPF_ORCHESTRATOR_MAX_RETRIES:-3}"
+TPF_ORCHESTRATOR_RETRY_DELAY="${TPF_ORCHESTRATOR_RETRY_DELAY:-PT1S}"
 
 RUNNER="${MONOLITH_DIR}/target/quarkus-app/quarkus-run.jar"
 if [[ ! -f "${RUNNER}" ]]; then
@@ -48,6 +50,8 @@ mkdir -p "${TPF_LOG_DIR}" "${TPF_PID_DIR}" "${TPF_BUNDLE_STORE_ROOT}"
     -Dpipeline.orchestrator.admin.admin-token="${TPF_ADMIN_TOKEN}" \
     -Dpipeline.orchestrator.bundles.registry.provider=file \
     -Dpipeline.orchestrator.bundles.storage.root="${TPF_BUNDLE_STORE_ROOT}" \
+    -Dpipeline.orchestrator.max-retries="${TPF_ORCHESTRATOR_MAX_RETRIES}" \
+    -Dpipeline.orchestrator.retry-delay="${TPF_ORCHESTRATOR_RETRY_DELAY}" \
     -Dpipeline.orchestrator.strict-startup=false \
     -jar "${RUNNER}"
 ) > "${TPF_LOG_DIR}/coordinator.log" 2>&1 &

--- a/framework/runtime/src/main/java/org/pipelineframework/invocation/PipelineInvocationStrategy.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/invocation/PipelineInvocationStrategy.java
@@ -4,7 +4,9 @@ import java.util.Objects;
 import java.util.function.LongConsumer;
 
 import org.pipelineframework.awaitable.AwaitExecutionContext;
+import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
 import org.pipelineframework.context.PipelineContext;
+import org.pipelineframework.context.PipelineContextHolder;
 
 interface PipelineInvocationStrategy {
 
@@ -93,6 +95,8 @@ final class TransitionWorkerInvocationStrategy implements PipelineInvocationStra
 final class TransportBoundaryInvocationStrategy implements PipelineInvocationStrategy {
     private final TransportBoundaryDescriptor descriptor;
     private final TransportBoundaryDiagnostics diagnostics;
+    private final PipelineContext pipelineContext;
+    private final AwaitExecutionContext awaitContext;
 
     TransportBoundaryInvocationStrategy(TransportBoundaryInvocation boundary, TransportBoundaryDiagnostics diagnostics) {
         if (boundary == null) {
@@ -100,16 +104,18 @@ final class TransportBoundaryInvocationStrategy implements PipelineInvocationStr
         }
         this.descriptor = Objects.requireNonNull(boundary.transportBoundary(), "transport boundary must not be null");
         this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics must not be null");
+        this.pipelineContext = PipelineContextHolder.get();
+        this.awaitContext = AwaitExecutionContextHolder.get();
     }
 
     @Override
     public PipelineContext pipelineContext() {
-        return null;
+        return pipelineContext;
     }
 
     @Override
     public AwaitExecutionContext awaitContext() {
-        return null;
+        return awaitContext;
     }
 
     @Override

--- a/framework/runtime/src/test/java/org/pipelineframework/invocation/PipelineInvocationRuntimeTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/invocation/PipelineInvocationRuntimeTest.java
@@ -2,6 +2,7 @@ package org.pipelineframework.invocation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -147,6 +148,34 @@ class PipelineInvocationRuntimeTest {
             () -> runtime.invokeTransportUni(null, () -> Uni.createFrom().item("ignored")));
 
         assertEquals("boundary must not be null", thrown.getMessage());
+    }
+
+    @Test
+    void transportBoundaryPreservesAmbientContextAtCreationTime() {
+        PipelineContext boundaryPipeline = new PipelineContext("boundary", "tenant-boundary", "prefer-cache");
+        AwaitExecutionContext boundaryAwait = new AwaitExecutionContext("tenant-boundary", "exec-boundary", 5);
+        AtomicReference<PipelineContext> observedPipeline = new AtomicReference<>();
+        AtomicReference<AwaitExecutionContext> observedAwait = new AtomicReference<>();
+
+        PipelineContextHolder.set(boundaryPipeline);
+        AwaitExecutionContextHolder.set(boundaryAwait);
+        Uni<String> result;
+        try {
+            result = runtime.invokeTransportUni(boundary, () -> {
+                observedPipeline.set(PipelineContextHolder.get());
+                observedAwait.set(AwaitExecutionContextHolder.get());
+                return Uni.createFrom().item("ok");
+            });
+        } finally {
+            PipelineContextHolder.clear();
+            AwaitExecutionContextHolder.clear();
+        }
+
+        assertEquals("ok", result.await().indefinitely());
+        assertSame(boundaryPipeline, observedPipeline.get());
+        assertSame(boundaryAwait, observedAwait.get());
+        assertNull(PipelineContextHolder.get());
+        assertNull(AwaitExecutionContextHolder.get());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- adds a self-hosted restaurant incident demo that drives an await completion into terminal failure/DLQ visibility
- documents the production-ish self-hosted deployment recipe for coordinator, workers, durable stores, queues, secrets, and manual drain
- documents the target pipeline contract + release descriptor model so JAR bundle registration remains the current local implementation form, not the long-term conceptual unit

## Validation
- `./examples/restaurant-approval/self-host/run-self-hosted-incident.sh --ci`
- `./examples/restaurant-approval/self-host/run-self-hosted-demo.sh --ci`
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=PipelineInvocationRuntimeTest test`
- `npm --prefix docs run build`
- `git diff --check`
- `cr review --prompt-only --base codex/boundary-invocation-model --config ./AGENTS.md`

## CodeRabbit
Local prompt-only review reported three actionable findings. Fixed in `0b14ffdf6`:
- corrected the self-hosted deployment docs link in the restaurant README
- documented why the incident script defaults retries to zero
- aligned bundle manifest wording to "v1 identity artifact"
