### PR TITLE
runtime: introduce framework-core runtime adapter seam for portability

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -203,6 +203,7 @@ const mainSidebar = [
             },
             {text: 'Annotation Processor Architecture (Compat)', link: '/guide/evolve/annotation-processor-architecture'},
             {text: 'Compiler Pipeline Architecture', link: '/guide/evolve/compiler-pipeline-architecture'},
+            {text: 'Runtime Core Decoupling', link: '/guide/evolve/runtime-core-decoupling'},
             {text: 'Operators Internals', link: '/guide/evolve/operators-internals'},
             {text: 'Data Types', link: '/guide/evolve/data-types'},
             {text: 'Typed Union Output Contracts', link: '/guide/evolve/typed-union-output-contracts'},

--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -32,7 +32,11 @@ Deployment now accepts and validates `pipeline.codegen.rendererProfile` in disco
 - `quarkus` (default)
 - `spring` (currently mapped to the same renderer selection strategy as `quarkus`)
 
-`FunctionHandlerRendererFactory` now has profile-aware factory methods used by generation.
+For the surrounding configuration model, see [build configuration](/guide/build/configuration/) and
+[application configuration](/guide/application/configuration).
+
+`FunctionHandlerRendererFactory` now has profile-aware factory methods used by generation. The generation phase context is described in
+[annotation processor generation and rendering](/guide/evolve/annotation-processor/generation-and-rendering).
 
 `PipelineGenerationPhase` passes the profile through and uses renderer-instance FQCN helpers when recording role metadata for orchestrator function handlers. That avoids hard-coding a provider class name at generation time.
 
@@ -40,8 +44,8 @@ Deployment now accepts and validates `pipeline.codegen.rendererProfile` in disco
 
 The important seam for future portability is where Vert.x is used:
 
-- `Framework/runtime-core`: no direct `io.quarkus` / `io.vertx` references.
-- `Framework/runtime`: `io.vertx.core` remains in `RuntimeAdapterBootstrap` for context capture.
+- `framework/runtime-core`: no direct `io.quarkus` / `io.vertx` references.
+- `framework/runtime`: `io.vertx.core` remains in `RuntimeAdapterBootstrap` for context capture.
 
 To make this explicit and enforceable, this slice adds dependency-seam tests:
 

--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -27,7 +27,7 @@ The goal is:
 
 ## Renderer profile plumbing
 
-Deployment now accepts and validates `pipeline.codegen.renderer-profile` in discovery:
+Deployment now accepts and validates `pipeline.codegen.rendererProfile` in discovery:
 
 - `quarkus` (default)
 - `spring` (currently mapped to the same renderer selection strategy as `quarkus`)

--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -1,0 +1,60 @@
+# Runtime-Core Decoupling (Renderer Profile + Vert.x Seam)
+
+## Why this slice exists
+
+This iteration creates the minimum boundary needed to start Quarkus-Spring portability work without changing current runtime semantics.
+
+The goal is:
+- keep existing Quarkus behavior intact,
+- move runtime-adapter assumptions into explicit contracts,
+- and keep runtime behavior selection controlled in deployment/runtime profiles.
+
+## New runtime boundary
+
+`framework/runtime-core` now holds framework-neutral contracts used by execution code:
+
+- `BeanLookup`
+- `ConfigProvider`
+- `ReactiveRuntime`
+- `ExecutionContextCarrier`
+- `SchedulerBoundary`
+- `TransactionBoundary`
+- `EventBusBridge`
+- `WorkDispatcher`
+- `RuntimeAdapters`
+
+`framework/runtime` remains Quarkus-first today and registers concrete implementations in `RuntimeAdapterBootstrap`.
+
+## Renderer profile plumbing
+
+Deployment now accepts and validates `pipeline.codegen.renderer-profile` in discovery:
+
+- `quarkus` (default)
+- `spring` (currently mapped to the same renderer selection strategy as `quarkus`)
+
+`FunctionHandlerRendererFactory` now has profile-aware factory methods used by generation.
+
+`PipelineGenerationPhase` passes the profile through and uses renderer-instance FQCN helpers when recording role metadata for orchestrator function handlers. That avoids hard-coding a provider class name at generation time.
+
+## Vert.x seam and context propagation
+
+The important seam for future portability is where Vert.x is used:
+
+- `Framework/runtime-core`: no direct `io.quarkus` / `io.vertx` references.
+- `Framework/runtime`: `io.vertx.core` remains in `RuntimeAdapterBootstrap` for context capture.
+
+To make this explicit and enforceable, this slice adds dependency-seam tests:
+
+- `runtime-core` guard: no `io.quarkus` and no `io.vertx` in `src/main/java`.
+- `runtime` guard: `io.vertx` must only appear outside a single seam (`RuntimeAdapterBootstrap`).
+
+## Acceptance outcome for this slice
+
+- Quarkus pipeline generation and execution paths remain unchanged.
+- Renderer-profile is now a compile-time configuration surface in deployment.
+- The core/runtime split becomes the stable seam for subsequent Spring adapter work.
+
+## Notes
+
+- No annotation-removal or async runtime-choice changes were made in this slice.
+- Vert.x is treated as container runtime execution plumbing, not as core runtime contract.

--- a/examples/csv-payments/build-modular-observability-images.sh
+++ b/examples/csv-payments/build-modular-observability-images.sh
@@ -45,8 +45,11 @@ case "$(uname -m)" in
     ;;
 esac
 IMAGE_PLATFORMS="${CSV_E2E_IMAGE_PLATFORMS:-$DEFAULT_IMAGE_PLATFORMS}"
+MAVEN_IMAGE_THREADS="${CSV_E2E_IMAGE_MAVEN_THREADS:-1}"
 
-./mvnw -f examples/csv-payments/pom.xml -DskipTests clean package \
+# Jib writes shared cache metadata during image packaging; keep this reactor serialized
+# unless a caller explicitly opts into parallelism.
+./mvnw -T "$MAVEN_IMAGE_THREADS" -f examples/csv-payments/pom.xml -DskipTests clean package \
   -Dtpf.build.transport=GRPC \
   -Dquarkus.container-image.tag="${IMAGE_TAG}" \
   -Dquarkus.container-image.platforms="${IMAGE_PLATFORMS}" \

--- a/examples/csv-payments/build-modular-telemetry-images.sh
+++ b/examples/csv-payments/build-modular-telemetry-images.sh
@@ -47,8 +47,11 @@ case "$(uname -m)" in
     ;;
 esac
 IMAGE_PLATFORMS="${CSV_E2E_IMAGE_PLATFORMS:-$DEFAULT_IMAGE_PLATFORMS}"
+MAVEN_IMAGE_THREADS="${CSV_E2E_IMAGE_MAVEN_THREADS:-1}"
 
-./mvnw -f examples/csv-payments/pom.xml -DskipTests clean package \
+# Jib writes shared cache metadata during image packaging; keep this reactor serialized
+# unless a caller explicitly opts into parallelism.
+./mvnw -T "$MAVEN_IMAGE_THREADS" -f examples/csv-payments/pom.xml -DskipTests clean package \
   -Dtpf.build.transport=GRPC \
   -Dquarkus.container-image.tag="${IMAGE_TAG}" \
   -Dquarkus.container-image.platforms="${IMAGE_PLATFORMS}" \

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompilationContext.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompilationContext.java
@@ -28,6 +28,8 @@ import org.pipelineframework.processor.mapping.PipelineRuntimeMappingResolution;
 @Getter
 public class PipelineCompilationContext {
 
+    public static final String DEFAULT_RENDERER_PROFILE = "quarkus";
+
     // Getters
     private final ProcessingEnvironment processingEnv;
     private final RoundEnvironment roundEnv;
@@ -54,6 +56,9 @@ public class PipelineCompilationContext {
     // Renderer-specific bindings (keyed by transport or target)
     @Setter
     private Map<String, Object> rendererBindings;
+
+    @Setter
+    private String rendererProfile;
     
     // Output paths and module information
     @Setter
@@ -102,6 +107,8 @@ public class PipelineCompilationContext {
         this.pluginHost = false;
         this.orchestratorGenerated = false;
         this.functionHttpBridge = false;
+        this.transportMode = PipelineTransport.GRPC;
+        this.rendererProfile = DEFAULT_RENDERER_PROFILE;
         this.transportMode = PipelineTransport.GRPC;
         this.platformMode = PlatformMode.COMPUTE;
     }
@@ -290,6 +297,15 @@ public class PipelineCompilationContext {
     }
 
     /**
+     * Returns the selected renderer profile used during handler rendering.
+     *
+     * @return renderer profile, defaults to {@link #DEFAULT_RENDERER_PROFILE}
+     */
+    public String getRendererProfile() {
+        return rendererProfile == null || rendererProfile.isBlank() ? DEFAULT_RENDERER_PROFILE : rendererProfile;
+    }
+
+    /**
      * Returns the loaded protobuf descriptor set, if available.
      *
      * @return the loaded protobuf descriptor set, if available
@@ -388,6 +404,18 @@ public class PipelineCompilationContext {
      */
     public void setRendererBindings(Map<String, Object> rendererBindings) {
         this.rendererBindings = rendererBindings;
+    }
+
+    /**
+     * Sets the renderer profile used for selecting deployment-specific renderers.
+     *
+     * @param rendererProfile renderer profile (for example, {@code quarkus} or {@code spring});
+     *                        blank values are treated as the default
+     */
+    public void setRendererProfile(String rendererProfile) {
+        this.rendererProfile = (rendererProfile == null || rendererProfile.isBlank())
+            ? DEFAULT_RENDERER_PROFILE
+            : rendererProfile;
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
@@ -39,7 +39,7 @@ import org.pipelineframework.annotation.PipelineStep;
     "pipeline.rest.naming.strategy", // Optional: REST naming strategy (LEGACY|RESOURCEFUL)
     "pipeline.mapper.fallback.enabled", // Optional: enables delegated mapper fallback engine
     "pipeline.parallelism", // Optional: parallelism mode (PARALLEL|SEQUENTIAL|AUTO)
-    "pipeline.codegen.renderer-profile" // Optional: renderer profile selection (quarkus|spring)
+    "pipeline.codegen.rendererProfile" // Optional: renderer profile selection (quarkus|spring)
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 public class PipelineCompiler extends AbstractProcessingTool {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
@@ -38,7 +38,8 @@ import org.pipelineframework.annotation.PipelineStep;
     "pipeline.transport", // Optional: transport mode (GRPC|REST|LOCAL)
     "pipeline.rest.naming.strategy", // Optional: REST naming strategy (LEGACY|RESOURCEFUL)
     "pipeline.mapper.fallback.enabled", // Optional: enables delegated mapper fallback engine
-    "pipeline.parallelism" // Optional: parallelism mode (PARALLEL|SEQUENTIAL|AUTO)
+    "pipeline.parallelism", // Optional: parallelism mode (PARALLEL|SEQUENTIAL|AUTO)
+    "pipeline.codegen.renderer-profile" // Optional: renderer profile selection (quarkus|spring)
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 public class PipelineCompiler extends AbstractProcessingTool {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineStepProcessor.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineStepProcessor.java
@@ -33,7 +33,8 @@ import javax.lang.model.element.TypeElement;
     "pipeline.transport", // Optional: transport mode (GRPC|REST|LOCAL)
     "pipeline.rest.naming.strategy", // Optional: REST naming strategy (LEGACY|RESOURCEFUL)
     "pipeline.mapper.fallback.enabled", // Optional: enables delegated mapper fallback engine
-    "pipeline.parallelism" // Optional: parallelism mode (PARALLEL|SEQUENTIAL|AUTO)
+    "pipeline.parallelism", // Optional: parallelism mode (PARALLEL|SEQUENTIAL|AUTO)
+    "pipeline.codegen.renderer-profile" // Optional: renderer profile selection (quarkus|spring)
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 @Deprecated(forRemoval = true)

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineStepProcessor.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineStepProcessor.java
@@ -34,7 +34,7 @@ import javax.lang.model.element.TypeElement;
     "pipeline.rest.naming.strategy", // Optional: REST naming strategy (LEGACY|RESOURCEFUL)
     "pipeline.mapper.fallback.enabled", // Optional: enables delegated mapper fallback engine
     "pipeline.parallelism", // Optional: parallelism mode (PARALLEL|SEQUENTIAL|AUTO)
-    "pipeline.codegen.renderer-profile" // Optional: renderer profile selection (quarkus|spring)
+    "pipeline.codegen.rendererProfile" // Optional: renderer profile selection (quarkus|spring)
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 @Deprecated(forRemoval = true)

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhase.java
@@ -36,6 +36,7 @@ import org.pipelineframework.processor.parser.StepDefinitionParser;
 public class PipelineDiscoveryPhase implements PipelineCompilationPhase {
     private static final PipelineStepConfigLoader.StepConfig DEFAULT_STEP_CONFIG =
         new PipelineStepConfigLoader.StepConfig("", "GRPC", "COMPUTE", List.of(), List.of());
+    private static final String RENDERER_PROFILE_OPTION = "pipeline.codegen.renderer-profile";
     private final DiscoveryPathResolver discoveryPathResolver;
     private final DiscoveryConfigLoader discoveryConfigLoader;
     private final TransportPlatformResolver transportPlatformResolver;
@@ -143,6 +144,7 @@ public class PipelineDiscoveryPhase implements PipelineCompilationPhase {
         boolean isPluginHost = !pluginElements.isEmpty();
         ctx.setPluginHost(isPluginHost);
         ctx.setFunctionHttpBridge(parseStrictBooleanOption(options, "pipeline.function.httpBridge", false));
+        ctx.setRendererProfile(parseRendererProfile(options));
 
         // Load pipeline aspects
         List<PipelineAspectModel> aspects = loadPipelineAspects(configPath, messager);
@@ -189,6 +191,21 @@ public class PipelineDiscoveryPhase implements PipelineCompilationPhase {
 
         throw new IllegalArgumentException(
             "Invalid value for '" + key + "': '" + rawValue + "'. Expected 'true' or 'false'.");
+    }
+
+    private String parseRendererProfile(Map<String, String> options) {
+        String rawValue = options.get(RENDERER_PROFILE_OPTION);
+        if (rawValue == null || rawValue.isBlank()) {
+            return PipelineCompilationContext.DEFAULT_RENDERER_PROFILE;
+        }
+
+        String normalized = rawValue.trim().toLowerCase(java.util.Locale.ROOT);
+        return switch (normalized) {
+            case "quarkus", "spring" -> normalized;
+            default -> throw new IllegalArgumentException(
+                "Invalid value for '" + RENDERER_PROFILE_OPTION + "': '" + rawValue
+                    + "'. Supported values: quarkus, spring.");
+        };
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhase.java
@@ -36,7 +36,8 @@ import org.pipelineframework.processor.parser.StepDefinitionParser;
 public class PipelineDiscoveryPhase implements PipelineCompilationPhase {
     private static final PipelineStepConfigLoader.StepConfig DEFAULT_STEP_CONFIG =
         new PipelineStepConfigLoader.StepConfig("", "GRPC", "COMPUTE", List.of(), List.of());
-    private static final String RENDERER_PROFILE_OPTION = "pipeline.codegen.renderer-profile";
+    private static final String RENDERER_PROFILE_OPTION = "pipeline.codegen.rendererProfile";
+    private static final String RENDERER_PROFILE_OPTION_LEGACY = "pipeline.codegen.renderer-profile";
     private final DiscoveryPathResolver discoveryPathResolver;
     private final DiscoveryConfigLoader discoveryConfigLoader;
     private final TransportPlatformResolver transportPlatformResolver;
@@ -195,6 +196,9 @@ public class PipelineDiscoveryPhase implements PipelineCompilationPhase {
 
     private String parseRendererProfile(Map<String, String> options) {
         String rawValue = options.get(RENDERER_PROFILE_OPTION);
+        if ((rawValue == null || rawValue.isBlank()) && options.containsKey(RENDERER_PROFILE_OPTION_LEGACY)) {
+            rawValue = options.get(RENDERER_PROFILE_OPTION_LEGACY);
+        }
         if (rawValue == null || rawValue.isBlank()) {
             return PipelineCompilationContext.DEFAULT_RENDERER_PROFILE;
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -92,7 +92,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
         OrchestratorGrpcRenderer orchestratorGrpcRenderer = new OrchestratorGrpcRenderer();
         OrchestratorRestResourceRenderer orchestratorRestRenderer = new OrchestratorRestResourceRenderer();
         AbstractOrchestratorFunctionHandlerRenderer orchestratorFunctionHandlerRenderer =
-            FunctionHandlerRendererFactory.createOrchestratorRenderer();
+            FunctionHandlerRendererFactory.createOrchestratorRenderer(ctx.getRendererProfile());
         OrchestratorCliRenderer orchestratorCliRenderer = new OrchestratorCliRenderer();
         OrchestratorIngestClientRenderer orchestratorIngestClientRenderer = new OrchestratorIngestClientRenderer();
         CheckpointPublicationDescriptorRenderer checkpointPublicationDescriptorRenderer =
@@ -599,16 +599,16 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
                         cacheKeyGenerator,
                         descriptorSet));
                     roleMetadataGenerator.recordClassWithRole(
-                        AwsLambdaOrchestratorRenderer.handlerFqcn(binding.basePackage()),
+                        orchestratorFunctionHandlerRenderer.handlerFqcn(binding.basePackage()),
                         role.name());
                     roleMetadataGenerator.recordClassWithRole(
-                        AwsLambdaOrchestratorRenderer.runAsyncHandlerFqcn(binding.basePackage()),
+                        orchestratorFunctionHandlerRenderer.runAsyncHandlerFqcn(binding.basePackage()),
                         role.name());
                     roleMetadataGenerator.recordClassWithRole(
-                        AwsLambdaOrchestratorRenderer.statusHandlerFqcn(binding.basePackage()),
+                        orchestratorFunctionHandlerRenderer.statusHandlerFqcn(binding.basePackage()),
                         role.name());
                     roleMetadataGenerator.recordClassWithRole(
-                        AwsLambdaOrchestratorRenderer.resultHandlerFqcn(binding.basePackage()),
+                        orchestratorFunctionHandlerRenderer.resultHandlerFqcn(binding.basePackage()),
                         role.name());
                 }
             } else if (!local) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AbstractOrchestratorFunctionHandlerRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AbstractOrchestratorFunctionHandlerRenderer.java
@@ -135,6 +135,46 @@ protected AbstractOrchestratorFunctionHandlerRenderer() {}
     protected abstract String getExecutionIdExpression();
 
     /**
+     * Build the fully-qualified class name for the main orchestrator handler.
+     *
+     * @param basePackage the configured base package for generated orchestrator artifacts
+     * @return the handler class FQCN
+     */
+    public String handlerFqcn(String basePackage) {
+        return basePackage + "." + RESOURCE_CLASS + "." + HANDLER_CLASS;
+    }
+
+    /**
+     * Build the fully-qualified class name for the run-async orchestrator handler.
+     *
+     * @param basePackage the configured base package for generated orchestrator artifacts
+     * @return the run-async handler class FQCN
+     */
+    public String runAsyncHandlerFqcn(String basePackage) {
+        return basePackage + "." + RESOURCE_CLASS + "." + RUN_ASYNC_HANDLER_CLASS;
+    }
+
+    /**
+     * Build the fully-qualified class name for the execution-status handler.
+     *
+     * @param basePackage the configured base package for generated orchestrator artifacts
+     * @return the status handler class FQCN
+     */
+    public String statusHandlerFqcn(String basePackage) {
+        return basePackage + "." + RESOURCE_CLASS + "." + STATUS_HANDLER_CLASS;
+    }
+
+    /**
+     * Build the fully-qualified class name for the execution-result handler.
+     *
+     * @param basePackage the configured base package for generated orchestrator artifacts
+     * @return the result handler class FQCN
+     */
+    public String resultHandlerFqcn(String basePackage) {
+        return basePackage + "." + RESOURCE_CLASS + "." + RESULT_HANDLER_CLASS;
+    }
+
+    /**
      * Generates and writes the orchestrator REST handler class (PipelineRunFunctionHandler) and any provider-specific async handlers and DTOs based on the given binding.
      *
      * <p>Reads streaming input/output flags and base package from {@code binding}, computes DTO and transport types, builds a handler type implementing the provider-specific handler interface, writes the generated Java file to the generation context output directory, and delegates generation of async handlers to {@link #renderAsyncHandlers(OrchestratorBinding, GenerationContext, String, ClassName, ClassName, boolean, boolean)}.

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AbstractOrchestratorFunctionHandlerRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AbstractOrchestratorFunctionHandlerRenderer.java
@@ -141,7 +141,7 @@ protected AbstractOrchestratorFunctionHandlerRenderer() {}
      * @return the handler class FQCN
      */
     public String handlerFqcn(String basePackage) {
-        return basePackage + "." + RESOURCE_CLASS + "." + HANDLER_CLASS;
+        return basePackage + "." + "orchestrator.service." + HANDLER_CLASS;
     }
 
     /**
@@ -151,7 +151,7 @@ protected AbstractOrchestratorFunctionHandlerRenderer() {}
      * @return the run-async handler class FQCN
      */
     public String runAsyncHandlerFqcn(String basePackage) {
-        return basePackage + "." + RESOURCE_CLASS + "." + RUN_ASYNC_HANDLER_CLASS;
+        return basePackage + "." + "orchestrator.service." + RUN_ASYNC_HANDLER_CLASS;
     }
 
     /**
@@ -161,7 +161,7 @@ protected AbstractOrchestratorFunctionHandlerRenderer() {}
      * @return the status handler class FQCN
      */
     public String statusHandlerFqcn(String basePackage) {
-        return basePackage + "." + RESOURCE_CLASS + "." + STATUS_HANDLER_CLASS;
+        return basePackage + "." + "orchestrator.service." + STATUS_HANDLER_CLASS;
     }
 
     /**
@@ -171,7 +171,7 @@ protected AbstractOrchestratorFunctionHandlerRenderer() {}
      * @return the result handler class FQCN
      */
     public String resultHandlerFqcn(String basePackage) {
-        return basePackage + "." + RESOURCE_CLASS + "." + RESULT_HANDLER_CLASS;
+        return basePackage + "." + "orchestrator.service." + RESULT_HANDLER_CLASS;
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwsLambdaOrchestratorRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/AwsLambdaOrchestratorRenderer.java
@@ -48,8 +48,8 @@ public class AwsLambdaOrchestratorRenderer extends AbstractOrchestratorFunctionH
      * @param basePackage the base Java package to use as the prefix
      * @return the fully-qualified class name of the main handler
      */
-    public static String handlerFqcn(String basePackage) {
-        return basePackage + ".orchestrator.service." + HANDLER_CLASS;
+    public static String handlerFqcnStatic(String basePackage) {
+        return new AwsLambdaOrchestratorRenderer().handlerFqcn(basePackage);
     }
 
     /**
@@ -58,8 +58,8 @@ public class AwsLambdaOrchestratorRenderer extends AbstractOrchestratorFunctionH
      * @param basePackage the root package to which the orchestrator service package will be appended
      * @return the fully qualified class name of the run-async handler
      */
-    public static String runAsyncHandlerFqcn(String basePackage) {
-        return basePackage + ".orchestrator.service." + RUN_ASYNC_HANDLER_CLASS;
+    public static String runAsyncHandlerFqcnStatic(String basePackage) {
+        return new AwsLambdaOrchestratorRenderer().runAsyncHandlerFqcn(basePackage);
     }
 
     /**
@@ -68,8 +68,8 @@ public class AwsLambdaOrchestratorRenderer extends AbstractOrchestratorFunctionH
      * @param basePackage the root package to prepend (e.g., "com.example")
      * @return the fully qualified class name of the status handler
      */
-    public static String statusHandlerFqcn(String basePackage) {
-        return basePackage + ".orchestrator.service." + STATUS_HANDLER_CLASS;
+    public static String statusHandlerFqcnStatic(String basePackage) {
+        return new AwsLambdaOrchestratorRenderer().statusHandlerFqcn(basePackage);
     }
 
     /**
@@ -78,8 +78,8 @@ public class AwsLambdaOrchestratorRenderer extends AbstractOrchestratorFunctionH
      * @param basePackage the root package to which the orchestrator service package is appended
      * @return the fully-qualified class name of the result handler
      */
-    public static String resultHandlerFqcn(String basePackage) {
-        return basePackage + ".orchestrator.service." + RESULT_HANDLER_CLASS;
+    public static String resultHandlerFqcnStatic(String basePackage) {
+        return new AwsLambdaOrchestratorRenderer().resultHandlerFqcn(basePackage);
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/FunctionHandlerRendererFactory.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/FunctionHandlerRendererFactory.java
@@ -43,6 +43,8 @@ public final class FunctionHandlerRendererFactory {
     private static final String PROVIDER_AZURE = "azure";
     private static final String PROVIDER_GCP = "gcp";
     private static final String PROVIDER_DEFAULT = PROVIDER_AWS;
+    private static final String RENDERER_PROFILE_QUARKUS = "quarkus";
+    private static final String RENDERER_PROFILE_SPRING = "spring";
 
     private static final String EXTENSION_AWS = "io.quarkus.amazon.lambda.runtime.AmazonLambdaHandler";
     private static final String EXTENSION_AZURE = "io.quarkus.azure.functions.runtime.AzureFunctionsHandler";
@@ -75,6 +77,27 @@ public final class FunctionHandlerRendererFactory {
     }
 
     /**
+     * Selects a function handler renderer for the requested renderer profile.
+     *
+     * @param rendererProfile target profile such as {@code quarkus} or {@code spring}
+     * @return renderer instance for the selected profile
+     * @throws IllegalArgumentException when the profile is unknown
+     */
+    public static AbstractFunctionHandlerRenderer createRenderer(String rendererProfile) {
+        String normalizedProfile = normalizeRendererProfile(rendererProfile);
+        if (normalizedProfile == null) {
+            return createRenderer();
+        }
+
+        if (RENDERER_PROFILE_QUARKUS.equals(normalizedProfile) || RENDERER_PROFILE_SPRING.equals(normalizedProfile)) {
+            return createRenderer();
+        }
+
+        throw new IllegalArgumentException(
+            "Unsupported renderer profile: '" + rendererProfile + "'. Expected one of: quarkus, spring");
+    }
+
+    /**
      * Selects and returns an orchestrator renderer for cloud functions using explicit configuration or auto-detection.
      *
      * <p>The provider selection follows this precedence: explicit system properties (`pipeline.function.provider`,
@@ -94,6 +117,34 @@ public final class FunctionHandlerRendererFactory {
         }
 
         return createOrchestratorRendererForProvider(PROVIDER_DEFAULT);
+    }
+
+    /**
+     * Selects a function handler renderer for orchestrator execution using the requested renderer profile.
+     *
+     * @param rendererProfile target profile such as {@code quarkus} or {@code spring}
+     * @return orchestrator renderer for the selected profile
+     * @throws IllegalArgumentException when the profile is unknown
+     */
+    public static AbstractOrchestratorFunctionHandlerRenderer createOrchestratorRenderer(String rendererProfile) {
+        String normalizedProfile = normalizeRendererProfile(rendererProfile);
+        if (normalizedProfile == null) {
+            return createOrchestratorRenderer();
+        }
+
+        if (RENDERER_PROFILE_QUARKUS.equals(normalizedProfile) || RENDERER_PROFILE_SPRING.equals(normalizedProfile)) {
+            return createOrchestratorRenderer();
+        }
+
+        throw new IllegalArgumentException(
+            "Unsupported renderer profile: '" + rendererProfile + "'. Expected one of: quarkus, spring");
+    }
+
+    private static String normalizeRendererProfile(String rendererProfile) {
+        if (rendererProfile == null || rendererProfile.isBlank()) {
+            return null;
+        }
+        return rendererProfile.toLowerCase(Locale.ROOT).trim();
     }
 
     /**

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhaseTest.java
@@ -123,6 +123,43 @@ class PipelineDiscoveryPhaseTest {
     }
 
     @Test
+    void testDiscoveryPhaseExecution_defaultsRendererProfileToQuarkus() throws Exception {
+        PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
+
+        phase.execute(context);
+
+        assertEquals(PipelineCompilationContext.DEFAULT_RENDERER_PROFILE, context.getRendererProfile());
+    }
+
+    @Test
+    void testDiscoveryPhaseExecution_acceptsRendererProfileOption() throws Exception {
+        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.renderer-profile", "SPRING"));
+
+        PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
+
+        phase.execute(context);
+
+        assertEquals("spring", context.getRendererProfile());
+    }
+
+    @Test
+    void testDiscoveryPhaseExecution_rejectsUnknownRendererProfileOption() {
+        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.renderer-profile", "vertx"));
+
+        PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
+
+        IllegalArgumentException error =
+            assertThrows(IllegalArgumentException.class, () -> phase.execute(context));
+
+        assertTrue(error.getMessage().contains("pipeline.codegen.renderer-profile"));
+        assertTrue(error.getMessage().contains("quarkus"));
+        assertTrue(error.getMessage().contains("spring"));
+    }
+
+    @Test
     void testDiscoveryPhaseExecution_nullRoundEnv() throws Exception {
         PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, null);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineDiscoveryPhaseTest.java
@@ -134,7 +134,7 @@ class PipelineDiscoveryPhaseTest {
 
     @Test
     void testDiscoveryPhaseExecution_acceptsRendererProfileOption() throws Exception {
-        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.renderer-profile", "SPRING"));
+        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.rendererProfile", "SPRING"));
 
         PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
@@ -146,7 +146,7 @@ class PipelineDiscoveryPhaseTest {
 
     @Test
     void testDiscoveryPhaseExecution_rejectsUnknownRendererProfileOption() {
-        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.renderer-profile", "vertx"));
+        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.rendererProfile", "vertx"));
 
         PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
@@ -154,9 +154,21 @@ class PipelineDiscoveryPhaseTest {
         IllegalArgumentException error =
             assertThrows(IllegalArgumentException.class, () -> phase.execute(context));
 
-        assertTrue(error.getMessage().contains("pipeline.codegen.renderer-profile"));
+        assertTrue(error.getMessage().contains("pipeline.codegen.rendererProfile"));
         assertTrue(error.getMessage().contains("quarkus"));
         assertTrue(error.getMessage().contains("spring"));
+    }
+
+    @Test
+    void testDiscoveryPhaseExecution_acceptsLegacyRendererProfileOption() throws Exception {
+        when(processingEnv.getOptions()).thenReturn(Map.of("pipeline.codegen.renderer-profile", "SPRING"));
+
+        PipelineDiscoveryPhase phase = new PipelineDiscoveryPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
+
+        phase.execute(context);
+
+        assertEquals("spring", context.getRendererProfile());
     }
 
     @Test

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/AwsLambdaOrchestratorRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/AwsLambdaOrchestratorRendererTest.java
@@ -227,25 +227,25 @@ class AwsLambdaOrchestratorRendererTest {
 
     @Test
     void handlerFqcnReturnsCorrectPath() {
-        String fqcn = AwsLambdaOrchestratorRenderer.handlerFqcn("com.example");
+        String fqcn = AwsLambdaOrchestratorRenderer.handlerFqcnStatic("com.example");
         assertEquals("com.example.orchestrator.service.PipelineRunFunctionHandler", fqcn);
     }
 
     @Test
     void runAsyncHandlerFqcnReturnsCorrectPath() {
-        String fqcn = AwsLambdaOrchestratorRenderer.runAsyncHandlerFqcn("com.example");
+        String fqcn = AwsLambdaOrchestratorRenderer.runAsyncHandlerFqcnStatic("com.example");
         assertEquals("com.example.orchestrator.service.PipelineRunAsyncFunctionHandler", fqcn);
     }
 
     @Test
     void statusHandlerFqcnReturnsCorrectPath() {
-        String fqcn = AwsLambdaOrchestratorRenderer.statusHandlerFqcn("com.example");
+        String fqcn = AwsLambdaOrchestratorRenderer.statusHandlerFqcnStatic("com.example");
         assertEquals("com.example.orchestrator.service.PipelineExecutionStatusFunctionHandler", fqcn);
     }
 
     @Test
     void resultHandlerFqcnReturnsCorrectPath() {
-        String fqcn = AwsLambdaOrchestratorRenderer.resultHandlerFqcn("com.example");
+        String fqcn = AwsLambdaOrchestratorRenderer.resultHandlerFqcnStatic("com.example");
         assertEquals("com.example.orchestrator.service.PipelineExecutionResultFunctionHandler", fqcn);
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/FunctionHandlerRendererFactoryTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/FunctionHandlerRendererFactoryTest.java
@@ -1,0 +1,49 @@
+package org.pipelineframework.processor.renderer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FunctionHandlerRendererFactoryTest {
+
+    @Test
+    void createRendererResolvesProfileDefaults() {
+        assertDoesNotThrow(() -> {
+            AbstractFunctionHandlerRenderer renderer = FunctionHandlerRendererFactory.createRenderer(null);
+            assertNotNull(renderer);
+
+            AbstractOrchestratorFunctionHandlerRenderer orchestratorRenderer =
+                FunctionHandlerRendererFactory.createOrchestratorRenderer(null);
+            assertNotNull(orchestratorRenderer);
+        });
+    }
+
+    @Test
+    void createRendererSupportsQuarkusProfile() {
+        AbstractFunctionHandlerRenderer renderer = FunctionHandlerRendererFactory.createRenderer("quarkus");
+        AbstractOrchestratorFunctionHandlerRenderer orchestratorRenderer =
+            FunctionHandlerRendererFactory.createOrchestratorRenderer("quarkus");
+
+        assertNotNull(renderer);
+        assertNotNull(orchestratorRenderer);
+    }
+
+    @Test
+    void createRendererSupportsSpringProfile() {
+        AbstractFunctionHandlerRenderer renderer = FunctionHandlerRendererFactory.createRenderer("spring");
+        AbstractOrchestratorFunctionHandlerRenderer orchestratorRenderer =
+            FunctionHandlerRendererFactory.createOrchestratorRenderer("spring");
+
+        assertNotNull(renderer);
+        assertNotNull(orchestratorRenderer);
+    }
+
+    @Test
+    void createRendererRejectsUnsupportedProfile() {
+        assertThrows(IllegalArgumentException.class, () -> FunctionHandlerRendererFactory.createRenderer("reactive"));
+        assertThrows(IllegalArgumentException.class,
+            () -> FunctionHandlerRendererFactory.createOrchestratorRenderer("reactive"));
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/FunctionHandlerRendererFactoryTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/FunctionHandlerRendererFactoryTest.java
@@ -41,6 +41,16 @@ class FunctionHandlerRendererFactoryTest {
     }
 
     @Test
+    void createRendererNormalizesProfileInput() {
+        AbstractFunctionHandlerRenderer renderer = FunctionHandlerRendererFactory.createRenderer("  QuArKuS  ");
+        AbstractOrchestratorFunctionHandlerRenderer orchestratorRenderer =
+            FunctionHandlerRendererFactory.createOrchestratorRenderer("  SpRiNg  ");
+
+        assertNotNull(renderer);
+        assertNotNull(orchestratorRenderer);
+    }
+
+    @Test
     void createRendererRejectsUnsupportedProfile() {
         assertThrows(IllegalArgumentException.class, () -> FunctionHandlerRendererFactory.createRenderer("reactive"));
         assertThrows(IllegalArgumentException.class,

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -76,6 +76,7 @@
     </properties>
 
     <modules>
+        <module>runtime-core</module>
         <module>runtime</module>
         <module>deployment</module>
     </modules>

--- a/framework/runtime-core/pom.xml
+++ b/framework/runtime-core/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -30,10 +30,6 @@
     <description>Framework-neutral runtime abstractions used by the Pipeline runtime</description>
 
     <dependencies>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/framework/runtime-core/pom.xml
+++ b/framework/runtime-core/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023-2026 Mariano Barcia
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.pipelineframework</groupId>
+        <artifactId>framework-parent</artifactId>
+        <version>26.5.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>pipelineframework-runtime-core</artifactId>
+    <version>26.5.2-SNAPSHOT</version>
+    <name>The Pipeline Framework Runtime Core</name>
+    <description>Framework-neutral runtime abstractions used by the Pipeline runtime</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/framework/runtime-core/pom.xml
+++ b/framework/runtime-core/pom.xml
@@ -21,12 +21,11 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.5.2-SNAPSHOT</version>
+        <version>26.6.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>pipelineframework-runtime-core</artifactId>
-    <version>26.5.2-SNAPSHOT</version>
     <name>The Pipeline Framework Runtime Core</name>
     <description>Framework-neutral runtime abstractions used by the Pipeline runtime</description>
 

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/BeanLookup.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/BeanLookup.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.Optional;
+
+/**
+ * Neutral contract for resolving framework beans from the active runtime container.
+ */
+public interface BeanLookup {
+
+    /**
+     * Returns an optional bean for the requested type.
+     *
+     * @param beanType expected bean type
+     * @param <T> bean type
+     * @return bean instance if available
+     */
+    <T> Optional<T> get(Class<T> beanType);
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/ConfigProvider.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/ConfigProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.Optional;
+
+/**
+ * Neutral contract for reading runtime configuration contracts.
+ */
+public interface ConfigProvider {
+
+    /**
+     * Resolves a configuration binding from the active runtime container.
+     *
+     * @param configType config class type
+     * @param <T> config type
+     * @return configuration object when available
+     */
+    <T> Optional<T> get(Class<T> configType);
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/EventBusBridge.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/EventBusBridge.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+/**
+ * Event-bus abstraction used by adapters that need lightweight runtime publishing.
+ */
+public interface EventBusBridge {
+    /**
+     * Publishes an event to the active runtime bus.
+     *
+     * @param address event target
+     * @param event payload
+     */
+    void publish(String address, Object event);
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/ExecutionContextCarrier.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/ExecutionContextCarrier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+/**
+ * Neutral abstraction for runtime-local execution metadata propagation.
+ */
+public interface ExecutionContextCarrier {
+
+    /**
+     * Reads a typed context value by key.
+     *
+     * @param key context key
+     * @param type expected value type
+     * @param <T> expected value type
+     * @return typed value if present and compatible
+     */
+    <T> T get(String key, Class<T> type);
+
+    /**
+     * Writes a context value for the given key.
+     *
+     * @param key context key
+     * @param value value to publish
+     */
+    void put(String key, Object value);
+
+    /**
+     * Clears the context value for the given key.
+     *
+     * @param key context key
+     */
+    void clear(String key);
+
+    /**
+     * Clears all context values managed by this carrier.
+     */
+    void clear();
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/ReactiveRuntime.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/ReactiveRuntime.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Runtime-neutral abstraction for running potentially blocking work.
+ */
+public interface ReactiveRuntime {
+
+    /**
+     * Executes a supplier and returns a completion stage that captures the scheduled work.
+     *
+     * @param supplier task to execute
+     * @param offloadToVirtualThread whether virtual-thread scheduling is desired
+     * @param <T> result type
+     * @return completion stage with the result
+     */
+    <T> CompletionStage<T> executeBlocking(Supplier<T> supplier, boolean offloadToVirtualThread);
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/RuntimeAdapters.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/RuntimeAdapters.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Runtime-agnostic adapter registry.
+ *
+ * <p>Runtime modules (for example, Quarkus) register implementations that bridge
+ * the core interfaces to their native primitives at startup. The defaults are safe
+ * and intentionally conservative for non-container/unit-test execution.</p>
+ */
+public final class RuntimeAdapters {
+    private static volatile BeanLookup beanLookup = new NoopBeanLookup();
+    private static volatile ConfigProvider configProvider = new NoopConfigProvider();
+    private static volatile ExecutionContextCarrier executionContextCarrier = ThreadLocalExecutionContextCarrier.INSTANCE;
+    private static volatile SchedulerBoundary schedulerBoundary = new NoopSchedulerBoundary();
+    private static volatile TransactionBoundary transactionBoundary = new NoopTransactionBoundary();
+    private static volatile EventBusBridge eventBusBridge = new NoopEventBusBridge();
+    private static volatile WorkDispatcher workDispatcher = new NoopWorkDispatcher();
+    private static volatile ReactiveRuntime reactiveRuntime = new NoopReactiveRuntime();
+
+    private RuntimeAdapters() {
+    }
+
+    public static <T> Optional<T> resolveBean(Class<T> beanType) {
+        return beanLookup.get(beanType);
+    }
+
+    public static <T> Optional<T> resolveConfig(Class<T> configType) {
+        return configProvider.get(configType);
+    }
+
+    public static ExecutionContextCarrier executionContextCarrier() {
+        return executionContextCarrier;
+    }
+
+    public static <T> T executionContext(String key, Class<T> type) {
+        return executionContextCarrier.get(key, type);
+    }
+
+    public static void setExecutionContext(String key, Object value) {
+        executionContextCarrier.put(key, value);
+    }
+
+    public static void clearExecutionContext(String key) {
+        executionContextCarrier.clear(key);
+    }
+
+    public static void clearExecutionContext() {
+        executionContextCarrier.clear();
+    }
+
+    public static <T> java.util.concurrent.CompletionStage<T> executeBlocking(
+        Callable<T> task,
+        boolean offloadToVirtualThread
+    ) {
+        return reactiveRuntime.executeBlocking(() -> {
+            try {
+                return task.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, offloadToVirtualThread);
+    }
+
+    public static <T> java.util.concurrent.CompletionStage<T> schedule(Callable<T> task) {
+        return schedulerBoundary.schedule(task);
+    }
+
+    public static <T> T runInTransaction(java.util.concurrent.Callable<T> task) {
+        return transactionBoundary.executeInTransaction(task);
+    }
+
+    public static EventBusBridge eventBusBridge() {
+        return eventBusBridge;
+    }
+
+    public static WorkDispatcher workDispatcher() {
+        return workDispatcher;
+    }
+
+    public static void registerBeanLookup(BeanLookup beanLookup) {
+        RuntimeAdapters.beanLookup = beanLookup == null ? new NoopBeanLookup() : beanLookup;
+    }
+
+    public static void registerConfigProvider(ConfigProvider configProvider) {
+        RuntimeAdapters.configProvider = configProvider == null ? new NoopConfigProvider() : configProvider;
+    }
+
+    public static void registerExecutionContextCarrier(ExecutionContextCarrier executionContextCarrier) {
+        RuntimeAdapters.executionContextCarrier =
+            executionContextCarrier == null ? ThreadLocalExecutionContextCarrier.INSTANCE : executionContextCarrier;
+    }
+
+    public static void registerSchedulerBoundary(SchedulerBoundary schedulerBoundary) {
+        RuntimeAdapters.schedulerBoundary = schedulerBoundary == null ? new NoopSchedulerBoundary() : schedulerBoundary;
+    }
+
+    public static void registerTransactionBoundary(TransactionBoundary transactionBoundary) {
+        RuntimeAdapters.transactionBoundary = transactionBoundary == null ? new NoopTransactionBoundary() : transactionBoundary;
+    }
+
+    public static void registerReactiveRuntime(ReactiveRuntime reactiveRuntime) {
+        RuntimeAdapters.reactiveRuntime = reactiveRuntime == null ? new NoopReactiveRuntime() : reactiveRuntime;
+    }
+
+    public static void registerEventBusBridge(EventBusBridge eventBusBridge) {
+        RuntimeAdapters.eventBusBridge = eventBusBridge == null ? new NoopEventBusBridge() : eventBusBridge;
+    }
+
+    public static void registerWorkDispatcher(WorkDispatcher workDispatcher) {
+        RuntimeAdapters.workDispatcher = workDispatcher == null ? new NoopWorkDispatcher() : workDispatcher;
+    }
+
+    public static void resetForTests() {
+        registerBeanLookup(new NoopBeanLookup());
+        registerConfigProvider(new NoopConfigProvider());
+        registerExecutionContextCarrier(ThreadLocalExecutionContextCarrier.INSTANCE);
+        registerSchedulerBoundary(new NoopSchedulerBoundary());
+        registerTransactionBoundary(new NoopTransactionBoundary());
+        registerEventBusBridge(new NoopEventBusBridge());
+        registerWorkDispatcher(new NoopWorkDispatcher());
+        registerReactiveRuntime(new NoopReactiveRuntime());
+    }
+
+    private static final class NoopBeanLookup implements BeanLookup {
+        @Override
+        public <T> Optional<T> get(Class<T> beanType) {
+            Objects.requireNonNull(beanType, "beanType");
+            return Optional.empty();
+        }
+    }
+
+    private static final class NoopConfigProvider implements ConfigProvider {
+        @Override
+        public <T> Optional<T> get(Class<T> configType) {
+            Objects.requireNonNull(configType, "configType");
+            return Optional.empty();
+        }
+    }
+
+    private static final class NoopSchedulerBoundary implements SchedulerBoundary {
+        @Override
+        public <T> java.util.concurrent.CompletionStage<T> schedule(Callable<T> task) {
+            Objects.requireNonNull(task, "task");
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    return task.call();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    private static final class NoopTransactionBoundary implements TransactionBoundary {
+        @Override
+        public <T> T executeInTransaction(Callable<T> callback) {
+            try {
+                return callback.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static final class NoopEventBusBridge implements EventBusBridge {
+        @Override
+        public void publish(String address, Object event) {
+            // No-op bridge in core-only runtime
+        }
+    }
+
+    private static final class NoopWorkDispatcher implements WorkDispatcher {
+        @Override
+        public CompletionStage<Void> enqueue(Object work) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class NoopReactiveRuntime implements ReactiveRuntime {
+        @Override
+        public <T> java.util.concurrent.CompletionStage<T> executeBlocking(java.util.function.Supplier<T> supplier, boolean offloadToVirtualThread) {
+            Objects.requireNonNull(supplier, "supplier");
+            try {
+                return CompletableFuture.completedFuture(supplier.get());
+            } catch (Exception failure) {
+                CompletableFuture<T> failed = new CompletableFuture<>();
+                failed.completeExceptionally(failure instanceof RuntimeException ? failure : new RuntimeException(failure));
+                return failed;
+            }
+        }
+    }
+
+    private static final class ThreadLocalExecutionContextCarrier implements ExecutionContextCarrier {
+        private static final ThreadLocal<java.util.Map<String, Object>> CONTEXT = ThreadLocal.withInitial(java.util.HashMap::new);
+        private static final ThreadLocalExecutionContextCarrier INSTANCE = new ThreadLocalExecutionContextCarrier();
+
+        static ThreadLocalExecutionContextCarrier instance() {
+            return INSTANCE;
+        }
+
+        private ThreadLocalExecutionContextCarrier() {
+        }
+
+        @Override
+        public <T> T get(String key, Class<T> type) {
+            Object value = CONTEXT.get().get(key);
+            if (value == null || type == null || !type.isInstance(value)) {
+                return null;
+            }
+            return type.cast(value);
+        }
+
+        @Override
+        public void put(String key, Object value) {
+            if (key == null) {
+                return;
+            }
+            if (value == null) {
+                CONTEXT.get().remove(key);
+            } else {
+                CONTEXT.get().put(key, value);
+            }
+        }
+
+        @Override
+        public void clear(String key) {
+            if (key == null) {
+                return;
+            }
+            CONTEXT.get().remove(key);
+        }
+
+        @Override
+        public void clear() {
+            CONTEXT.remove();
+        }
+    }
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/RuntimeAdapters.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/RuntimeAdapters.java
@@ -133,6 +133,8 @@ public final class RuntimeAdapters {
     }
 
     public static void resetForTests() {
+        executionContextCarrier.clear();
+        ThreadLocalExecutionContextCarrier.INSTANCE.clear();
         registerBeanLookup(new NoopBeanLookup());
         registerConfigProvider(new NoopConfigProvider());
         registerExecutionContextCarrier(ThreadLocalExecutionContextCarrier.INSTANCE);

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/SchedulerBoundary.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/SchedulerBoundary.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Runtime-neutral scheduler boundary abstraction.
+ */
+public interface SchedulerBoundary {
+
+    /**
+     * Runs a task on the runtime's scheduling boundary.
+     *
+     * @param task runnable task
+     * @param <T> result type
+     * @return completion stage of the scheduled work
+     */
+    <T> CompletionStage<T> schedule(Callable<T> task);
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/TransactionBoundary.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/TransactionBoundary.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+/**
+ * Neutral contract for transaction boundary handling in a runtime that supports one.
+ */
+public interface TransactionBoundary {
+
+    /**
+     * Wraps callback execution in a transaction boundary if available.
+     *
+     * @param callback callback to execute
+     * @param <T> callback return type
+     * @return callback result
+     */
+    <T> T executeInTransaction(java.util.concurrent.Callable<T> callback);
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/WorkDispatcher.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/WorkDispatcher.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Runtime-neutral contract for dispatching work items.
+ */
+public interface WorkDispatcher {
+
+    /**
+     * Enqueues a work payload and returns a completion stage once scheduling succeeds.
+     *
+     * @param work work payload
+     * @return completion stage for scheduling side-effects
+     */
+    CompletionStage<Void> enqueue(Object work);
+}

--- a/framework/runtime-core/src/test/java/org/pipelineframework/runtime/core/RuntimeCoreDependencyGuardTest.java
+++ b/framework/runtime-core/src/test/java/org/pipelineframework/runtime/core/RuntimeCoreDependencyGuardTest.java
@@ -36,10 +36,11 @@ class RuntimeCoreDependencyGuardTest {
         try {
             Path sourceRoot = Path.of("src/main/java");
             if (!Files.isDirectory(sourceRoot)) {
-                return Collections.emptyList();
+                return List.of("Unable to scan runtime-core sources: missing directory " + sourceRoot);
             }
 
             Map<Path, List<Integer>> matches = new HashMap<>();
+            List<String> scanErrors = new ArrayList<>();
             try (var stream = Files.walk(sourceRoot)) {
                 stream.filter(path -> path.toString().endsWith(".java")).forEach(path -> {
                     try {
@@ -49,8 +50,8 @@ class RuntimeCoreDependencyGuardTest {
                                 matches.computeIfAbsent(path, ignored -> new ArrayList<>()).add(lineNo);
                             }
                         }
-                    } catch (IOException ignored) {
-                        // Best effort: ignore ephemeral file access issues during test execution.
+                    } catch (IOException e) {
+                        scanErrors.add("Unable to read " + path + ": " + e.getMessage());
                     }
                 });
             }
@@ -61,6 +62,7 @@ class RuntimeCoreDependencyGuardTest {
                     violations.add(path + ":" + lineNo);
                 }
             });
+            violations.addAll(scanErrors);
             Collections.sort(violations);
             return violations;
         } catch (IOException e) {

--- a/framework/runtime-core/src/test/java/org/pipelineframework/runtime/core/RuntimeCoreDependencyGuardTest.java
+++ b/framework/runtime-core/src/test/java/org/pipelineframework/runtime/core/RuntimeCoreDependencyGuardTest.java
@@ -1,0 +1,70 @@
+package org.pipelineframework.runtime.core;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeCoreDependencyGuardTest {
+
+    @Test
+    void runtimeCoreHasNoQuarkusDependencies() {
+        assertNoForbiddenDependency("io.quarkus.");
+    }
+
+    @Test
+    void runtimeCoreHasNoVertxDependencies() {
+        assertNoForbiddenDependency("io.vertx.");
+    }
+
+    private void assertNoForbiddenDependency(String forbiddenToken) {
+        List<String> violations = collectViolations(forbiddenToken);
+        assertTrue(
+            violations.isEmpty(),
+            "runtime-core has forbidden dependency token '" + forbiddenToken + "':\n" + String.join("\n", violations));
+    }
+
+    private List<String> collectViolations(String token) {
+        try {
+            Path sourceRoot = Path.of("src/main/java");
+            if (!Files.isDirectory(sourceRoot)) {
+                return Collections.emptyList();
+            }
+
+            Map<Path, List<Integer>> matches = new HashMap<>();
+            try (var stream = Files.walk(sourceRoot)) {
+                stream.filter(path -> path.toString().endsWith(".java")).forEach(path -> {
+                    try {
+                        List<String> lines = Files.readAllLines(path);
+                        for (int lineNo = 1; lineNo <= lines.size(); lineNo++) {
+                            if (lines.get(lineNo - 1).contains(token)) {
+                                matches.computeIfAbsent(path, ignored -> new ArrayList<>()).add(lineNo);
+                            }
+                        }
+                    } catch (IOException ignored) {
+                        // Best effort: ignore ephemeral file access issues during test execution.
+                    }
+                });
+            }
+
+            List<String> violations = new ArrayList<>();
+            matches.forEach((path, lineNumbers) -> {
+                for (Integer lineNo : lineNumbers) {
+                    violations.add(path + ":" + lineNo);
+                }
+            });
+            Collections.sort(violations);
+            return violations;
+        } catch (IOException e) {
+            return List.of("Unable to scan runtime-core sources: " + e.getMessage());
+        }
+    }
+}

--- a/framework/runtime/pom.xml
+++ b/framework/runtime/pom.xml
@@ -58,6 +58,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.pipelineframework</groupId>
+            <artifactId>pipelineframework-runtime-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.18.0</version>

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineStepResolver.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineStepResolver.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 import org.jboss.logging.Logger;
 import org.pipelineframework.config.PipelineStepConfig;
@@ -120,9 +122,9 @@ class PipelineStepResolver {
       if (stepClass == null) {
         throw new ClassNotFoundException(stepClassName);
       }
-      io.quarkus.arc.InstanceHandle<?> handle = io.quarkus.arc.Arc.container().instance(stepClass);
-      if (!handle.isAvailable()) {
-        int beanCount = io.quarkus.arc.Arc.container().beanManager().getBeans(stepClass).size();
+      var bean = RuntimeAdapters.resolveBean(stepClass);
+      if (bean.isEmpty()) {
+        int beanCount = 0;
         ClassLoader loader = stepClass.getClassLoader();
         LOG.errorf("No CDI bean available for pipeline step %s (beans=%d, loader=%s)",
             stepClassName,
@@ -130,7 +132,7 @@ class PipelineStepResolver {
             loader);
         return null;
       }
-      return handle.get();
+      return bean.get();
     } catch (Exception e) {
       LOG.errorf(e, "Failed to instantiate pipeline step: %s, error: %s", stepClassName, e.getMessage());
       return null;

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContextHolder.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitExecutionContextHolder.java
@@ -1,15 +1,13 @@
 package org.pipelineframework.awaitable;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
- * Holder for internal await execution context using Vert.x local context when available and
- * falling back to thread-local storage otherwise.
+ * Holder for internal await execution context using framework adapter context propagation.
  *
  * <p>Callers that invoke {@link #set(AwaitExecutionContext)} must restore the previous value or call
  * {@link #clear()} in a {@code finally} block when the execution scope ends. This holder is intentionally
- * narrow: it is only safe while framework-managed await execution remains on the same Vert.x context or,
+ * narrow: it is only safe while framework-managed await execution remains on the same adapter context or,
  * when no Vert.x context exists, on the same thread.</p>
  *
  * <p>Because this falls back to {@link ThreadLocal}, pooled threads can leak stale context if cleanup is missed,
@@ -28,48 +26,27 @@ import io.vertx.core.Vertx;
  */
 public final class AwaitExecutionContextHolder {
     private static final String CONTEXT_KEY = AwaitExecutionContextHolder.class.getName() + ".context";
-    private static final ThreadLocal<AwaitExecutionContext> CURRENT = new ThreadLocal<>();
 
     private AwaitExecutionContextHolder() {
     }
 
     public static AwaitExecutionContext get() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                Object stored = context.getLocal(CONTEXT_KEY);
-                if (stored instanceof AwaitExecutionContext awaitExecutionContext) {
-                    return awaitExecutionContext;
-                }
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
+        Object value = RuntimeAdapters.executionContext(CONTEXT_KEY, Object.class);
+        if (value instanceof AwaitExecutionContext awaitExecutionContext) {
+            return awaitExecutionContext;
         }
-        return CURRENT.get();
+        return null;
     }
 
     public static void set(AwaitExecutionContext context) {
-        Context vertxContext = Vertx.currentContext();
-        if (vertxContext != null) {
-            try {
-                vertxContext.putLocal(CONTEXT_KEY, context);
-                return;
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
+        if (context == null) {
+            RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
+            return;
         }
-        CURRENT.set(context);
+        RuntimeAdapters.setExecutionContext(CONTEXT_KEY, context);
     }
 
     public static void clear() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                context.removeLocal(CONTEXT_KEY);
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
-        }
-        CURRENT.remove();
+        RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/blocking/BlockingExecutions.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/blocking/BlockingExecutions.java
@@ -21,9 +21,8 @@ import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
 import org.pipelineframework.annotation.PipelineStep;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
  * Runtime access helpers for blocking step default adapters.
@@ -57,11 +56,8 @@ public final class BlockingExecutions {
 
     private static BlockingExecutionSupport support() {
         try {
-            CDI<Object> cdi = CDI.current();
-            Instance<BlockingExecutionSupport> instance = cdi.select(BlockingExecutionSupport.class);
-            if (!instance.isUnsatisfied()) {
-                return instance.get();
-            }
+            return RuntimeAdapters.resolveBean(BlockingExecutionSupport.class)
+                .orElse(FALLBACK_SUPPORT);
         } catch (RuntimeException ignored) {
             // Tests and non-CDI callers fall back to the local support instance.
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/context/PipelineCacheStatusHolder.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/context/PipelineCacheStatusHolder.java
@@ -16,9 +16,8 @@
 
 package org.pipelineframework.context;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
 import org.pipelineframework.cache.CacheStatus;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
  * Holds cache status reported by cache plugin steps for the current request.
@@ -26,7 +25,6 @@ import org.pipelineframework.cache.CacheStatus;
 public final class PipelineCacheStatusHolder {
 
     private static final String CONTEXT_KEY = PipelineCacheStatusHolder.class.getName() + ".status";
-    private static final ThreadLocal<CacheStatus> THREAD_LOCAL = new ThreadLocal<>();
 
     private PipelineCacheStatusHolder() {
     }
@@ -37,18 +35,11 @@ public final class PipelineCacheStatusHolder {
      * @return the cache status, or null if none is set
      */
     public static CacheStatus get() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                Object stored = context.getLocal(CONTEXT_KEY);
-                if (stored instanceof CacheStatus status) {
-                    return status;
-                }
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
+        Object value = RuntimeAdapters.executionContext(CONTEXT_KEY, Object.class);
+        if (value instanceof CacheStatus status) {
+            return status;
         }
-        return THREAD_LOCAL.get();
+        return null;
     }
 
     /**
@@ -68,38 +59,17 @@ public final class PipelineCacheStatusHolder {
      * @param status the cache status to store
      */
     public static void set(CacheStatus status) {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                if (status == null) {
-                    context.removeLocal(CONTEXT_KEY);
-                } else {
-                    context.putLocal(CONTEXT_KEY, status);
-                }
-                return;
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
-        }
         if (status == null) {
-            THREAD_LOCAL.remove();
-        } else {
-            THREAD_LOCAL.set(status);
+            RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
+            return;
         }
+        RuntimeAdapters.setExecutionContext(CONTEXT_KEY, status);
     }
 
     /**
      * Clears the cache status from the current request context.
      */
     public static void clear() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                context.removeLocal(CONTEXT_KEY);
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
-        }
-        THREAD_LOCAL.remove();
+        RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/context/PipelineContextHolder.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/context/PipelineContextHolder.java
@@ -16,17 +16,14 @@
 
 package org.pipelineframework.context;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
- * Holds the current PipelineContext using Vert.x context when available, and
- * falls back to a ThreadLocal otherwise.
+ * Holds the current PipelineContext through a runtime adapter-backed execution context carrier.
  */
 public final class PipelineContextHolder {
 
     private static final String CONTEXT_KEY = PipelineContextHolder.class.getName() + ".context";
-    private static final ThreadLocal<PipelineContext> THREAD_LOCAL = new ThreadLocal<>();
 
     private PipelineContextHolder() {
     }
@@ -37,18 +34,7 @@ public final class PipelineContextHolder {
      * @return the pipeline context, or null if none is set
      */
     public static PipelineContext get() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                Object stored = context.getLocal(CONTEXT_KEY);
-                if (stored instanceof PipelineContext pipelineContext) {
-                    return pipelineContext;
-                }
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
-        }
-        return THREAD_LOCAL.get();
+        return RuntimeAdapters.executionContext(CONTEXT_KEY, PipelineContext.class);
     }
 
     /**
@@ -57,30 +43,17 @@ public final class PipelineContextHolder {
      * @param pipelineContext the context to store
      */
     public static void set(PipelineContext pipelineContext) {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                context.putLocal(CONTEXT_KEY, pipelineContext);
-                return;
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
+        if (pipelineContext == null) {
+            RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
+            return;
         }
-        THREAD_LOCAL.set(pipelineContext);
+        RuntimeAdapters.setExecutionContext(CONTEXT_KEY, pipelineContext);
     }
 
     /**
      * Clears the current pipeline context.
      */
     public static void clear() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                context.removeLocal(CONTEXT_KEY);
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
-        }
-        THREAD_LOCAL.remove();
+        RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/context/TransportDispatchMetadataHolder.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/context/TransportDispatchMetadataHolder.java
@@ -16,8 +16,7 @@
 
 package org.pipelineframework.context;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
  * Holds transport dispatch metadata using Vert.x context when available, and falls back to thread-local storage.
@@ -25,7 +24,6 @@ import io.vertx.core.Vertx;
 public final class TransportDispatchMetadataHolder {
 
     private static final String CONTEXT_KEY = TransportDispatchMetadataHolder.class.getName() + ".context";
-    private static final ThreadLocal<TransportDispatchMetadata> THREAD_LOCAL = new ThreadLocal<>();
 
     private TransportDispatchMetadataHolder() {
     }
@@ -36,18 +34,11 @@ public final class TransportDispatchMetadataHolder {
      * @return metadata, or null when absent
      */
     public static TransportDispatchMetadata get() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                Object stored = context.getLocal(CONTEXT_KEY);
-                if (stored instanceof TransportDispatchMetadata metadata) {
-                    return metadata;
-                }
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
+        Object value = RuntimeAdapters.executionContext(CONTEXT_KEY, Object.class);
+        if (value instanceof TransportDispatchMetadata metadata) {
+            return metadata;
         }
-        return THREAD_LOCAL.get();
+        return null;
     }
 
     /**
@@ -56,31 +47,17 @@ public final class TransportDispatchMetadataHolder {
      * @param metadata metadata to store
      */
     public static void set(TransportDispatchMetadata metadata) {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                context.putLocal(CONTEXT_KEY, metadata);
-                THREAD_LOCAL.remove();
-                return;
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
+        if (metadata == null) {
+            RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
+            return;
         }
-        THREAD_LOCAL.set(metadata);
+        RuntimeAdapters.setExecutionContext(CONTEXT_KEY, metadata);
     }
 
     /**
      * Clears transport dispatch metadata.
      */
     public static void clear() {
-        Context context = Vertx.currentContext();
-        if (context != null) {
-            try {
-                context.removeLocal(CONTEXT_KEY);
-            } catch (UnsupportedOperationException ignored) {
-                // Root contexts forbid locals; fall back to thread-local storage.
-            }
-        }
-        THREAD_LOCAL.remove();
+        RuntimeAdapters.clearExecutionContext(CONTEXT_KEY);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/runtime/RuntimeAdapterBootstrap.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/runtime/RuntimeAdapterBootstrap.java
@@ -17,9 +17,11 @@
 package org.pipelineframework.runtime;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -129,6 +131,7 @@ public class RuntimeAdapterBootstrap {
     private final class QuarkusExecutionContextCarrier implements ExecutionContextCarrier {
         private static final ThreadLocal<java.util.Map<String, Object>> FALLBACK =
             ThreadLocal.withInitial(java.util.HashMap::new);
+        private final Set<String> trackedKeys = ConcurrentHashMap.newKeySet();
 
         @Override
         public <T> T get(String key, Class<T> type) {
@@ -160,8 +163,10 @@ public class RuntimeAdapterBootstrap {
                 try {
                     if (value == null) {
                         context.removeLocal(key);
+                        trackedKeys.remove(key);
                     } else {
                         context.putLocal(key, value);
+                        trackedKeys.add(key);
                     }
                     return;
                 } catch (UnsupportedOperationException ignored) {
@@ -170,8 +175,10 @@ public class RuntimeAdapterBootstrap {
             }
             if (value == null) {
                 FALLBACK.get().remove(key);
+                trackedKeys.remove(key);
             } else {
                 FALLBACK.get().put(key, value);
+                trackedKeys.add(key);
             }
         }
 
@@ -184,12 +191,14 @@ public class RuntimeAdapterBootstrap {
             if (context != null) {
                 try {
                     context.removeLocal(key);
+                    trackedKeys.remove(key);
                     return;
                 } catch (UnsupportedOperationException ignored) {
                     // Fall back to thread-local cache.
                 }
             }
             FALLBACK.get().remove(key);
+            trackedKeys.remove(key);
         }
 
         @Override
@@ -197,13 +206,15 @@ public class RuntimeAdapterBootstrap {
             Context context = Vertx.currentContext();
             if (context != null) {
                 try {
-                    // Vert.x contexts are per-thread; remove known execution keys to avoid leaking values.
-                    context.removeLocal(PipelineContext.class.getName());
+                    for (String key : trackedKeys) {
+                        context.removeLocal(key);
+                    }
                 } catch (UnsupportedOperationException ignored) {
                     // Fall back to thread-local cache cleanup below.
                 }
             }
             FALLBACK.remove();
+            trackedKeys.clear();
         }
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/runtime/RuntimeAdapterBootstrap.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/runtime/RuntimeAdapterBootstrap.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import org.pipelineframework.config.PipelineConfig;
+import org.pipelineframework.config.PipelineStepConfig;
+import org.pipelineframework.context.PipelineContext;
+import org.pipelineframework.runtime.core.EventBusBridge;
+import org.pipelineframework.runtime.core.ExecutionContextCarrier;
+import org.pipelineframework.runtime.core.ReactiveRuntime;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
+import org.pipelineframework.runtime.core.SchedulerBoundary;
+import org.pipelineframework.runtime.core.TransactionBoundary;
+import org.pipelineframework.runtime.core.WorkDispatcher;
+
+/**
+ * Bootstrapper that wires Quarkus runtime implementations into framework-core adapters.
+ */
+@ApplicationScoped
+public class RuntimeAdapterBootstrap {
+    private static final Logger LOG = Logger.getLogger(RuntimeAdapterBootstrap.class);
+    private static final String EXECUTOR_THREAD_NAME = "quarkus-virtual-thread-runtime";
+
+    @Inject
+    PipelineConfig pipelineConfig;
+    @Inject
+    PipelineStepConfig pipelineStepConfig;
+
+    private final Executor virtualThreadExecutor = Executors.newThreadPerTaskExecutor(
+        Thread.ofVirtual().name(EXECUTOR_THREAD_NAME, 0).factory()
+    );
+    private final WorkDispatcher workDispatcher = work -> CompletableFuture.completedFuture(null);
+
+    public RuntimeAdapterBootstrap() {
+    }
+
+    void onStart(@Observes StartupEvent event) {
+        RuntimeAdapters.registerBeanLookup(new QuarkusBeanLookup());
+        RuntimeAdapters.registerConfigProvider(new QuarkusConfigProvider());
+        RuntimeAdapters.registerExecutionContextCarrier(new QuarkusExecutionContextCarrier());
+        RuntimeAdapters.registerReactiveRuntime(new QuarkusReactiveRuntime());
+        RuntimeAdapters.registerSchedulerBoundary(new QuarkusSchedulerBoundary());
+        RuntimeAdapters.registerTransactionBoundary(new QuarkusTransactionBoundary());
+        RuntimeAdapters.registerEventBusBridge(new QuarkusEventBusBridge());
+        RuntimeAdapters.registerWorkDispatcher(new QuarkusWorkDispatcher());
+
+        // Ensure baseline values are available during startup.
+        if (pipelineConfig == null) {
+            LOG.warn("PipelineConfig was not injected; adapter registry still remains active.");
+        }
+        if (pipelineStepConfig == null) {
+            LOG.warn("PipelineStepConfig was not injected; adapter registry still remains active.");
+        }
+    }
+
+    @PreDestroy
+    void onStop() {
+        try {
+            if (virtualThreadExecutor instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        } catch (Exception ignored) {
+            LOG.debug("Failed to close virtual-thread executor cleanly.");
+        } finally {
+            RuntimeAdapters.resetForTests();
+        }
+    }
+
+    private final class QuarkusBeanLookup implements org.pipelineframework.runtime.core.BeanLookup {
+        @Override
+        public <T> Optional<T> get(Class<T> beanType) {
+            try {
+                Instance<T> instance = CDI.current().select(beanType);
+                if (instance == null || instance.isUnsatisfied() || instance.isAmbiguous()) {
+                    if (instance != null && instance.isAmbiguous()) {
+                        LOG.warnf("Ambiguous bean resolution for %s during adapter bootstrap.", beanType.getName());
+                    }
+                    return Optional.empty();
+                }
+                return Optional.ofNullable(instance.get());
+            } catch (AmbiguousResolutionException | ContextNotActiveException | IllegalStateException ex) {
+                LOG.debugf("Skipping bean lookup for %s: %s", beanType.getName(), ex.toString());
+                return Optional.empty();
+            }
+        }
+    }
+
+    private final class QuarkusConfigProvider implements org.pipelineframework.runtime.core.ConfigProvider {
+        @Override
+        public <T> Optional<T> get(Class<T> configType) {
+            return new QuarkusBeanLookup().get(configType);
+        }
+    }
+
+    private final class QuarkusExecutionContextCarrier implements ExecutionContextCarrier {
+        private static final ThreadLocal<java.util.Map<String, Object>> FALLBACK =
+            ThreadLocal.withInitial(java.util.HashMap::new);
+
+        @Override
+        public <T> T get(String key, Class<T> type) {
+            Context context = Vertx.currentContext();
+            if (context != null) {
+                try {
+                    Object stored = context.getLocal(key);
+                    if (stored != null && type != null && type.isInstance(stored)) {
+                        return type.cast(stored);
+                    }
+                } catch (UnsupportedOperationException ignored) {
+                    // Fall back to local cache below.
+                }
+            }
+            Object value = FALLBACK.get().get(key);
+            if (value == null || type == null || !type.isInstance(value)) {
+                return null;
+            }
+            return type.cast(value);
+        }
+
+        @Override
+        public void put(String key, Object value) {
+            if (key == null) {
+                return;
+            }
+            Context context = Vertx.currentContext();
+            if (context != null) {
+                try {
+                    if (value == null) {
+                        context.removeLocal(key);
+                    } else {
+                        context.putLocal(key, value);
+                    }
+                    return;
+                } catch (UnsupportedOperationException ignored) {
+                    // Fall back to thread-local cache below.
+                }
+            }
+            if (value == null) {
+                FALLBACK.get().remove(key);
+            } else {
+                FALLBACK.get().put(key, value);
+            }
+        }
+
+        @Override
+        public void clear(String key) {
+            if (key == null) {
+                return;
+            }
+            Context context = Vertx.currentContext();
+            if (context != null) {
+                try {
+                    context.removeLocal(key);
+                    return;
+                } catch (UnsupportedOperationException ignored) {
+                    // Fall back to thread-local cache.
+                }
+            }
+            FALLBACK.get().remove(key);
+        }
+
+        @Override
+        public void clear() {
+            Context context = Vertx.currentContext();
+            if (context != null) {
+                try {
+                    // Vert.x contexts are per-thread; remove known execution keys to avoid leaking values.
+                    context.removeLocal(PipelineContext.class.getName());
+                } catch (UnsupportedOperationException ignored) {
+                    // Fall back to thread-local cache cleanup below.
+                }
+            }
+            FALLBACK.remove();
+        }
+    }
+
+    private final class QuarkusReactiveRuntime implements ReactiveRuntime {
+        @Override
+        public <T> CompletionStage<T> executeBlocking(java.util.function.Supplier<T> supplier, boolean offloadToVirtualThread) {
+            if (offloadToVirtualThread) {
+                return Uni.createFrom()
+                    .item(() -> {
+                        try {
+                            return supplier.get();
+                        } catch (RuntimeException ex) {
+                            throw ex;
+                        } catch (Exception ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    })
+                    .runSubscriptionOn(virtualThreadExecutor)
+                    .subscribeAsCompletionStage();
+            }
+            return Uni.createFrom()
+                .item(() -> {
+                    try {
+                        return supplier.get();
+                    } catch (RuntimeException ex) {
+                        throw ex;
+                    } catch (Exception ex) {
+                        throw new RuntimeException(ex);
+                    }
+                })
+                .subscribeAsCompletionStage();
+        }
+    }
+
+    private final class QuarkusSchedulerBoundary implements SchedulerBoundary {
+        @Override
+        public <T> CompletionStage<T> schedule(Callable<T> task) {
+            try {
+                Context context = Vertx.currentContext();
+                if (context == null) {
+                    return CompletableFuture.supplyAsync(() -> {
+                        try {
+                            return task.call();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
+
+                CompletableFuture<T> promise = new CompletableFuture<>();
+                context.runOnContext(v -> {
+                    try {
+                        promise.complete(task.call());
+                    } catch (Exception e) {
+                        promise.completeExceptionally(e);
+                    }
+                });
+                return promise;
+            } catch (Exception e) {
+                CompletableFuture<T> failed = new CompletableFuture<>();
+                failed.completeExceptionally(e);
+                return failed;
+            }
+        }
+    }
+
+    private final class QuarkusTransactionBoundary implements TransactionBoundary {
+        @Override
+        public <T> T executeInTransaction(Callable<T> callback) {
+            try {
+                return callback.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private final class QuarkusEventBusBridge implements EventBusBridge {
+        @Override
+        public void publish(String address, Object event) {
+            // Intentionally no-op for now; event bus consumers are still adapter-specific.
+        }
+    }
+
+    private final class QuarkusWorkDispatcher implements WorkDispatcher {
+        @Override
+        public CompletionStage<Void> enqueue(Object item) {
+            return workDispatcher.enqueue(item);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/step/ConfigFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/ConfigFactory.java
@@ -17,12 +17,12 @@
 package org.pipelineframework.step;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 
 import org.pipelineframework.config.PipelineConfig;
 import org.pipelineframework.config.PipelineStepConfig;
 import org.pipelineframework.config.StepConfig;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
  * A factory class for building configuration for pipeline steps.
@@ -52,9 +52,11 @@ public class ConfigFactory {
      */
     public StepConfig buildConfig(Class<?> stepClass, PipelineConfig pipelineConfig) {
 
-        // Get the new Quarkus configuration
-        PipelineStepConfig pipelineStepConfig = CDI.current()
-            .select(PipelineStepConfig.class).get();
+        PipelineStepConfig pipelineStepConfig = RuntimeAdapters.resolveConfig(PipelineStepConfig.class)
+            .orElse(null);
+        if (pipelineStepConfig == null) {
+            return pipelineConfig.newStepConfig();
+        }
 
         // Get config for the specific class if available
         String className = stepClass.getName();

--- a/framework/runtime/src/main/java/org/pipelineframework/step/ItemRejectable.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/step/ItemRejectable.java
@@ -20,10 +20,6 @@ import java.util.List;
 import java.util.Optional;
 
 import io.smallrye.mutiny.Uni;
-import jakarta.enterprise.context.ContextNotActiveException;
-import jakarta.enterprise.inject.CreationException;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
 import org.jboss.logging.Logger;
 import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
@@ -31,6 +27,7 @@ import org.pipelineframework.context.TransportDispatchMetadata;
 import org.pipelineframework.context.TransportDispatchMetadataHolder;
 import org.pipelineframework.reject.ItemRejectRouter;
 import org.pipelineframework.telemetry.PipelineTelemetry;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
 
 /**
  * Support for step-level reject-and-continue behaviour.
@@ -142,31 +139,10 @@ public interface ItemRejectable<I, O> {
     }
 
     private Optional<ItemRejectRouter> resolveRouter() {
-        CDI<Object> cdi;
         try {
-            cdi = CDI.current();
-        } catch (IllegalStateException unavailable) {
-            return Optional.empty();
-        }
-
-        Instance<ItemRejectRouter> instance;
-        try {
-            instance = cdi.select(ItemRejectRouter.class);
+            return RuntimeAdapters.resolveBean(ItemRejectRouter.class);
         } catch (RuntimeException selectionFailure) {
-            LOG.warnf(selectionFailure, "Failed selecting ItemRejectRouter from CDI.");
-            return Optional.empty();
-        }
-        if (instance.isUnsatisfied()) {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(instance.get());
-        } catch (ContextNotActiveException | CreationException creationFailure) {
-            LOG.warnf(creationFailure, "Item reject sink unavailable because ItemRejectRouter is not active.");
-            return Optional.empty();
-        } catch (RuntimeException creationFailure) {
-            LOG.warnf(creationFailure, "Failed to create ItemRejectRouter for item reject handling.");
+            LOG.warnf(selectionFailure, "Failed resolving ItemRejectRouter from runtime adapters.");
             return Optional.empty();
         }
     }

--- a/framework/runtime/src/test/java/org/pipelineframework/RuntimeAdapterSeamTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/RuntimeAdapterSeamTest.java
@@ -1,0 +1,44 @@
+package org.pipelineframework;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeAdapterSeamTest {
+
+    @Test
+    void runtimeUsesVertxOnlyInAdapterBootstrap() {
+        Path sourceRoot = Path.of("src/main/java");
+        Path allowedSeam = sourceRoot.resolve("org/pipelineframework/runtime/RuntimeAdapterBootstrap.java").normalize();
+
+        List<String> violations = new ArrayList<>();
+        try (var stream = Files.walk(sourceRoot)) {
+            stream.filter(path -> path.toString().endsWith(".java")).forEach(path -> {
+                if (path.normalize().equals(allowedSeam)) {
+                    return;
+                }
+
+                try {
+                    List<String> lines = Files.readAllLines(path);
+                    for (int lineNo = 1; lineNo <= lines.size(); lineNo++) {
+                        if (lines.get(lineNo - 1).contains("io.vertx.")) {
+                            violations.add(path + ":" + lineNo);
+                        }
+                    }
+                } catch (IOException ignored) {
+                    // Ignore transient read issues while scanning source files.
+                }
+            });
+        } catch (IOException e) {
+            violations.add("Unable to scan runtime sources: " + e.getMessage());
+        }
+
+        assertTrue(violations.isEmpty(), "Vert.x usage must stay in runtime adapter seam: " + violations);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/RuntimeAdapterSeamTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/RuntimeAdapterSeamTest.java
@@ -31,8 +31,8 @@ class RuntimeAdapterSeamTest {
                             violations.add(path + ":" + lineNo);
                         }
                     }
-                } catch (IOException ignored) {
-                    // Ignore transient read issues while scanning source files.
+                } catch (IOException e) {
+                    violations.add("Unable to read " + path + ": " + e.getMessage());
                 }
             });
         } catch (IOException e) {


### PR DESCRIPTION
## Scope

### In
- Add `framework/runtime-core` with neutral seams for bean lookup, config lookup, execution context propagation, scheduling, transactions, event bus, work dispatch, and blocking execution.
- Keep `framework/runtime` behavior unchanged while wiring Quarkus adapters through a bootstrap registry (`RuntimeAdapterBootstrap`).
- Move runtime call sites to adapter abstractions where feasible.
- Add renderer-profile plumbing to prepare for non-Quarkus renderer selection.
- Add dependency guard and seam tests plus evolving docs entry.

### Out
- No Spring runtime implementation
- No reactive-library migration (Mutiny remains)
- No annotation-removal behavior changes

## Validation
- `./mvnw -f framework/runtime-core test -q`
- `./mvnw -f framework/runtime -Dtest='RuntimeAdapterSeamTest' test -q`
- `./mvnw -f framework/runtime-core -q` (compile)
- `./mvnw -f framework/deployment -Dtest='PipelineDiscoveryPhaseTest,FunctionHandlerRendererFactoryTest,PipelineGenerationPhaseTest' test -q`
- `./mvnw -f framework/pom.xml -pl runtime-core,runtime,deployment -am -DskipTests compile`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime-core module with runtime-agnostic adapters for bean/config lookup, execution context, scheduling, transactions, event bus and work dispatch.
  * Added renderer profile support to select generation profiles (quarkus/spring).

* **Documentation**
  * New guide explaining runtime-core decoupling and renderer profile deployment options.

* **Refactor**
  * Runtime code updated to use the adapter registry for framework independence.

* **Tests**
  * New/updated tests enforcing dependency seams and renderer-profile behavior.

* **Chores**
  * Project modules/poms and example build scripts updated for the new module and configurable Maven threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->