### PR TITLE
Make YAML authoritative for internal step binding

### DIFF
--- a/docs/guide/build/pipeline-compilation.md
+++ b/docs/guide/build/pipeline-compilation.md
@@ -31,7 +31,7 @@ The Pipeline Framework uses YAML-first compilation to automatically generate the
 For internal `service:` steps:
 
 1. `pipeline.yaml` declares the service class, cardinality, domain input/output types, and optional inbound/outbound mappers
-2. `@PipelineStep` marks the Java service class, so the compiler can discover it
+2. The Java service implements one supported TPF service contract
 3. The compiler validates the YAML contract against the implemented reactive service interface
 4. It generates transport adapters and client steps for the configured transport (gRPC or REST)
 5. It expands configured aspects into synthetic side effect steps when a plugin host is present
@@ -67,7 +67,7 @@ CDI registration
 
 ### 1. Build-Time Discovery
 
-During the Maven build process, the compiler reads `pipeline.yaml` and resolves each internal `service:` step against a class annotated with `@PipelineStep`:
+During the Maven build process, the compiler reads `pipeline.yaml` and resolves each internal `service:` step against the declared service class. `@PipelineStep` is still supported for existing code and Java-local execution hints, but it is not required when YAML declares the step contract:
 
 ```yaml
 steps:
@@ -81,7 +81,6 @@ steps:
 ```
 
 ```java
-@PipelineStep
 @ApplicationScoped
 public class ProcessPaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
     @Override
@@ -91,7 +90,7 @@ public class ProcessPaymentService implements ReactiveService<PaymentRecord, Pay
 }
 ```
 
-The annotation is the marker plus Java-local execution hints. Current internal-step contract metadata belongs in YAML.
+YAML is the authoritative source for the step contract. If YAML and deprecated `@PipelineStep` contract metadata are both present, the compiler uses YAML and emits a warning.
 
 ### 1.1 Orchestrator and Plugin Annotations
 
@@ -274,8 +273,8 @@ The annotation processor runs during the `compile` phase:
 ```bash
 # During mvn compile
 [INFO] --- quarkus:3.28.0.CR1:generate-code (default) @ service-module ---
-[INFO] [org.pipelineframework.processor.PipelineStepProcessor] Generating adapters for annotated services
-[INFO] [org.pipelineframework.processor.PipelineStepProcessor] Found 3 @PipelineStep annotated services
+[INFO] [org.pipelineframework.processor.PipelineStepProcessor] Loading pipeline.yaml
+[INFO] [org.pipelineframework.processor.PipelineStepProcessor] Resolving YAML-declared services and operators
 [INFO] [org.pipelineframework.processor.PipelineStepProcessor] Generated ProcessPaymentServiceGrpcService
 [INFO] [org.pipelineframework.processor.PipelineStepProcessor] Generated ProcessPaymentGrpcClientStep
 [INFO] [org.pipelineframework.processor.PipelineStepProcessor] Generated SendPaymentServiceGrpcService

--- a/docs/guide/build/pipeline-compilation.md
+++ b/docs/guide/build/pipeline-compilation.md
@@ -67,7 +67,7 @@ CDI registration
 
 ### 1. Build-Time Discovery
 
-During the Maven build process, the compiler reads `pipeline.yaml` and resolves each internal `service:` step against the declared service class. `@PipelineStep` is still supported for existing code and Java-local execution hints, but it is not required when YAML declares the step contract:
+During the Maven build process, the compiler reads `pipeline.yaml` and resolves each internal `service:` step against the declared service class. `@PipelineStep` is still supported for existing code, but it is not required when YAML declares the step contract:
 
 ```yaml
 steps:

--- a/docs/guide/evolve/annotation-processor/index.md
+++ b/docs/guide/evolve/annotation-processor/index.md
@@ -39,7 +39,10 @@ flowchart LR
 
 Internal `service:` steps can now be authored against reactive service interfaces, materialising blocking service interfaces, or the incremental blocking iterator service interface.
 
+- YAML is the authoritative binding surface for declared internal steps. `@PipelineStep` remains backward-compatible, but it is no longer required when YAML names the service class.
+- The processor advertises a broad annotation trigger so YAML-only modules still enter compilation, then exits early when no pipeline configuration signal is present.
 - Model extraction classifies the authored service contract family and validates YAML cardinality against it.
+- When YAML and deprecated `@PipelineStep` contract metadata both exist, model extraction uses YAML and emits a warning instead of failing on annotation/YAML disagreement.
 - Model extraction emits build-time warnings for materialising blocking streaming contracts and points users toward `BlockingIteratorService` for incremental `1 -> N` cases.
 - Target resolution adds a generated reactive bridge target for blocking-authored internal services.
 - Transport renderers still target reactive service contracts. They inject the generated bridge instead of the authored blocking service directly.

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
@@ -81,8 +81,8 @@ public class PipelineCompiler extends AbstractProcessingTool {
      *
      * @param annotations the set of annotation types requested to be processed in this round
      * @param roundEnv the environment for information about the current and previous round
-     * @return `true` if this processor performed work during this round (including when a phase failed),
-     *         `false` otherwise
+     * @return always `false` so the YAML-capable wildcard trigger does not claim annotations from
+     *         other processors
      */
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
@@ -138,19 +138,20 @@ public class PipelineCompiler extends AbstractProcessingTool {
                         "Cause: " + cause.getClass().getSimpleName() + ": " + cause.getMessage());
                 }
                 compilationExecuted = true;
-                return true; // Return true to indicate processing happened (even if it failed)
+                return false;
             }
         }
 
         compilationExecuted = true;
-        return true;
+        return false;
     }
     /**
      * Detects whether a pipeline configuration signal is present for the compiler.
      *
      * Checks the explicit processor option "pipeline.config" first. If that option is not set,
      * determines a base directory from "pipeline.moduleDir", then "pipeline.generatedSourcesDir",
-     * then the system property "user.dir", and looks for a pipeline.yaml file at either
+     * then "project.basedir", then "maven.multiModuleProjectDirectory", and looks for a
+     * pipeline.yaml file at either
      * {baseDir}/pipeline.yaml or {baseDir}/src/main/resources/pipeline.yaml.
      *
      * @return `true` if the "pipeline.config" option is set or a pipeline.yaml file is found,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompiler.java
@@ -19,6 +19,7 @@ import org.pipelineframework.annotation.PipelineStep;
  * with a phased compilation approach.
  */
 @SupportedAnnotationTypes({
+    "*",
     "org.pipelineframework.annotation.PipelineStep",
     "org.pipelineframework.annotation.PipelinePlugin",
     "org.pipelineframework.annotation.PipelineOrchestrator"

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineStepProcessor.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineStepProcessor.java
@@ -8,12 +8,13 @@ import javax.lang.model.element.TypeElement;
 
 /**
  * Java annotation processor that generates both gRPC client and server step implementations
- * based on @PipelineStep annotated service classes.
+ * from YAML-declared pipeline steps and legacy @PipelineStep annotated service classes.
  * <p>
  * This class now serves as a facade that delegates to the phased compiler architecture.
  */
 @SuppressWarnings("unused")
 @SupportedAnnotationTypes({
+    "*",
     "org.pipelineframework.annotation.PipelineStep",
     "org.pipelineframework.annotation.PipelinePlugin",
     "org.pipelineframework.annotation.PipelineOrchestrator"
@@ -105,7 +106,7 @@ public class PipelineStepProcessor extends AbstractProcessingTool {
      *
      * @param annotations the annotation types requested to be processed in this round
      * @param roundEnv the environment for information about the current and prior round
-     * @return {@code true} if at least one annotation was processed, {@code false} when no annotations were present
+     * @return {@code true} if pipeline compilation work was performed, {@code false} otherwise
      */
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
@@ -10,8 +10,8 @@ import org.pipelineframework.parallelism.OrderingRequirement;
 import org.pipelineframework.parallelism.ThreadSafety;
 
 /**
- * Contains only semantic information derived from @PipelineStep annotations. This class captures all the essential
- * information needed to generate pipeline artifacts.
+ * Contains semantic information derived from YAML step definitions or legacy {@code @PipelineStep} annotations.
+ * This class captures all the essential information needed to generate pipeline artifacts.
  *
  * @param serviceName Gets the name of the service.
  * @param generatedName Gets the generated class name base for the service.

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepKind.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepKind.java
@@ -22,7 +22,7 @@ package org.pipelineframework.processor.ir;
 public enum StepKind {
     /**
      * An internal step where the execution service is implemented within the application
-     * and annotated with @PipelineStep.
+     * and bound from YAML or legacy @PipelineStep metadata.
      */
     INTERNAL,
     

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -37,8 +37,7 @@ import org.pipelineframework.processor.ir.TypeMapping;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
 
 /**
- * Extracts semantic models from annotated elements.
- * This phase discovers and extracts PipelineStepModel instances from @PipelineStep annotated classes.
+ * Extracts semantic models from YAML step definitions and legacy {@code @PipelineStep} annotations.
  */
 public class ModelExtractionPhase implements PipelineCompilationPhase {
     public static final String NO_YAML_DEFINITIONS_MESSAGE =
@@ -152,7 +151,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
     }
 
     /**
-     * Fallback extraction path for annotation-driven internal steps.
+     * Fallback extraction path for legacy annotation-driven internal steps.
      *
      * @param ctx the compilation context containing the current round environment
      * @return list of extracted step models from @PipelineStep-annotated classes
@@ -179,9 +178,10 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
     /**
      * Builds a PipelineStepModel that represents the provided StepDefinition.
      *
-     * For INTERNAL steps, verifies the referenced service class exists and is annotated with
-     * @PipelineStep, extracts semantic information from the class, and applies the YAML-derived
-     * identity. For DELEGATED steps, constructs a delegated model via createDelegatedStepModel.
+     * For INTERNAL steps, verifies the referenced service class exists, extracts the implemented
+     * service contract, and applies YAML-derived identity and mappings. {@code @PipelineStep}
+     * metadata remains a compatibility source when present, but YAML is authoritative.
+     * For DELEGATED steps, constructs a delegated model via createDelegatedStepModel.
      * For REMOTE steps, constructs a generated remote-adapter model from template contract metadata.
      *
      * @param ctx the compilation context
@@ -327,20 +327,6 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return null;
         }
 
-        if (serviceClass.getAnnotation(PipelineStep.class) == null) {
-            ctx.getProcessingEnv().getMessager().printMessage(
-                javax.tools.Diagnostic.Kind.ERROR,
-                "Internal step service class '" + stepDef.executionClass().canonicalName() +
-                    "' must be annotated with @PipelineStep for step '" + stepDef.name() + "'");
-            return null;
-        }
-
-        var extracted = irExtractor.extract(serviceClass);
-        if (extracted == null) {
-            return null;
-        }
-        PipelineStepModel extractedModel = extracted.model();
-
         SupportedServiceSignature serviceSignature = resolveSupportedInternalSignature(
             serviceClass,
             ctx.getProcessingEnv().getTypeUtils(),
@@ -350,6 +336,11 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal step service '" + stepDef.executionClass().canonicalName()
                     + "' must implement exactly one supported service interface for step '" + stepDef.name() + "'");
+            return null;
+        }
+
+        PipelineStepModel extractedModel = createYamlInternalBaseModel(ctx, serviceClass, serviceSignature, irExtractor);
+        if (extractedModel == null) {
             return null;
         }
 
@@ -412,6 +403,52 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .inputMapping(new TypeMapping(inputType, inboundMapper, inboundMapper != null, inputType))
             .outputMapping(new TypeMapping(outputType, outboundMapper, outboundMapper != null, outputType))
             .streamingShape(serviceSignature.shape())
+            .serviceApiKind(serviceSignature.apiKind())
+            .build();
+    }
+
+    private PipelineStepModel createYamlInternalBaseModel(
+            PipelineCompilationContext ctx,
+            TypeElement serviceClass,
+            SupportedServiceSignature serviceSignature,
+            PipelineStepIRExtractor irExtractor) {
+        if (serviceClass.getAnnotation(PipelineStep.class) != null) {
+            var extracted = irExtractor.extract(serviceClass);
+            return extracted == null ? null : extracted.model();
+        }
+
+        String qualifiedServiceName = serviceClass.getQualifiedName().toString();
+        ClassName serviceClassName = null;
+        try {
+            serviceClassName = ClassName.get(serviceClass);
+        } catch (Exception e) {
+            if (qualifiedServiceName != null && !qualifiedServiceName.isBlank()) {
+                serviceClassName = ClassName.bestGuess(qualifiedServiceName);
+            }
+        }
+        if (serviceClassName == null) {
+            ctx.getProcessingEnv().getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Could not resolve service class name for YAML internal step service '"
+                    + qualifiedServiceName + "'");
+            return null;
+        }
+
+        return new PipelineStepModel.Builder()
+            .serviceName(serviceClass.getSimpleName().toString())
+            .generatedName(serviceClass.getSimpleName().toString())
+            .servicePackage(ctx.getProcessingEnv().getElementUtils().getPackageOf(serviceClass).getQualifiedName().toString())
+            .serviceClassName(serviceClassName)
+            .inputMapping(new TypeMapping(serviceSignature.inputType(), null, false, serviceSignature.inputType()))
+            .outputMapping(new TypeMapping(serviceSignature.outputType(), null, false, serviceSignature.outputType()))
+            .streamingShape(serviceSignature.shape())
+            .enabledTargets(EnumSet.of(GenerationTarget.GRPC_SERVICE, GenerationTarget.CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .orderingRequirement(OrderingRequirement.RELAXED)
+            .threadSafety(ThreadSafety.SAFE)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .sideEffect(false)
+            .cacheKeyGenerator(null)
             .serviceApiKind(serviceSignature.apiKind())
             .build();
     }
@@ -1148,12 +1185,19 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             TypeName annotationType,
             TypeName reactiveType) {
         if (yamlType != null) {
-            if (annotationType != null && !yamlType.equals(annotationType)) {
+            if (reactiveType != null && !yamlType.equals(reactiveType)) {
                 ctx.getProcessingEnv().getMessager().printMessage(
                     javax.tools.Diagnostic.Kind.ERROR,
                     "Internal step '" + stepName + "' declares " + direction + " type '" + yamlType
-                        + "' in YAML, but deprecated @PipelineStep metadata still declares '" + annotationType + "'.");
+                        + "' in YAML, but service implementation declares '" + reactiveType + "'.");
                 return null;
+            }
+            if (annotationType != null) {
+                ctx.getProcessingEnv().getMessager().printMessage(
+                    javax.tools.Diagnostic.Kind.WARNING,
+                    "Internal step '" + stepName + "' declares " + direction + " type '" + yamlType
+                        + "' in YAML and deprecated @PipelineStep metadata declares '" + annotationType
+                        + "'. YAML is authoritative.");
             }
             return yamlType;
         }
@@ -1178,13 +1222,12 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             ClassName yamlMapper,
             ClassName annotationMapper,
             TypeName expectedDomainType) {
-        if (yamlMapper != null && annotationMapper != null && !yamlMapper.equals(annotationMapper)) {
+        if (yamlMapper != null && annotationMapper != null) {
             ctx.getProcessingEnv().getMessager().printMessage(
-                javax.tools.Diagnostic.Kind.ERROR,
+                javax.tools.Diagnostic.Kind.WARNING,
                 "Internal step '" + stepName + "' declares " + fieldName + " '" + yamlMapper.canonicalName()
-                    + "' in YAML, but deprecated @PipelineStep metadata still declares '"
-                    + annotationMapper.canonicalName() + "'.");
-            return INVALID_CLASS_NAME;
+                    + "' in YAML and deprecated @PipelineStep metadata declares '"
+                    + annotationMapper.canonicalName() + "'. YAML is authoritative.");
         }
         ClassName effective = yamlMapper != null ? yamlMapper : annotationMapper;
         if (effective == null) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/NamingPolicy.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/NamingPolicy.java
@@ -55,7 +55,7 @@ class NamingPolicy {
         if (input == null || input.isBlank()) {
             return "";
         }
-        String[] parts = input.split(" ");
+        String[] parts = input.split("[^a-zA-Z0-9]+");
         StringBuilder builder = new StringBuilder();
         for (String part : parts) {
             if (part == null || part.isBlank()) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
@@ -461,7 +461,6 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
                 var typeUtils = ctx.getProcessingEnv().getTypeUtils();
                 boolean isValidReactiveService = implementsAnyReactiveService(
                     delegateElement,
-                    elementUtils,
                     typeUtils);
 
                 if (!isValidReactiveService) {
@@ -493,9 +492,10 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
                         continue;
                     }
 
-                    boolean implementsExternalMapper =
-                        typeUtils.isAssignable(externalMapperElement.asType(), externalMapperInterfaceElement.asType());
-                    if (!implementsExternalMapper) {
+                    if (findReactiveSupertype(
+                            typeUtils,
+                            externalMapperElement.asType(),
+                            "org.pipelineframework.mapper.ExternalMapper") == null) {
                         messager.printMessage(
                             Diagnostic.Kind.ERROR,
                             "Operator mapper '" + model.externalMapper().canonicalName() + 
@@ -594,11 +594,9 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
      */
     private boolean implementsAnyReactiveService(
             TypeElement delegateElement,
-            javax.lang.model.util.Elements elementUtils,
             Types typeUtils) {
         for (String interfaceName : REACTIVE_SERVICE_INTERFACE_NAMES) {
-            TypeElement interfaceElement = elementUtils.getTypeElement(interfaceName);
-            if (interfaceElement != null && typeUtils.isAssignable(delegateElement.asType(), interfaceElement.asType())) {
+            if (findReactiveSupertype(typeUtils, delegateElement.asType(), interfaceName) != null) {
                 return true;
             }
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
@@ -822,7 +822,7 @@ public final class PipelineTemplateSchemaExporter {
         },
         "service": {
           "type": "string",
-          "description": "Fully qualified class name of the internal service annotated with @PipelineStep",
+          "description": "Fully qualified class name of the YAML-declared internal service",
           "pattern": "^[a-zA-Z_$][a-zA-Z\\\\d_$]*(\\\\.[a-zA-Z_$][a-zA-Z\\\\d_$]*)*\\\\.[A-Z][a-zA-Z\\\\d_$]*$"
         },
         "operator": {

--- a/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
+++ b/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
@@ -788,7 +788,7 @@
         },
         "service": {
           "type": "string",
-          "description": "Fully qualified class name of the internal service annotated with @PipelineStep",
+          "description": "Fully qualified class name of the YAML-declared internal service",
           "pattern": "^[a-zA-Z_$][a-zA-Z\\d_$]*(\\.[a-zA-Z_$][a-zA-Z\\d_$]*)*\\.[A-Z][a-zA-Z\\d_$]*$"
         },
         "operator": {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineCompilerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineCompilerTest.java
@@ -1,7 +1,6 @@
 package org.pipelineframework.processor;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -59,8 +58,8 @@ class PipelineCompilerTest {
         boolean firstResult = compiler.process(Set.<TypeElement>of(), roundOne);
         boolean secondResult = compiler.process(Set.<TypeElement>of(), roundTwo);
 
-        assertTrue(firstResult, "First YAML-driven round should execute compilation");
-        assertFalse(secondResult, "Subsequent rounds should not execute compilation again");
+        assertFalse(firstResult, "YAML-driven compilation should not claim annotations from other processors");
+        assertFalse(secondResult, "Subsequent rounds should not claim annotations either");
         verify(phase, times(1)).execute(org.mockito.ArgumentMatchers.any(PipelineCompilationContext.class));
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineStepProcessorTest.java
@@ -343,11 +343,11 @@ class PipelineStepProcessorTest {
 
         localProcessor.init(localProcessingEnv);
 
-        // When annotations are present (i.e., @PipelineStep), processing should occur and return
-        // true
+        // Processing occurs, but the wildcard YAML trigger must not claim annotations from
+        // other processors.
         boolean result = localProcessor.process(annotations, roundEnv);
 
-        assertTrue(result);
+        assertFalse(result);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -472,11 +472,11 @@ class PipelineStepProcessorTest {
 
         localProcessor.init(localProcessingEnv);
 
-        // When annotations are present (i.e., @PipelineStep), processing should occur and return
-        // true
+        // Processing occurs, but the wildcard YAML trigger must not claim annotations from
+        // other processors.
         boolean result = localProcessor.process(annotations, roundEnv);
 
-        assertTrue(result);
+        assertFalse(result);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
@@ -183,15 +183,81 @@ class YamlDrivenStepGenerationTest {
             triggerSource, delegateSource, libInput, libOutput, appInput, appOutput,
             externalMapperContract, reactiveServiceContract, mapperSource));
 
-        assertFalse(result.success(), "Expected deterministic contract validation failure in this harness");
-        String errors = result.errorSummary();
-        assertTrue(errors.contains("Delegate service 'com.example.lib.EmbeddingService'"),
-            "Expected delegated-service validation diagnostic: " + errors);
+        assertTrue(result.success(), "Expected delegated YAML step with explicit mapper to compile: " + result.errorSummary());
     }
 
     @Test
-    void failsYamlInternalStepWhenServiceIsNotAnnotated() throws IOException {
-        Path yamlFile = tempDir.resolve("pipeline-invalid-internal.yaml");
+    void generatesYamlInternalStepWithoutPipelineStepAnnotation() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-yaml-only.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import io.smallrye.mutiny.Uni;
+            import org.pipelineframework.service.ReactiveService;
+
+            public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
+                @Override
+                public Uni<PaymentStatus> process(PaymentRecord input) {
+                    return Uni.createFrom().item(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path uniStub = writeUniStub();
+
+        CompilationResult result = compile(yamlFile, List.of(paymentService, paymentRecord, paymentStatus, uniStub));
+        assertTrue(result.success(), "Expected annotation-free YAML internal service compilation to succeed: " + result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenServiceClassIsMissing() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-missing-internal.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.MissingPaymentService"
+            """);
+
+        Path markerSource = writeSource("MarkerMissingService.java", """
+            package com.example.app;
+
+            public class MarkerMissingService {
+            }
+            """);
+
+        CompilationResult result = compile(yamlFile, List.of(markerSource));
+        assertFalse(result.success(), "Expected missing YAML internal service class to fail");
+        assertTrue(result.errorSummary().contains("not found for step 'pay'"), result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenServiceDoesNotImplementSupportedContract() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-bad-internal-shape.yaml");
         Files.writeString(yamlFile, """
             appName: "Test App"
             basePackage: "com.example"
@@ -201,26 +267,21 @@ class YamlDrivenStepGenerationTest {
                 service: "com.example.app.PaymentService"
             """);
 
-        Path triggerSource = writeSource("TriggerStep2.java", """
-            package com.example.app;
-
-            import org.pipelineframework.annotation.PipelineStep;
-
-            @PipelineStep(inputType = String.class, outputType = String.class)
-            public class TriggerStep2 {
-            }
-            """);
-        Path nonAnnotatedService = writeSource("PaymentService.java", """
+        Path nonService = writeSource("PaymentService.java", """
             package com.example.app;
 
             public class PaymentService {
+                public String process(String input) {
+                    return input;
+                }
             }
             """);
 
-        CompilationResult result = compile(yamlFile, List.of(triggerSource, nonAnnotatedService));
-        assertFalse(result.success(), "Expected failure when YAML internal service lacks @PipelineStep");
-        String errors = result.errorSummary().toLowerCase(Locale.ROOT);
-        assertTrue(errors.contains("must be annotated with @pipelinestep"), result.errorSummary());
+        CompilationResult result = compile(yamlFile, List.of(nonService));
+        assertFalse(result.success(), "Expected unsupported internal service contract to fail");
+        assertTrue(
+            result.errorSummary().contains("must implement exactly one supported service interface"),
+            result.errorSummary());
     }
 
     @Test
@@ -244,10 +305,8 @@ class YamlDrivenStepGenerationTest {
             package com.example.app;
 
             import io.smallrye.mutiny.Uni;
-            import org.pipelineframework.annotation.PipelineStep;
             import org.pipelineframework.service.ReactiveService;
 
-            @PipelineStep
             public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
                 @Override
                 public Uni<PaymentStatus> process(PaymentRecord input) {
@@ -340,10 +399,8 @@ class YamlDrivenStepGenerationTest {
             package com.example.app;
 
             import io.smallrye.mutiny.Uni;
-            import org.pipelineframework.annotation.PipelineStep;
             import org.pipelineframework.service.ReactiveService;
 
-            @PipelineStep
             public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
                 @Override
                 public Uni<PaymentStatus> process(PaymentRecord input) {
@@ -392,10 +449,8 @@ class YamlDrivenStepGenerationTest {
             package com.example.app;
 
             import io.smallrye.mutiny.Uni;
-            import org.pipelineframework.annotation.PipelineStep;
             import org.pipelineframework.service.ReactiveService;
 
-            @PipelineStep
             public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
                 @Override
                 public Uni<PaymentStatus> process(PaymentRecord input) {
@@ -453,6 +508,109 @@ class YamlDrivenStepGenerationTest {
         assertTrue(
             result.errorSummary().contains("must declare Mapper<"),
             "Expected mapper mismatch diagnostic: " + result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenYamlTypesConflictWithServiceContract() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-bad-type.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import io.smallrye.mutiny.Uni;
+            import org.pipelineframework.service.ReactiveService;
+
+            public class PaymentService implements ReactiveService<WrongRecord, PaymentStatus> {
+                @Override
+                public Uni<PaymentStatus> process(WrongRecord input) {
+                    return Uni.createFrom().item(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path wrongRecord = writeSource("WrongRecord.java", """
+            package com.example.app;
+
+            public class WrongRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path uniStub = writeUniStub();
+
+        CompilationResult result = compile(yamlFile, List.of(paymentService, paymentRecord, wrongRecord, paymentStatus, uniStub));
+        assertFalse(result.success(), "Expected YAML/code type mismatch to fail");
+        assertTrue(
+            result.errorSummary().contains("declares input type 'com.example.app.PaymentRecord' in YAML"),
+            "Expected YAML/code type mismatch diagnostic: " + result.errorSummary());
+    }
+
+    @Test
+    void warnsWhenYamlOverridesDeprecatedPipelineStepMetadata() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-annotation-secondary.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import io.smallrye.mutiny.Uni;
+            import org.pipelineframework.annotation.PipelineStep;
+            import org.pipelineframework.service.ReactiveService;
+
+            @PipelineStep(inputType = String.class, outputType = String.class)
+            public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
+                @Override
+                public Uni<PaymentStatus> process(PaymentRecord input) {
+                    return Uni.createFrom().item(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path uniStub = writeUniStub();
+
+        CompilationResult result = compile(yamlFile, List.of(paymentService, paymentRecord, paymentStatus, uniStub));
+        assertTrue(result.success(), "Expected YAML to override annotation metadata without failing: " + result.errorSummary());
+        String warnings = result.messagesOfKind(Diagnostic.Kind.WARNING);
+        assertTrue(warnings.contains("YAML is authoritative"), "Expected YAML-authoritative warning: " + warnings);
     }
 
     @Test

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/NamingPolicyTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/NamingPolicyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2025 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class NamingPolicyTest {
+
+    @Test
+    void formatForClassNamePreservesSpaceSeparatedNames() {
+        assertEquals("CustomerOrder", NamingPolicy.formatForClassName("Customer Order"));
+        assertEquals("CustomerOrder", NamingPolicy.formatForClassName("customer order"));
+    }
+
+    @Test
+    void formatForClassNameNormalizesPunctuationSeparatedNames() {
+        assertEquals("ProcessCustomer", NamingPolicy.formatForClassName("Process-Customer"));
+        assertEquals("FallbackEmbed", NamingPolicy.formatForClassName("fallback-embed"));
+        assertEquals("CustomerOrder", NamingPolicy.formatForClassName("customer_order"));
+    }
+
+    @Test
+    void toPascalCaseUsesSameSeparatorFamilyForSideEffectNames() {
+        assertEquals("CacheInvalidate", NamingPolicy.toPascalCase("cache-invalidate"));
+        assertEquals("CacheInvalidate", NamingPolicy.toPascalCase("cache invalidate"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow YAML-declared internal services to compile without `@PipelineStep` when the service contract matches
- keep `@PipelineStep` backward-compatible, but treat YAML as authoritative when both metadata sources are present
- fail build-time validation for missing classes, unsupported service contracts, YAML/code type mismatches, cardinality mismatches, and mapper mismatches
- update schema/docs and add focused compiler/naming coverage

## Scope
This is one compiler-binding slice. It does not add Spring support, remove annotations, change runtime semantics, alter mapper pair validation, or change transport/platform behavior.

## Review Notes
Local CodeRabbit was run against `origin/main`. It produced three low-severity findings: one test coverage suggestion was addressed with `NamingPolicyTest`; two warning-suppression suggestions were intentionally rejected because this slice explicitly warns when YAML and annotation metadata both exist and YAML is used.

## Validation
- `./mvnw -f framework/pom.xml -pl deployment -Dtest=YamlDrivenStepGenerationTest,PipelineStepProcessorTest test`
- `./mvnw -f framework/pom.xml -pl deployment -Dtest=PipelineTemplateSchemaExporterTest,YamlDrivenStepGenerationTest,PipelineStepProcessorTest test`
- `./mvnw -f framework/pom.xml verify`
- `./mvnw -f examples/search/pom.xml -pl orchestrator-svc -am -Dpipeline.platform=FUNCTION -Dpipeline.transport=REST -Dpipeline.rest.naming.strategy=RESOURCEFUL -DskipTests compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YAML-declared pipeline steps are authoritative; annotations are optional and YAML overrides emit warnings.

* **Documentation**
  * Guides updated to explain YAML-first behavior, conflict handling, and backward compatibility with legacy annotations.

* **Tests**
  * Added and adjusted tests validating YAML-driven step generation, type/contract checks, warning emission, and name-formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->