### PR TITLE
Add Spring runtime adapter skeleton

### DIFF
--- a/docs/guide/evolve/framework-portability-assessment/roadmap-and-guardrails.md
+++ b/docs/guide/evolve/framework-portability-assessment/roadmap-and-guardrails.md
@@ -10,6 +10,7 @@
 | Split `framework/runtime` into core plus Quarkus runtime artifact | Medium-High | High | Creates real portability boundary |
 | Convert store SPIs to neutral async types | Medium | High | Enables non-Mutiny providers |
 | Add renderer-profile registry | Medium | Medium | Keeps semantic model stable while adding Spring generation |
+| Add Spring Boot runtime adapter skeleton | Medium | Medium | Proves Spring can host runtime-core seams without Quarkus runtime dependencies |
 | Build minimal Spring Boot unary/local REST pipeline | High | High | First portability proof |
 | Add full Spring WebFlux/Reactor/gRPC/await/checkpoint parity | High | High | Production-capable portability |
 

--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -24,6 +24,19 @@ The goal is:
 - `RuntimeAdapters`
 
 `framework/runtime` remains Quarkus-first today and registers concrete implementations in `RuntimeAdapterBootstrap`.
+`framework/runtime-spring` provides the first Spring Boot adapter for these same contracts without depending on the
+Quarkus runtime artifact.
+
+The Spring adapter currently proves host integration only:
+
+- Spring bean and config lookup through `ApplicationContext`.
+- Thread-local execution context propagation.
+- Spring task execution and Java virtual-thread blocking offload.
+- Optional Spring transaction manager integration.
+- Spring application-event publishing for event and work dispatch seams.
+
+It does not yet provide generated Spring pipeline execution, WebFlux resources, Reactor context propagation, persistence
+providers, broker integration, or REST/gRPC transport parity.
 
 ## Renderer profile plumbing
 
@@ -57,6 +70,7 @@ To make this explicit and enforceable, this slice adds dependency-seam tests:
 - Quarkus pipeline generation and execution paths remain unchanged.
 - Renderer-profile is now a compile-time configuration surface in deployment.
 - The core/runtime split becomes the stable seam for subsequent Spring adapter work.
+- Spring Boot can now host the neutral adapter registry without importing the Quarkus runtime module.
 
 ## Notes
 

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -64,7 +64,6 @@
         <enablePreview>true</enablePreview>
         <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.amazon.services.bom.version>3.14.1</quarkus.amazon.services.bom.version>
-        <spring.boot.version>4.0.7</spring.boot.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <version.jandex>3.5.0</version.jandex>
@@ -97,13 +96,6 @@
                 <groupId>io.quarkiverse.amazonservices</groupId>
                 <artifactId>quarkus-amazon-services-bom</artifactId>
                 <version>${quarkus.amazon.services.bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -64,6 +64,7 @@
         <enablePreview>true</enablePreview>
         <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.amazon.services.bom.version>3.14.1</quarkus.amazon.services.bom.version>
+        <spring.boot.version>4.0.7</spring.boot.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <version.jandex>3.5.0</version.jandex>
@@ -77,6 +78,7 @@
 
     <modules>
         <module>runtime-core</module>
+        <module>runtime-spring</module>
         <module>runtime</module>
         <module>deployment</module>
     </modules>
@@ -95,6 +97,13 @@
                 <groupId>io.quarkiverse.amazonservices</groupId>
                 <artifactId>quarkus-amazon-services-bom</artifactId>
                 <version>${quarkus.amazon.services.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/framework/runtime-spring/pom.xml
+++ b/framework/runtime-spring/pom.xml
@@ -29,6 +29,22 @@
     <name>The Pipeline Framework Runtime Spring</name>
     <description>Spring Boot adapter for Pipeline Framework runtime-core contracts</description>
 
+    <properties>
+        <spring.boot.version>4.0.7</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.pipelineframework</groupId>

--- a/framework/runtime-spring/pom.xml
+++ b/framework/runtime-spring/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023-2026 Mariano Barcia
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.pipelineframework</groupId>
+        <artifactId>framework-parent</artifactId>
+        <version>26.6.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>pipelineframework-runtime-spring</artifactId>
+    <name>The Pipeline Framework Runtime Spring</name>
+    <description>Spring Boot adapter for Pipeline Framework runtime-core contracts</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.pipelineframework</groupId>
+            <artifactId>pipelineframework-runtime-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdapterBootstrap.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdapterBootstrap.java
@@ -106,16 +106,15 @@ public class SpringRuntimeAdapterBootstrap implements InitializingBean, Disposab
             ownedVirtualThreadExecutor.close();
         } finally {
             synchronized (REGISTRATION_LOCK) {
-                if (registration == null) {
-                    return;
-                }
-                ACTIVE_REGISTRATIONS.remove(registration);
-                registration = null;
-                SpringAdapterRegistration activeRegistration = ACTIVE_REGISTRATIONS.peekLast();
-                if (activeRegistration == null) {
-                    RuntimeAdapters.resetForTests();
-                } else {
-                    activeRegistration.install();
+                if (registration != null) {
+                    ACTIVE_REGISTRATIONS.remove(registration);
+                    registration = null;
+                    SpringAdapterRegistration activeRegistration = ACTIVE_REGISTRATIONS.peekLast();
+                    if (activeRegistration == null) {
+                        RuntimeAdapters.resetForTests();
+                    } else {
+                        activeRegistration.install();
+                    }
                 }
             }
         }

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdapterBootstrap.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdapterBootstrap.java
@@ -16,6 +16,8 @@
 
 package org.pipelineframework.runtime.spring;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -51,12 +53,15 @@ import org.springframework.transaction.support.TransactionTemplate;
  */
 public class SpringRuntimeAdapterBootstrap implements InitializingBean, DisposableBean {
     private static final String EXECUTOR_THREAD_NAME = "tpf-spring-runtime-";
+    private static final Object REGISTRATION_LOCK = new Object();
+    private static final Deque<SpringAdapterRegistration> ACTIVE_REGISTRATIONS = new ArrayDeque<>();
 
     private final ApplicationContext applicationContext;
     private final ApplicationEventPublisher eventPublisher;
     private final Executor executor;
     private final PlatformTransactionManager transactionManager;
     private final ExecutorService ownedVirtualThreadExecutor;
+    private SpringAdapterRegistration registration;
 
     public SpringRuntimeAdapterBootstrap(
         ApplicationContext applicationContext,
@@ -75,14 +80,24 @@ public class SpringRuntimeAdapterBootstrap implements InitializingBean, Disposab
     @Override
     public void afterPropertiesSet() {
         SpringBeanLookup beanLookup = new SpringBeanLookup(applicationContext);
-        RuntimeAdapters.registerBeanLookup(beanLookup);
-        RuntimeAdapters.registerConfigProvider(new SpringConfigProvider(beanLookup));
-        RuntimeAdapters.registerExecutionContextCarrier(new SpringExecutionContextCarrier());
-        RuntimeAdapters.registerReactiveRuntime(new SpringReactiveRuntime(executor, ownedVirtualThreadExecutor));
-        RuntimeAdapters.registerSchedulerBoundary(new SpringSchedulerBoundary(executor));
-        RuntimeAdapters.registerTransactionBoundary(new SpringTransactionBoundary(transactionManager));
-        RuntimeAdapters.registerEventBusBridge(new SpringEventBusBridge(eventPublisher));
-        RuntimeAdapters.registerWorkDispatcher(new SpringWorkDispatcher(eventPublisher));
+        SpringAdapterRegistration nextRegistration = new SpringAdapterRegistration(
+            beanLookup,
+            new SpringConfigProvider(beanLookup),
+            new SpringExecutionContextCarrier(),
+            new SpringReactiveRuntime(executor, ownedVirtualThreadExecutor),
+            new SpringSchedulerBoundary(executor),
+            new SpringTransactionBoundary(transactionManager),
+            new SpringEventBusBridge(eventPublisher),
+            new SpringWorkDispatcher(eventPublisher));
+
+        synchronized (REGISTRATION_LOCK) {
+            if (registration != null) {
+                ACTIVE_REGISTRATIONS.remove(registration);
+            }
+            registration = nextRegistration;
+            ACTIVE_REGISTRATIONS.addLast(nextRegistration);
+            nextRegistration.install();
+        }
     }
 
     @Override
@@ -90,7 +105,41 @@ public class SpringRuntimeAdapterBootstrap implements InitializingBean, Disposab
         try {
             ownedVirtualThreadExecutor.close();
         } finally {
-            RuntimeAdapters.resetForTests();
+            synchronized (REGISTRATION_LOCK) {
+                if (registration == null) {
+                    return;
+                }
+                ACTIVE_REGISTRATIONS.remove(registration);
+                registration = null;
+                SpringAdapterRegistration activeRegistration = ACTIVE_REGISTRATIONS.peekLast();
+                if (activeRegistration == null) {
+                    RuntimeAdapters.resetForTests();
+                } else {
+                    activeRegistration.install();
+                }
+            }
+        }
+    }
+
+    private record SpringAdapterRegistration(
+        BeanLookup beanLookup,
+        ConfigProvider configProvider,
+        ExecutionContextCarrier executionContextCarrier,
+        ReactiveRuntime reactiveRuntime,
+        SchedulerBoundary schedulerBoundary,
+        TransactionBoundary transactionBoundary,
+        EventBusBridge eventBusBridge,
+        WorkDispatcher workDispatcher
+    ) {
+        private void install() {
+            RuntimeAdapters.registerBeanLookup(beanLookup);
+            RuntimeAdapters.registerConfigProvider(configProvider);
+            RuntimeAdapters.registerExecutionContextCarrier(executionContextCarrier);
+            RuntimeAdapters.registerReactiveRuntime(reactiveRuntime);
+            RuntimeAdapters.registerSchedulerBoundary(schedulerBoundary);
+            RuntimeAdapters.registerTransactionBoundary(transactionBoundary);
+            RuntimeAdapters.registerEventBusBridge(eventBusBridge);
+            RuntimeAdapters.registerWorkDispatcher(workDispatcher);
         }
     }
 

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdapterBootstrap.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdapterBootstrap.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+import org.pipelineframework.runtime.core.BeanLookup;
+import org.pipelineframework.runtime.core.ConfigProvider;
+import org.pipelineframework.runtime.core.EventBusBridge;
+import org.pipelineframework.runtime.core.ExecutionContextCarrier;
+import org.pipelineframework.runtime.core.ReactiveRuntime;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
+import org.pipelineframework.runtime.core.SchedulerBoundary;
+import org.pipelineframework.runtime.core.TransactionBoundary;
+import org.pipelineframework.runtime.core.WorkDispatcher;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Lifecycle bean that registers Spring implementations of TPF runtime-core adapters.
+ */
+public class SpringRuntimeAdapterBootstrap implements InitializingBean, DisposableBean {
+    private static final String EXECUTOR_THREAD_NAME = "tpf-spring-runtime-";
+
+    private final ApplicationContext applicationContext;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Executor executor;
+    private final PlatformTransactionManager transactionManager;
+    private final ExecutorService ownedVirtualThreadExecutor;
+
+    public SpringRuntimeAdapterBootstrap(
+        ApplicationContext applicationContext,
+        ApplicationEventPublisher eventPublisher,
+        Executor executor,
+        PlatformTransactionManager transactionManager
+    ) {
+        this.applicationContext = Objects.requireNonNull(applicationContext, "applicationContext");
+        this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+        this.transactionManager = transactionManager;
+        this.ownedVirtualThreadExecutor = Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name(EXECUTOR_THREAD_NAME, 0).factory());
+        this.executor = executor == null ? ownedVirtualThreadExecutor : executor;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        SpringBeanLookup beanLookup = new SpringBeanLookup(applicationContext);
+        RuntimeAdapters.registerBeanLookup(beanLookup);
+        RuntimeAdapters.registerConfigProvider(new SpringConfigProvider(beanLookup));
+        RuntimeAdapters.registerExecutionContextCarrier(new SpringExecutionContextCarrier());
+        RuntimeAdapters.registerReactiveRuntime(new SpringReactiveRuntime(executor, ownedVirtualThreadExecutor));
+        RuntimeAdapters.registerSchedulerBoundary(new SpringSchedulerBoundary(executor));
+        RuntimeAdapters.registerTransactionBoundary(new SpringTransactionBoundary(transactionManager));
+        RuntimeAdapters.registerEventBusBridge(new SpringEventBusBridge(eventPublisher));
+        RuntimeAdapters.registerWorkDispatcher(new SpringWorkDispatcher(eventPublisher));
+    }
+
+    @Override
+    public void destroy() {
+        try {
+            ownedVirtualThreadExecutor.close();
+        } finally {
+            RuntimeAdapters.resetForTests();
+        }
+    }
+
+    private record SpringBeanLookup(ApplicationContext applicationContext) implements BeanLookup {
+        @Override
+        public <T> Optional<T> get(Class<T> beanType) {
+            Objects.requireNonNull(beanType, "beanType");
+            try {
+                return Optional.ofNullable(applicationContext.getBeanProvider(beanType).getIfAvailable());
+            } catch (NoUniqueBeanDefinitionException ex) {
+                return Optional.empty();
+            } catch (BeansException | IllegalStateException ex) {
+                return Optional.empty();
+            }
+        }
+    }
+
+    private record SpringConfigProvider(BeanLookup beanLookup) implements ConfigProvider {
+        @Override
+        public <T> Optional<T> get(Class<T> configType) {
+            return beanLookup.get(configType);
+        }
+    }
+
+    private static final class SpringExecutionContextCarrier implements ExecutionContextCarrier {
+        private static final ThreadLocal<Map<String, Object>> CONTEXT = ThreadLocal.withInitial(HashMap::new);
+
+        @Override
+        public <T> T get(String key, Class<T> type) {
+            Object value = CONTEXT.get().get(key);
+            if (value == null || type == null || !type.isInstance(value)) {
+                return null;
+            }
+            return type.cast(value);
+        }
+
+        @Override
+        public void put(String key, Object value) {
+            if (key == null) {
+                return;
+            }
+            if (value == null) {
+                CONTEXT.get().remove(key);
+            } else {
+                CONTEXT.get().put(key, value);
+            }
+        }
+
+        @Override
+        public void clear(String key) {
+            if (key != null) {
+                CONTEXT.get().remove(key);
+            }
+        }
+
+        @Override
+        public void clear() {
+            CONTEXT.remove();
+        }
+    }
+
+    private static final class SpringReactiveRuntime implements ReactiveRuntime {
+        private final Executor executor;
+        private final Executor virtualThreadExecutor;
+
+        private SpringReactiveRuntime(Executor executor, Executor virtualThreadExecutor) {
+            this.executor = Objects.requireNonNull(executor, "executor");
+            this.virtualThreadExecutor = Objects.requireNonNull(virtualThreadExecutor, "virtualThreadExecutor");
+        }
+
+        @Override
+        public <T> CompletionStage<T> executeBlocking(Supplier<T> supplier, boolean offloadToVirtualThread) {
+            Objects.requireNonNull(supplier, "supplier");
+            return submit(() -> supplier.get(), offloadToVirtualThread ? virtualThreadExecutor : executor);
+        }
+    }
+
+    private static final class SpringSchedulerBoundary implements SchedulerBoundary {
+        private final Executor executor;
+
+        private SpringSchedulerBoundary(Executor executor) {
+            this.executor = Objects.requireNonNull(executor, "executor");
+        }
+
+        @Override
+        public <T> CompletionStage<T> schedule(Callable<T> task) {
+            return submit(task, executor);
+        }
+    }
+
+    private static final class SpringTransactionBoundary implements TransactionBoundary {
+        private final TransactionTemplate transactionTemplate;
+
+        private SpringTransactionBoundary(PlatformTransactionManager transactionManager) {
+            this.transactionTemplate = transactionManager == null ? null : new TransactionTemplate(transactionManager);
+        }
+
+        @Override
+        public <T> T executeInTransaction(Callable<T> callback) {
+            Objects.requireNonNull(callback, "callback");
+            if (transactionTemplate == null) {
+                return call(callback);
+            }
+            return transactionTemplate.execute(status -> call(callback));
+        }
+    }
+
+    private record SpringEventBusBridge(ApplicationEventPublisher eventPublisher) implements EventBusBridge {
+        @Override
+        public void publish(String address, Object event) {
+            eventPublisher.publishEvent(new SpringRuntimeEvent(address, event));
+        }
+    }
+
+    private record SpringWorkDispatcher(ApplicationEventPublisher eventPublisher) implements WorkDispatcher {
+        @Override
+        public CompletionStage<Void> enqueue(Object work) {
+            eventPublisher.publishEvent(new SpringRuntimeWorkEvent(work));
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static <T> CompletionStage<T> submit(Callable<T> task, Executor executor) {
+        Objects.requireNonNull(task, "task");
+        Objects.requireNonNull(executor, "executor");
+        CompletableFuture<T> result = new CompletableFuture<>();
+        try {
+            executor.execute(() -> {
+                try {
+                    result.complete(task.call());
+                } catch (Throwable failure) {
+                    result.completeExceptionally(failure);
+                }
+            });
+        } catch (Throwable failure) {
+            result.completeExceptionally(failure);
+        }
+        return result;
+    }
+
+    private static <T> T call(Callable<T> callback) {
+        try {
+            return callback.call();
+        } catch (RuntimeException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfiguration.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+import java.util.concurrent.Executor;
+
+import org.pipelineframework.runtime.core.RuntimeAdapters;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Spring Boot auto-configuration that installs Spring implementations of TPF runtime-core adapters.
+ */
+@AutoConfiguration
+@ConditionalOnClass(RuntimeAdapters.class)
+public class SpringRuntimeAdaptersAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SpringRuntimeAdapterBootstrap springRuntimeAdapterBootstrap(
+        ApplicationContext applicationContext,
+        ApplicationEventPublisher eventPublisher,
+        ObjectProvider<TaskExecutor> taskExecutor,
+        ObjectProvider<PlatformTransactionManager> transactionManager
+    ) {
+        Executor executor = taskExecutor.getIfAvailable();
+        return new SpringRuntimeAdapterBootstrap(
+            applicationContext,
+            eventPublisher,
+            executor,
+            transactionManager.getIfAvailable());
+    }
+}

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeEvent.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+/**
+ * Spring application event emitted by the TPF runtime-core event bus bridge.
+ *
+ * @param address logical event address
+ * @param payload event payload
+ */
+public record SpringRuntimeEvent(String address, Object payload) {
+}

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeEvent.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeEvent.java
@@ -23,4 +23,10 @@ package org.pipelineframework.runtime.spring;
  * @param payload event payload
  */
 public record SpringRuntimeEvent(String address, Object payload) {
+    public SpringRuntimeEvent {
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("Spring runtime event address must not be blank");
+        }
+        address = address.trim();
+    }
 }

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeWorkEvent.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeWorkEvent.java
@@ -16,10 +16,15 @@
 
 package org.pipelineframework.runtime.spring;
 
+import java.util.Objects;
+
 /**
  * Spring application event emitted by the TPF runtime-core work dispatcher.
  *
  * @param work dispatched work payload
  */
 public record SpringRuntimeWorkEvent(Object work) {
+    public SpringRuntimeWorkEvent {
+        Objects.requireNonNull(work, "work must not be null");
+    }
 }

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeWorkEvent.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeWorkEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+/**
+ * Spring application event emitted by the TPF runtime-core work dispatcher.
+ *
+ * @param work dispatched work payload
+ */
+public record SpringRuntimeWorkEvent(Object work) {
+}

--- a/framework/runtime-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/framework/runtime-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.pipelineframework.runtime.spring.SpringRuntimeAdaptersAutoConfiguration

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/RuntimeSpringDependencyGuardTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/RuntimeSpringDependencyGuardTest.java
@@ -50,7 +50,8 @@ class RuntimeSpringDependencyGuardTest {
 
         assertFalse(pom.contains("<artifactId>pipelineframework</artifactId>"),
             "runtime-spring must depend on runtime-core, not the Quarkus runtime artifact");
-        assertTrue(pom.contains("<artifactId>pipelineframework-runtime-core</artifactId>"));
+        assertTrue(pom.contains("<artifactId>pipelineframework-runtime-core</artifactId>"),
+            "runtime-spring must depend on runtime-core");
     }
 
     private void assertNoForbiddenMainSourceToken(String forbiddenToken) {

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/RuntimeSpringDependencyGuardTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/RuntimeSpringDependencyGuardTest.java
@@ -45,7 +45,7 @@ class RuntimeSpringDependencyGuardTest {
     }
 
     @Test
-    void runtimeSpringDoesNotDependOnQuarkusRuntimeArtifact() throws Exception {
+    void runtimeSpringDoesNotDependOnQuarkusRuntimeArtifact() throws IOException {
         String pom = Files.readString(Path.of("pom.xml"));
 
         assertFalse(pom.contains("<artifactId>pipelineframework</artifactId>"),

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/RuntimeSpringDependencyGuardTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/RuntimeSpringDependencyGuardTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RuntimeSpringDependencyGuardTest {
+
+    @Test
+    void runtimeSpringHasNoQuarkusReferences() {
+        assertNoForbiddenMainSourceToken("io.quarkus.");
+    }
+
+    @Test
+    void runtimeSpringHasNoVertxReferences() {
+        assertNoForbiddenMainSourceToken("io.vertx.");
+    }
+
+    @Test
+    void runtimeSpringHasNoMutinyReferences() {
+        assertNoForbiddenMainSourceToken("io.smallrye.mutiny");
+    }
+
+    @Test
+    void runtimeSpringDoesNotDependOnQuarkusRuntimeArtifact() throws Exception {
+        String pom = Files.readString(Path.of("pom.xml"));
+
+        assertFalse(pom.contains("<artifactId>pipelineframework</artifactId>"),
+            "runtime-spring must depend on runtime-core, not the Quarkus runtime artifact");
+        assertTrue(pom.contains("<artifactId>pipelineframework-runtime-core</artifactId>"));
+    }
+
+    private void assertNoForbiddenMainSourceToken(String forbiddenToken) {
+        List<String> violations = collectViolations(forbiddenToken);
+        assertTrue(
+            violations.isEmpty(),
+            "runtime-spring has forbidden dependency token '" + forbiddenToken + "':\n" + String.join("\n", violations));
+    }
+
+    private List<String> collectViolations(String token) {
+        Path sourceRoot = Path.of("src/main/java");
+        if (!Files.isDirectory(sourceRoot)) {
+            return List.of("Unable to scan runtime-spring sources: missing directory " + sourceRoot);
+        }
+
+        List<String> violations = new ArrayList<>();
+        try (var stream = Files.walk(sourceRoot)) {
+            stream.filter(path -> path.toString().endsWith(".java"))
+                .forEach(path -> collectFileViolations(path, token, violations));
+        } catch (IOException e) {
+            violations.add("Unable to scan runtime-spring sources: " + e.getMessage());
+        }
+        Collections.sort(violations);
+        return violations;
+    }
+
+    private void collectFileViolations(Path path, String token, List<String> violations) {
+        try {
+            List<String> lines = Files.readAllLines(path);
+            for (int lineNo = 1; lineNo <= lines.size(); lineNo++) {
+                if (lines.get(lineNo - 1).contains(token)) {
+                    violations.add(path + ":" + lineNo);
+                }
+            }
+        } catch (IOException e) {
+            violations.add("Unable to read " + path + ": " + e.getMessage());
+        }
+    }
+}

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.pipelineframework.runtime.core.RuntimeAdapters;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -133,6 +134,41 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
             .run(context -> assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isPresent()));
 
         assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isEmpty());
+    }
+
+    @Test
+    void closingLatestContextRestoresPreviousRuntimeAdapters() {
+        AnnotationConfigApplicationContext firstContext = springContextWithService("first");
+        AnnotationConfigApplicationContext secondContext = springContextWithService("second");
+        SpringRuntimeAdapterBootstrap firstBootstrap = new SpringRuntimeAdapterBootstrap(firstContext, firstContext, null, null);
+        SpringRuntimeAdapterBootstrap secondBootstrap = new SpringRuntimeAdapterBootstrap(secondContext, secondContext, null, null);
+
+        try {
+            firstBootstrap.afterPropertiesSet();
+            assertEquals("first", RuntimeAdapters.resolveBean(SampleService.class).orElseThrow().name());
+
+            secondBootstrap.afterPropertiesSet();
+            assertEquals("second", RuntimeAdapters.resolveBean(SampleService.class).orElseThrow().name());
+
+            secondBootstrap.destroy();
+            secondContext.close();
+
+            assertEquals("first", RuntimeAdapters.resolveBean(SampleService.class).orElseThrow().name());
+        } finally {
+            secondBootstrap.destroy();
+            secondContext.close();
+            firstBootstrap.destroy();
+            firstContext.close();
+        }
+
+        assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isEmpty());
+    }
+
+    private AnnotationConfigApplicationContext springContextWithService(String name) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.registerBean(SampleService.class, () -> new SampleService(name));
+        context.refresh();
+        return context;
     }
 
     record SampleService(String name) {

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.runtime.core.RuntimeAdapters;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.event.EventListener;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpringRuntimeAdaptersAutoConfigurationTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(SpringRuntimeAdaptersAutoConfiguration.class));
+
+    @AfterEach
+    void resetAdapters() {
+        RuntimeAdapters.resetForTests();
+    }
+
+    @Test
+    void autoConfigurationRegistersSpringRuntimeAdapters() {
+        contextRunner
+            .withUserConfiguration(SingleBeanConfig.class)
+            .run(context -> {
+                assertTrue(context.containsBean("springRuntimeAdapterBootstrap"));
+                assertEquals("primary", RuntimeAdapters.resolveBean(SampleService.class).orElseThrow().name());
+                assertEquals("config-value", RuntimeAdapters.resolveConfig(SampleConfig.class).orElseThrow().value());
+            });
+    }
+
+    @Test
+    void beanLookupReturnsEmptyForAmbiguousBeansWithoutPrimary() {
+        contextRunner
+            .withUserConfiguration(AmbiguousBeanConfig.class)
+            .run(context -> assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isEmpty()));
+    }
+
+    @Test
+    void executionContextCarrierStoresTypedValues() {
+        contextRunner.run(context -> {
+            RuntimeAdapters.setExecutionContext("tenant", "tenant-1");
+
+            assertEquals("tenant-1", RuntimeAdapters.executionContext("tenant", String.class));
+            assertNull(RuntimeAdapters.executionContext("tenant", Integer.class));
+
+            RuntimeAdapters.clearExecutionContext("tenant");
+            assertNull(RuntimeAdapters.executionContext("tenant", String.class));
+        });
+    }
+
+    @Test
+    void schedulerAndBlockingRuntimeCompleteWork() {
+        contextRunner.run(context -> {
+            assertEquals("scheduled", RuntimeAdapters.schedule(() -> "scheduled")
+                .toCompletableFuture()
+                .get(5, TimeUnit.SECONDS));
+            assertEquals("blocking", RuntimeAdapters.executeBlocking(() -> "blocking", false)
+                .toCompletableFuture()
+                .get(5, TimeUnit.SECONDS));
+            assertTrue(RuntimeAdapters.executeBlocking(() -> Thread.currentThread().isVirtual(), true)
+                .toCompletableFuture()
+                .get(5, TimeUnit.SECONDS));
+        });
+    }
+
+    @Test
+    void transactionBoundaryRunsDirectlyWhenNoTransactionManagerExists() {
+        contextRunner.run(context -> assertEquals("direct", RuntimeAdapters.runInTransaction(() -> "direct")));
+    }
+
+    @Test
+    void transactionBoundaryUsesSpringTransactionManagerWhenPresent() {
+        contextRunner
+            .withUserConfiguration(TransactionManagerConfig.class)
+            .run(context -> {
+                CountingTransactionManager transactionManager = context.getBean(CountingTransactionManager.class);
+
+                assertEquals("transactional", RuntimeAdapters.runInTransaction(() -> "transactional"));
+                assertEquals(1, transactionManager.begins.get());
+                assertEquals(1, transactionManager.commits.get());
+                assertEquals(0, transactionManager.rollbacks.get());
+            });
+    }
+
+    @Test
+    void eventBusAndWorkDispatcherPublishSpringEvents() {
+        contextRunner
+            .withUserConfiguration(EventListenerConfig.class)
+            .run(context -> {
+                RecordingEvents events = context.getBean(RecordingEvents.class);
+
+                RuntimeAdapters.eventBusBridge().publish("orders.ready", "payload");
+                RuntimeAdapters.workDispatcher().enqueue("work-item").toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+                assertEquals(List.of(new SpringRuntimeEvent("orders.ready", "payload")), events.runtimeEvents);
+                assertEquals(List.of(new SpringRuntimeWorkEvent("work-item")), events.workEvents);
+            });
+    }
+
+    @Test
+    void contextShutdownResetsRuntimeAdapters() {
+        contextRunner
+            .withUserConfiguration(SingleBeanConfig.class)
+            .run(context -> assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isPresent()));
+
+        assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isEmpty());
+    }
+
+    record SampleService(String name) {
+    }
+
+    record SampleConfig(String value) {
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class SingleBeanConfig {
+        @Bean
+        SampleService sampleService() {
+            return new SampleService("primary");
+        }
+
+        @Bean
+        SampleConfig sampleConfig() {
+            return new SampleConfig("config-value");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class AmbiguousBeanConfig {
+        @Bean
+        SampleService firstService() {
+            return new SampleService("first");
+        }
+
+        @Bean
+        SampleService secondService() {
+            return new SampleService("second");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TransactionManagerConfig {
+        @Bean
+        @Primary
+        CountingTransactionManager transactionManager() {
+            return new CountingTransactionManager();
+        }
+    }
+
+    static final class CountingTransactionManager implements PlatformTransactionManager {
+        private final AtomicInteger begins = new AtomicInteger();
+        private final AtomicInteger commits = new AtomicInteger();
+        private final AtomicInteger rollbacks = new AtomicInteger();
+
+        @Override
+        public TransactionStatus getTransaction(TransactionDefinition definition) {
+            begins.incrementAndGet();
+            return new SimpleTransactionStatus();
+        }
+
+        @Override
+        public void commit(TransactionStatus status) {
+            commits.incrementAndGet();
+        }
+
+        @Override
+        public void rollback(TransactionStatus status) {
+            rollbacks.incrementAndGet();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class EventListenerConfig {
+        @Bean
+        RecordingEvents recordingEvents() {
+            return new RecordingEvents();
+        }
+    }
+
+    static final class RecordingEvents {
+        private final List<SpringRuntimeEvent> runtimeEvents = new CopyOnWriteArrayList<>();
+        private final List<SpringRuntimeWorkEvent> workEvents = new CopyOnWriteArrayList<>();
+
+        @EventListener
+        void onRuntimeEvent(SpringRuntimeEvent event) {
+            runtimeEvents.add(event);
+        }
+
+        @EventListener
+        void onWorkEvent(SpringRuntimeWorkEvent event) {
+            workEvents.add(event);
+        }
+    }
+}

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
@@ -142,6 +142,8 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
         AnnotationConfigApplicationContext secondContext = springContextWithService("second");
         SpringRuntimeAdapterBootstrap firstBootstrap = new SpringRuntimeAdapterBootstrap(firstContext, firstContext, null, null);
         SpringRuntimeAdapterBootstrap secondBootstrap = new SpringRuntimeAdapterBootstrap(secondContext, secondContext, null, null);
+        boolean firstCleaned = false;
+        boolean secondCleaned = false;
 
         try {
             firstBootstrap.afterPropertiesSet();
@@ -152,13 +154,19 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
 
             secondBootstrap.destroy();
             secondContext.close();
+            secondCleaned = true;
 
             assertEquals("first", RuntimeAdapters.resolveBean(SampleService.class).orElseThrow().name());
         } finally {
-            secondBootstrap.destroy();
-            secondContext.close();
-            firstBootstrap.destroy();
-            firstContext.close();
+            if (!secondCleaned) {
+                secondBootstrap.destroy();
+                secondContext.close();
+            }
+            if (!firstCleaned) {
+                firstBootstrap.destroy();
+                firstContext.close();
+                firstCleaned = true;
+            }
         }
 
         assertTrue(RuntimeAdapters.resolveBean(SampleService.class).isEmpty());


### PR DESCRIPTION
## Summary

Adds the first Spring Boot runtime adapter skeleton while preserving the existing Quarkus path:

- Adds `framework/runtime-spring` as a separate module depending on `runtime-core`, not the Quarkus runtime artifact.
- Registers Spring implementations for the runtime-core seams: bean lookup, config lookup, execution context, scheduler, transaction boundary, event bus, work dispatcher, and blocking/runtime execution.
- Adds Spring Boot auto-configuration metadata and tests covering registration, no-op reset, event/work dispatch, transaction behavior, virtual-thread blocking execution, and dependency guards.
- Updates the portability roadmap docs to record the Spring adapter direction.

## Out of scope

- No Spring renderer or generated Spring application scaffolding yet.
- No Reactor migration.
- No `ExecutionContextCarrier` API change to `Optional<T>`; CodeRabbit suggested this, but it is a `runtime-core` contract change and belongs in a separate core API slice if we want it.
- No Quarkus runtime behavior changes.

## Review notes

Local CodeRabbit CLI was run against `origin/main`. Accepted feedback was fixed in this branch:

- Validate Spring runtime event addresses.
- Reject null Spring work events.
- Avoid unconditional global adapter reset on Spring context destroy by tracking active Spring adapter registrations and restoring the latest remaining registration.
- Tighten the dependency-guard test signature/message.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime-core,runtime-spring test`
- `./mvnw -f framework/pom.xml verify`
- `npm --prefix docs ci`
- `npm --prefix docs run build`
- `git diff --check`

Notes: the Maven runs emit existing JBoss LogManager/classpath warnings, but the test gates pass. `npm --prefix docs ci` reports the repo's existing npm audit findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spring Boot runtime adapter enabling Spring Boot applications to host Pipeline Framework runtime adapters without Quarkus dependencies.
  * Spring-specific integrations now available for bean resolution, transaction boundaries, and event publishing.

* **Documentation**
  * Updated framework portability guide with Spring adapter roadmap, capabilities, and feature parity documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->