### PR TITLE
Add shared release artifact store

### DIFF
--- a/docs/guide/evolve/durable-coordinator/bundle-contract.md
+++ b/docs/guide/evolve/durable-coordinator/bundle-contract.md
@@ -29,4 +29,4 @@ Existing executions, retries, await resumes, and result reads stay pinned to the
 
 Workers must already host matching code. The coordinator validates, activates, pins, and dispatches releases; it does not dynamically load registered artifacts into a worker runtime.
 
-Local artifact storage is still local to the coordinator host. Multi-coordinator self-host deployments should use the S3-compatible artifact store so every coordinator validates the same managed artifact object.
+Local artifact storage is still local to the coordinator host. Multi-coordinator self-host deployments should use the S3-compatible artifact store only for coordinator-managed blob artifacts. Container images should stay in OCI registries and be referenced by digest from the release descriptor.

--- a/docs/guide/evolve/durable-coordinator/bundle-contract.md
+++ b/docs/guide/evolve/durable-coordinator/bundle-contract.md
@@ -19,7 +19,7 @@ The self-host release path has three runtime pieces:
 
 1. `PipelineReleaseRegistry` stores release records and activation history for each tenant and pipeline.
 2. `PipelineReleaseRegistrar` validates `pipeline-release.json` and verifies artifact identity.
-3. `PipelineReleaseArtifactStore` stores local executable artifacts in a coordinator-owned content-addressed store where applicable.
+3. `PipelineReleaseArtifactStore` stores executable artifacts in a coordinator-owned content-addressed store where applicable.
 
 Hosted-style execution submission requires `pipelineId`. The coordinator resolves the active release, verifies the stored artifact, verifies worker availability, and stores `pipelineId + contractVersion + releaseVersion` on the `ExecutionRecord`.
 
@@ -29,4 +29,4 @@ Existing executions, retries, await resumes, and result reads stay pinned to the
 
 Workers must already host matching code. The coordinator validates, activates, pins, and dispatches releases; it does not dynamically load registered artifacts into a worker runtime.
 
-Local artifact storage is still local to the coordinator host. Multi-host artifact replication remains deployment-owned until a shared artifact-store provider exists.
+Local artifact storage is still local to the coordinator host. Multi-coordinator self-host deployments should use the S3-compatible artifact store so every coordinator validates the same managed artifact object.

--- a/docs/guide/evolve/durable-coordinator/local-apis.md
+++ b/docs/guide/evolve/durable-coordinator/local-apis.md
@@ -31,10 +31,11 @@ Enable the local release admin resource:
 pipeline.orchestrator.admin.enabled=true
 pipeline.orchestrator.admin.admin-token=local-admin-token
 pipeline.orchestrator.releases.registry.provider=file
+pipeline.orchestrator.releases.storage.provider=local
 pipeline.orchestrator.releases.storage.root=target/tpf-releases
 ```
 
-Use `pipeline.orchestrator.releases.registry.provider=dynamo` plus `pipeline.orchestrator.dynamo.release-table` when the release metadata must survive multiple coordinator instances. The Dynamo registry stores immutable release records and append-only activation events.
+Use `pipeline.orchestrator.releases.registry.provider=dynamo` plus `pipeline.orchestrator.dynamo.release-table` when the release metadata must survive multiple coordinator instances. Pair it with `pipeline.orchestrator.releases.storage.provider=s3` for shared artifact storage. The Dynamo registry stores immutable release records and append-only activation events.
 
 Main endpoints:
 
@@ -44,4 +45,4 @@ Main endpoints:
 4. `GET /tpf/admin/tenants/{tenantId}/pipelines/{pipelineId}/releases/{releaseVersion}`
 5. `POST /tpf/admin/tenants/{tenantId}/pipelines/{pipelineId}/releases/{releaseVersion}/activate`
 
-The registration API accepts an absolute local `pipeline-release.json` path. The release descriptor pins one or more artifacts by kind and digest. For executable local JAR artifacts, the registrar validates embedded `META-INF/pipeline/pipeline-contract.json`, copies the JAR into the local store, records size/checksum metadata, and stores the managed artifact path.
+The registration API accepts an absolute local `pipeline-release.json` path. The release descriptor pins one or more artifacts by kind and digest. For executable local artifacts, the registrar validates embedded `META-INF/pipeline/pipeline-contract.json` when present, copies the artifact into the configured release artifact store, records size/checksum metadata, and stores the managed artifact URI.

--- a/docs/guide/evolve/durable-coordinator/local-apis.md
+++ b/docs/guide/evolve/durable-coordinator/local-apis.md
@@ -35,7 +35,7 @@ pipeline.orchestrator.releases.storage.provider=local
 pipeline.orchestrator.releases.storage.root=target/tpf-releases
 ```
 
-Use `pipeline.orchestrator.releases.registry.provider=dynamo` plus `pipeline.orchestrator.dynamo.release-table` when the release metadata must survive multiple coordinator instances. Pair it with `pipeline.orchestrator.releases.storage.provider=s3` for shared artifact storage. The Dynamo registry stores immutable release records and append-only activation events.
+Use `pipeline.orchestrator.releases.registry.provider=dynamo` plus `pipeline.orchestrator.dynamo.release-table` when the release metadata must survive multiple coordinator instances. Pair it with `pipeline.orchestrator.releases.storage.provider=s3` only for artifacts that should be coordinator-managed blobs. Container images should stay in OCI registries and be referenced by digest. The Dynamo registry stores immutable release records and append-only activation events.
 
 Main endpoints:
 
@@ -45,4 +45,4 @@ Main endpoints:
 4. `GET /tpf/admin/tenants/{tenantId}/pipelines/{pipelineId}/releases/{releaseVersion}`
 5. `POST /tpf/admin/tenants/{tenantId}/pipelines/{pipelineId}/releases/{releaseVersion}/activate`
 
-The registration API accepts an absolute local `pipeline-release.json` path. The release descriptor pins one or more artifacts by kind and digest. For executable local artifacts, the registrar validates embedded `META-INF/pipeline/pipeline-contract.json` when present, copies the artifact into the configured release artifact store, records size/checksum metadata, and stores the managed artifact URI.
+The registration API accepts an absolute local `pipeline-release.json` path. The release descriptor pins one or more artifacts by kind and digest. For executable local artifacts, the registrar validates embedded `META-INF/pipeline/pipeline-contract.json` when present, copies the artifact into the configured release artifact store, records size/checksum metadata, and stores the managed artifact URI. For container-image artifacts, registration records the immutable OCI reference; platform deployment and worker capability checks prove the running worker identity.

--- a/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
+++ b/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
@@ -87,7 +87,7 @@ The release descriptor accepts these artifact kinds:
 | `lambda-image` | `oci://ecr.example/payment-lambda@sha256:...` | OCI registry, usually ECR for AWS Lambda | AWS Lambda container image. |
 | `external-endpoint` | `https://payments.internal/step` | existing service deployment and service discovery | Pre-existing service that satisfies a step contract. |
 
-Local artifacts are valid, but they still need a digest. Current runtime validation is strongest for local/JAR artifacts. Container, function, and external endpoint artifacts are descriptor-level identities until platform-specific deployers and richer worker capability metadata mature.
+Local artifacts are valid, but they still need a digest. Current runtime validation is strongest for local/JAR artifacts. Container images are already treated as digest-backed release identities and remain in OCI registries. Function and external endpoint artifacts are descriptor-level identities until platform-specific deployers and richer worker capability metadata mature.
 
 Production releases should prefer immutable references in the artifact's native repository: OCI digests for images, Maven coordinates plus checksum for JVM artifacts, S3 object version plus checksum for ZIP/blob artifacts, or a signed local manifest in air-gapped deployments.
 

--- a/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
+++ b/docs/guide/evolve/durable-coordinator/pipeline-contract-release-model.md
@@ -36,7 +36,7 @@ Inter-pipeline handoff contracts remain a follow-up extension.
 
 ## Release Descriptor
 
-`pipeline-release.json` is emitted by a build or release process after artifacts are built and addressable.
+`pipeline-release.json` is emitted by a build or release process after artifacts are built and addressable in the system that naturally owns that artifact form. TPF should not force every artifact through one store.
 
 It includes:
 
@@ -73,21 +73,31 @@ Example:
 
 The coordinator validates and activates releases. It does not become the deployment engine. Platform-specific tools deploy the artifacts, then the coordinator verifies that workers report matching contract/release capability before accepting work.
 
-## Artifact Kinds
+## Artifact Form Factors
 
 The release descriptor accepts these artifact kinds:
 
-| Kind | Example | Typical use |
+| Kind | Example | Primary backing system | Typical use |
 | --- | --- | --- |
-| `local-file` | `/var/lib/tpf/artifacts/worker.jar` | Local/self-host pilots and air-gapped installs. |
-| `jar` | `file:///opt/tpf/restaurant-worker.jar` or Maven coordinates plus checksum | JVM worker process. |
-| `native-binary` | `/opt/tpf/workers/payment-worker` | Quarkus native worker. |
-| `container-image` | `oci://ecr.example/payments/worker@sha256:...` | Kubernetes, ECS, and production container platforms. |
-| `lambda-zip` | `s3://bucket/payment-worker.zip#sha256:...` | AWS Lambda zip deployment. |
-| `lambda-image` | `oci://ecr.example/payment-lambda@sha256:...` | AWS Lambda container image. |
-| `external-endpoint` | `https://payments.internal/step` | Pre-existing service that satisfies a step contract. |
+| `local-file` | `/var/lib/tpf/artifacts/worker.jar` | local filesystem or managed blob store | Local/self-host pilots and air-gapped installs. |
+| `jar` | Maven coordinate plus checksum or `file:///opt/tpf/restaurant-worker.jar` | Maven repository, JFrog Artifactory, Nexus, or managed blob store | JVM worker process. |
+| `native-binary` | `/opt/tpf/workers/payment-worker` | local filesystem, generic OCI artifact, or managed blob store | Quarkus native worker. |
+| `container-image` | `oci://ecr.example/payments/worker@sha256:...` | OCI registry: ECR, GHCR, JFrog, Harbor, Docker registry | Kubernetes, ECS, and production container platforms. |
+| `lambda-zip` | `s3://bucket/payment-worker.zip#sha256:...` | S3 or S3-compatible object store | AWS Lambda zip deployment. |
+| `lambda-image` | `oci://ecr.example/payment-lambda@sha256:...` | OCI registry, usually ECR for AWS Lambda | AWS Lambda container image. |
+| `external-endpoint` | `https://payments.internal/step` | existing service deployment and service discovery | Pre-existing service that satisfies a step contract. |
 
-Local artifacts are valid, but they still need a digest. Current runtime validation is strongest for local/JAR artifacts. Container, function, and external endpoint artifacts are descriptor-level identities until platform-specific deployers and richer worker capability metadata mature. Production releases should prefer immutable references such as OCI digests, S3 object version plus checksum, Maven coordinate plus checksum, or a signed local manifest in air-gapped deployments.
+Local artifacts are valid, but they still need a digest. Current runtime validation is strongest for local/JAR artifacts. Container, function, and external endpoint artifacts are descriptor-level identities until platform-specific deployers and richer worker capability metadata mature.
+
+Production releases should prefer immutable references in the artifact's native repository: OCI digests for images, Maven coordinates plus checksum for JVM artifacts, S3 object version plus checksum for ZIP/blob artifacts, or a signed local manifest in air-gapped deployments.
+
+### S3 Is A Blob Store, Not The Artifact Repository Strategy
+
+The S3-compatible release artifact store exists so a self-hosted coordinator can copy and verify blob-like artifacts that do not already live in a better artifact repository. Good fits are local/JAR/native artifacts in small self-host installs, Lambda ZIP packages, release descriptor blobs, provenance attachments, and MinIO/LocalStack development setups.
+
+It is not the preferred target for container images. Tools such as Jib produce OCI images; those should be pushed to an OCI registry and referenced from `pipeline-release.json` by immutable digest. TPF should not copy those images into S3.
+
+The release descriptor is the integration point across repositories. A single release can pin a Jib-produced image in ECR, a JVM helper artifact in JFrog, and a Lambda ZIP in S3, while the coordinator validates the contract/release identity and worker capability reports.
 
 ## Ownership Models
 
@@ -132,6 +142,6 @@ CNAB, Open Application Model, Serverless Workflow, and CDEvents are useful refer
 
 ## Relationship To Current Runtime
 
-The current self-host runtime registers releases directly. For local/JAR artifacts, registration can inspect embedded `META-INF/pipeline/pipeline-contract.json` and rejects artifacts whose contract identity does not match the release descriptor.
+The current self-host runtime registers releases directly. For local/JAR artifacts, registration can inspect embedded `META-INF/pipeline/pipeline-contract.json` and rejects artifacts whose contract identity does not match the release descriptor. For container images, the runtime treats the digest as release identity and relies on platform deployment plus worker capability checks; it does not pull, unpack, or copy image layers.
 
 The coordinator validates, activates, pins, and dispatches releases. Platform-specific tools still deploy artifacts outside TPF.

--- a/docs/guide/evolve/durable-coordinator/runtime-boundaries-performance.md
+++ b/docs/guide/evolve/durable-coordinator/runtime-boundaries-performance.md
@@ -43,8 +43,8 @@ The relevant cost boundary is not class count. It is where work runs.
 
 | Path | Work performed | Performance expectation |
 | --- | --- | --- |
-| Admin registration | parse release descriptor, inspect local/JAR artifact, compute checksum, copy managed artifact | off hot path; can perform blocking file work |
-| Activation | update active release pointer and validate stored artifact identity | operator path; not per transition |
+| Admin registration | parse release descriptor, inspect local/JAR artifact, compute checksum, copy or upload managed artifact | off hot path; can perform blocking file/network work |
+| Activation | append activation metadata and validate stored artifact identity | operator path; not per transition |
 | Hosted submit | read active release, verify stored artifact metadata, check worker capability, create execution | one-time admission cost per execution |
 | Transition dispatch | claim lease, build pinned transition envelope, invoke selected worker, commit outcome | hot path; must not hash artifacts or scan registries |
 | Await resume | use release identity pinned on the execution record | hot path; independent of the currently active release |
@@ -70,4 +70,5 @@ This split is intentionally bounded. It does not move the transition worker prot
 1. The one-process monolith remains valid for local/dev proof, not as the recommended separated deployment.
 2. Worker lifecycle, heartbeat, drain, and stale-worker state are still outside this slice.
 3. File-backed release registry is still local/single-coordinator oriented; Dynamo release metadata is the HA path.
-4. Runtime worker-reported artifact digest drift remains a follow-up; current capability checks cover pipeline, contract, release, and executable bundle identity.
+4. Local release artifact storage is still local/single-coordinator oriented; S3-compatible release artifact storage is the multi-coordinator path.
+5. Runtime worker-reported artifact digest drift remains a follow-up; current capability checks cover pipeline, contract, release, and configured artifact identity.

--- a/docs/guide/evolve/durable-coordinator/runtime-boundaries-performance.md
+++ b/docs/guide/evolve/durable-coordinator/runtime-boundaries-performance.md
@@ -43,7 +43,7 @@ The relevant cost boundary is not class count. It is where work runs.
 
 | Path | Work performed | Performance expectation |
 | --- | --- | --- |
-| Admin registration | parse release descriptor, inspect local/JAR artifact, compute checksum, copy or upload managed artifact | off hot path; can perform blocking file/network work |
+| Admin registration | parse release descriptor, inspect local/JAR artifact, compute checksum, copy/upload coordinator-managed blobs, record immutable external artifact references | off hot path; can perform blocking file/network work |
 | Activation | append activation metadata and validate stored artifact identity | operator path; not per transition |
 | Hosted submit | read active release, verify stored artifact metadata, check worker capability, create execution | one-time admission cost per execution |
 | Transition dispatch | claim lease, build pinned transition envelope, invoke selected worker, commit outcome | hot path; must not hash artifacts or scan registries |
@@ -70,5 +70,5 @@ This split is intentionally bounded. It does not move the transition worker prot
 1. The one-process monolith remains valid for local/dev proof, not as the recommended separated deployment.
 2. Worker lifecycle, heartbeat, drain, and stale-worker state are still outside this slice.
 3. File-backed release registry is still local/single-coordinator oriented; Dynamo release metadata is the HA path.
-4. Local release artifact storage is still local/single-coordinator oriented; S3-compatible release artifact storage is the multi-coordinator path.
+4. Local release artifact storage is still local/single-coordinator oriented; S3-compatible release artifact storage is the multi-coordinator path only for blob artifacts that the coordinator manages directly.
 5. Runtime worker-reported artifact digest drift remains a follow-up; current capability checks cover pipeline, contract, release, and configured artifact identity.

--- a/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
@@ -24,7 +24,7 @@ This is the fastest way to prove the model, but it is not crash-surviving HA. If
 
 Use this shape when you want a real control-plane/data-plane boundary.
 
-The coordinator process enables the control-plane and admin APIs, owns execution/await state, and selects a remote transition worker through configured REST or gRPC target properties. Worker processes host the same pipeline bundle code and expose the default-disabled worker endpoint or service.
+The coordinator process enables the control-plane and admin APIs, owns execution/await state, and selects a remote transition worker through configured REST or gRPC target properties. Worker processes host the same pipeline release code and expose the default-disabled worker endpoint or service.
 
 REST worker selection example:
 
@@ -83,7 +83,10 @@ pipeline.orchestrator.admin.enabled=true
 pipeline.orchestrator.admin.admin-token-ref=env:TPF_ADMIN_TOKEN
 
 pipeline.orchestrator.releases.registry.provider=dynamo
-pipeline.orchestrator.releases.storage.root=/var/lib/tpf/releases
+pipeline.orchestrator.releases.storage.provider=s3
+pipeline.orchestrator.releases.storage.s3.bucket=tpf-release-artifacts
+pipeline.orchestrator.releases.storage.s3.prefix=tpf/releases
+pipeline.orchestrator.releases.storage.s3.region=eu-west-1
 ```
 
 The await interaction table must provide these ALL-projected GSIs:
@@ -99,6 +102,8 @@ SQS request/reply worker protocol has one additional v1 constraint: `pipeline.or
 
 The Dynamo release registry stores immutable release records plus append-only activation events. Active release lookup reads the latest activation event for the tenant and pipeline; it does not update a mutable active pointer. New coordinator metadata stores should follow this rule. Existing execution and await Dynamo stores still use conditional updates for leases and state transitions until that storage model is redesigned.
 
+For one-process local development, use `pipeline.orchestrator.releases.storage.provider=local` with `pipeline.orchestrator.releases.storage.root=/var/lib/tpf/releases`. For multi-coordinator self-host deployments, prefer the S3-compatible provider so every coordinator verifies the same managed artifact object. AWS S3, MinIO, and LocalStack-style endpoints fit this model; use `endpoint-override` and `path-style-access=true` for non-AWS S3-compatible stores.
+
 ## Startup Checklist
 
 Before accepting work:
@@ -111,7 +116,7 @@ Before accepting work:
 6. Register and activate the release for the tenant and pipeline.
 7. Submit one canary execution and verify status, pending await interaction, completion, and result.
 
-The current coordinator does not dynamically load registered JAR code. Release registration validates the release descriptor and, for local executable JAR artifacts, validates and stores the artifact. Workers must already host matching code. Worker availability checks verify the active contract/release identity before hosted execution submission, and artifact id/digest when both sides provide it.
+The current coordinator does not dynamically load registered JAR code. Release registration validates the release descriptor and, for local executable artifacts, validates and stores the artifact in the configured release artifact store. Workers must already host matching code. Worker availability checks verify the active contract/release identity before hosted execution submission, and artifact id/digest when both sides provide it.
 
 `pipeline.orchestrator.control-plane.require-remote-worker=true` is recommended for separated self-host deployments. It prevents a coordinator process from silently falling back to the local in-process worker when no REST, gRPC, or SQS worker target is configured. Leave it disabled for the one-process local demo. See [Runtime Boundaries And Performance](/guide/evolve/durable-coordinator/runtime-boundaries-performance).
 
@@ -159,11 +164,11 @@ There is no built-in generic DLQ replay endpoint yet. The DLQ proves durable fai
 
 The current safe upgrade procedure is conservative:
 
-1. Deploy workers that host the new bundle version.
+1. Deploy workers that host the new release version.
 2. Register and activate the new release.
 3. Submit canary executions and verify worker availability and results.
-4. Leave old workers running until executions pinned to the old bundle drain.
-5. Stop old workers only after status queries show no active executions for the old bundle.
+4. Leave old workers running until executions pinned to the old release drain.
+5. Stop old workers only after status queries show no active executions for the old release.
 
 There is no worker lifecycle registry yet. Operators must track healthy, stale, draining, and unavailable worker states outside the framework for now.
 
@@ -192,4 +197,4 @@ This recipe intentionally does not include:
 5. worker registration, heartbeat, or drain state,
 6. production tenancy, RBAC, or org/principal management.
 
-The file-backed bundle registry is suitable for local/dev and single-coordinator self-host pilots. Use the Dynamo release registry for multi-coordinator release metadata. Artifact storage is still local filesystem based in this recipe; shared or replicated artifact storage remains deployment-owned.
+The file-backed release registry is suitable for local/dev and single-coordinator self-host pilots. Use the Dynamo release registry for multi-coordinator release metadata. Use the S3-compatible release artifact store for shared artifact objects across coordinator instances.

--- a/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
@@ -102,7 +102,20 @@ SQS request/reply worker protocol has one additional v1 constraint: `pipeline.or
 
 The Dynamo release registry stores immutable release records plus append-only activation events. Active release lookup reads the latest activation event for the tenant and pipeline; it does not update a mutable active pointer. New coordinator metadata stores should follow this rule. Existing execution and await Dynamo stores still use conditional updates for leases and state transitions until that storage model is redesigned.
 
-For one-process local development, use `pipeline.orchestrator.releases.storage.provider=local` with `pipeline.orchestrator.releases.storage.root=/var/lib/tpf/releases`. For multi-coordinator self-host deployments, prefer the S3-compatible provider so every coordinator verifies the same managed artifact object. AWS S3, MinIO, and LocalStack-style endpoints fit this model; use `endpoint-override` and `path-style-access=true` for non-AWS S3-compatible stores.
+For one-process local development, use `pipeline.orchestrator.releases.storage.provider=local` with `pipeline.orchestrator.releases.storage.root=/var/lib/tpf/releases`.
+
+For multi-coordinator self-host deployments, choose the artifact backing system by artifact form:
+
+| Artifact form | Recommended backing system |
+| --- | --- |
+| Container worker image, including Jib output | OCI registry such as ECR, GHCR, JFrog, Harbor, or Docker registry. Reference by digest in `pipeline-release.json`; do not copy image layers into the coordinator artifact store. |
+| JVM JAR | Maven/JFrog/Nexus when it is a published JVM artifact, or S3-compatible blob storage when the coordinator must manage the blob directly. |
+| Native binary | OCI generic artifact, local managed filesystem for single-host, or S3-compatible blob storage for shared self-host access. |
+| Lambda ZIP | S3 or S3-compatible object storage. |
+| Lambda container image | OCI registry, usually ECR on AWS. |
+| External endpoint | Existing deployment/service discovery; the descriptor pins endpoint identity and digest/provenance metadata where available. |
+
+The S3-compatible provider is therefore a shared blob-store option, not the default artifact repository strategy. AWS S3, MinIO, and LocalStack-style endpoints fit this model; use `endpoint-override` and `path-style-access=true` for non-AWS S3-compatible stores.
 
 ## Startup Checklist
 
@@ -116,7 +129,7 @@ Before accepting work:
 6. Register and activate the release for the tenant and pipeline.
 7. Submit one canary execution and verify status, pending await interaction, completion, and result.
 
-The current coordinator does not dynamically load registered JAR code. Release registration validates the release descriptor and, for local executable artifacts, validates and stores the artifact in the configured release artifact store. Workers must already host matching code. Worker availability checks verify the active contract/release identity before hosted execution submission, and artifact id/digest when both sides provide it.
+The current coordinator does not dynamically load registered code. Release registration validates the release descriptor and, for local executable artifacts, validates and stores the artifact in the configured release artifact store. Container images remain in the OCI registry; the coordinator records their immutable reference and uses worker capability checks to verify that deployed workers host the active release. Workers must already host matching code. Worker availability checks verify the active contract/release identity before hosted execution submission, and artifact id/digest when both sides provide it.
 
 `pipeline.orchestrator.control-plane.require-remote-worker=true` is recommended for separated self-host deployments. It prevents a coordinator process from silently falling back to the local in-process worker when no REST, gRPC, or SQS worker target is configured. Leave it disabled for the one-process local demo. See [Runtime Boundaries And Performance](/guide/evolve/durable-coordinator/runtime-boundaries-performance).
 
@@ -197,4 +210,4 @@ This recipe intentionally does not include:
 5. worker registration, heartbeat, or drain state,
 6. production tenancy, RBAC, or org/principal management.
 
-The file-backed release registry is suitable for local/dev and single-coordinator self-host pilots. Use the Dynamo release registry for multi-coordinator release metadata. Use the S3-compatible release artifact store for shared artifact objects across coordinator instances.
+The file-backed release registry is suitable for local/dev and single-coordinator self-host pilots. Use the Dynamo release registry for multi-coordinator release metadata. Use the S3-compatible release artifact store only for artifacts that should be coordinator-managed blobs; use OCI or Maven-style repositories for artifacts that already have native repository semantics.

--- a/docs/guide/evolve/durable-coordinator/worker-protocols.md
+++ b/docs/guide/evolve/durable-coordinator/worker-protocols.md
@@ -9,7 +9,7 @@ The coordinator owns durable state and scheduling. The worker owns business step
 The worker receives a `TransitionCommandEnvelope` containing:
 
 1. tenant and execution identity,
-2. pipeline and bundle identity,
+2. pipeline, contract, and release identity,
 3. current step index and attempt,
 4. transition key and result shape,
 5. typed serialized payload metadata.

--- a/examples/restaurant-approval/self-host/README.md
+++ b/examples/restaurant-approval/self-host/README.md
@@ -152,7 +152,7 @@ Current recovery boundary: this self-host reference exposes status, terminal err
 ## What This Proves
 
 1. A coordinator process can submit and inspect executions without using generated `/pipeline/*` app routes.
-2. Bundle registration, activation, artifact storage, execution pinning, and worker availability checks are exercised.
+2. Release registration, activation, artifact storage, execution pinning, and worker availability checks are exercised.
 3. Local transition execution works without configuring a remote worker target.
 4. Await suspension and completion happen through the hosted control-plane API.
 5. Terminal failure and DLQ publication are visible in the self-host operator flow.

--- a/framework/runtime/pom.xml
+++ b/framework/runtime/pom.xml
@@ -221,6 +221,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
         </dependency>
     </dependencies>

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineExecutionService.java
@@ -60,6 +60,7 @@ import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
 import org.pipelineframework.orchestrator.TransitionPayloadCodec;
 import org.pipelineframework.orchestrator.TransitionResultEnvelope;
 import org.pipelineframework.orchestrator.TransitionWorkerCommand;
+import org.pipelineframework.orchestrator.release.PipelineContractDescriptor;
 import org.pipelineframework.step.StepManyToMany;
 import org.pipelineframework.step.functional.ManyToOne;
 
@@ -381,6 +382,12 @@ public class PipelineExecutionService implements PipelineTransitionWorker {
   private java.util.Optional<String> validateCommandIdentity(
       TransitionCommandEnvelope command,
       boolean allowLocalFallbackIdentity) {
+    if (allowLocalFallbackIdentity
+        && PipelineContractDescriptor.DEFAULT_PIPELINE_ID.equals(command.pipelineId())
+        && PipelineContractDescriptor.DEFAULT_CONTRACT_VERSION.equals(command.contractVersion())
+        && PipelineContractDescriptor.DEFAULT_CONTRACT_VERSION.equals(command.releaseVersion())) {
+      return java.util.Optional.empty();
+    }
     return releaseIdentityResolver().validateCommandIdentity(command, orchestratorConfig);
   }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/GrpcPipelineTransitionWorker.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/GrpcPipelineTransitionWorker.java
@@ -83,7 +83,7 @@ public class GrpcPipelineTransitionWorker implements PipelineTransitionWorker, T
     }
 
     /**
-     * Fetches worker bundle capabilities from the gRPC worker.
+     * Fetches worker release capabilities from the gRPC worker.
      *
      * @return remote worker capabilities
      */

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/LocalPipelineReleaseArtifactStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/LocalPipelineReleaseArtifactStore.java
@@ -95,10 +95,20 @@ public class LocalPipelineReleaseArtifactStore implements PipelineReleaseArtifac
         if (artifactUri == null || artifactUri.isBlank()) {
             throw new IllegalArgumentException("Release artifact URI is required");
         }
-        if (artifactUri.startsWith("file:")) {
-            return Path.of(URI.create(artifactUri));
+        URI uri;
+        try {
+            uri = URI.create(artifactUri);
+        } catch (IllegalArgumentException ignored) {
+            return Path.of(artifactUri);
         }
-        return Path.of(artifactUri);
+        if (uri.getScheme() == null) {
+            return Path.of(artifactUri);
+        }
+        if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return Path.of(uri);
+        }
+        throw new IllegalArgumentException(
+            "Unsupported release artifact URI scheme for local artifact store: " + uri.getScheme());
     }
 
     private Path artifactPath(String checksum, Path sourcePath) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/LocalPipelineReleaseArtifactStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/LocalPipelineReleaseArtifactStore.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.orchestrator;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -39,7 +40,7 @@ public class LocalPipelineReleaseArtifactStore implements PipelineReleaseArtifac
             Files.createDirectories(target.getParent());
             if (Files.exists(target)) {
                 verifyStoredArtifact(target, size, checksum);
-                return new PipelineReleaseStoredArtifact(target.toString(), size, checksum);
+                return new PipelineReleaseStoredArtifact(target.toUri().toString(), size, checksum);
             }
             Path temporary = Files.createTempFile(target.getParent(), "release-artifact-", ".tmp");
             try {
@@ -48,20 +49,20 @@ public class LocalPipelineReleaseArtifactStore implements PipelineReleaseArtifac
                     Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE);
                 } catch (FileAlreadyExistsException e) {
                     verifyStoredArtifact(target, size, checksum);
-                    return new PipelineReleaseStoredArtifact(target.toString(), size, checksum);
+                    return new PipelineReleaseStoredArtifact(target.toUri().toString(), size, checksum);
                 } catch (AtomicMoveNotSupportedException e) {
                     try {
                         Files.move(temporary, target);
                     } catch (FileAlreadyExistsException alreadyStored) {
                         verifyStoredArtifact(target, size, checksum);
-                        return new PipelineReleaseStoredArtifact(target.toString(), size, checksum);
+                        return new PipelineReleaseStoredArtifact(target.toUri().toString(), size, checksum);
                     }
                 }
             } finally {
                 Files.deleteIfExists(temporary);
             }
             verifyStoredArtifact(target, size, checksum);
-            return new PipelineReleaseStoredArtifact(target.toString(), size, checksum);
+            return new PipelineReleaseStoredArtifact(target.toUri().toString(), size, checksum);
         } catch (IllegalArgumentException | IllegalStateException e) {
             throw e;
         } catch (Exception e) {
@@ -76,7 +77,7 @@ public class LocalPipelineReleaseArtifactStore implements PipelineReleaseArtifac
         }
         try {
             verifyStoredArtifact(
-                Path.of(record.primaryArtifactPath()),
+                artifactPathFromUri(record.primaryArtifactUri()),
                 record.primaryArtifactSizeBytes(),
                 record.primaryArtifactChecksum());
         } catch (IllegalArgumentException | IllegalStateException e) {
@@ -88,6 +89,16 @@ public class LocalPipelineReleaseArtifactStore implements PipelineReleaseArtifac
 
     Path root() {
         return root;
+    }
+
+    static Path artifactPathFromUri(String artifactUri) {
+        if (artifactUri == null || artifactUri.isBlank()) {
+            throw new IllegalArgumentException("Release artifact URI is required");
+        }
+        if (artifactUri.startsWith("file:")) {
+            return Path.of(URI.create(artifactUri));
+        }
+        return Path.of(artifactUri);
     }
 
     private Path artifactPath(String checksum, Path sourcePath) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineBundleCapabilities.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineBundleCapabilities.java
@@ -3,9 +3,9 @@ package org.pipelineframework.orchestrator;
 import java.util.List;
 
 /**
- * Runtime capabilities declared by a generated pipeline bundle.
+ * Runtime capabilities declared by a generated pipeline contract.
  *
- * @param localTransitionExecution whether the bundle can execute transitions in-process
+ * @param localTransitionExecution whether the runtime can execute transitions in-process
  * @param transitionWorkerProtocols supported transition worker protocols
  */
 public record PipelineBundleCapabilities(

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineOrchestratorConfig.java
@@ -531,12 +531,12 @@ public interface PipelineOrchestratorConfig {
     }
 
     /**
-     * Local/dev hosted bundle registry and artifact storage settings.
+     * Release registry and artifact storage settings.
      */
     interface ReleasesConfig {
 
         /**
-         * Bundle registry metadata provider settings.
+         * Release registry metadata provider settings.
          *
          * @return registry config
          */
@@ -544,7 +544,7 @@ public interface PipelineOrchestratorConfig {
         ReleaseRegistryConfig registry();
 
         /**
-         * Bundle artifact storage settings.
+         * Release artifact storage settings.
          *
          * @return storage config
          */
@@ -553,7 +553,7 @@ public interface PipelineOrchestratorConfig {
     }
 
     /**
-     * Bundle registry provider settings.
+     * Release registry provider settings.
      */
     interface ReleaseRegistryConfig {
 
@@ -573,6 +573,15 @@ public interface PipelineOrchestratorConfig {
     interface ReleaseStorageConfig {
 
         /**
+         * Release artifact storage provider name.
+         *
+         * @return local or s3
+         */
+        @WithName("provider")
+        @WithDefault("local")
+        String provider();
+
+        /**
          * Local root directory for managed release artifacts and file-backed registry metadata.
          *
          * @return storage root path
@@ -580,6 +589,62 @@ public interface PipelineOrchestratorConfig {
         @WithName("root")
         @WithDefault("target/tpf-releases")
         String root();
+
+        /**
+         * S3-compatible release artifact storage settings.
+         *
+         * @return S3 storage config
+         */
+        @WithName("s3")
+        ReleaseStorageS3Config s3();
+    }
+
+    /**
+     * S3-compatible release artifact storage settings.
+     */
+    interface ReleaseStorageS3Config {
+
+        /**
+         * Bucket for managed release artifacts.
+         *
+         * @return bucket name
+         */
+        @WithName("bucket")
+        Optional<String> bucket();
+
+        /**
+         * Object key prefix for managed release artifacts.
+         *
+         * @return object key prefix
+         */
+        @WithName("prefix")
+        @WithDefault("tpf/releases")
+        String prefix();
+
+        /**
+         * Optional S3 region override.
+         *
+         * @return region
+         */
+        @WithName("region")
+        Optional<String> region();
+
+        /**
+         * Optional S3-compatible endpoint override, for example MinIO or LocalStack.
+         *
+         * @return endpoint URI
+         */
+        @WithName("endpoint-override")
+        Optional<String> endpointOverride();
+
+        /**
+         * Enable path-style access for MinIO/LocalStack style endpoints.
+         *
+         * @return true when path-style access should be used
+         */
+        @WithName("path-style-access")
+        @WithDefault("false")
+        boolean pathStyleAccess();
     }
 
     /**

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseRuntimeBeans.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseRuntimeBeans.java
@@ -7,8 +7,11 @@ import org.pipelineframework.orchestrator.release.PipelineReleaseRegistry;
 import java.nio.file.Path;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
  * Selects local/dev release runtime collaborators from orchestrator config.
@@ -20,6 +23,9 @@ public class PipelineReleaseRuntimeBeans {
 
     @Inject
     PipelineOrchestratorConfig orchestratorConfig;
+
+    @Inject
+    Instance<S3Client> s3Clients;
 
     @Produces
     @ApplicationScoped
@@ -33,10 +39,25 @@ public class PipelineReleaseRuntimeBeans {
             return new LocalPipelineReleaseArtifactStore(storageRoot());
         }
         if ("s3".equalsIgnoreCase(provider)) {
-            return new S3PipelineReleaseArtifactStore(orchestratorConfig);
+            return new S3PipelineReleaseArtifactStore(
+                s3Clients.get(),
+                S3PipelineReleaseArtifactStore.bucket(orchestratorConfig),
+                S3PipelineReleaseArtifactStore.prefix(orchestratorConfig));
         }
         throw new IllegalStateException(
             "Unsupported pipeline.orchestrator.releases.storage.provider '" + provider + "'");
+    }
+
+    @Produces
+    @ApplicationScoped
+    S3Client s3Client() {
+        return S3PipelineReleaseArtifactStore.newClient(orchestratorConfig);
+    }
+
+    void closeS3Client(@Disposes S3Client client) {
+        if (client != null) {
+            client.close();
+        }
     }
 
     @Produces

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseRuntimeBeans.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseRuntimeBeans.java
@@ -24,7 +24,19 @@ public class PipelineReleaseRuntimeBeans {
     @Produces
     @ApplicationScoped
     PipelineReleaseArtifactStore pipelineReleaseArtifactStore() {
-        return new LocalPipelineReleaseArtifactStore(storageRoot());
+        String provider = orchestratorConfig == null
+            || orchestratorConfig.releases() == null
+            || orchestratorConfig.releases().storage() == null
+                ? "local"
+                : orchestratorConfig.releases().storage().provider();
+        if (provider == null || provider.isBlank() || "local".equalsIgnoreCase(provider)) {
+            return new LocalPipelineReleaseArtifactStore(storageRoot());
+        }
+        if ("s3".equalsIgnoreCase(provider)) {
+            return new S3PipelineReleaseArtifactStore(orchestratorConfig);
+        }
+        throw new IllegalStateException(
+            "Unsupported pipeline.orchestrator.releases.storage.provider '" + provider + "'");
     }
 
     @Produces

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseStoredArtifact.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseStoredArtifact.java
@@ -3,12 +3,12 @@ package org.pipelineframework.orchestrator;
 import java.util.Objects;
 
 public record PipelineReleaseStoredArtifact(
-    String artifactPath,
+    String artifactUri,
     long artifactSizeBytes,
     String artifactChecksum
 ) {
     public PipelineReleaseStoredArtifact {
-        Objects.requireNonNull(artifactPath, "artifactPath");
+        Objects.requireNonNull(artifactUri, "artifactUri");
         Objects.requireNonNull(artifactChecksum, "artifactChecksum");
         if (artifactSizeBytes < 0) {
             throw new IllegalArgumentException("artifactSizeBytes must be non-negative");

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/RestPipelineTransitionWorker.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/RestPipelineTransitionWorker.java
@@ -79,7 +79,7 @@ public class RestPipelineTransitionWorker implements PipelineTransitionWorker, T
     }
 
     /**
-     * Fetches worker bundle capabilities from the REST worker.
+     * Fetches worker release capabilities from the REST worker.
      *
      * @return remote worker capabilities
      */

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStore.java
@@ -32,10 +32,6 @@ public class S3PipelineReleaseArtifactStore implements PipelineReleaseArtifactSt
     private final String bucket;
     private final String prefix;
 
-    public S3PipelineReleaseArtifactStore(PipelineOrchestratorConfig config) {
-        this(newClient(config), bucket(config), prefix(config));
-    }
-
     S3PipelineReleaseArtifactStore(S3Client client, String bucket, String prefix) {
         if (client == null) {
             throw new IllegalArgumentException("S3 client is required");
@@ -123,7 +119,7 @@ public class S3PipelineReleaseArtifactStore implements PipelineReleaseArtifactSt
         return prefix.isBlank() ? key : prefix + "/" + key;
     }
 
-    private static S3Client newClient(PipelineOrchestratorConfig config) {
+    static S3Client newClient(PipelineOrchestratorConfig config) {
         PipelineOrchestratorConfig.ReleaseStorageS3Config s3 = s3Config(config);
         var builder = S3Client.builder()
             .httpClientBuilder(UrlConnectionHttpClient.builder())
@@ -139,14 +135,14 @@ public class S3PipelineReleaseArtifactStore implements PipelineReleaseArtifactSt
         return builder.build();
     }
 
-    private static String bucket(PipelineOrchestratorConfig config) {
+    static String bucket(PipelineOrchestratorConfig config) {
         return s3Config(config).bucket()
             .filter(value -> !value.isBlank())
             .orElseThrow(() -> new IllegalStateException(
                 "pipeline.orchestrator.releases.storage.s3.bucket must not be blank"));
     }
 
-    private static String prefix(PipelineOrchestratorConfig config) {
+    static String prefix(PipelineOrchestratorConfig config) {
         return s3Config(config).prefix();
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStore.java
@@ -1,0 +1,219 @@
+package org.pipelineframework.orchestrator;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Locale;
+
+import org.pipelineframework.orchestrator.release.PipelineReleaseRecord;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * S3-compatible release artifact store for multi-coordinator self-hosted deployments.
+ */
+public class S3PipelineReleaseArtifactStore implements PipelineReleaseArtifactStore {
+
+    private static final String SHA_256_PREFIX = "sha256:";
+
+    private final S3Client client;
+    private final String bucket;
+    private final String prefix;
+
+    public S3PipelineReleaseArtifactStore(PipelineOrchestratorConfig config) {
+        this(newClient(config), bucket(config), prefix(config));
+    }
+
+    S3PipelineReleaseArtifactStore(S3Client client, String bucket, String prefix) {
+        if (client == null) {
+            throw new IllegalArgumentException("S3 client is required");
+        }
+        if (bucket == null || bucket.isBlank()) {
+            throw new IllegalArgumentException(
+                "pipeline.orchestrator.releases.storage.s3.bucket must not be blank");
+        }
+        this.client = client;
+        this.bucket = bucket.trim();
+        this.prefix = normalizePrefix(prefix);
+    }
+
+    @Override
+    public PipelineReleaseStoredArtifact store(Path sourcePath) {
+        if (sourcePath == null || !Files.isRegularFile(sourcePath) || !Files.isReadable(sourcePath)) {
+            throw new IllegalArgumentException("artifactPath must point to a readable release artifact");
+        }
+        try {
+            String checksum = checksum(sourcePath);
+            long size = Files.size(sourcePath);
+            String key = objectKey(checksum, sourcePath);
+            client.putObject(
+                PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .metadata(java.util.Map.of(
+                        "sha256", stripChecksumPrefix(checksum),
+                        "size", Long.toString(size)))
+                    .build(),
+                RequestBody.fromFile(sourcePath));
+            return new PipelineReleaseStoredArtifact(s3Uri(bucket, key), size, checksum);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to store S3 release artifact: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void verify(PipelineReleaseRecord record) {
+        if (record == null) {
+            throw new IllegalArgumentException("Release record is required");
+        }
+        S3Location location = parse(record.primaryArtifactUri());
+        try {
+            HeadObjectResponse head = client.headObject(HeadObjectRequest.builder()
+                .bucket(location.bucket())
+                .key(location.key())
+                .build());
+            if (record.primaryArtifactSizeBytes() >= 0
+                && head.contentLength() != record.primaryArtifactSizeBytes()) {
+                throw new IllegalStateException("Stored S3 release artifact size does not match registry metadata");
+            }
+            String checksum = checksum(client.getObject(GetObjectRequest.builder()
+                .bucket(location.bucket())
+                .key(location.key())
+                .build()));
+            if (!checksum.equals(record.primaryArtifactChecksum())) {
+                throw new IllegalStateException("Stored S3 release artifact checksum does not match registry metadata");
+            }
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw e;
+        } catch (S3Exception e) {
+            throw new IllegalStateException("Stored S3 release artifact is missing or unreadable", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to verify S3 release artifact: " + e.getMessage(), e);
+        }
+    }
+
+    String bucket() {
+        return bucket;
+    }
+
+    String prefix() {
+        return prefix;
+    }
+
+    private String objectKey(String checksum, Path sourcePath) {
+        String filename = stripChecksumPrefix(checksum);
+        String sourceName = sourcePath.getFileName() == null ? "" : sourcePath.getFileName().toString();
+        int dot = sourceName.lastIndexOf('.');
+        String extension = dot >= 0 ? sourceName.substring(dot) : ".artifact";
+        String key = "sha256/" + filename + extension;
+        return prefix.isBlank() ? key : prefix + "/" + key;
+    }
+
+    private static S3Client newClient(PipelineOrchestratorConfig config) {
+        PipelineOrchestratorConfig.ReleaseStorageS3Config s3 = s3Config(config);
+        var builder = S3Client.builder()
+            .httpClientBuilder(UrlConnectionHttpClient.builder())
+            .serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(s3.pathStyleAccess())
+                .build());
+        s3.region().filter(value -> !value.isBlank())
+            .map(Region::of)
+            .ifPresent(builder::region);
+        s3.endpointOverride().filter(value -> !value.isBlank())
+            .map(URI::create)
+            .ifPresent(builder::endpointOverride);
+        return builder.build();
+    }
+
+    private static String bucket(PipelineOrchestratorConfig config) {
+        return s3Config(config).bucket()
+            .filter(value -> !value.isBlank())
+            .orElseThrow(() -> new IllegalStateException(
+                "pipeline.orchestrator.releases.storage.s3.bucket must not be blank"));
+    }
+
+    private static String prefix(PipelineOrchestratorConfig config) {
+        return s3Config(config).prefix();
+    }
+
+    private static PipelineOrchestratorConfig.ReleaseStorageS3Config s3Config(PipelineOrchestratorConfig config) {
+        if (config == null || config.releases() == null || config.releases().storage() == null
+            || config.releases().storage().s3() == null) {
+            throw new IllegalStateException(
+                "S3 release artifact store requires pipeline.orchestrator.releases.storage.s3.* configuration");
+        }
+        return config.releases().storage().s3();
+    }
+
+    private static S3Location parse(String artifactUri) {
+        if (artifactUri == null || artifactUri.isBlank()) {
+            throw new IllegalArgumentException("Release artifact URI is required");
+        }
+        URI uri = URI.create(artifactUri);
+        if (!"s3".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null || uri.getHost().isBlank()) {
+            throw new IllegalArgumentException("Release artifact URI must use s3://bucket/key");
+        }
+        String key = uri.getPath() == null ? "" : uri.getPath().replaceFirst("^/", "");
+        if (key.isBlank()) {
+            throw new IllegalArgumentException("Release artifact URI must include an object key");
+        }
+        return new S3Location(uri.getHost(), key);
+    }
+
+    private static String s3Uri(String bucket, String key) {
+        return "s3://" + bucket + "/" + key;
+    }
+
+    private static String normalizePrefix(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return value.trim().replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+
+    private static String checksum(Path path) throws Exception {
+        try (InputStream input = Files.newInputStream(path)) {
+            return checksum(input);
+        }
+    }
+
+    private static String checksum(InputStream input) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream stream = input) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = stream.read(buffer)) >= 0) {
+                if (read > 0) {
+                    digest.update(buffer, 0, read);
+                }
+            }
+        }
+        return SHA_256_PREFIX + HexFormat.of().formatHex(digest.digest()).toLowerCase(Locale.ROOT);
+    }
+
+    private static String stripChecksumPrefix(String checksum) {
+        if (checksum == null || checksum.isBlank()) {
+            throw new IllegalArgumentException("Artifact checksum is required");
+        }
+        return checksum.startsWith(SHA_256_PREFIX)
+            ? checksum.substring(SHA_256_PREFIX.length())
+            : checksum;
+    }
+
+    private record S3Location(String bucket, String key) {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/TransitionResultEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/TransitionResultEnvelope.java
@@ -130,7 +130,7 @@ public record TransitionResultEnvelope(
      * Returns output items in the representation the coordinator should persist.
      * In-process workers can carry decoded Java objects. Remote workers return
      * portable payload envelopes, which the coordinator must not eagerly decode
-     * when it may not own the application bundle classes.
+     * when it may not own the application classes.
      *
      * @return decoded local outputs or serialized remote outputs
      */

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/DynamoPipelineReleaseRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/DynamoPipelineReleaseRegistry.java
@@ -48,7 +48,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
     private static final String RELEASE_VERSION = "release_version";
     private static final String PRIMARY_ARTIFACT_ID = "primary_artifact_id";
     private static final String PRIMARY_ARTIFACT_DIGEST = "primary_artifact_digest";
-    private static final String PRIMARY_ARTIFACT_PATH = "primary_artifact_path";
+    private static final String PRIMARY_ARTIFACT_URI = "primary_artifact_uri";
     private static final String PRIMARY_ARTIFACT_SIZE_BYTES = "primary_artifact_size_bytes";
     private static final String PRIMARY_ARTIFACT_CHECKSUM = "primary_artifact_checksum";
     private static final String DESCRIPTOR_JSON = "descriptor_json";
@@ -271,7 +271,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
             fromJson(stringValue(item, DESCRIPTOR_JSON), PipelineReleaseDescriptor.class),
             stringValue(item, PRIMARY_ARTIFACT_ID),
             stringValue(item, PRIMARY_ARTIFACT_DIGEST),
-            stringValue(item, PRIMARY_ARTIFACT_PATH),
+            stringValue(item, PRIMARY_ARTIFACT_URI),
             longValue(item, PRIMARY_ARTIFACT_SIZE_BYTES),
             stringValue(item, PRIMARY_ARTIFACT_CHECKSUM),
             fromJson(stringValue(item, CONTRACT_JSON), PipelineContractDescriptor.class),
@@ -291,7 +291,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
             Map.entry(RELEASE_VERSION, avS(record.releaseVersion())),
             Map.entry(PRIMARY_ARTIFACT_ID, avS(record.primaryArtifactId())),
             Map.entry(PRIMARY_ARTIFACT_DIGEST, avS(record.primaryArtifactDigest())),
-            Map.entry(PRIMARY_ARTIFACT_PATH, avS(record.primaryArtifactPath())),
+            Map.entry(PRIMARY_ARTIFACT_URI, avS(record.primaryArtifactUri())),
             Map.entry(PRIMARY_ARTIFACT_SIZE_BYTES, avN(record.primaryArtifactSizeBytes())),
             Map.entry(PRIMARY_ARTIFACT_CHECKSUM, avS(record.primaryArtifactChecksum())),
             Map.entry(DESCRIPTOR_JSON, avS(toJson(record.descriptor()))),
@@ -429,7 +429,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
             && left.releaseVersion().equals(right.releaseVersion())
             && left.primaryArtifactId().equals(right.primaryArtifactId())
             && left.primaryArtifactDigest().equals(right.primaryArtifactDigest())
-            && left.primaryArtifactPath().equals(right.primaryArtifactPath())
+            && left.primaryArtifactUri().equals(right.primaryArtifactUri())
             && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
             && left.primaryArtifactChecksum().equals(right.primaryArtifactChecksum())
             && toJson(left.descriptor()).equals(toJson(right.descriptor()))

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/DynamoPipelineReleaseRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/DynamoPipelineReleaseRegistry.java
@@ -49,6 +49,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
     private static final String PRIMARY_ARTIFACT_ID = "primary_artifact_id";
     private static final String PRIMARY_ARTIFACT_DIGEST = "primary_artifact_digest";
     private static final String PRIMARY_ARTIFACT_URI = "primary_artifact_uri";
+    private static final String LEGACY_PRIMARY_ARTIFACT_PATH = "primary_artifact_path";
     private static final String PRIMARY_ARTIFACT_SIZE_BYTES = "primary_artifact_size_bytes";
     private static final String PRIMARY_ARTIFACT_CHECKSUM = "primary_artifact_checksum";
     private static final String DESCRIPTOR_JSON = "descriptor_json";
@@ -133,7 +134,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
             record.releaseVersion());
         if (existing.isPresent()) {
             PipelineReleaseRecord current = existing.get();
-            if (!sameImmutableMetadata(current, record)) {
+            if (!PipelineReleaseRecordMetadata.sameImmutableMetadata(current, record)) {
                 throw new IllegalStateException("Release version is already registered with different metadata");
             }
             return current;
@@ -149,7 +150,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
         } catch (ConditionalCheckFailedException ignored) {
             PipelineReleaseRecord current = getBlocking(record.tenantId(), record.pipelineId(), record.releaseVersion())
                 .orElseThrow(() -> new IllegalStateException("Release registration lost race but no record was found"));
-            if (!sameImmutableMetadata(current, record)) {
+            if (!PipelineReleaseRecordMetadata.sameImmutableMetadata(current, record)) {
                 throw new IllegalStateException("Release version is already registered with different metadata");
             }
             return current;
@@ -271,7 +272,7 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
             fromJson(stringValue(item, DESCRIPTOR_JSON), PipelineReleaseDescriptor.class),
             stringValue(item, PRIMARY_ARTIFACT_ID),
             stringValue(item, PRIMARY_ARTIFACT_DIGEST),
-            stringValue(item, PRIMARY_ARTIFACT_URI),
+            artifactUriValue(item),
             longValue(item, PRIMARY_ARTIFACT_SIZE_BYTES),
             stringValue(item, PRIMARY_ARTIFACT_CHECKSUM),
             fromJson(stringValue(item, CONTRACT_JSON), PipelineContractDescriptor.class),
@@ -400,6 +401,19 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
         return value.s();
     }
 
+    private static String artifactUriValue(Map<String, AttributeValue> item) {
+        AttributeValue current = item.get(PRIMARY_ARTIFACT_URI);
+        if (current != null && current.s() != null && !current.s().isBlank()) {
+            return current.s();
+        }
+        AttributeValue legacy = item.get(LEGACY_PRIMARY_ARTIFACT_PATH);
+        if (legacy != null && legacy.s() != null && !legacy.s().isBlank()) {
+            return legacy.s();
+        }
+        throw new IllegalStateException(
+            "Dynamo release registry record is missing string attribute " + PRIMARY_ARTIFACT_URI);
+    }
+
     private static long longValue(Map<String, AttributeValue> item, String name) {
         AttributeValue value = item.get(name);
         if (value == null || value.n() == null) {
@@ -422,18 +436,6 @@ public class DynamoPipelineReleaseRegistry implements PipelineReleaseRegistry {
         } catch (Exception e) {
             throw new IllegalStateException("Failed deserializing release registry value " + type.getName(), e);
         }
-    }
-
-    private static boolean sameImmutableMetadata(PipelineReleaseRecord left, PipelineReleaseRecord right) {
-        return left.contractVersion().equals(right.contractVersion())
-            && left.releaseVersion().equals(right.releaseVersion())
-            && left.primaryArtifactId().equals(right.primaryArtifactId())
-            && left.primaryArtifactDigest().equals(right.primaryArtifactDigest())
-            && left.primaryArtifactUri().equals(right.primaryArtifactUri())
-            && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
-            && left.primaryArtifactChecksum().equals(right.primaryArtifactChecksum())
-            && toJson(left.descriptor()).equals(toJson(right.descriptor()))
-            && toJson(left.contract()).equals(toJson(right.contract()));
     }
 
     private static <T> Uni<T> blocking(java.util.function.Supplier<T> supplier) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/FileBackedPipelineReleaseRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/FileBackedPipelineReleaseRegistry.java
@@ -170,7 +170,7 @@ public class FileBackedPipelineReleaseRegistry implements PipelineReleaseRegistr
 
     private static boolean sameMetadata(PipelineReleaseRecord left, PipelineReleaseRecord right) {
         return left.contractVersion().equals(right.contractVersion())
-            && left.primaryArtifactPath().equals(right.primaryArtifactPath())
+            && left.primaryArtifactUri().equals(right.primaryArtifactUri())
             && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
             && left.primaryArtifactChecksum().equals(right.primaryArtifactChecksum());
     }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/FileBackedPipelineReleaseRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/FileBackedPipelineReleaseRegistry.java
@@ -45,7 +45,7 @@ public class FileBackedPipelineReleaseRegistry implements PipelineReleaseRegistr
                     .findFirst();
                 if (existing.isPresent()) {
                     PipelineReleaseRecord value = existing.get();
-                    if (!sameMetadata(value, record)) {
+                    if (!PipelineReleaseRecordMetadata.sameImmutableMetadata(value, record)) {
                         throw new IllegalStateException(
                             "Release version is already registered with different metadata");
                     }
@@ -168,10 +168,4 @@ public class FileBackedPipelineReleaseRegistry implements PipelineReleaseRegistr
             && record.releaseVersion().equals(releaseVersion);
     }
 
-    private static boolean sameMetadata(PipelineReleaseRecord left, PipelineReleaseRecord right) {
-        return left.contractVersion().equals(right.contractVersion())
-            && left.primaryArtifactUri().equals(right.primaryArtifactUri())
-            && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
-            && left.primaryArtifactChecksum().equals(right.primaryArtifactChecksum());
-    }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/InMemoryPipelineReleaseRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/InMemoryPipelineReleaseRegistry.java
@@ -26,7 +26,7 @@ public class InMemoryPipelineReleaseRegistry implements PipelineReleaseRegistry 
                 String key = key(record.tenantId(), record.pipelineId(), record.releaseVersion());
                 PipelineReleaseRecord existing = releasesByKey.get(key);
                 if (existing != null) {
-                    if (!sameMetadata(existing, record)) {
+                    if (!PipelineReleaseRecordMetadata.sameImmutableMetadata(existing, record)) {
                         throw new IllegalStateException(
                             "Release version is already registered with different metadata");
                     }
@@ -105,10 +105,4 @@ public class InMemoryPipelineReleaseRegistry implements PipelineReleaseRegistry 
         return tenantId + "\u001f" + pipelineId + "\u001f" + releaseVersion;
     }
 
-    private static boolean sameMetadata(PipelineReleaseRecord left, PipelineReleaseRecord right) {
-        return left.contractVersion().equals(right.contractVersion())
-            && left.primaryArtifactUri().equals(right.primaryArtifactUri())
-            && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
-            && left.primaryArtifactChecksum().equals(right.primaryArtifactChecksum());
-    }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/InMemoryPipelineReleaseRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/InMemoryPipelineReleaseRegistry.java
@@ -107,7 +107,7 @@ public class InMemoryPipelineReleaseRegistry implements PipelineReleaseRegistry 
 
     private static boolean sameMetadata(PipelineReleaseRecord left, PipelineReleaseRecord right) {
         return left.contractVersion().equals(right.contractVersion())
-            && left.primaryArtifactPath().equals(right.primaryArtifactPath())
+            && left.primaryArtifactUri().equals(right.primaryArtifactUri())
             && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
             && left.primaryArtifactChecksum().equals(right.primaryArtifactChecksum());
     }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/PipelineReleaseRecord.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/PipelineReleaseRecord.java
@@ -14,7 +14,7 @@ public record PipelineReleaseRecord(
     PipelineReleaseDescriptor descriptor,
     String primaryArtifactId,
     String primaryArtifactDigest,
-    String primaryArtifactPath,
+    String primaryArtifactUri,
     long primaryArtifactSizeBytes,
     String primaryArtifactChecksum,
     PipelineContractDescriptor contract,
@@ -31,7 +31,7 @@ public record PipelineReleaseRecord(
         Objects.requireNonNull(descriptor, "descriptor");
         primaryArtifactId = primaryArtifactId == null ? "" : primaryArtifactId;
         primaryArtifactDigest = primaryArtifactDigest == null ? "" : primaryArtifactDigest;
-        primaryArtifactPath = primaryArtifactPath == null ? "" : primaryArtifactPath;
+        primaryArtifactUri = primaryArtifactUri == null ? "" : primaryArtifactUri;
         primaryArtifactChecksum = primaryArtifactChecksum == null ? "" : primaryArtifactChecksum;
     }
 
@@ -45,7 +45,7 @@ public record PipelineReleaseRecord(
             descriptor,
             primaryArtifactId,
             primaryArtifactDigest,
-            primaryArtifactPath,
+            primaryArtifactUri,
             primaryArtifactSizeBytes,
             primaryArtifactChecksum,
             contract,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/PipelineReleaseRecordMetadata.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/PipelineReleaseRecordMetadata.java
@@ -1,0 +1,21 @@
+package org.pipelineframework.orchestrator.release;
+
+import java.util.Objects;
+
+final class PipelineReleaseRecordMetadata {
+
+    private PipelineReleaseRecordMetadata() {
+    }
+
+    static boolean sameImmutableMetadata(PipelineReleaseRecord left, PipelineReleaseRecord right) {
+        return Objects.equals(left.contractVersion(), right.contractVersion())
+            && Objects.equals(left.releaseVersion(), right.releaseVersion())
+            && Objects.equals(left.primaryArtifactId(), right.primaryArtifactId())
+            && Objects.equals(left.primaryArtifactDigest(), right.primaryArtifactDigest())
+            && Objects.equals(left.primaryArtifactUri(), right.primaryArtifactUri())
+            && left.primaryArtifactSizeBytes() == right.primaryArtifactSizeBytes()
+            && Objects.equals(left.primaryArtifactChecksum(), right.primaryArtifactChecksum())
+            && Objects.equals(left.descriptor(), right.descriptor())
+            && Objects.equals(left.contract(), right.contract());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/PipelineReleaseRegistrar.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/release/PipelineReleaseRegistrar.java
@@ -73,7 +73,7 @@ public class PipelineReleaseRegistrar {
             descriptor,
             primary.artifactId(),
             primary.artifactDigest(),
-            primary.artifactPath(),
+            primary.artifactUri(),
             primary.artifactSizeBytes(),
             primary.artifactChecksum(),
             primary.contract().orElse(null),
@@ -95,7 +95,7 @@ public class PipelineReleaseRegistrar {
         if (record == null) {
             throw new IllegalArgumentException("Release record is required");
         }
-        if (record.primaryArtifactPath() != null && !record.primaryArtifactPath().isBlank()) {
+        if (record.primaryArtifactUri() != null && !record.primaryArtifactUri().isBlank()) {
             artifactStore().verify(record);
         }
     }
@@ -154,7 +154,7 @@ public class PipelineReleaseRegistrar {
         return new ValidatedArtifact(
             artifact.artifactId(),
             artifact.digest(),
-            stored.artifactPath(),
+            stored.artifactUri(),
             stored.artifactSizeBytes(),
             stored.artifactChecksum(),
             Optional.of(contract));
@@ -164,15 +164,16 @@ public class PipelineReleaseRegistrar {
         PipelineReleaseDescriptor descriptor,
         PipelineReleaseArtifactDescriptor artifact) {
         Path artifactPath = readableLocalPath(artifact, "Release local artifact must point to a readable file");
-        String checksum = validateDigest(artifact, artifactPath);
+        validateDigest(artifact, artifactPath);
         Optional<PipelineContractDescriptor> contract = loadContractFromJar(artifactPath);
         contract.ifPresent(value -> validateContractCompatibility(descriptor, value));
+        PipelineReleaseStoredArtifact stored = artifactStore().store(artifactPath);
         return new ValidatedArtifact(
             artifact.artifactId(),
             artifact.digest(),
-            artifactPath.toAbsolutePath().normalize().toString(),
-            size(artifactPath),
-            "sha256:" + checksum,
+            stored.artifactUri(),
+            stored.artifactSizeBytes(),
+            stored.artifactChecksum(),
             contract);
     }
 
@@ -228,14 +229,6 @@ public class PipelineReleaseRegistrar {
         return Path.of(uri).toAbsolutePath().normalize();
     }
 
-    private static long size(Path path) {
-        try {
-            return Files.size(path);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to read artifact size: " + e.getMessage(), e);
-        }
-    }
-
     private static String sha256(Path path) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
@@ -279,7 +272,7 @@ public class PipelineReleaseRegistrar {
     private record ValidatedArtifact(
         String artifactId,
         String artifactDigest,
-        String artifactPath,
+        String artifactUri,
         long artifactSizeBytes,
         String artifactChecksum,
         Optional<PipelineContractDescriptor> contract

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/worker/DefaultPipelineWorkerAvailability.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/worker/DefaultPipelineWorkerAvailability.java
@@ -15,7 +15,7 @@ import org.pipelineframework.orchestrator.RestPipelineTransitionWorker;
 import org.pipelineframework.orchestrator.TransitionPayloadEncoding;
 
 /**
- * Checks bundle availability on the worker selected by runtime configuration.
+ * Checks release availability on the worker selected by runtime configuration.
  */
 @ApplicationScoped
 public class DefaultPipelineWorkerAvailability implements PipelineWorkerAvailability {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/worker/PipelineWorkerAvailability.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/worker/PipelineWorkerAvailability.java
@@ -5,12 +5,12 @@ import org.pipelineframework.orchestrator.worker.PipelineWorkerAvailabilityResul
 import io.smallrye.mutiny.Uni;
 
 /**
- * Checks whether the selected transition worker can execute a pinned bundle.
+ * Checks whether the selected transition worker can execute a pinned release.
  */
 public interface PipelineWorkerAvailability {
 
     /**
-     * Checks selected worker availability for a hosted bundle.
+     * Checks selected worker availability for a hosted release.
      *
      * @param request availability request
      * @return availability result

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/worker/PipelineWorkerAvailabilityResult.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/worker/PipelineWorkerAvailabilityResult.java
@@ -6,9 +6,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Selected worker availability for a pinned bundle.
+ * Selected worker availability for a pinned release.
  *
- * @param available true when the worker can execute the requested bundle
+ * @param available true when the worker can execute the requested release
  * @param providerName selected worker provider
  * @param capability worker capability when available
  * @param message diagnostic message

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineExecutionServiceTest.java
@@ -128,12 +128,12 @@ class PipelineExecutionServiceTest {
             "application/tpf-transition+json",
             "{not-json");
         when(releaseIdentityResolver.validateCommandIdentity(command, null))
-            .thenReturn(Optional.of("bundle mismatch"));
+            .thenReturn(Optional.of("identity mismatch sentinel"));
 
         TransitionResultEnvelope result = service.executeTransition(command).await().indefinitely();
 
         assertEquals(TransitionWorkerOutcome.FAILED, result.outcome());
-        assertTrue(result.failure().message().contains("bundle mismatch"));
+        assertTrue(result.failure().message().contains("identity mismatch sentinel"));
     }
 
     @Test
@@ -142,7 +142,7 @@ class PipelineExecutionServiceTest {
             "tenant-1",
             "exec-6",
             "local-pipeline",
-            "local-bundle",
+            "local-contract",
             0,
             0,
             ExecutionResultShape.SINGLE,
@@ -152,13 +152,10 @@ class PipelineExecutionServiceTest {
             "java.lang.String",
             "application/tpf-transition+json",
             "\"input\"");
-        when(releaseIdentityResolver.validateCommandIdentity(command, null))
-            .thenReturn(Optional.of("bundle mismatch"));
-
         TransitionResultEnvelope result = service.executeTransition(command).await().indefinitely();
 
         assertEquals(TransitionWorkerOutcome.FAILED, result.outcome());
-        assertFalse(result.failure().message().contains("bundle mismatch"));
+        assertFalse(result.failure().message().contains("identity mismatch sentinel"));
     }
 
     @Test
@@ -167,7 +164,7 @@ class PipelineExecutionServiceTest {
             "tenant-1",
             "exec-7",
             "local-pipeline",
-            "local-bundle",
+            "local-contract",
             0,
             0,
             ExecutionResultShape.SINGLE,
@@ -178,11 +175,11 @@ class PipelineExecutionServiceTest {
             "application/tpf-transition+json",
             "\"input\"");
         when(releaseIdentityResolver.validateCommandIdentity(command, null))
-            .thenReturn(Optional.of("bundle mismatch"));
+            .thenReturn(Optional.of("identity mismatch sentinel"));
 
         TransitionResultEnvelope result = service.executePortableTransition(command).await().indefinitely();
 
         assertEquals(TransitionWorkerOutcome.FAILED, result.outcome());
-        assertTrue(result.failure().message().contains("bundle mismatch"));
+        assertTrue(result.failure().message().contains("identity mismatch sentinel"));
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/HostedPipelineControlPlaneResourceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/HostedPipelineControlPlaneResourceTest.java
@@ -354,7 +354,7 @@ class HostedPipelineControlPlaneResourceTest {
         PipelineReleaseRecord release = releaseRecord();
         when(releaseRegistry.active("tenant-1", "org.example.restaurant"))
             .thenReturn(Uni.createFrom().item(Optional.of(release)));
-        doThrow(new IllegalStateException("Stored bundle artifact is missing or unreadable"))
+        doThrow(new IllegalStateException("Stored release artifact is missing or unreadable"))
             .when(releaseRegistrar).verify(release);
         HostedExecutionSubmitRequest request = new HostedExecutionSubmitRequest(
             "org.example.restaurant",

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStoreTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStoreTest.java
@@ -1,0 +1,167 @@
+package org.pipelineframework.orchestrator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.orchestrator.release.PipelineContractDescriptor;
+import org.pipelineframework.orchestrator.release.PipelineReleaseArtifactDescriptor;
+import org.pipelineframework.orchestrator.release.PipelineReleaseDescriptor;
+import org.pipelineframework.orchestrator.release.PipelineReleaseRecord;
+import org.pipelineframework.orchestrator.release.PipelineReleaseStatus;
+
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+class S3PipelineReleaseArtifactStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void storesContentAddressedArtifactAndReturnsS3Uri() throws Exception {
+        S3Client client = mock(S3Client.class);
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenReturn(PutObjectResponse.builder().build());
+        Path artifact = Files.writeString(tempDir.resolve("app.jar"), "artifact-content");
+        String checksum = sha256(Files.readAllBytes(artifact));
+        S3PipelineReleaseArtifactStore store = new S3PipelineReleaseArtifactStore(client, "tpf-artifacts", "tenant/releases");
+
+        PipelineReleaseStoredArtifact stored = store.store(artifact);
+
+        assertEquals("sha256:" + checksum, stored.artifactChecksum());
+        assertEquals(Files.size(artifact), stored.artifactSizeBytes());
+        assertEquals("s3://tpf-artifacts/tenant/releases/sha256/" + checksum + ".jar", stored.artifactUri());
+        verify(client).putObject(argThat((PutObjectRequest request) ->
+            "tpf-artifacts".equals(request.bucket())
+                && request.key().equals("tenant/releases/sha256/" + checksum + ".jar")
+                && checksum.equals(request.metadata().get("sha256"))), any(RequestBody.class));
+    }
+
+    @Test
+    void verifiesStoredObjectSizeAndChecksum() {
+        S3Client client = mock(S3Client.class);
+        byte[] bytes = "artifact-content".getBytes(StandardCharsets.UTF_8);
+        PipelineReleaseRecord record = releaseRecord(
+            "s3://tpf-artifacts/tenant/releases/sha256/" + sha256(bytes) + ".jar",
+            bytes.length,
+            "sha256:" + sha256(bytes));
+        when(client.headObject(any(HeadObjectRequest.class)))
+            .thenReturn(HeadObjectResponse.builder().contentLength((long) bytes.length).build());
+        when(client.getObject(any(GetObjectRequest.class)))
+            .thenReturn(response(bytes));
+        S3PipelineReleaseArtifactStore store = new S3PipelineReleaseArtifactStore(client, "tpf-artifacts", "tenant/releases");
+
+        store.verify(record);
+
+        verify(client).headObject(argThat((HeadObjectRequest request) ->
+            "tpf-artifacts".equals(request.bucket())
+                && request.key().startsWith("tenant/releases/sha256/")));
+    }
+
+    @Test
+    void rejectsMissingStoredObject() {
+        S3Client client = mock(S3Client.class);
+        PipelineReleaseRecord record = releaseRecord("s3://tpf-artifacts/releases/app.jar", 1L, "sha256:abc");
+        when(client.headObject(any(HeadObjectRequest.class)))
+            .thenThrow(S3Exception.builder().statusCode(404).message("not found").build());
+        S3PipelineReleaseArtifactStore store = new S3PipelineReleaseArtifactStore(client, "tpf-artifacts", "releases");
+
+        assertThrows(IllegalStateException.class, () -> store.verify(record));
+    }
+
+    @Test
+    void rejectsTamperedStoredObject() {
+        S3Client client = mock(S3Client.class);
+        byte[] bytes = "artifact-content".getBytes(StandardCharsets.UTF_8);
+        PipelineReleaseRecord record = releaseRecord(
+            "s3://tpf-artifacts/releases/app.jar",
+            bytes.length,
+            "sha256:" + sha256("different".getBytes(StandardCharsets.UTF_8)));
+        when(client.headObject(any(HeadObjectRequest.class)))
+            .thenReturn(HeadObjectResponse.builder().contentLength((long) bytes.length).build());
+        when(client.getObject(any(GetObjectRequest.class)))
+            .thenReturn(response(bytes));
+        S3PipelineReleaseArtifactStore store = new S3PipelineReleaseArtifactStore(client, "tpf-artifacts", "releases");
+
+        assertThrows(IllegalStateException.class, () -> store.verify(record));
+    }
+
+    @Test
+    void rejectsNegativeStoredArtifactSize() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new PipelineReleaseStoredArtifact("s3://bucket/key", -1L, "sha256:abc"));
+    }
+
+    private static ResponseInputStream<GetObjectResponse> response(byte[] bytes) {
+        return new ResponseInputStream<>(
+            GetObjectResponse.builder().contentLength((long) bytes.length).build(),
+            AbortableInputStream.create(new ByteArrayInputStream(bytes)));
+    }
+
+    private static PipelineReleaseRecord releaseRecord(String uri, long size, String checksum) {
+        PipelineContractDescriptor contract = PipelineContractDescriptor.localFallback();
+        PipelineReleaseArtifactDescriptor artifact = new PipelineReleaseArtifactDescriptor(
+            "app",
+            "jar",
+            uri,
+            checksum,
+            List.of(),
+            List.of());
+        PipelineReleaseDescriptor descriptor = new PipelineReleaseDescriptor(
+            PipelineReleaseDescriptor.CURRENT_SCHEMA_VERSION,
+            contract.pipelineId(),
+            contract.contractVersion(),
+            "release-1",
+            List.of(artifact));
+        return new PipelineReleaseRecord(
+            "tenant-1",
+            contract.pipelineId(),
+            contract.contractVersion(),
+            "release-1",
+            PipelineReleaseStatus.REGISTERED,
+            descriptor,
+            artifact.artifactId(),
+            artifact.digest(),
+            uri,
+            size,
+            checksum,
+            contract,
+            1000L,
+            1000L,
+            0L);
+    }
+
+    private static String sha256(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(bytes));
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 digest algorithm is unavailable", e);
+        }
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/release/PipelineReleaseRegistryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/release/PipelineReleaseRegistryTest.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.orchestrator.release;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -14,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.net.URI;
 import java.security.MessageDigest;
+import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
@@ -98,6 +100,45 @@ class PipelineReleaseRegistryTest {
     }
 
     @Test
+    void localArtifactStoreRejectsRemoteArtifactUri() {
+        LocalPipelineReleaseArtifactStore store = new LocalPipelineReleaseArtifactStore(tempDir);
+        PipelineReleaseRecord record = withArtifactUri(releaseRecord(), "s3://bucket/releases/app.jar");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () -> store.verify(record));
+
+        assertTrue(error.getMessage().contains("Unsupported release artifact URI scheme"));
+    }
+
+    @Test
+    void memoryAndFileRegistriesRejectDuplicateReleaseWithDifferentImmutableMetadata() {
+        PipelineReleaseRecord existing = releaseRecord();
+        PipelineReleaseRecord conflicting = new PipelineReleaseRecord(
+            existing.tenantId(),
+            existing.pipelineId(),
+            existing.contractVersion(),
+            existing.releaseVersion(),
+            existing.status(),
+            existing.descriptor(),
+            existing.primaryArtifactId(),
+            "sha256:different-artifact",
+            existing.primaryArtifactUri(),
+            existing.primaryArtifactSizeBytes(),
+            existing.primaryArtifactChecksum(),
+            existing.contract(),
+            existing.createdAtEpochMs(),
+            existing.updatedAtEpochMs(),
+            existing.activatedAtEpochMs());
+
+        PipelineReleaseRegistry memory = new InMemoryPipelineReleaseRegistry();
+        memory.register(existing).await().indefinitely();
+        assertThrows(IllegalStateException.class, () -> memory.register(conflicting).await().indefinitely());
+
+        PipelineReleaseRegistry file = new FileBackedPipelineReleaseRegistry(tempDir.resolve("file-registry"));
+        file.register(existing).await().indefinitely();
+        assertThrows(IllegalStateException.class, () -> file.register(conflicting).await().indefinitely());
+    }
+
+    @Test
     void dynamoRegistryRegistersReleaseWithConditionalPut() {
         DynamoDbClient client = mock(DynamoDbClient.class);
         PipelineReleaseRecord record = releaseRecord();
@@ -131,6 +172,23 @@ class PipelineReleaseRegistryTest {
 
         assertEquals(record.releaseVersion(), registered.releaseVersion());
         verify(client, never()).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    void dynamoRegistryReadsLegacyPrimaryArtifactPathRows() {
+        DynamoDbClient client = mock(DynamoDbClient.class);
+        PipelineReleaseRecord record = releaseRecord();
+        PipelineReleaseRegistry registry = new DynamoPipelineReleaseRegistry(client, dynamoConfig());
+        when(client.query(any(QueryRequest.class)))
+            .thenReturn(QueryResponse.builder().items(List.of()).build());
+        when(client.getItem(any(GetItemRequest.class)))
+            .thenReturn(GetItemResponse.builder().item(legacyDynamoReleaseItem(record)).build());
+
+        PipelineReleaseRecord read = registry.get(record.tenantId(), record.pipelineId(), record.releaseVersion())
+            .await().indefinitely()
+            .orElseThrow();
+
+        assertEquals(record.primaryArtifactUri(), read.primaryArtifactUri());
     }
 
     @Test
@@ -219,9 +277,9 @@ class PipelineReleaseRegistryTest {
             .resolve("src/main/java/org/pipelineframework/orchestrator/release/DynamoPipelineReleaseRegistry.java");
         String content = Files.readString(source);
 
-        assertTrue(!content.contains("UpdateItemRequest"), "Dynamo release registry must not use UpdateItemRequest");
-        assertTrue(!content.contains(".updateItem("), "Dynamo release registry must not call updateItem");
-        assertTrue(!content.contains("return null"), "Dynamo release registry must not return null");
+        assertFalse(content.contains("UpdateItemRequest"), "Dynamo release registry must not use UpdateItemRequest");
+        assertFalse(content.contains(".updateItem("), "Dynamo release registry must not call updateItem");
+        assertFalse(content.contains("return null"), "Dynamo release registry must not return null");
     }
 
     private PipelineReleaseRegistrar registrar() {
@@ -253,6 +311,25 @@ class PipelineReleaseRegistryTest {
             0L);
     }
 
+    private PipelineReleaseRecord withArtifactUri(PipelineReleaseRecord record, String artifactUri) {
+        return new PipelineReleaseRecord(
+            record.tenantId(),
+            record.pipelineId(),
+            record.contractVersion(),
+            record.releaseVersion(),
+            record.status(),
+            record.descriptor(),
+            record.primaryArtifactId(),
+            record.primaryArtifactDigest(),
+            artifactUri,
+            record.primaryArtifactSizeBytes(),
+            record.primaryArtifactChecksum(),
+            record.contract(),
+            record.createdAtEpochMs(),
+            record.updatedAtEpochMs(),
+            record.activatedAtEpochMs());
+    }
+
     private PipelineOrchestratorConfig dynamoConfig() {
         PipelineOrchestratorConfig config = mock(PipelineOrchestratorConfig.class);
         PipelineOrchestratorConfig.DynamoConfig dynamo = mock(PipelineOrchestratorConfig.DynamoConfig.class);
@@ -282,6 +359,13 @@ class PipelineReleaseRegistryTest {
             Map.entry("created_at_epoch_ms", avN(record.createdAtEpochMs())),
             Map.entry("updated_at_epoch_ms", avN(record.updatedAtEpochMs())),
             Map.entry("activated_at_epoch_ms", avN(record.activatedAtEpochMs())));
+    }
+
+    private Map<String, AttributeValue> legacyDynamoReleaseItem(PipelineReleaseRecord record) {
+        Map<String, AttributeValue> item = new HashMap<>(dynamoReleaseItem(record));
+        item.remove("primary_artifact_uri");
+        item.put("primary_artifact_path", avS(record.primaryArtifactUri()));
+        return item;
     }
 
     private Map<String, AttributeValue> dynamoActivationItem(PipelineReleaseRecord record, long activatedAtEpochMs) {

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/release/PipelineReleaseRegistryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/release/PipelineReleaseRegistryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.net.URI;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.List;
@@ -59,7 +60,7 @@ class PipelineReleaseRegistryTest {
         assertEquals("sha256:contract", record.contractVersion());
         assertEquals("restaurant", record.primaryArtifactId());
         assertEquals("sha256:" + sha256(jar), record.primaryArtifactDigest());
-        assertTrue(Files.isRegularFile(Path.of(record.primaryArtifactPath())));
+        assertTrue(Files.isRegularFile(Path.of(URI.create(record.primaryArtifactUri()))));
         registrar.verify(record);
     }
 
@@ -145,7 +146,7 @@ class PipelineReleaseRegistryTest {
             existing.descriptor(),
             existing.primaryArtifactId(),
             existing.primaryArtifactDigest(),
-            existing.primaryArtifactPath(),
+            existing.primaryArtifactUri(),
             existing.primaryArtifactSizeBytes(),
             "different-checksum",
             existing.contract(),
@@ -243,7 +244,7 @@ class PipelineReleaseRegistryTest {
             descriptor,
             "restaurant",
             "sha256:artifact",
-            "/tmp/restaurant.jar",
+            Path.of("/tmp/restaurant.jar").toUri().toString(),
             100L,
             "artifact",
             contract,
@@ -273,7 +274,7 @@ class PipelineReleaseRegistryTest {
             Map.entry("release_version", avS(record.releaseVersion())),
             Map.entry("primary_artifact_id", avS(record.primaryArtifactId())),
             Map.entry("primary_artifact_digest", avS(record.primaryArtifactDigest())),
-            Map.entry("primary_artifact_path", avS(record.primaryArtifactPath())),
+            Map.entry("primary_artifact_uri", avS(record.primaryArtifactUri())),
             Map.entry("primary_artifact_size_bytes", avN(record.primaryArtifactSizeBytes())),
             Map.entry("primary_artifact_checksum", avS(record.primaryArtifactChecksum())),
             Map.entry("descriptor_json", avS(writeJson(record.descriptor()))),


### PR DESCRIPTION
## Summary
- add shared release artifact storage with S3-compatible support for coordinator-managed blob artifacts
- clarify artifact form factors: OCI/JFrog/Maven remain native artifact repositories; S3 is a blob-store option
- keep release descriptor as the integration point across local files, JARs, native binaries, images, function artifacts, and external endpoints

## Scope
- no deployment automation
- no dynamic code loading
- no worker lifecycle in this PR

## Validation
Covered by the stacked branch gate after this slice:
- ./mvnw -f framework/pom.xml -pl runtime,deployment -am test
- ./mvnw -f examples/restaurant-approval/pom.xml -pl monolith-svc -am -DskipUnitTests=true -Dit.test=RestaurantApprovalHostedCoordinatorRestWorkerIT verify
- TPF_SKIP_FRAMEWORK_INSTALL=true ./examples/restaurant-approval/self-host/run-self-hosted-demo.sh --ci
- TPF_SKIP_FRAMEWORK_INSTALL=true ./examples/restaurant-approval/self-host/run-self-hosted-incident.sh --ci
- npm --prefix docs run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added S3-compatible artifact storage support for multi-coordinator self-hosted deployments.

* **Documentation**
  * Enhanced self-hosted deployment guides with improved artifact storage configuration guidance.
  * Expanded release registration and artifact handling documentation for clarity.

* **Chores**
  * Updated terminology and references from "bundle" to "release" throughout documentation and codebase.
  * Migrated artifact storage to use URIs instead of filesystem paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->