### PR TITLE
Add Spring unary local pipeline smoke

### DIFF
--- a/docs/guide/evolve/framework-portability-assessment/roadmap-and-guardrails.md
+++ b/docs/guide/evolve/framework-portability-assessment/roadmap-and-guardrails.md
@@ -11,7 +11,7 @@
 | Convert store SPIs to neutral async types | Medium | High | Enables non-Mutiny providers |
 | Add renderer-profile registry | Medium | Medium | Keeps semantic model stable while adding Spring generation |
 | Add Spring Boot runtime adapter skeleton | Medium | Medium | Proves Spring can host runtime-core seams without Quarkus runtime dependencies |
-| Build minimal Spring Boot unary/local REST pipeline | High | High | First portability proof |
+| Build minimal Spring Boot unary/local pipeline | Medium | High | First generated Spring local unary proof |
 | Add full Spring WebFlux/Reactor/gRPC/await/checkpoint parity | High | High | Production-capable portability |
 
 First portability PR gates:

--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -43,7 +43,7 @@ providers, broker integration, or REST/gRPC transport parity.
 Deployment now accepts and validates `pipeline.codegen.rendererProfile` in discovery:
 
 - `quarkus` (default)
-- `spring` (currently mapped to the same renderer selection strategy as `quarkus`)
+- `spring`
 
 For the surrounding configuration model, see [build configuration](/guide/build/configuration/) and
 [application configuration](/guide/application/configuration).
@@ -52,6 +52,20 @@ For the surrounding configuration model, see [build configuration](/guide/build/
 [annotation processor generation and rendering](/guide/evolve/annotation-processor/generation-and-rendering).
 
 `PipelineGenerationPhase` passes the profile through and uses renderer-instance FQCN helpers when recording role metadata for orchestrator function handlers. That avoids hard-coding a provider class name at generation time.
+
+## Spring unary local smoke
+
+The `spring` renderer profile now has one real generated execution proof:
+
+- `pipeline.transport=LOCAL`
+- `pipeline.platform=COMPUTE`
+- YAML-declared internal services
+- reactive-authored `UNARY_UNARY` steps
+- generated Spring `@Component` local step beans
+
+Generated Spring local step beans implement the neutral `runtime-core` `PipelineUnaryStep<I, O>` contract and adapt the authored Mutiny service boundary to `CompletionStage` at the generated-code edge. `framework/runtime-spring` contributes a minimal `SpringUnaryPipelineRunner` that executes discovered unary step beans in a Spring context.
+
+Unsupported Spring profile combinations fail at build time instead of falling back to Quarkus generation. The unsupported set still includes REST/WebFlux resources, Reactor-native generated contracts, gRPC, function handlers, await/durable/checkpoint/broker paths, persistence, delegated/operator steps, side effects, and non-unary streaming shapes.
 
 ## Vert.x seam and context propagation
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -77,13 +77,16 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
 
         // Get the bindings map from the context
         Map<String, Object> bindingsMap = ctx.getRendererBindings();
+        SpringRendererProfileSupport.validateGenerationSupported(ctx);
+        boolean springProfile = SpringRendererProfileSupport.isSpringProfile(ctx);
 
         // Initialize renderers
         GrpcServiceAdapterRenderer grpcRenderer = new GrpcServiceAdapterRenderer(GenerationTarget.GRPC_SERVICE);
         org.pipelineframework.processor.renderer.ClientStepRenderer clientRenderer =
             new org.pipelineframework.processor.renderer.ClientStepRenderer(GenerationTarget.CLIENT_STEP);
-        org.pipelineframework.processor.renderer.LocalClientStepRenderer localClientRenderer =
-            new org.pipelineframework.processor.renderer.LocalClientStepRenderer();
+        PipelineRenderer<LocalBinding> localClientRenderer = springProfile
+            ? new SpringLocalClientStepRenderer()
+            : new org.pipelineframework.processor.renderer.LocalClientStepRenderer();
         RestClientStepRenderer restClientRenderer = new RestClientStepRenderer();
         RestResourceRenderer restRenderer = new RestResourceRenderer();
         RestFunctionHandlerRenderer restFunctionHandlerRenderer = new RestFunctionHandlerRenderer();
@@ -473,7 +476,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             RoleMetadataGenerator roleMetadataGenerator,
             GrpcServiceAdapterRenderer grpcRenderer,
             org.pipelineframework.processor.renderer.ClientStepRenderer clientRenderer,
-            org.pipelineframework.processor.renderer.LocalClientStepRenderer localClientRenderer,
+            PipelineRenderer<LocalBinding> localClientRenderer,
             RestClientStepRenderer restClientRenderer,
             RestResourceRenderer restRenderer,
             RestFunctionHandlerRenderer restFunctionHandlerRenderer,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -71,7 +71,7 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
         // Apply transport targets and resolve client/server roles for each step model
         List<PipelineStepModel> updatedModels = new ArrayList<>();
         for (PipelineStepModel model : ctx.getStepModels()) {
-            Set<GenerationTarget> targets = resolveTargetsForModel(model, transportMode);
+            Set<GenerationTarget> targets = resolveTargetsForModel(ctx, model, transportMode);
             PipelineStepModel updatedModel = model.toBuilder()
                 .enabledTargets(targets)
                 .build();
@@ -113,7 +113,10 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
      * @param transportMode the transport mode used to influence resolution (may be null if caller applies a default)
      * @return a set of GenerationTarget values applicable to the given step model
      */
-    private Set<GenerationTarget> resolveTargetsForModel(PipelineStepModel model, PipelineTransport transportMode) {
+    private Set<GenerationTarget> resolveTargetsForModel(
+            PipelineCompilationContext ctx,
+            PipelineStepModel model,
+            PipelineTransport transportMode) {
         if (model.serviceClassName() != null
             && AWAIT_STEP_DESCRIPTOR_CLASS.equals(model.serviceClassName().canonicalName())) {
             return Set.of(GenerationTarget.AWAIT_CLIENT_STEP);
@@ -132,6 +135,12 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
         if (transportMode == PipelineTransport.LOCAL
             && model.sideEffect()
             && model.deploymentRole() == DeploymentRole.PLUGIN_SERVER) {
+            return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
+        }
+        if (SpringRendererProfileSupport.isSpringProfile(ctx)
+            && transportMode == PipelineTransport.LOCAL
+            && !model.sideEffect()
+            && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
         LinkedHashSet<GenerationTarget> targets = new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode));

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.phase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.tools.Diagnostic;
+
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+
+/**
+ * Validation and selection helpers for the narrow Spring renderer profile.
+ */
+final class SpringRendererProfileSupport {
+    private static final String SPRING_PROFILE = "spring";
+
+    private SpringRendererProfileSupport() {
+    }
+
+    static boolean isSpringProfile(PipelineCompilationContext ctx) {
+        return ctx != null && SPRING_PROFILE.equalsIgnoreCase(ctx.getRendererProfile());
+    }
+
+    static void validateGenerationSupported(PipelineCompilationContext ctx) {
+        if (!isSpringProfile(ctx)) {
+            return;
+        }
+
+        List<String> errors = new ArrayList<>();
+        if (!ctx.isTransportModeLocal()) {
+            errors.add("Spring renderer profile currently supports only pipeline.transport=LOCAL.");
+        }
+        if (ctx.isPlatformModeFunction()) {
+            errors.add("Spring renderer profile currently supports only pipeline.platform=COMPUTE.");
+        }
+        if (ctx.isOrchestratorGenerated()) {
+            errors.add("Spring renderer profile does not yet support generated orchestrator artifacts.");
+        }
+
+        for (PipelineStepModel model : ctx.getStepModels()) {
+            validateModel(model, errors);
+        }
+
+        if (!errors.isEmpty()) {
+            String message = errors.stream().distinct().collect(Collectors.joining(" "));
+            if (ctx.getProcessingEnv() != null && ctx.getProcessingEnv().getMessager() != null) {
+                ctx.getProcessingEnv().getMessager().printMessage(Diagnostic.Kind.ERROR, message);
+            }
+            throw new IllegalStateException(message);
+        }
+    }
+
+    private static void validateModel(PipelineStepModel model, List<String> errors) {
+        Set<GenerationTarget> supportedTargets = Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
+        if (!supportedTargets.containsAll(model.enabledTargets())) {
+            errors.add("Spring renderer profile currently supports only LOCAL_CLIENT_STEP generation; step '"
+                + model.serviceName() + "' resolved targets " + model.enabledTargets() + ".");
+        }
+        if (model.streamingShape() != StreamingShape.UNARY_UNARY) {
+            errors.add("Spring renderer profile currently supports only unary-unary steps; step '"
+                + model.serviceName() + "' has shape " + model.streamingShape() + ".");
+        }
+        if (model.serviceApiKind() != ServiceApiKind.REACTIVE) {
+            errors.add("Spring renderer profile currently supports only reactive-authored services; step '"
+                + model.serviceName() + "' has API kind " + model.serviceApiKind() + ".");
+        }
+        if (model.sideEffect()) {
+            errors.add("Spring renderer profile does not yet support side-effect steps; step '"
+                + model.serviceName() + "'.");
+        }
+        if (model.delegateService() != null || model.remoteExecution() != null) {
+            errors.add("Spring renderer profile currently supports only internal local steps; step '"
+                + model.serviceName() + "'.");
+        }
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -19,7 +19,7 @@ import org.pipelineframework.processor.renderer.ClientStepRenderer;
 import org.pipelineframework.processor.renderer.BlockingReactiveBridgeRenderer;
 import org.pipelineframework.processor.renderer.GenerationContext;
 import org.pipelineframework.processor.renderer.GrpcServiceAdapterRenderer;
-import org.pipelineframework.processor.renderer.LocalClientStepRenderer;
+import org.pipelineframework.processor.renderer.PipelineRenderer;
 import org.pipelineframework.processor.renderer.RemoteOperatorAdapterRenderer;
 import org.pipelineframework.processor.renderer.RestClientStepRenderer;
 import org.pipelineframework.processor.renderer.AbstractFunctionHandlerRenderer;
@@ -87,7 +87,7 @@ class StepArtifactGenerationService {
             RoleMetadataGenerator roleMetadataGenerator,
             GrpcServiceAdapterRenderer grpcRenderer,
             ClientStepRenderer clientRenderer,
-            LocalClientStepRenderer localClientRenderer,
+            PipelineRenderer<LocalBinding> localClientRenderer,
             RestClientStepRenderer restClientRenderer,
             RestResourceRenderer restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
@@ -366,7 +366,7 @@ class StepArtifactGenerationService {
             RoleMetadataGenerator roleMetadataGenerator,
             GrpcServiceAdapterRenderer grpcRenderer,
             ClientStepRenderer clientRenderer,
-            LocalClientStepRenderer localClientRenderer,
+            PipelineRenderer<LocalBinding> localClientRenderer,
             RestClientStepRenderer restClientRenderer,
             RestResourceRenderer restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import java.util.concurrent.CompletionStage;
+import javax.lang.model.element.Modifier;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.LocalBinding;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+
+/**
+ * Spring renderer for the first supported portability slice: local unary client steps.
+ */
+public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBinding> {
+
+    @Override
+    public GenerationTarget target() {
+        return GenerationTarget.LOCAL_CLIENT_STEP;
+    }
+
+    @Override
+    public void render(LocalBinding binding, GenerationContext ctx) throws IOException {
+        PipelineStepModel model = binding.model();
+        validateSupported(model);
+
+        TypeSpec clientStepClass = buildClientStepClass(model);
+        JavaFile.builder(model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX, clientStepClass)
+            .build()
+            .writeTo(ctx.outputDir());
+    }
+
+    private TypeSpec buildClientStepClass(PipelineStepModel model) {
+        TypeName inputType = resolveDomainType(model.inboundDomainType());
+        TypeName outputType = resolveDomainType(model.outboundDomainType());
+        TypeName stepInterface = ParameterizedTypeName.get(
+            ClassName.get("org.pipelineframework.runtime.core", "PipelineUnaryStep"),
+            inputType,
+            outputType);
+        TypeName completionStage = ParameterizedTypeName.get(ClassName.get(CompletionStage.class), outputType);
+        TypeName serviceType = model.serviceClassName();
+        String serviceFieldName = decapitalize(model.serviceClassName().simpleName());
+
+        FieldSpec serviceField = FieldSpec.builder(serviceType, serviceFieldName, Modifier.PRIVATE, Modifier.FINAL)
+            .build();
+        MethodSpec constructor = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(serviceType, serviceFieldName)
+            .addStatement("this.$N = $N", serviceFieldName, serviceFieldName)
+            .build();
+        MethodSpec applyMethod = MethodSpec.methodBuilder("apply")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(completionStage)
+            .addParameter(inputType, "input")
+            .addStatement("return this.$N.process(input).subscribeAsCompletionStage()", serviceFieldName)
+            .build();
+
+        return TypeSpec.classBuilder(getClientStepClassName(model))
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.stereotype", "Component")).build())
+            .addSuperinterface(stepInterface)
+            .addField(serviceField)
+            .addMethod(constructor)
+            .addMethod(applyMethod)
+            .build();
+    }
+
+    private void validateSupported(PipelineStepModel model) {
+        if (model.streamingShape() != StreamingShape.UNARY_UNARY) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only unary-unary LOCAL steps; step '"
+                    + model.serviceName() + "' has shape " + model.streamingShape());
+        }
+        if (model.serviceApiKind() != ServiceApiKind.REACTIVE) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only reactive-authored services; step '"
+                    + model.serviceName() + "' has API kind " + model.serviceApiKind());
+        }
+        if (model.sideEffect()) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile does not yet support side-effect steps; step '" + model.serviceName() + "'");
+        }
+        if (model.delegateService() != null || model.remoteExecution() != null) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only internal local steps; step '" + model.serviceName() + "'");
+        }
+    }
+
+    private String getClientStepClassName(PipelineStepModel model) {
+        String serviceClassName = model.generatedName();
+        if (serviceClassName.endsWith("Service")) {
+            serviceClassName = serviceClassName.substring(0, serviceClassName.length() - "Service".length());
+        }
+        return serviceClassName + "LocalClientStep";
+    }
+
+    private TypeName resolveDomainType(TypeName type) {
+        return type != null ? type : ClassName.OBJECT;
+    }
+
+    private String decapitalize(String simpleName) {
+        if (simpleName == null || simpleName.isBlank()) {
+            return "service";
+        }
+        if (simpleName.length() == 1) {
+            return simpleName.toLowerCase();
+        }
+        return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java
@@ -176,6 +176,95 @@ class PipelineGenerationPhaseIntegrationTest {
     }
 
     @Test
+    void springProfileGeneratesYamlOnlyLocalUnaryClientStep() throws IOException {
+        Path projectRoot = tempDir;
+        Files.writeString(projectRoot.resolve("pom.xml"), """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>spring-smoke</artifactId>
+              <version>1.0.0</version>
+              <packaging>pom</packaging>
+            </project>
+            """);
+
+        Path moduleDir = projectRoot.resolve("spring-smoke");
+        Path generatedSourcesDir = moduleDir.resolve("target/generated-sources/pipeline");
+        Files.createDirectories(generatedSourcesDir);
+
+        Path pipelineConfig = projectRoot.resolve("pipeline.spring.yaml");
+        Files.writeString(pipelineConfig, """
+            appName: "Spring Smoke"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            platform: "COMPUTE"
+            steps:
+              - name: "payment"
+                service: "com.example.service.PaymentService"
+                input: "com.example.service.PaymentRecord"
+                output: "com.example.service.PaymentStatus"
+            """);
+
+        Compilation compilation = Compiler.javac()
+            .withProcessors(new PipelineStepProcessor())
+            .withOptions(
+                "-Apipeline.generatedSourcesDir=" + generatedSourcesDir.toString().replace('\\', '/'),
+                "-Apipeline.config=" + pipelineConfig.toString().replace('\\', '/'),
+                "-Apipeline.transport=LOCAL",
+                "-Apipeline.platform=COMPUTE",
+                "-Apipeline.codegen.rendererProfile=spring")
+            .compile(
+                JavaFileObjects.forSourceString(
+                    "com.example.service.PaymentService",
+                    """
+                        package com.example.service;
+
+                        import io.smallrye.mutiny.Uni;
+                        import org.pipelineframework.service.ReactiveService;
+
+                        public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
+                            @Override
+                            public Uni<PaymentStatus> process(PaymentRecord input) {
+                                return Uni.createFrom().item(new PaymentStatus());
+                            }
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.service.PaymentRecord",
+                    """
+                        package com.example.service;
+
+                        public class PaymentRecord {
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.service.PaymentStatus",
+                    """
+                        package com.example.service;
+
+                        public class PaymentStatus {
+                        }
+                        """));
+
+        assertThat(compilation).succeeded();
+
+        Path springClientStep = findGeneratedClass(generatedSourcesDir, "ProcessPaymentLocalClientStep");
+        assertTrue(
+            Files.exists(springClientStep),
+            "Expected Spring local client step source to be generated under "
+                + generatedSourcesDir
+                + "; found "
+                + generatedJavaFiles(generatedSourcesDir));
+        String source = Files.readString(springClientStep);
+        assertTrue(source.contains("import org.pipelineframework.runtime.core.PipelineUnaryStep;"));
+        assertTrue(source.contains("import org.springframework.stereotype.Component;"));
+        assertFalse(source.contains("io.quarkus."));
+        assertFalse(source.contains("jakarta.enterprise."));
+        assertFalse(source.contains("io.vertx."));
+        assertTrue(compilation.generatedFile(StandardLocation.CLASS_OUTPUT, "META-INF/pipeline", "roles.json").isPresent());
+    }
+
+    @Test
     void generatesRestServerArtifactsForRuntimeMappedModularFunctionStepModule() throws IOException {
         Path projectRoot = tempDir;
         Files.writeString(projectRoot.resolve("pom.xml"), """
@@ -354,13 +443,33 @@ class PipelineGenerationPhaseIntegrationTest {
     }
 
     private boolean hasGeneratedClass(Path rootDir, String className) throws IOException {
+        return Files.exists(findGeneratedClass(rootDir, className));
+    }
+
+    private Path findGeneratedClass(Path rootDir, String className) throws IOException {
         if (!Files.exists(rootDir)) {
-            return false;
+            return rootDir.resolve(className + ".java");
         }
         try (var stream = Files.walk(rootDir)) {
             return stream.filter(path -> path.toString().endsWith(".java"))
-                .anyMatch(path -> path.getFileName() != null
-                    && path.getFileName().toString().equals(className + ".java"));
+                .filter(path -> path.getFileName() != null
+                    && path.getFileName().toString().equals(className + ".java"))
+                .findFirst()
+                .orElse(rootDir.resolve(className + ".java"));
+        }
+    }
+
+    private String generatedJavaFiles(Path rootDir) throws IOException {
+        if (!Files.exists(rootDir)) {
+            return "[]";
+        }
+        try (var stream = Files.walk(rootDir)) {
+            return stream.filter(path -> path.toString().endsWith(".java"))
+                .map(rootDir::relativize)
+                .map(Path::toString)
+                .sorted()
+                .toList()
+                .toString();
         }
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -77,6 +77,21 @@ class PipelineTargetResolutionPhaseTest {
     }
 
     @Test
+    void springProfileResolvesLocalServerStepToLocalClientStep() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        context.setRendererProfile("spring");
+        context.setTransportMode(PipelineTransport.LOCAL);
+        context.setStepModels(List.of(step("SpringLocalStep", DeploymentRole.PIPELINE_SERVER)));
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertEquals(Set.of(GenerationTarget.LOCAL_CLIENT_STEP), updated.enabledTargets());
+        assertEquals(Set.of(GenerationTarget.LOCAL_CLIENT_STEP), context.getResolvedTargets());
+    }
+
+    @Test
     void defaultsToGrpcWhenTransportModeIsNull() throws Exception {
         PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.phase;
+
+import java.util.List;
+import java.util.Set;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.PlatformMode;
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.PipelineTransport;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SpringRendererProfileSupportTest {
+
+    @Test
+    void acceptsLocalComputeUnaryStep() {
+        PipelineCompilationContext context = context();
+
+        assertDoesNotThrow(() -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
+    void rejectsRestTransport() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.REST);
+
+        assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
+    void rejectsFunctionPlatform() {
+        PipelineCompilationContext context = context();
+        context.setPlatformMode(PlatformMode.FUNCTION);
+
+        assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
+    void rejectsUnsupportedTargets() {
+        PipelineCompilationContext context = context();
+        context.setStepModels(List.of(step(Set.of(GenerationTarget.REST_RESOURCE), StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE)));
+
+        assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    private PipelineCompilationContext context() {
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        context.setRendererProfile("spring");
+        context.setTransportMode(PipelineTransport.LOCAL);
+        context.setPlatformMode(PlatformMode.COMPUTE);
+        context.setStepModels(List.of(step(Set.of(GenerationTarget.LOCAL_CLIENT_STEP), StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE)));
+        return context;
+    }
+
+    private PipelineStepModel step(
+        Set<GenerationTarget> targets,
+        StreamingShape shape,
+        ServiceApiKind apiKind
+    ) {
+        return new PipelineStepModel.Builder()
+            .serviceName("PaymentService")
+            .generatedName("PaymentService")
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", "PaymentService"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentRecord"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentStatus"), null, false))
+            .streamingShape(shape)
+            .enabledTargets(targets)
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .serviceApiKind(apiKind)
+            .build();
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.renderer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.LocalBinding;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpringLocalClientStepRendererTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rendersSpringNativeUnaryLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(model(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE)),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/PaymentLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("import org.pipelineframework.runtime.core.PipelineUnaryStep;"));
+        assertTrue(source.contains("import org.springframework.stereotype.Component;"));
+        assertTrue(source.contains("public class PaymentLocalClientStep implements PipelineUnaryStep<PaymentRecord, PaymentStatus>"));
+        assertTrue(source.contains("private final PaymentService paymentService;"));
+        assertTrue(source.contains("public PaymentLocalClientStep(PaymentService paymentService)"));
+        assertTrue(source.contains("return this.paymentService.process(input).subscribeAsCompletionStage();"));
+        assertFalse(source.contains("io.quarkus."));
+        assertFalse(source.contains("jakarta.enterprise."));
+        assertFalse(source.contains("jakarta.inject."));
+        assertFalse(source.contains("io.vertx."));
+        assertFalse(source.contains("org.jboss.resteasy."));
+        assertFalse(source.contains("jakarta.ws.rs."));
+    }
+
+    @Test
+    void rejectsNonUnaryShape() {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new LocalBinding(model(StreamingShape.UNARY_STREAMING, ServiceApiKind.REACTIVE)),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+    }
+
+    @Test
+    void rejectsBlockingAuthoredService() {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new LocalBinding(model(StreamingShape.UNARY_UNARY, ServiceApiKind.BLOCKING)),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+    }
+
+    private PipelineStepModel model(StreamingShape shape, ServiceApiKind apiKind) {
+        return new PipelineStepModel.Builder()
+            .serviceName("PaymentService")
+            .generatedName("PaymentService")
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", "PaymentService"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentRecord"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentStatus"), null, false))
+            .streamingShape(shape)
+            .enabledTargets(Set.of(GenerationTarget.LOCAL_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .serviceApiKind(apiKind)
+            .build();
+    }
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/PipelineUnaryStep.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/PipelineUnaryStep.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Framework-neutral unary pipeline step contract used by non-Quarkus runtime adapters.
+ *
+ * @param <I> input type
+ * @param <O> output type
+ */
+public interface PipelineUnaryStep<I, O> {
+
+    /**
+     * Apply this unary step to one input item.
+     *
+     * @param input input item
+     * @return stage that completes with the transformed output item
+     */
+    CompletionStage<O> apply(I input);
+}

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfiguration.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfiguration.java
@@ -17,7 +17,9 @@
 package org.pipelineframework.runtime.spring;
 
 import java.util.concurrent.Executor;
+import java.util.List;
 
+import org.pipelineframework.runtime.core.PipelineUnaryStep;
 import org.pipelineframework.runtime.core.RuntimeAdapters;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -50,5 +52,11 @@ public class SpringRuntimeAdaptersAutoConfiguration {
             eventPublisher,
             executor,
             transactionManager.getIfAvailable());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SpringUnaryPipelineRunner springUnaryPipelineRunner(List<PipelineUnaryStep<?, ?>> pipelineSteps) {
+        return new SpringUnaryPipelineRunner(pipelineSteps);
     }
 }

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringUnaryPipelineRunner.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringUnaryPipelineRunner.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.spring;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.pipelineframework.runtime.core.PipelineUnaryStep;
+
+/**
+ * Minimal Spring-local runner for unary generated pipeline steps.
+ *
+ * <p>This is a first portability proof for local unary pipelines, not the durable TPF runtime engine.</p>
+ */
+public class SpringUnaryPipelineRunner {
+    private final List<PipelineUnaryStep<?, ?>> steps;
+
+    public SpringUnaryPipelineRunner(List<PipelineUnaryStep<?, ?>> steps) {
+        this.steps = List.copyOf(Objects.requireNonNull(steps, "steps"));
+    }
+
+    /**
+     * Run all configured unary steps sequentially.
+     *
+     * @param input input for the first step
+     * @return stage that completes with the final step output
+     */
+    public CompletionStage<Object> run(Object input) {
+        CompletionStage<Object> current = CompletableFuture.completedFuture(input);
+        for (PipelineUnaryStep<?, ?> step : steps) {
+            current = current.thenCompose(value -> applyUntyped(step, value));
+        }
+        return current;
+    }
+
+    public int stepCount() {
+        return steps.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletionStage<Object> applyUntyped(PipelineUnaryStep<?, ?> step, Object input) {
+        PipelineUnaryStep<Object, Object> typedStep = (PipelineUnaryStep<Object, Object>) step;
+        return typedStep.apply(input);
+    }
+}

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
@@ -17,12 +17,14 @@
 package org.pipelineframework.runtime.spring;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.pipelineframework.runtime.core.PipelineUnaryStep;
 import org.pipelineframework.runtime.core.RuntimeAdapters;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -124,6 +126,18 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
 
                 assertEquals(List.of(new SpringRuntimeEvent("orders.ready", "payload")), events.runtimeEvents);
                 assertEquals(List.of(new SpringRuntimeWorkEvent("work-item")), events.workEvents);
+            });
+    }
+
+    @Test
+    void unaryPipelineRunnerExecutesSpringStepBeans() {
+        contextRunner
+            .withUserConfiguration(UnaryStepConfig.class)
+            .run(context -> {
+                SpringUnaryPipelineRunner runner = context.getBean(SpringUnaryPipelineRunner.class);
+
+                assertEquals(2, runner.stepCount());
+                assertEquals("HELLO!", runner.run("hello").toCompletableFuture().get(5, TimeUnit.SECONDS));
             });
     }
 
@@ -262,6 +276,19 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
         @EventListener
         void onWorkEvent(SpringRuntimeWorkEvent event) {
             workEvents.add(event);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class UnaryStepConfig {
+        @Bean
+        PipelineUnaryStep<String, String> uppercaseStep() {
+            return input -> CompletableFuture.completedFuture(input.toUpperCase());
+        }
+
+        @Bean
+        PipelineUnaryStep<String, String> suffixStep() {
+            return input -> CompletableFuture.completedFuture(input + "!");
         }
     }
 }


### PR DESCRIPTION
## Summary
- adds a neutral runtime-core `PipelineUnaryStep` contract plus a minimal Spring unary runner
- adds a narrow Spring renderer path for YAML-only LOCAL + COMPUTE unary internal services
- rejects unsupported Spring renderer-profile combinations instead of falling back to Quarkus generation
- documents the current Spring smoke boundary in evolve docs

## Validation
- `./mvnw -f framework/pom.xml -pl runtime-core,runtime-spring,deployment test -Dtest=RuntimeCoreDependencyGuardTest,RuntimeSpringDependencyGuardTest,SpringRuntimeAdaptersAutoConfigurationTest,SpringLocalClientStepRendererTest,SpringRendererProfileSupportTest,PipelineTargetResolutionPhaseTest,PipelineGenerationPhaseIntegrationTest`
- `./mvnw -f framework/pom.xml verify`
- `npm --prefix docs run build`

## Notes
- Spring support remains intentionally limited to local unary generated step beans in this slice.
- REST/WebFlux, Reactor-native contracts, gRPC, await/durable/checkpoint/broker, persistence, delegated/operator steps, side effects, and streaming shapes remain out of scope.