### PR TITLE
docs: add brokered boundary design guides

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -214,6 +214,18 @@ const mainSidebar = [
                     {text: 'Overview', link: '/guide/evolve/durable-coordinator/'},
                     {text: 'Worker Protocols', link: '/guide/evolve/durable-coordinator/worker-protocols'},
                     {text: 'Step-Aware Invocation Runtime', link: '/guide/evolve/durable-coordinator/boundary-invocation-model'},
+                    {
+                        text: 'Brokered Runtime Boundaries',
+                        link: '/guide/evolve/brokered-boundaries/',
+                        collapsed: true,
+                        items: [
+                            {text: 'Overview', link: '/guide/evolve/brokered-boundaries/'},
+                            {text: 'Boundary Taxonomy', link: '/guide/evolve/brokered-boundaries/boundary-taxonomy'},
+                            {text: 'Dispatch Substrates', link: '/guide/evolve/brokered-boundaries/dispatch-substrates'},
+                            {text: 'Envelope And Data Policy', link: '/guide/evolve/brokered-boundaries/envelope-and-data-policy'},
+                            {text: 'Adoption And Slices', link: '/guide/evolve/brokered-boundaries/adoption-and-slices'}
+                        ]
+                    },
                     {text: 'Bundle Contract', link: '/guide/evolve/durable-coordinator/bundle-contract'},
                     {text: 'Pipeline Contract And Release Model', link: '/guide/evolve/durable-coordinator/pipeline-contract-release-model'},
                     {text: 'Runtime Boundaries And Performance', link: '/guide/evolve/durable-coordinator/runtime-boundaries-performance'},

--- a/docs/guide/evolve/architecture.md
+++ b/docs/guide/evolve/architecture.md
@@ -5,6 +5,9 @@ The Pipeline Framework is designed as a modular, extensible system for building 
 ## Related Architecture Topics
 
 - [Annotation Processor Guide](/guide/evolve/annotation-processor/): Deep dive into build-time phases, IR, bindings, and renderers
+- [Brokered Runtime Boundaries](/guide/evolve/brokered-boundaries/): Architecture guardrails for Kafka/SQS-style substrates under TPF-owned runtime semantics
+- [Boundary Taxonomy](/guide/evolve/brokered-boundaries/boundary-taxonomy): Mapping between broker concepts and TPF runtime boundaries
+- [Envelope And Data Policy](/guide/evolve/brokered-boundaries/envelope-and-data-policy): Design guidance for typed DTOs, generated protobuf, loose envelopes, and payload references
 
 ## Orchestrator Control Plane (Current)
 

--- a/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
+++ b/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
@@ -1,0 +1,66 @@
+# Adoption And Slices
+
+This page captures the product value and implementation ordering for brokered boundary work.
+
+## Value Proposition
+
+Brokered boundaries are attractive because many organisations already trust Kafka operationally. They have teams, dashboards, retention policies, ACLs, incident playbooks, and scaling patterns around it.
+
+The TPF value proposition is not "you no longer need brokers." It is:
+
+- Application teams do not have to encode pipeline semantics as topic naming, offset handling, Redis key conventions, and sidecar logic.
+- Platform teams can keep trusted broker infrastructure where it is useful.
+- TPF keeps the execution model explicit: authored steps, typed or envelope contracts, deterministic lineage, replay topology, and generated/runtime validation.
+- Self-hosted TPF deployments can keep backing broker/cache choices explicit while preserving one TPF model for application code.
+
+This lowers adoption risk for enterprise users without weakening the core TPF model.
+
+## Adoption Ramp
+
+```mermaid
+flowchart LR
+    Loose["Envelope payload<br/>fast onboarding"]
+    Hints["Envelope + schema hints<br/>declared drift boundary"]
+    Proto["Generated protobuf<br/>polyglot typed contract"]
+    DTO["Typed DTO + mapper validation<br/>strongest TPF path"]
+
+    Loose --> Hints --> Proto --> DTO
+```
+
+Platform teams can start with a loose envelope where adoption matters, then move stable domains toward generated protobuf or typed DTO contracts.
+
+## Candidate Slices
+
+Prefer these implementation slices if this work becomes active:
+
+1. Kafka-backed checkpoint publication/subscription.
+2. Kafka-backed await transport.
+3. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
+4. Protobuf-backed external step-host contract generation for non-Java implementations.
+5. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
+6. Brokered step-host dispatch only after the earlier boundary types are proven.
+
+Avoid starting with a broad "Kafka transport" PR. That would mix unrelated risks and blur TPF semantics.
+
+## Non-Goals
+
+Envelope and brokered boundary work should not:
+
+1. replace typed TPF as the default,
+2. make mapper pair validation irrelevant for typed paths,
+3. hide drift by treating all payloads as arbitrary objects,
+4. turn Kafka offsets into TPF replay state,
+5. force users to operate Kafka when local, REST, gRPC, or SQS runtime boundaries are enough,
+6. introduce a second workflow engine inside TPF.
+
+## Guardrails
+
+Preserve these invariants:
+
+1. Typed TPF remains the default path.
+2. Envelope compatibility is explicit and weaker than typed DTO mode.
+3. Dispatch policy is independent from payload policy.
+4. Broker-backed dispatch does not move core validation from build time to runtime when typed contracts are available.
+5. Kafka, SQS, REST, gRPC, and local substrates are implementation choices under TPF-owned boundaries.
+6. Replay viewer and telemetry interpret TPF events, not broker offsets.
+7. Runtime layout and build topology remain distinct from broker topology.

--- a/docs/guide/evolve/brokered-boundaries/boundary-taxonomy.md
+++ b/docs/guide/evolve/brokered-boundaries/boundary-taxonomy.md
@@ -1,0 +1,76 @@
+# Boundary Taxonomy
+
+Brokered execution belongs under runtime boundary policy, not under a global pipeline transport switch.
+
+## Translation Table
+
+Use TPF terms when discussing brokered designs:
+
+| Broker term | TPF meaning |
+| --- | --- |
+| Topic | Step inbox, await request/response channel, checkpoint publication channel, or transition dispatch queue |
+| Consumer group | Scaled step-host group for one boundary |
+| Partition key | Item key, lineage key, document id, fan-in key, or await correlation key |
+| Offset | Delivery cursor, not the TPF replay pointer |
+| Retention | Transport-level redelivery window, not business persistence |
+| Lag | Boundary pressure signal |
+| DLQ topic | Item reject sink or failed execution lane |
+| Record | TPF envelope carrying typed payload, serialized payload, payload reference, or controlled loose payload |
+
+Kafka replay means re-reading records from a log. TPF replay means re-running or reusing a known pipeline boundary with step identity, lineage, cache/persistence policy, and replay metadata.
+
+## Boundary Types
+
+| TPF boundary | Meaning | Broker fit |
+| --- | --- | --- |
+| Local step boundary | Same process, direct invocation | Usually no |
+| Remote operator boundary | Immediate request/response external step host | Usually HTTP/gRPC/protobuf first |
+| Await boundary | Execution parks and resumes after correlated completion | Strong fit for request/response topics |
+| Checkpoint handoff | One pipeline publishes work to another owner | Strong fit for publication/subscription |
+| Transition-worker boundary | Durable coordinator dispatches one bounded continuation | Possible dispatcher provider |
+| Brokered step-host boundary | A step is executed by a scaled step-host group | Future design candidate |
+| Envelope compatibility boundary | Step host receives a generic envelope rather than a strong DTO | Possible across any dispatch substrate |
+
+```mermaid
+flowchart TB
+    Runtime["TPF runtime boundary"]
+    Await["Await boundary<br/>same execution parks/resumes"]
+    Checkpoint["Checkpoint handoff<br/>new owner admits work"]
+    Transition["Transition-worker dispatch<br/>coordinator continuation"]
+    StepHost["Brokered step host<br/>future scaled step execution"]
+
+    Kafka["Kafka/SQS/etc.<br/>durable dispatch substrate"]
+
+    Runtime --> Await
+    Runtime --> Checkpoint
+    Runtime --> Transition
+    Runtime --> StepHost
+
+    Await -. request/response topics .-> Kafka
+    Checkpoint -. publication channel .-> Kafka
+    Transition -. command/result queue .-> Kafka
+    StepHost -. step inbox .-> Kafka
+```
+
+## Ownership
+
+TPF should own:
+
+1. pipeline definition and release identity,
+2. step identity and step order,
+3. cardinality and fan-out/fan-in semantics,
+4. lineage, item identity, and parent-child relationships,
+5. retry, reject, and replay metadata,
+6. typed DTO contracts or declared envelope contracts,
+7. replay topology and viewer interpretation.
+
+The dispatch substrate should own:
+
+1. durable delivery,
+2. queue depth and lag,
+3. partition-local ordering,
+4. consumer group distribution,
+5. broker-level redelivery,
+6. retention and substrate ACLs.
+
+The substrate must not own step meaning, fan-in correctness, replay meaning, mapper selection, or pipeline topology.

--- a/docs/guide/evolve/brokered-boundaries/boundary-taxonomy.md
+++ b/docs/guide/evolve/brokered-boundaries/boundary-taxonomy.md
@@ -24,12 +24,14 @@ Kafka replay means re-reading records from a log. TPF replay means re-running or
 | TPF boundary | Meaning | Broker fit |
 | --- | --- | --- |
 | Local step boundary | Same process, direct invocation | Usually no |
-| Remote operator boundary | Immediate request/response external step host | Usually HTTP/gRPC/protobuf first |
+| Remote operator boundary | Immediate request/response external step host | Usually REST/gRPC/LOCAL transport first |
 | Await boundary | Execution parks and resumes after correlated completion | Strong fit for request/response topics |
 | Checkpoint handoff | One pipeline publishes work to another owner | Strong fit for publication/subscription |
 | Transition-worker boundary | Durable coordinator dispatches one bounded continuation | Possible dispatcher provider |
 | Brokered step-host boundary | A step is executed by a scaled step-host group | Future design candidate |
 | Envelope compatibility boundary | Step host receives a generic envelope rather than a strong DTO | Possible across any dispatch substrate |
+
+Serialization choices such as protobuf, JSON, bytes, or payload references belong to payload policy, not broker fit. See [Envelope And Data Policy](/guide/evolve/brokered-boundaries/envelope-and-data-policy).
 
 ```mermaid
 flowchart TB
@@ -61,7 +63,7 @@ TPF should own:
 3. cardinality and fan-out/fan-in semantics,
 4. lineage, item identity, and parent-child relationships,
 5. retry, reject, and replay metadata,
-6. typed DTO contracts or declared envelope contracts,
+6. declared DTO/envelope contracts,
 7. replay topology and viewer interpretation.
 
 The dispatch substrate should own:

--- a/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
+++ b/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
@@ -1,0 +1,73 @@
+# Dispatch Substrates
+
+Dispatch substrate is the mechanism used to move a TPF command, payload, or envelope across a boundary.
+
+It is not the same decision as transport mode, platform mode, runtime layout, or payload policy.
+
+## Substrate Matrix
+
+| Substrate | Best fit | Caution |
+| --- | --- | --- |
+| Local | tests, demos, monoliths, low-friction adoption | no crash-surviving handoff by itself |
+| REST | simple request/response step hosts and transition workers | immediate call semantics; not durable buffering |
+| gRPC | efficient typed request/response and protobuf contracts | still immediate unless paired with await/checkpoint semantics |
+| SQS | durable coordinator dispatch and DLQ-oriented cloud deployments | weaker ordering/grouping model than Kafka |
+| Kafka | enterprise broker backbone, durable fan-out/fan-in pressure boundaries, checkpoint streams | do not treat offsets as TPF replay semantics |
+
+## Not `transport: KAFKA`
+
+Do not flatten Kafka into the same top-level decision as REST or gRPC.
+
+REST and gRPC are immediate call transports. Kafka is a brokered dispatch substrate with different timing, correlation, retry, and ownership implications.
+
+Prefer boundary-specific configuration shapes:
+
+```yaml
+kind: await
+await:
+  transport:
+    type: kafka
+```
+
+```yaml
+checkpoint:
+  publish:
+    target:
+      kind: kafka
+```
+
+```properties
+pipeline.orchestrator.dispatcher-provider=kafka
+```
+
+These examples are design direction, not committed public API.
+
+## Relationship To Existing Work
+
+This guide extends existing boundary seams:
+
+- [Step-Aware Invocation Runtime](/guide/evolve/durable-coordinator/boundary-invocation-model) defines shared invocation points for step, transition-worker, and transport-boundary execution.
+- [Worker Protocols](/guide/evolve/durable-coordinator/worker-protocols) already model transition-worker command/result envelopes over local, REST, gRPC, and SQS.
+- [Await Unit Runtime](/guide/evolve/await-unit-runtime/) defines durable suspend/resume semantics that can use different transports.
+- [Checkpoint Handoff](/guide/development/orchestrator-runtime/checkpoint-handoff) is the natural user-facing shape for pipeline-to-pipeline publication.
+- [Runtime Core Decoupling](/guide/evolve/runtime-core-decoupling) keeps runtime-adapter concerns out of core semantics.
+
+Kafka should extend these seams. It should not introduce an independent workflow engine inside TPF.
+
+## Pressure And Replay
+
+```mermaid
+sequenceDiagram
+    participant TPF as "TPF boundary"
+    participant Broker as "Broker substrate"
+    participant Host as "Step host"
+    participant Store as "TPF state/cache/persistence"
+
+    TPF->>Broker: publish envelope with TPF lineage
+    Broker-->>TPF: lag/pressure signal
+    Host->>Broker: consume by boundary key
+    Host-->>TPF: result envelope / completion
+    TPF->>Store: commit replay-aware state
+```
+
+Broker retention can help recover delivery. TPF replay still needs step identity, contract version, item lineage, fan-in completion, and cache/persistence policy.

--- a/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
+++ b/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
@@ -36,6 +36,8 @@ checkpoint:
       kind: kafka
 ```
 
+The checkpoint snippet is illustrative only. Current supported checkpoint handoff target configuration uses `pipeline.handoff.bindings.<publication>.targets.<target>.*`, and broker-backed `KAFKA` publication targets are not supported yet.
+
 ```properties
 pipeline.orchestrator.dispatcher-provider=kafka
 ```

--- a/docs/guide/evolve/brokered-boundaries/envelope-and-data-policy.md
+++ b/docs/guide/evolve/brokered-boundaries/envelope-and-data-policy.md
@@ -1,0 +1,110 @@
+# Envelope And Data Policy
+
+Envelope mode is a payload compatibility policy. It does not imply Kafka.
+
+The same envelope can be used over local execution, REST, gRPC, SQS, Kafka, or file-backed tests.
+
+## Recommendation
+
+Keep typed DTO contracts as the normal TPF model. Add envelope compatibility only as an explicit boundary policy for onboarding, polyglot step hosts, and legacy or loose payload domains.
+
+The control envelope must remain strict even when the payload is loose.
+
+```mermaid
+flowchart TB
+    Envelope["TPF envelope"]
+    Control["Strict control metadata<br/>pipeline, execution, step, item, attempt, lineage"]
+    Contract["Contract hints<br/>schema, content type, encoding, payload hash"]
+    Payload["Payload region<br/>typed DTO, protobuf, JSON, bytes, payload_ref"]
+
+    Envelope --> Control
+    Envelope --> Contract
+    Envelope --> Payload
+```
+
+Do not allow arbitrary `Object` to become the whole runtime contract. Only the payload region may be loose.
+
+## Why Envelope Mode Exists
+
+Use envelope mode for:
+
+1. Python or non-Java step hosts that should not depend on TPF internals,
+2. external services that already accept generic document envelopes,
+3. compatibility with platforms that use object-like payloads,
+4. gradual migration from loose payloads to typed contracts,
+5. exploratory AI/indexing pipelines where schemas are still changing.
+
+Do not use it to avoid modeling stable business contracts. If the data shape is stable and correctness matters, typed DTOs and mapper validation remain the stronger TPF path.
+
+## Independent Decisions
+
+| Decision | Examples | Owner |
+| --- | --- | --- |
+| Dispatch policy | local, REST, gRPC, SQS, Kafka | Runtime boundary |
+| Payload policy | typed DTO, protobuf message, JSON envelope, bytes envelope, payload reference | Data contract |
+| Persistence policy | append-only record, cache entry, repository claim check, materialized output unit | Plugin/runtime store |
+| Replay policy | require cache, prefer cache, recompute, replay from durable execution state | TPF runtime semantics |
+
+Valid combinations include:
+
+| Boundary | Payload policy |
+| --- | --- |
+| local step host | typed DTO or envelope |
+| REST remote operator | typed protobuf-over-HTTP or envelope |
+| gRPC step host | typed protobuf or envelope bytes |
+| SQS transition worker | command/result envelope with typed serialized payload |
+| Kafka checkpoint | typed event or envelope event |
+
+If envelope mode requires Kafka, it becomes a Kafka feature. If envelope mode is independent from Kafka, it becomes a TPF compatibility policy.
+
+## Data Shapes
+
+| Shape | Safety | Use when |
+| --- | --- | --- |
+| Typed DTO | Strongest | Java/TPF-owned code or stable domain contracts |
+| Generated protobuf | Strong | Non-Java step hosts can compile generated contracts |
+| Envelope with schema hint | Medium | Payload evolves but schema/version is still declared |
+| Envelope with JSON/bytes payload | Weakest | Compatibility and rapid onboarding matter more than compile-time safety |
+| Envelope with payload reference | Medium | Payload is large and should be materialized out of line |
+
+Payload references are a data policy, not a broker policy. They can point to a repository, object store, SQL-backed materialization provider, Redis-backed cache, or local test harness.
+
+## Control Fields
+
+A future envelope should reserve strict fields for TPF control semantics:
+
+| Field group | Purpose |
+| --- | --- |
+| Pipeline identity | tenant, pipeline id, release version, contract version |
+| Execution identity | execution id, step id, step index, attempt |
+| Item identity | item id, parent item ids, lineage key, fan-in key |
+| Boundary identity | boundary kind, dispatch protocol, step-host id when known |
+| Correlation | correlation id, idempotency key, await interaction id when relevant |
+| Replay/cache | pipeline version, cache policy, replay flag, checkpoint id |
+| Payload metadata | payload encoding, schema hint, content type, payload hash |
+| Payload location | inline payload, bytes, JSON, or payload reference |
+
+The payload may be loose. These control fields may not be loose.
+
+## Envelope Without Kafka
+
+Envelope mode should be usable without Kafka:
+
+1. **Local envelope host**: compatibility tests and gradual typing inside one process.
+2. **REST envelope host**: non-Java services that do not want generated DTO classes yet.
+3. **gRPC envelope host**: protobuf framing with loose payloads.
+4. **SQS transition worker**: current command/result envelope shape with serialized payload metadata.
+
+## Brokered Data Flow
+
+For brokered execution, the record should carry a TPF envelope. The broker record key should derive from TPF semantics:
+
+| Flow | Candidate key |
+| --- | --- |
+| one-to-one step | item id or idempotency key |
+| one-to-many output | parent item id plus output index |
+| many-to-one fan-in | fan-in key or document id |
+| await request | interaction id or correlation id |
+| checkpoint handoff | checkpoint id or business aggregate id |
+
+The broker key should support ordering and grouping, but fan-in correctness remains a TPF responsibility.

--- a/docs/guide/evolve/brokered-boundaries/index.md
+++ b/docs/guide/evolve/brokered-boundaries/index.md
@@ -1,0 +1,46 @@
+# Brokered Runtime Boundaries
+
+This implementation-facing guide explains where Kafka-style brokerage fits in TPF without turning Kafka into a new pipeline semantic.
+
+## Recommendation
+
+Do not introduce a general "Kafka mode" for TPF.
+
+Kafka, SQS, REST, gRPC, and local execution should be implementation choices under TPF-owned runtime boundaries. TPF must still own step identity, cardinality, lineage, replay metadata, retry/reject meaning, and typed or declared envelope contracts.
+
+```mermaid
+flowchart LR
+    Model["TPF semantic model<br/>steps, cardinality, lineage, replay"]
+    Boundary["Runtime boundary policy<br/>await, checkpoint, transition dispatch, step host"]
+    Payload["Payload policy<br/>typed DTO, protobuf, envelope, payload_ref"]
+    Substrate["Dispatch substrate<br/>local, REST, gRPC, SQS, Kafka"]
+
+    Model --> Boundary
+    Model --> Payload
+    Boundary --> Substrate
+    Payload --> Substrate
+```
+
+The important separation is:
+
+1. **TPF semantics** define what the pipeline means.
+2. **Boundary policy** defines where execution crosses a runtime seam.
+3. **Payload policy** defines how data is represented at that seam.
+4. **Substrate policy** defines how bytes or envelopes move.
+
+## Guide Map
+
+1. [Boundary Taxonomy](/guide/evolve/brokered-boundaries/boundary-taxonomy) maps broker concepts into TPF runtime boundaries.
+2. [Dispatch Substrates](/guide/evolve/brokered-boundaries/dispatch-substrates) explains why Kafka is a substrate, not a TPF mode.
+3. [Envelope And Data Policy](/guide/evolve/brokered-boundaries/envelope-and-data-policy) separates loose payloads from strict TPF control metadata.
+4. [Adoption And Slices](/guide/evolve/brokered-boundaries/adoption-and-slices) captures the value proposition and implementation ordering.
+
+## Naming
+
+Use **step host** for an external process, service, pod, or function that executes a TPF step boundary.
+
+Keep **transition worker** only for the existing durable coordinator concept described in [Worker Protocols](/guide/evolve/durable-coordinator/worker-protocols). Avoid using "worker" as a generic synonym in this guide because it clashes with existing runtime worker terminology.
+
+## Core Guardrail
+
+Kafka can provide durable delivery, consumer scaling, and operational familiarity. It must not define the pipeline topology, replay meaning, mapper validation, fan-in correctness, or step contract.

--- a/docs/guide/evolve/brokered-boundaries/index.md
+++ b/docs/guide/evolve/brokered-boundaries/index.md
@@ -6,7 +6,7 @@ This implementation-facing guide explains where Kafka-style brokerage fits in TP
 
 Do not introduce a general "Kafka mode" for TPF.
 
-Kafka, SQS, REST, gRPC, and local execution should be implementation choices under TPF-owned runtime boundaries. TPF must still own step identity, cardinality, lineage, replay metadata, retry/reject meaning, and typed or declared envelope contracts.
+Kafka, SQS, REST, gRPC, and local execution should be implementation choices under TPF-owned runtime boundaries. TPF must still own step identity, cardinality, lineage, replay metadata, retry/reject meaning, and declared DTO/envelope contracts.
 
 ```mermaid
 flowchart LR

--- a/docs/guide/evolve/durable-coordinator/index.md
+++ b/docs/guide/evolve/durable-coordinator/index.md
@@ -42,13 +42,17 @@ sequenceDiagram
 
 1. [Worker Protocols](/guide/evolve/durable-coordinator/worker-protocols) explains local, REST, gRPC, and SQS transition workers.
 2. [Step-Aware Invocation Runtime](/guide/evolve/durable-coordinator/boundary-invocation-model) explains the shared invocation seam used by pipeline steps and transition workers.
-3. [Contract And Release Identity](/guide/evolve/durable-coordinator/bundle-contract) explains generated contracts, release activation, and execution pinning.
-4. [Pipeline Contract And Release Model](/guide/evolve/durable-coordinator/pipeline-contract-release-model) describes contract/release descriptors, artifacts, deployment plans, and drift detection.
-5. [Runtime Boundaries And Performance](/guide/evolve/durable-coordinator/runtime-boundaries-performance) explains runtime mapping, patterns, package boundaries, and hot-path guardrails.
-6. [Local APIs](/guide/evolve/durable-coordinator/local-apis) documents the current default-disabled control-plane and admin APIs.
-7. [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment) gives the production-ish self-host topology, configuration, and operator runbooks.
-8. [Self-Hosted HA Roadmap](/guide/evolve/durable-coordinator/self-hosted-ha-roadmap) tracks the hardening work left after the container reference.
-9. [Self-Hosted Milestone](/guide/evolve/durable-coordinator/self-hosted-milestone) tracks what remains after the current self-host proof.
+3. [Brokered Runtime Boundaries](/guide/evolve/brokered-boundaries/) is the entry point for Kafka/SQS-style substrates under TPF-owned semantics.
+4. [Boundary Taxonomy](/guide/evolve/brokered-boundaries/boundary-taxonomy) maps broker concepts into TPF runtime boundaries.
+5. [Dispatch Substrates](/guide/evolve/brokered-boundaries/dispatch-substrates) separates substrate policy from transport, platform, and payload policy.
+6. [Envelope And Data Policy](/guide/evolve/brokered-boundaries/envelope-and-data-policy) separates loose payloads from strict TPF control metadata.
+7. [Contract And Release Identity](/guide/evolve/durable-coordinator/bundle-contract) explains generated contracts, release activation, and execution pinning.
+8. [Pipeline Contract And Release Model](/guide/evolve/durable-coordinator/pipeline-contract-release-model) describes contract/release descriptors, artifacts, deployment plans, and drift detection.
+9. [Runtime Boundaries And Performance](/guide/evolve/durable-coordinator/runtime-boundaries-performance) explains runtime mapping, patterns, package boundaries, and hot-path guardrails.
+10. [Local APIs](/guide/evolve/durable-coordinator/local-apis) documents the current default-disabled control-plane and admin APIs.
+11. [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment) gives the production-ish self-host topology, configuration, and operator runbooks.
+12. [Self-Hosted HA Roadmap](/guide/evolve/durable-coordinator/self-hosted-ha-roadmap) tracks the hardening work left after the container reference.
+13. [Self-Hosted Milestone](/guide/evolve/durable-coordinator/self-hosted-milestone) tracks what remains after the current self-host proof.
 
 ## Limits
 


### PR DESCRIPTION
## Summary

Adds implementation-facing Evolve guidance for Kafka/SQS-style brokered runtime boundaries without introducing a generic Kafka mode.

Includes:
- brokered runtime boundary overview and guardrails
- boundary taxonomy that maps broker concepts into TPF semantics
- dispatch substrate guidance for local, REST, gRPC, SQS, and Kafka
- envelope/data policy, including envelope use without Kafka
- adoption/value proposition and implementation slice ordering

## Scope

Docs only. This PR does not implement Kafka support, envelope runtime APIs, new config keys, or durable coordinator behavior changes.

## Validation

Passed locally:
- `git diff --cached --check`
- `rg` check for TPF Cloud / managed-cloud mentions in `docs/guide/evolve/brokered-boundaries`
- `npm --prefix docs run build`

Local CodeRabbit review was attempted but could not run because the CLI is not authenticated in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive "Brokered Runtime Boundaries" implementation guide with new sections on boundary taxonomy, dispatch substrate patterns, envelope and data policy frameworks, and adoption roadmap with recommended candidate slices and preservation guardrails.
  * Updated site navigation sidebar to improve discoverability of brokered boundary resources and related architecture topics across the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->