### PR TITLE
Add Spring REST unary smoke with neutral runner core

### DIFF
--- a/docs/guide/evolve/framework-portability-assessment/roadmap-and-guardrails.md
+++ b/docs/guide/evolve/framework-portability-assessment/roadmap-and-guardrails.md
@@ -8,10 +8,12 @@
 | Add `ExecutionContextCarrier` abstraction for Vert.x locals | Medium | Medium | Required for Reactors context propagation |
 | Make YAML services valid without `@PipelineStep` | Medium | Medium | Unlocks annotation-removal trajectory |
 | Split `framework/runtime` into core plus Quarkus runtime artifact | Medium-High | High | Creates real portability boundary |
+| Extract neutral runner sequencing core | Medium | High | Lets Quarkus and Spring share execution ordering instead of forking runners |
 | Convert store SPIs to neutral async types | Medium | High | Enables non-Mutiny providers |
 | Add renderer-profile registry | Medium | Medium | Keeps semantic model stable while adding Spring generation |
 | Add Spring Boot runtime adapter skeleton | Medium | Medium | Proves Spring can host runtime-core seams without Quarkus runtime dependencies |
 | Build minimal Spring Boot unary/local pipeline | Medium | High | First generated Spring local unary proof |
+| Build minimal Spring Boot unary/REST pipeline | Medium | High | First generated Spring WebFlux unary proof |
 | Add full Spring WebFlux/Reactor/gRPC/await/checkpoint parity | High | High | Production-capable portability |
 
 First portability PR gates:

--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -22,6 +22,7 @@ The goal is:
 - `EventBusBridge`
 - `WorkDispatcher`
 - `RuntimeAdapters`
+- `PipelineRunnerCore`
 
 `framework/runtime` remains Quarkus-first today and registers concrete implementations in `RuntimeAdapterBootstrap`.
 `framework/runtime-spring` provides the first Spring Boot adapter for these same contracts without depending on the
@@ -35,8 +36,8 @@ The Spring adapter currently proves host integration only:
 - Optional Spring transaction manager integration.
 - Spring application-event publishing for event and work dispatch seams.
 
-It does not yet provide generated Spring pipeline execution, WebFlux resources, Reactor context propagation, persistence
-providers, broker integration, or REST/gRPC transport parity.
+It does not yet provide production Spring parity, Reactor context propagation, persistence providers, broker integration,
+or gRPC transport parity.
 
 ## Renderer profile plumbing
 
@@ -53,9 +54,9 @@ For the surrounding configuration model, see [build configuration](/guide/build/
 
 `PipelineGenerationPhase` passes the profile through and uses renderer-instance FQCN helpers when recording role metadata for orchestrator function handlers. That avoids hard-coding a provider class name at generation time.
 
-## Spring unary local smoke
+## Spring unary smoke
 
-The `spring` renderer profile now has one real generated execution proof:
+The `spring` renderer profile now has two narrow generated execution proofs:
 
 - `pipeline.transport=LOCAL`
 - `pipeline.platform=COMPUTE`
@@ -63,9 +64,11 @@ The `spring` renderer profile now has one real generated execution proof:
 - reactive-authored `UNARY_UNARY` steps
 - generated Spring `@Component` local step beans
 
-Generated Spring local step beans implement the neutral `runtime-core` `PipelineUnaryStep<I, O>` contract and adapt the authored Mutiny service boundary to `CompletionStage` at the generated-code edge. `framework/runtime-spring` contributes a minimal `SpringUnaryPipelineRunner` that executes discovered unary step beans in a Spring context.
+Generated Spring local step beans implement the neutral `runtime-core` `PipelineUnaryStep<I, O>` contract and adapt the authored Mutiny service boundary to `CompletionStage` at the generated-code edge. `framework/runtime-spring` contributes `SpringPipelineRunner`, an adapter over the shared `PipelineRunnerCore`; the Quarkus `PipelineRunner` also delegates ordered step sequencing to that same core.
 
-Unsupported Spring profile combinations fail at build time instead of falling back to Quarkus generation. The unsupported set still includes REST/WebFlux resources, Reactor-native generated contracts, gRPC, function handlers, await/durable/checkpoint/broker paths, persistence, delegated/operator steps, side effects, and non-unary streaming shapes.
+The same profile also supports a constrained `pipeline.transport=REST`, `pipeline.platform=COMPUTE` unary smoke. Generation emits Spring WebFlux `@RestController` resources and the matching Spring unary step beans, then routes the HTTP request through `SpringPipelineRunner` and the shared runner core.
+
+Unsupported Spring profile combinations fail at build time instead of falling back to Quarkus generation. The unsupported set still includes Reactor-native generated service contracts, gRPC, function handlers, await/durable/checkpoint/broker paths, persistence, delegated/operator steps, side effects, and non-unary streaming shapes.
 
 ## Vert.x seam and context propagation
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -88,7 +88,9 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             ? new SpringLocalClientStepRenderer()
             : new org.pipelineframework.processor.renderer.LocalClientStepRenderer();
         RestClientStepRenderer restClientRenderer = new RestClientStepRenderer();
-        RestResourceRenderer restRenderer = new RestResourceRenderer();
+        PipelineRenderer<RestBinding> restRenderer = springProfile
+            ? new SpringRestResourceRenderer()
+            : new RestResourceRenderer();
         RestFunctionHandlerRenderer restFunctionHandlerRenderer = new RestFunctionHandlerRenderer();
         BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer = new BlockingReactiveBridgeRenderer();
         RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer = new RemoteOperatorAdapterRenderer();
@@ -478,7 +480,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             org.pipelineframework.processor.renderer.ClientStepRenderer clientRenderer,
             PipelineRenderer<LocalBinding> localClientRenderer,
             RestClientStepRenderer restClientRenderer,
-            RestResourceRenderer restRenderer,
+            PipelineRenderer<RestBinding> restRenderer,
             RestFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
             RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -143,6 +143,12 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
+        if (SpringRendererProfileSupport.isSpringProfile(ctx)
+            && transportMode == PipelineTransport.REST
+            && !model.sideEffect()
+            && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
+            return Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP);
+        }
         LinkedHashSet<GenerationTarget> targets = new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode));
         if (model.serviceApiKind() != ServiceApiKind.REACTIVE
             && model.delegateService() == null

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
@@ -25,6 +25,7 @@ import javax.tools.Diagnostic;
 import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 
@@ -47,8 +48,9 @@ final class SpringRendererProfileSupport {
         }
 
         List<String> errors = new ArrayList<>();
-        if (!ctx.isTransportModeLocal()) {
-            errors.add("Spring renderer profile currently supports only pipeline.transport=LOCAL.");
+        PipelineTransport transportMode = ctx.getTransportMode();
+        if (transportMode != PipelineTransport.LOCAL && transportMode != PipelineTransport.REST) {
+            errors.add("Spring renderer profile currently supports only pipeline.transport=LOCAL or REST.");
         }
         if (ctx.isPlatformModeFunction()) {
             errors.add("Spring renderer profile currently supports only pipeline.platform=COMPUTE.");
@@ -58,7 +60,7 @@ final class SpringRendererProfileSupport {
         }
 
         for (PipelineStepModel model : ctx.getStepModels()) {
-            validateModel(model, errors);
+            validateModel(model, transportMode, errors);
         }
 
         if (!errors.isEmpty()) {
@@ -70,10 +72,12 @@ final class SpringRendererProfileSupport {
         }
     }
 
-    private static void validateModel(PipelineStepModel model, List<String> errors) {
-        Set<GenerationTarget> supportedTargets = Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
+    private static void validateModel(PipelineStepModel model, PipelineTransport transportMode, List<String> errors) {
+        Set<GenerationTarget> supportedTargets = transportMode == PipelineTransport.REST
+            ? Set.of(GenerationTarget.LOCAL_CLIENT_STEP, GenerationTarget.REST_RESOURCE)
+            : Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         if (!supportedTargets.containsAll(model.enabledTargets())) {
-            errors.add("Spring renderer profile currently supports only LOCAL_CLIENT_STEP generation; step '"
+            errors.add("Spring renderer profile currently supports only " + supportedTargets + " generation; step '"
                 + model.serviceName() + "' resolved targets " + model.enabledTargets() + ".");
         }
         if (model.streamingShape() != StreamingShape.UNARY_UNARY) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -89,7 +89,7 @@ class StepArtifactGenerationService {
             ClientStepRenderer clientRenderer,
             PipelineRenderer<LocalBinding> localClientRenderer,
             RestClientStepRenderer restClientRenderer,
-            RestResourceRenderer restRenderer,
+            PipelineRenderer<RestBinding> restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
             RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer,
@@ -368,7 +368,7 @@ class StepArtifactGenerationService {
             ClientStepRenderer clientRenderer,
             PipelineRenderer<LocalBinding> localClientRenderer,
             RestClientStepRenderer restClientRenderer,
-            RestResourceRenderer restRenderer,
+            PipelineRenderer<RestBinding> restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
             RemoteOperatorAdapterRenderer remoteOperatorAdapterRenderer) throws IOException {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestResourceRenderer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import javax.lang.model.element.Modifier;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.RestBinding;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.util.DtoTypeUtils;
+import org.pipelineframework.processor.util.ResourceNameUtils;
+import org.pipelineframework.processor.util.RestPathResolver;
+
+/**
+ * Spring WebFlux renderer for the narrow REST unary portability smoke.
+ */
+public class SpringRestResourceRenderer implements PipelineRenderer<RestBinding> {
+
+    @Override
+    public GenerationTarget target() {
+        return GenerationTarget.REST_RESOURCE;
+    }
+
+    @Override
+    public void render(RestBinding binding, GenerationContext ctx) throws IOException {
+        PipelineStepModel model = binding.model();
+        validateSupported(model);
+
+        TypeSpec resourceClass = buildResourceClass(binding, ctx);
+        JavaFile.builder(model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX, resourceClass)
+            .build()
+            .writeTo(ctx.outputDir());
+    }
+
+    private TypeSpec buildResourceClass(RestBinding binding, GenerationContext ctx) {
+        PipelineStepModel model = binding.model();
+        TypeName inputDomainType = resolveDomainType(model.inboundDomainType());
+        TypeName outputDomainType = resolveDomainType(model.outboundDomainType());
+        TypeName inputDtoType = DtoTypeUtils.toDtoType(inputDomainType);
+        TypeName outputDtoType = DtoTypeUtils.toDtoType(outputDomainType);
+        String servicePath = binding.restPathOverride() != null
+            ? binding.restPathOverride()
+            : RestPathResolver.resolveResourcePath(model, ctx.processingEnv());
+
+        FieldSpec runnerField = FieldSpec.builder(
+                ClassName.get("org.pipelineframework.runtime.spring", "SpringPipelineRunner"),
+                "pipelineRunner",
+                Modifier.PRIVATE,
+                Modifier.FINAL)
+            .build();
+        FieldSpec inboundMapperField = FieldSpec.builder(
+                mapperType(inputDomainType, inputDtoType),
+                "inboundMapper",
+                Modifier.PRIVATE,
+                Modifier.FINAL)
+            .build();
+        FieldSpec outboundMapperField = FieldSpec.builder(
+                mapperType(outputDomainType, outputDtoType),
+                "outboundMapper",
+                Modifier.PRIVATE,
+                Modifier.FINAL)
+            .build();
+
+        return TypeSpec.classBuilder(resourceClassName(model))
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.web.bind.annotation", "RestController"))
+                .build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.web.bind.annotation", "RequestMapping"))
+                .addMember("value", "$S", servicePath)
+                .build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.pipelineframework.annotation", "GeneratedRole"))
+                .addMember("value", "$T.$L",
+                    ClassName.get("org.pipelineframework.annotation", "GeneratedRole", "Role"),
+                    ctx.role().name())
+                .build())
+            .addField(runnerField)
+            .addField(inboundMapperField)
+            .addField(outboundMapperField)
+            .addMethod(constructor(inputDomainType, inputDtoType, outputDomainType, outputDtoType))
+            .addMethod(processMethod(ctx, inputDomainType, outputDomainType, inputDtoType, outputDtoType))
+            .build();
+    }
+
+    private MethodSpec constructor(
+            TypeName inputDomainType,
+            TypeName inputDtoType,
+            TypeName outputDomainType,
+            TypeName outputDtoType) {
+        TypeName runnerType = ClassName.get("org.pipelineframework.runtime.spring", "SpringPipelineRunner");
+        MethodSpec.Builder builder = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(runnerType, "pipelineRunner")
+            .addParameter(mapperType(inputDomainType, inputDtoType), "inboundMapper")
+            .addParameter(mapperType(outputDomainType, outputDtoType), "outboundMapper")
+            .addStatement("this.pipelineRunner = pipelineRunner")
+            .addStatement("this.inboundMapper = inboundMapper")
+            .addStatement("this.outboundMapper = outboundMapper");
+        return builder.build();
+    }
+
+    private MethodSpec processMethod(
+            GenerationContext ctx,
+            TypeName inputDomainType,
+            TypeName outputDomainType,
+            TypeName inputDtoType,
+            TypeName outputDtoType) {
+        TypeName monoOutput = ParameterizedTypeName.get(ClassName.get("reactor.core.publisher", "Mono"), outputDtoType);
+        String operationPath = RestPathResolver.resolveOperationPath(ctx.processingEnv());
+
+        return MethodSpec.methodBuilder("process")
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.web.bind.annotation", "PostMapping"))
+                .addMember("value", "$S", operationPath)
+                .build())
+            .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
+                .addMember("value", "$S", "unchecked")
+                .build())
+            .addModifiers(Modifier.PUBLIC)
+            .returns(monoOutput)
+            .addParameter(ParameterSpec.builder(inputDtoType, "inputDto")
+                .addAnnotation(ClassName.get("org.springframework.web.bind.annotation", "RequestBody"))
+                .build())
+            .addStatement("$T inputDomain = this.inboundMapper.fromExternal(inputDto)", inputDomainType)
+            .addStatement("return $T.fromCompletionStage(this.pipelineRunner.run(inputDomain))\n"
+                    + ".map(output -> this.outboundMapper.toExternal(($T) output))",
+                ClassName.get("reactor.core.publisher", "Mono"),
+                outputDomainType)
+            .build();
+    }
+
+    private TypeName mapperType(TypeName domainType, TypeName dtoType) {
+        return ParameterizedTypeName.get(ClassName.get("org.pipelineframework.mapper", "Mapper"), domainType, dtoType);
+    }
+
+    private void validateSupported(PipelineStepModel model) {
+        if (model.streamingShape() != StreamingShape.UNARY_UNARY) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only unary-unary REST resources; step '"
+                    + model.serviceName() + "' has shape " + model.streamingShape());
+        }
+        if (model.inboundDomainType() == null || model.outboundDomainType() == null) {
+            throw new IllegalArgumentException(
+                "Unary-unary REST resources require non-null input and output domain types; step '"
+                    + model.serviceName() + "'");
+        }
+        if (model.serviceApiKind() != ServiceApiKind.REACTIVE) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only reactive-authored services; step '"
+                    + model.serviceName() + "' has API kind " + model.serviceApiKind());
+        }
+        if (model.sideEffect()) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile does not yet support side-effect REST resources; step '" + model.serviceName() + "'");
+        }
+        if (model.delegateService() != null || model.remoteExecution() != null) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only internal REST resources; step '" + model.serviceName() + "'");
+        }
+    }
+
+    private String resourceClassName(PipelineStepModel model) {
+        return ResourceNameUtils.normalizeBaseName(model.generatedName()) + PipelineStepProcessor.REST_RESOURCE_SUFFIX;
+    }
+
+    private TypeName resolveDomainType(TypeName type) {
+        return type != null ? type : ClassName.OBJECT;
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestResourceRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestResourceRenderer.java
@@ -61,8 +61,8 @@ public class SpringRestResourceRenderer implements PipelineRenderer<RestBinding>
 
     private TypeSpec buildResourceClass(RestBinding binding, GenerationContext ctx) {
         PipelineStepModel model = binding.model();
-        TypeName inputDomainType = resolveDomainType(model.inboundDomainType());
-        TypeName outputDomainType = resolveDomainType(model.outboundDomainType());
+        TypeName inputDomainType = model.inboundDomainType();
+        TypeName outputDomainType = model.outboundDomainType();
         TypeName inputDtoType = DtoTypeUtils.toDtoType(inputDomainType);
         TypeName outputDtoType = DtoTypeUtils.toDtoType(outputDomainType);
         String servicePath = binding.restPathOverride() != null
@@ -186,9 +186,5 @@ public class SpringRestResourceRenderer implements PipelineRenderer<RestBinding>
 
     private String resourceClassName(PipelineStepModel model) {
         return ResourceNameUtils.normalizeBaseName(model.generatedName()) + PipelineStepProcessor.REST_RESOURCE_SUFFIX;
-    }
-
-    private TypeName resolveDomainType(TypeName type) {
-        return type != null ? type : ClassName.OBJECT;
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java
@@ -412,6 +412,16 @@ class PipelineGenerationPhaseIntegrationTest {
         assertFalse(resourceSource.contains("io.vertx."));
         assertFalse(resourceSource.contains("org.jboss.resteasy."));
         assertFalse(resourceSource.contains("jakarta.ws.rs."));
+
+        String clientStepSource = Files.readString(springClientStep);
+        assertTrue(clientStepSource.contains("import org.springframework.stereotype.Component;"));
+        assertTrue(clientStepSource.contains("import java.util.concurrent.CompletionStage;"));
+        assertTrue(clientStepSource.contains("implements PipelineUnaryStep<PaymentRecord, PaymentStatus>"));
+        assertFalse(clientStepSource.contains("io.quarkus."));
+        assertFalse(clientStepSource.contains("jakarta.enterprise."));
+        assertFalse(clientStepSource.contains("io.vertx."));
+        assertFalse(clientStepSource.contains("org.jboss.resteasy."));
+        assertFalse(clientStepSource.contains("jakarta.ws.rs."));
         assertTrue(compilation.generatedFile(StandardLocation.CLASS_OUTPUT, "META-INF/pipeline", "roles.json").isPresent());
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/PipelineGenerationPhaseIntegrationTest.java
@@ -265,6 +265,157 @@ class PipelineGenerationPhaseIntegrationTest {
     }
 
     @Test
+    void springProfileGeneratesYamlOnlyRestUnaryResourceAndStepBean() throws IOException {
+        Path projectRoot = tempDir;
+        Files.writeString(projectRoot.resolve("pom.xml"), """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>spring-rest-smoke</artifactId>
+              <version>1.0.0</version>
+              <packaging>pom</packaging>
+            </project>
+            """);
+
+        Path moduleDir = projectRoot.resolve("spring-rest-smoke");
+        Path generatedSourcesDir = moduleDir.resolve("target/generated-sources/pipeline");
+        Files.createDirectories(generatedSourcesDir);
+
+        Path pipelineConfig = projectRoot.resolve("pipeline.spring-rest.yaml");
+        Files.writeString(pipelineConfig, """
+            appName: "Spring REST Smoke"
+            basePackage: "com.example"
+            transport: "REST"
+            platform: "COMPUTE"
+            steps:
+              - name: "payment"
+                service: "com.example.service.PaymentService"
+                input: "com.example.domain.PaymentRecord"
+                inboundMapper: "com.example.mapper.PaymentRecordMapper"
+                output: "com.example.domain.PaymentStatus"
+                outboundMapper: "com.example.mapper.PaymentStatusMapper"
+            """);
+
+        Compilation compilation = Compiler.javac()
+            .withProcessors(new PipelineStepProcessor())
+            .withOptions(
+                "-Apipeline.generatedSourcesDir=" + generatedSourcesDir.toString().replace('\\', '/'),
+                "-Apipeline.config=" + pipelineConfig.toString().replace('\\', '/'),
+                "-Apipeline.transport=REST",
+                "-Apipeline.platform=COMPUTE",
+                "-Apipeline.codegen.rendererProfile=spring")
+            .compile(
+                JavaFileObjects.forSourceString(
+                    "com.example.service.PaymentService",
+                    """
+                        package com.example.service;
+
+                        import com.example.domain.PaymentRecord;
+                        import com.example.domain.PaymentStatus;
+                        import io.smallrye.mutiny.Uni;
+                        import org.pipelineframework.service.ReactiveService;
+
+                        public class PaymentService implements ReactiveService<PaymentRecord, PaymentStatus> {
+                            @Override
+                            public Uni<PaymentStatus> process(PaymentRecord input) {
+                                return Uni.createFrom().item(new PaymentStatus());
+                            }
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.domain.PaymentRecord",
+                    """
+                        package com.example.domain;
+
+                        public class PaymentRecord {
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.domain.PaymentStatus",
+                    """
+                        package com.example.domain;
+
+                        public class PaymentStatus {
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.dto.PaymentRecordDto",
+                    """
+                        package com.example.dto;
+
+                        public class PaymentRecordDto {
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.dto.PaymentStatusDto",
+                    """
+                        package com.example.dto;
+
+                        public class PaymentStatusDto {
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.mapper.PaymentRecordMapper",
+                    """
+                        package com.example.mapper;
+
+                        import com.example.domain.PaymentRecord;
+                        import com.example.dto.PaymentRecordDto;
+                        import org.pipelineframework.mapper.Mapper;
+
+                        public class PaymentRecordMapper implements Mapper<PaymentRecord, PaymentRecordDto> {
+                            @Override
+                            public PaymentRecord fromExternal(PaymentRecordDto external) {
+                                return new PaymentRecord();
+                            }
+
+                            @Override
+                            public PaymentRecordDto toExternal(PaymentRecord domain) {
+                                return new PaymentRecordDto();
+                            }
+                        }
+                        """),
+                JavaFileObjects.forSourceString(
+                    "com.example.mapper.PaymentStatusMapper",
+                    """
+                        package com.example.mapper;
+
+                        import com.example.domain.PaymentStatus;
+                        import com.example.dto.PaymentStatusDto;
+                        import org.pipelineframework.mapper.Mapper;
+
+                        public class PaymentStatusMapper implements Mapper<PaymentStatus, PaymentStatusDto> {
+                            @Override
+                            public PaymentStatus fromExternal(PaymentStatusDto external) {
+                                return new PaymentStatus();
+                            }
+
+                            @Override
+                            public PaymentStatusDto toExternal(PaymentStatus domain) {
+                                return new PaymentStatusDto();
+                            }
+                        }
+                        """));
+
+        assertThat(compilation).succeeded();
+
+        Path springResource = findGeneratedClass(generatedSourcesDir, "ProcessPaymentResource");
+        Path springClientStep = findGeneratedClass(generatedSourcesDir, "ProcessPaymentLocalClientStep");
+        assertTrue(Files.exists(springResource), "Expected Spring REST resource in " + generatedJavaFiles(generatedSourcesDir));
+        assertTrue(Files.exists(springClientStep), "Expected Spring unary step bean in " + generatedJavaFiles(generatedSourcesDir));
+
+        String resourceSource = Files.readString(springResource);
+        assertTrue(resourceSource.contains("import org.springframework.web.bind.annotation.RestController;"));
+        assertTrue(resourceSource.contains("import reactor.core.publisher.Mono;"));
+        assertFalse(resourceSource.contains("io.quarkus."));
+        assertFalse(resourceSource.contains("jakarta.enterprise."));
+        assertFalse(resourceSource.contains("io.vertx."));
+        assertFalse(resourceSource.contains("org.jboss.resteasy."));
+        assertFalse(resourceSource.contains("jakarta.ws.rs."));
+        assertTrue(compilation.generatedFile(StandardLocation.CLASS_OUTPUT, "META-INF/pipeline", "roles.json").isPresent());
+    }
+
+    @Test
     void generatesRestServerArtifactsForRuntimeMappedModularFunctionStepModule() throws IOException {
         Path projectRoot = tempDir;
         Files.writeString(projectRoot.resolve("pom.xml"), """

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -92,6 +92,21 @@ class PipelineTargetResolutionPhaseTest {
     }
 
     @Test
+    void springProfileResolvesRestServerStepToRestResourceAndUnaryStep() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        context.setRendererProfile("spring");
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(step("SpringRestStep", DeploymentRole.PIPELINE_SERVER)));
+
+        phase.execute(context);
+
+        PipelineStepModel updated = context.getStepModels().getFirst();
+        assertEquals(Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP), updated.enabledTargets());
+        assertEquals(Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP), context.getResolvedTargets());
+    }
+
+    @Test
     void defaultsToGrpcWhenTransportModeIsNull() throws Exception {
         PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
@@ -45,9 +45,21 @@ class SpringRendererProfileSupportTest {
     }
 
     @Test
-    void rejectsRestTransport() {
+    void acceptsRestComputeUnaryStep() {
         PipelineCompilationContext context = context();
         context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(step(
+            Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP),
+            StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE)));
+
+        assertDoesNotThrow(() -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
+    void rejectsGrpcTransport() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.GRPC);
 
         assertThrows(IllegalStateException.class,
             () -> SpringRendererProfileSupport.validateGenerationSupported(context));

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestResourceRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestResourceRendererTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.renderer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.RestBinding;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpringRestResourceRendererTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rendersSpringNativeUnaryRestResource() throws Exception {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE), "/payments"),
+            new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null));
+
+        Path resource = tempDir.resolve("com/example/service/pipeline/PaymentResource.java");
+        String source = Files.readString(resource);
+        assertTrue(source.contains("import org.springframework.web.bind.annotation.PostMapping;"));
+        assertTrue(source.contains("import org.springframework.web.bind.annotation.RequestMapping;"));
+        assertTrue(source.contains("import org.springframework.web.bind.annotation.RequestBody;"));
+        assertTrue(source.contains("import org.springframework.web.bind.annotation.RestController;"));
+        assertTrue(source.contains("import reactor.core.publisher.Mono;"));
+        assertTrue(source.contains("private final SpringPipelineRunner pipelineRunner;"));
+        assertTrue(source.contains("public PaymentResource(SpringPipelineRunner pipelineRunner,"));
+        assertTrue(source.contains("public Mono<PaymentStatusDto> process(@RequestBody PaymentRecordDto inputDto)"));
+        assertTrue(source.contains("PaymentRecord inputDomain = this.inboundMapper.fromExternal(inputDto);"));
+        assertTrue(source.contains("return Mono.fromCompletionStage(this.pipelineRunner.run(inputDomain))"));
+        assertTrue(source.contains(".map(output -> this.outboundMapper.toExternal((PaymentStatus) output));"));
+        assertFalse(source.contains("io.quarkus."));
+        assertFalse(source.contains("jakarta.enterprise."));
+        assertFalse(source.contains("jakarta.inject."));
+        assertFalse(source.contains("io.vertx."));
+        assertFalse(source.contains("org.jboss.resteasy."));
+        assertFalse(source.contains("jakarta.ws.rs."));
+    }
+
+    @Test
+    void resolvesDefaultResourcePathWhenOverrideIsAbsent() throws Exception {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE), null),
+            new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null));
+
+        Path resource = tempDir.resolve("com/example/service/pipeline/PaymentResource.java");
+        String source = Files.readString(resource);
+        assertTrue(source.contains("@RequestMapping(\"/api/v1/payment-status\")"));
+    }
+
+    @Test
+    void rejectsNonUnaryShape() {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_STREAMING, ServiceApiKind.REACTIVE), null),
+                new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null)));
+    }
+
+    @Test
+    void rejectsBlockingAuthoredService() {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, ServiceApiKind.BLOCKING), null),
+                new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null)));
+    }
+
+    @Test
+    void rejectsMissingUnaryDomainTypes() {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        PipelineStepModel missingInput = modelBuilder(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE)
+            .inputMapping(new TypeMapping(null, null, false))
+            .build();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(missingInput, null),
+                new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null)));
+    }
+
+    @Test
+    void rejectsMissingUnaryOutputDomainType() {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        PipelineStepModel missingOutput = modelBuilder(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE)
+            .outputMapping(new TypeMapping(null, null, false))
+            .build();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(missingOutput, null),
+                new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null)));
+    }
+
+    @Test
+    void rejectsSideEffectResource() {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        PipelineStepModel sideEffect = modelBuilder(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE)
+            .sideEffect(true)
+            .build();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(sideEffect, null),
+                new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null)));
+    }
+
+    @Test
+    void rejectsDelegatedResource() {
+        SpringRestResourceRenderer renderer = new SpringRestResourceRenderer();
+
+        PipelineStepModel delegated = modelBuilder(StreamingShape.UNARY_UNARY, ServiceApiKind.REACTIVE)
+            .delegateService(ClassName.get("com.example.service", "DelegateService"))
+            .build();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(delegated, null),
+                new GenerationContext(null, tempDir, DeploymentRole.REST_SERVER, Set.of(), null, null)));
+    }
+
+    private PipelineStepModel model(StreamingShape shape, ServiceApiKind apiKind) {
+        return modelBuilder(shape, apiKind).build();
+    }
+
+    private PipelineStepModel.Builder modelBuilder(StreamingShape shape, ServiceApiKind apiKind) {
+        return new PipelineStepModel.Builder()
+            .serviceName("PaymentService")
+            .generatedName("PaymentService")
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", "PaymentService"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.service.domain", "PaymentRecord"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.service.domain", "PaymentStatus"), null, false))
+            .streamingShape(shape)
+            .enabledTargets(Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .serviceApiKind(apiKind);
+    }
+}

--- a/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/PipelineRunnerCore.java
+++ b/framework/runtime-core/src/main/java/org/pipelineframework/runtime/core/PipelineRunnerCore.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Framework-neutral sequencing core for ordered pipeline step execution.
+ *
+ * <p>The core owns step iteration and range validation only. Host runtimes keep responsibility for
+ * transport binding, telemetry, cache, lifecycle, and actual step invocation semantics.</p>
+ */
+public final class PipelineRunnerCore {
+
+    /**
+     * Run an ordered step range synchronously from the caller perspective.
+     *
+     * @param input input object for the first selected step
+     * @param steps ordered steps
+     * @param startStepIndex first step index to run
+     * @param stopBeforeStepIndex exclusive stop index
+     * @param invoker runtime-specific step invoker
+     * @param <S> step type
+     * @return output from the last invoked step, or the original input when no step is invoked
+     */
+    public <S> Object runSync(
+            Object input,
+            List<S> steps,
+            int startStepIndex,
+            int stopBeforeStepIndex,
+            SyncStepInvoker<S> invoker) {
+        return runSync(input, steps, startStepIndex, stopBeforeStepIndex, invoker, index -> {
+        });
+    }
+
+    /**
+     * Run an ordered step range synchronously with a null-step callback.
+     *
+     * @param input input object for the first selected step
+     * @param steps ordered steps
+     * @param startStepIndex first step index to run
+     * @param stopBeforeStepIndex exclusive stop index
+     * @param invoker runtime-specific step invoker
+     * @param nullStepHandler callback for skipped null steps
+     * @param <S> step type
+     * @return output from the last invoked step, or the original input when no step is invoked
+     */
+    public <S> Object runSync(
+            Object input,
+            List<S> steps,
+            int startStepIndex,
+            int stopBeforeStepIndex,
+            SyncStepInvoker<S> invoker,
+            NullStepHandler nullStepHandler) {
+        Objects.requireNonNull(steps, "steps must not be null");
+        Objects.requireNonNull(invoker, "invoker must not be null");
+        Objects.requireNonNull(nullStepHandler, "nullStepHandler must not be null");
+        validateRange(steps, startStepIndex, stopBeforeStepIndex);
+
+        Object current = input;
+        for (int index = startStepIndex; index < stopBeforeStepIndex; index++) {
+            S step = steps.get(index);
+            if (step == null) {
+                nullStepHandler.onNullStep(index);
+                continue;
+            }
+            current = invoker.invoke(step, current, index);
+        }
+        return current;
+    }
+
+    /**
+     * Run all ordered steps with asynchronous step boundaries.
+     *
+     * @param input input object for the first step
+     * @param steps ordered steps
+     * @param invoker runtime-specific asynchronous step invoker
+     * @param <S> step type
+     * @return stage that completes with the last step output
+     */
+    public <S> CompletionStage<Object> runAsync(Object input, List<S> steps, AsyncStepInvoker<S> invoker) {
+        Objects.requireNonNull(steps, "steps must not be null");
+        Objects.requireNonNull(invoker, "invoker must not be null");
+
+        CompletionStage<Object> current = CompletableFuture.completedFuture(input);
+        for (int index = 0; index < steps.size(); index++) {
+            S step = steps.get(index);
+            if (step == null) {
+                continue;
+            }
+            int stepIndex = index;
+            current = current.thenCompose(value -> invoker.invoke(step, value, stepIndex));
+        }
+        return current;
+    }
+
+    private void validateRange(List<?> steps, int startStepIndex, int stopBeforeStepIndex) {
+        if (startStepIndex < 0 || startStepIndex > steps.size()) {
+            throw new IllegalArgumentException("startStepIndex is out of range: " + startStepIndex);
+        }
+        if (stopBeforeStepIndex < startStepIndex || stopBeforeStepIndex > steps.size()) {
+            throw new IllegalArgumentException("stopBeforeStepIndex is out of range: " + stopBeforeStepIndex);
+        }
+    }
+
+    @FunctionalInterface
+    public interface SyncStepInvoker<S> {
+        Object invoke(S step, Object current, int stepIndex);
+    }
+
+    @FunctionalInterface
+    public interface AsyncStepInvoker<S> {
+        CompletionStage<Object> invoke(S step, Object current, int stepIndex);
+    }
+
+    @FunctionalInterface
+    public interface NullStepHandler {
+        void onNullStep(int stepIndex);
+    }
+}

--- a/framework/runtime-core/src/test/java/org/pipelineframework/runtime/core/PipelineRunnerCoreTest.java
+++ b/framework/runtime-core/src/test/java/org/pipelineframework/runtime/core/PipelineRunnerCoreTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.runtime.core;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PipelineRunnerCoreTest {
+
+    private final PipelineRunnerCore core = new PipelineRunnerCore();
+
+    @Test
+    void runSyncSequencesSelectedStepRange() {
+        Object result = core.runSync(
+            "a",
+            List.of("b", "c", "d"),
+            1,
+            3,
+            (step, current, index) -> current + ":" + index + ":" + step);
+
+        assertEquals("a:1:c:2:d", result);
+    }
+
+    @Test
+    void runSyncRejectsInvalidRange() {
+        assertThrows(IllegalArgumentException.class,
+            () -> core.runSync("a", List.of("b"), 1, 0, (step, current, index) -> current));
+    }
+
+    @Test
+    void runSyncReportsSkippedNullSteps() {
+        AtomicInteger skippedIndex = new AtomicInteger(-1);
+
+        Object result = core.runSync(
+            "a",
+            Arrays.asList("b", null, "d"),
+            0,
+            3,
+            (step, current, index) -> current + ":" + step,
+            skippedIndex::set);
+
+        assertEquals("a:b:d", result);
+        assertEquals(1, skippedIndex.get());
+    }
+
+    @Test
+    void runAsyncSequencesCompletionStageSteps() throws Exception {
+        Object result = core.runAsync(
+                "pay",
+                List.of("validate", "approve"),
+                (step, current, index) -> CompletableFuture.completedFuture(current + ":" + step))
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
+
+        assertEquals("pay:validate:approve", result);
+    }
+
+    @Test
+    void runAsyncSkipsNullSteps() throws Exception {
+        Object result = core.runAsync(
+                "start",
+                Arrays.asList("step1", null, "step2"),
+                (step, current, index) -> CompletableFuture.completedFuture(current + ":" + step))
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
+
+        assertEquals("start:step1:step2", result);
+    }
+}

--- a/framework/runtime-spring/pom.xml
+++ b/framework/runtime-spring/pom.xml
@@ -65,6 +65,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringPipelineRunner.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringPipelineRunner.java
@@ -18,20 +18,20 @@ package org.pipelineframework.runtime.spring;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.pipelineframework.runtime.core.PipelineRunnerCore;
 import org.pipelineframework.runtime.core.PipelineUnaryStep;
 
 /**
- * Minimal Spring-local runner for unary generated pipeline steps.
- *
- * <p>This is a first portability proof for local unary pipelines, not the durable TPF runtime engine.</p>
+ * Spring adapter for the framework-neutral pipeline runner core.
  */
-public class SpringUnaryPipelineRunner {
+public class SpringPipelineRunner {
+    private final PipelineRunnerCore runnerCore;
     private final List<PipelineUnaryStep<?, ?>> steps;
 
-    public SpringUnaryPipelineRunner(List<PipelineUnaryStep<?, ?>> steps) {
+    public SpringPipelineRunner(PipelineRunnerCore runnerCore, List<PipelineUnaryStep<?, ?>> steps) {
+        this.runnerCore = Objects.requireNonNull(runnerCore, "runnerCore");
         this.steps = List.copyOf(Objects.requireNonNull(steps, "steps"));
     }
 
@@ -42,11 +42,7 @@ public class SpringUnaryPipelineRunner {
      * @return stage that completes with the final step output
      */
     public CompletionStage<Object> run(Object input) {
-        CompletionStage<Object> current = CompletableFuture.completedFuture(input);
-        for (PipelineUnaryStep<?, ?> step : steps) {
-            current = current.thenCompose(value -> applyUntyped(step, value));
-        }
-        return current;
+        return runnerCore.runAsync(input, steps, this::applyUntyped);
     }
 
     public int stepCount() {
@@ -54,7 +50,7 @@ public class SpringUnaryPipelineRunner {
     }
 
     @SuppressWarnings("unchecked")
-    private CompletionStage<Object> applyUntyped(PipelineUnaryStep<?, ?> step, Object input) {
+    private CompletionStage<Object> applyUntyped(PipelineUnaryStep<?, ?> step, Object input, int stepIndex) {
         PipelineUnaryStep<Object, Object> typedStep = (PipelineUnaryStep<Object, Object>) step;
         return typedStep.apply(input);
     }

--- a/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfiguration.java
+++ b/framework/runtime-spring/src/main/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.pipelineframework.runtime.spring;
 import java.util.concurrent.Executor;
 import java.util.List;
 
+import org.pipelineframework.runtime.core.PipelineRunnerCore;
 import org.pipelineframework.runtime.core.PipelineUnaryStep;
 import org.pipelineframework.runtime.core.RuntimeAdapters;
 import org.springframework.beans.factory.ObjectProvider;
@@ -56,7 +57,16 @@ public class SpringRuntimeAdaptersAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SpringUnaryPipelineRunner springUnaryPipelineRunner(List<PipelineUnaryStep<?, ?>> pipelineSteps) {
-        return new SpringUnaryPipelineRunner(pipelineSteps);
+    public PipelineRunnerCore pipelineRunnerCore() {
+        return new PipelineRunnerCore();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SpringPipelineRunner springPipelineRunner(
+        PipelineRunnerCore pipelineRunnerCore,
+        List<PipelineUnaryStep<?, ?>> pipelineSteps
+    ) {
+        return new SpringPipelineRunner(pipelineRunnerCore, pipelineSteps);
     }
 }

--- a/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
+++ b/framework/runtime-spring/src/test/java/org/pipelineframework/runtime/spring/SpringRuntimeAdaptersAutoConfigurationTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.runtime.core.PipelineUnaryStep;
 import org.pipelineframework.runtime.core.RuntimeAdapters;
+import reactor.core.publisher.Mono;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -33,10 +34,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.EventListener;
+import org.springframework.http.MediaType;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -130,14 +137,34 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
     }
 
     @Test
-    void unaryPipelineRunnerExecutesSpringStepBeans() {
+    void springPipelineRunnerExecutesSpringStepBeansThroughCore() {
         contextRunner
             .withUserConfiguration(UnaryStepConfig.class)
             .run(context -> {
-                SpringUnaryPipelineRunner runner = context.getBean(SpringUnaryPipelineRunner.class);
+                SpringPipelineRunner runner = context.getBean(SpringPipelineRunner.class);
 
                 assertEquals(2, runner.stepCount());
                 assertEquals("HELLO!", runner.run("hello").toCompletableFuture().get(5, TimeUnit.SECONDS));
+            });
+    }
+
+    @Test
+    void webFluxControllerCanExecuteUnaryPipelineRunner() {
+        contextRunner
+            .withUserConfiguration(RestUnaryStepConfig.class)
+            .run(context -> {
+                WebTestClient client = WebTestClient
+                    .bindToController(context.getBean(RestUnarySmokeController.class))
+                    .build();
+
+                client.post()
+                    .uri("/payments/process")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(new PaymentRecord("p-100"))
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody(PaymentStatus.class)
+                    .value(status -> assertEquals("approved:p-100", status.value()));
             });
     }
 
@@ -289,6 +316,40 @@ class SpringRuntimeAdaptersAutoConfigurationTest {
         @Bean
         PipelineUnaryStep<String, String> suffixStep() {
             return input -> CompletableFuture.completedFuture(input + "!");
+        }
+    }
+
+    record PaymentRecord(String value) {
+    }
+
+    record PaymentStatus(String value) {
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class RestUnaryStepConfig {
+        @Bean
+        PipelineUnaryStep<PaymentRecord, PaymentStatus> approvePaymentStep() {
+            return input -> CompletableFuture.completedFuture(new PaymentStatus("approved:" + input.value()));
+        }
+
+        @Bean
+        RestUnarySmokeController restUnarySmokeController(SpringPipelineRunner runner) {
+            return new RestUnarySmokeController(runner);
+        }
+    }
+
+    @RestController
+    @RequestMapping("/payments")
+    static class RestUnarySmokeController {
+        private final SpringPipelineRunner runner;
+
+        RestUnarySmokeController(SpringPipelineRunner runner) {
+            this.runner = runner;
+        }
+
+        @PostMapping("/process")
+        Mono<PaymentStatus> process(@RequestBody PaymentRecord input) {
+            return Mono.fromCompletionStage(runner.run(input)).map(PaymentStatus.class::cast);
         }
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
@@ -34,6 +34,7 @@ import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
 import org.pipelineframework.awaitable.AwaitExecutionContext;
 import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
+import org.pipelineframework.runtime.core.PipelineRunnerCore;
 import org.pipelineframework.step.Configurable;
 import org.pipelineframework.step.ConfigFactory;
 import org.pipelineframework.step.StepOneToOne;
@@ -72,6 +73,8 @@ public class PipelineRunner implements AutoCloseable {
 
     @Inject
     PipelineStepExecutor stepExecutor;
+
+    private final PipelineRunnerCore runnerCore = new PipelineRunnerCore();
 
     /**
      * Default constructor for PipelineRunner.
@@ -135,47 +138,47 @@ public class PipelineRunner implements AutoCloseable {
             throw new IllegalArgumentException("stopBeforeStepIndex is out of range: " + stopBeforeStepIndex);
         }
 
-        Object current = input;
         ParallelismPolicy parallelismPolicy = parallelismPolicyResolver.resolveParallelismPolicy(pipelineConfig);
         int maxConcurrency = parallelismPolicyResolver.resolveMaxConcurrency(pipelineConfig);
         PipelineTelemetry.RunContext telemetryContext =
-            telemetry.startRun(current, orderedSteps.size(), parallelismPolicy, maxConcurrency);
-        current = telemetry.instrumentInput(current, telemetryContext);
+            telemetry.startRun(input, orderedSteps.size(), parallelismPolicy, maxConcurrency);
+        Object instrumentedInput = telemetry.instrumentInput(input, telemetryContext);
 
         PipelineContext contextSnapshot = PipelineContextHolder.get();
         CacheReadSupport cacheReadSupport = cacheSupportFactory.buildCacheReadSupport();
         AwaitExecutionContext awaitContext = AwaitExecutionContextHolder.get();
-        for (int index = startStepIndex; index < stopBeforeStepIndex; index++) {
-            Object step = orderedSteps.get(index);
-            if (step == null) {
-                logger.warn("Warning: Found null step in configuration, skipping...");
-                continue;
-            }
-            AwaitExecutionContext awaitContextSnapshot = awaitContext == null
-                ? null
-                : new AwaitExecutionContext(awaitContext.tenantId(), awaitContext.executionId(), index);
+        Object current = runnerCore.runSync(
+            instrumentedInput,
+            orderedSteps,
+            startStepIndex,
+            stopBeforeStepIndex,
+            (step, value, index) -> {
+                AwaitExecutionContext awaitContextSnapshot = awaitContext == null
+                    ? null
+                    : new AwaitExecutionContext(awaitContext.tenantId(), awaitContext.executionId(), index);
 
-            if (step instanceof Configurable configurable) {
-                configurable.initialiseWithConfig(configFactory.buildConfig(step.getClass(), pipelineConfig));
-            }
+                if (step instanceof Configurable configurable) {
+                    configurable.initialiseWithConfig(configFactory.buildConfig(step.getClass(), pipelineConfig));
+                }
 
-            Class<?> clazz = step.getClass();
-            logger.debugf("Step class: %s", clazz.getName());
-            for (Class<?> iface : clazz.getInterfaces()) {
-                logger.debugf("Implements: %s", iface.getName());
-            }
+                Class<?> clazz = step.getClass();
+                logger.debugf("Step class: %s", clazz.getName());
+                for (Class<?> iface : clazz.getInterfaces()) {
+                    logger.debugf("Implements: %s", iface.getName());
+                }
 
-            current = stepExecutor.applyStep(
-                step,
-                current,
-                parallelismPolicy,
-                maxConcurrency,
-                telemetry,
-                telemetryContext,
-                cacheReadSupport,
-                contextSnapshot,
-                awaitContextSnapshot);
-        }
+                return stepExecutor.applyStep(
+                    step,
+                    value,
+                    parallelismPolicy,
+                    maxConcurrency,
+                    telemetry,
+                    telemetryContext,
+                    cacheReadSupport,
+                    contextSnapshot,
+                    awaitContextSnapshot);
+            },
+            index -> logger.warnf("Warning: Found null step at index %d in configuration, skipping...", index));
 
         return new ExecutionResult(telemetry.instrumentRunCompletion(current, telemetryContext), telemetryContext);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,14 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <defaultGoal>clean install</defaultGoal>
         <pluginManagement>


### PR DESCRIPTION
## Summary

Adds the next Spring portability proof as one cohesive slice:

- extracts a framework-neutral `PipelineRunnerCore` for ordered step sequencing
- keeps Quarkus `PipelineRunner` as the real Quarkus runtime facade while delegating sequencing to the core
- replaces the temporary Spring unary runner with `SpringPipelineRunner`
- adds Spring WebFlux REST unary generation for `pipeline.codegen.rendererProfile=spring`
- keeps unsupported Spring renderer combinations fail-fast and explicit
- documents the current Spring boundary as local/REST unary smoke only, not production parity

## Scope

In scope:
- Spring `REST + COMPUTE` unary smoke generation
- Spring runtime adapter proof through `SpringPipelineRunner`
- neutral runner-core extraction for shared sequencing
- renderer/profile validation and focused tests

Out of scope:
- Reactor migration
- Spring durable runtime parity
- Spring await/checkpoint/broker support
- WebFlux endpoint scaffolding beyond generated unary resource proof
- broad persistence/runtime migration

## CodeRabbit local review

Ran local CodeRabbit against `origin/main` because local `main` is stale and produced an oversized comparison.

Fixed:
- fail fast when Spring REST unary generation has missing input/output domain types
- include null step index in `PipelineRunner` skip warning
- add async null-step coverage in `PipelineRunnerCoreTest`
- make WebFlux starter test-scoped in `runtime-spring`
- add Spring REST renderer validation coverage
- assert Spring REST generation still emits `roles.json`

Rejected/stale:
- generic `SpringPipelineRunner` result typing: not correct for heterogenous step chains; generated terminal edge remains responsible for the terminal cast
- explicit `jboss-logmanager` version: dependency resolves through existing dependency management and full verify passes
- in-memory `Mapper` source in integration test: stale/wrong; the focused gate compiles and runs the test successfully with `Mapper` on the test classpath

## Validation

- `cr review --agent --base origin/main -c ./AGENTS.md`
- `./mvnw -f framework/pom.xml -pl runtime-core,runtime,runtime-spring,deployment -Dtest=PipelineRunnerCoreTest,PipelineRunnerTest,SpringRestResourceRendererTest,SpringLocalClientStepRendererTest,SpringRendererProfileSupportTest,PipelineTargetResolutionPhaseTest,PipelineGenerationPhaseIntegrationTest,SpringRuntimeAdaptersAutoConfigurationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml verify`
- `npm --prefix docs run build`
- `git diff --check && git diff --cached --check`

Notes:
- The old JBoss LogManager exception trace is gone.
- The existing SLF4J multiple-provider warning remains and is outside this slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Spring Boot REST controller code generation for unary pipeline steps.
  * Introduced framework-neutral pipeline execution core enabling simplified runtime integrations.

* **Documentation**
  * Updated framework evolution guides with Spring Boot runtime implementation details and portability roadmap.

* **Tests**
  * Added comprehensive test coverage for Spring REST code generation and runtime execution core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->