### PR TITLE
Add pipeline composition manifest IR

### DIFF
--- a/examples/checkout/README.md
+++ b/examples/checkout/README.md
@@ -69,7 +69,8 @@ single typed handoff graph so publication, subscription, terminal output, and en
 Validate the canonical composition contract through the framework runtime tests:
 
 ```bash
-./mvnw -f framework/pom.xml -pl runtime '-Dtest=PipelineComposition*Test,CheckoutReferenceContractTest' test
+./mvnw -f framework/pom.xml -pl runtime -am '-Dtest=PipelineComposition*Test,CheckoutReferenceContractTest' \
+  -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
 Build the full example:

--- a/examples/checkout/README.md
+++ b/examples/checkout/README.md
@@ -2,7 +2,9 @@
 
 `examples/checkout` is the canonical TPFGo example for reliable cross-pipeline handoff.
 
-It demonstrates an eight-pipeline application using only the framework checkpoint-publication model:
+It demonstrates an eight-pipeline application using only the framework checkpoint-publication model. The canonical
+composition manifest at `config/canonical/pipeline-composition.yaml` lists the pipeline YAML files; typed handoff edges
+are derived from each pipeline's `input.subscription` and `output.checkpoint` declarations.
 
 1. checkout
 2. consumer-validation
@@ -37,8 +39,9 @@ Concrete handoff targets are supplied at runtime through `pipeline.handoff.bindi
 
 ## Canonical contracts
 
-The canonical YAML contracts live under `config/canonical/`:
+The canonical YAML contracts and composition manifest live under `config/canonical/`:
 
+- `pipeline-composition.yaml`
 - `01-checkout-pipeline.yaml`
 - `02-consumer-validation-pipeline.yaml`
 - `03-restaurant-acceptance-pipeline.yaml`
@@ -48,7 +51,8 @@ The canonical YAML contracts live under `config/canonical/`:
 - `07-payment-capture-pipeline.yaml`
 - `08-compensation-failure-pipeline.yaml`
 
-Each file is kept in sync with the runnable module `pipeline.yaml`.
+Each pipeline file is kept in sync with the runnable module `pipeline.yaml`. The composition manifest is validated as a
+single typed handoff graph so publication, subscription, terminal output, and entry input contracts cannot drift.
 
 ## Runtime model
 
@@ -61,6 +65,12 @@ Each file is kept in sync with the runnable module `pipeline.yaml`.
 - idempotency is explicit on each publication boundary
 
 ## Validation
+
+Validate the canonical composition contract through the framework runtime tests:
+
+```bash
+./mvnw -f framework/pom.xml -pl runtime '-Dtest=PipelineComposition*Test,CheckoutReferenceContractTest' test
+```
 
 Build the full example:
 
@@ -83,4 +93,4 @@ Run the full TPFGo checkpoint-flow integration suite directly:
 
 ## Docs
 
-The user-facing walkthrough is in [docs/guide/development/tpfgo-example.md](/Users/mari/tpf5/docs/guide/development/tpfgo-example.md).
+The user-facing walkthrough is in [docs/guide/development/tpfgo-example.md](../../docs/guide/development/tpfgo-example.md).

--- a/examples/checkout/config/canonical/pipeline-composition.yaml
+++ b/examples/checkout/config/canonical/pipeline-composition.yaml
@@ -1,0 +1,19 @@
+version: 1
+name: tpfgo-checkout
+pipelines:
+  - id: checkout
+    path: 01-checkout-pipeline.yaml
+  - id: consumer-validation
+    path: 02-consumer-validation-pipeline.yaml
+  - id: restaurant-acceptance
+    path: 03-restaurant-acceptance-pipeline.yaml
+  - id: kitchen-preparation
+    path: 04-kitchen-preparation-pipeline.yaml
+  - id: dispatch
+    path: 05-dispatch-pipeline.yaml
+  - id: delivery-execution
+    path: 06-delivery-execution-pipeline.yaml
+  - id: payment-capture
+    path: 07-payment-capture-pipeline.yaml
+  - id: compensation-failure
+    path: 08-compensation-failure-pipeline.yaml

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionConfig.java
@@ -1,0 +1,44 @@
+package org.pipelineframework.config.composition;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Top-level typed pipeline composition manifest.
+ *
+ * @param version composition manifest version
+ * @param name logical composition name
+ * @param pipelines pipeline YAML files included in the composition
+ */
+public record PipelineCompositionConfig(
+    int version,
+    String name,
+    List<PipelineCompositionPipeline> pipelines
+) {
+    public PipelineCompositionConfig {
+        if (version != 1) {
+            throw new IllegalArgumentException("pipeline composition version must be 1");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("pipeline composition name must not be blank");
+        }
+        if (pipelines == null || pipelines.isEmpty()) {
+            throw new IllegalArgumentException("pipeline composition must declare at least one pipeline");
+        }
+        name = name.trim();
+        pipelines = List.copyOf(pipelines);
+
+        Set<String> ids = new LinkedHashSet<>();
+        List<String> duplicates = new ArrayList<>();
+        for (PipelineCompositionPipeline pipeline : pipelines) {
+            if (!ids.add(pipeline.id())) {
+                duplicates.add(pipeline.id());
+            }
+        }
+        if (!duplicates.isEmpty()) {
+            throw new IllegalArgumentException("Duplicate pipeline id(s) in composition: " + duplicates);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoader.java
@@ -1,0 +1,264 @@
+package org.pipelineframework.config.composition;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateConfigLoader;
+import org.pipelineframework.config.template.PipelineTemplateField;
+import org.pipelineframework.config.template.PipelineTemplateStep;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Loads a pipeline composition manifest and resolves it into a validated typed handoff IR.
+ */
+public class PipelineCompositionConfigLoader {
+    private final PipelineTemplateConfigLoader pipelineLoader;
+
+    public PipelineCompositionConfigLoader() {
+        this(new PipelineTemplateConfigLoader());
+    }
+
+    public PipelineCompositionConfigLoader(PipelineTemplateConfigLoader pipelineLoader) {
+        this.pipelineLoader = pipelineLoader == null ? new PipelineTemplateConfigLoader() : pipelineLoader;
+    }
+
+    public PipelineCompositionConfig load(Path manifestPath) {
+        Object root = loadYaml(manifestPath);
+        if (!(root instanceof Map<?, ?> rootMap)) {
+            throw new IllegalStateException("Pipeline composition root is not a map");
+        }
+        return new PipelineCompositionConfig(
+            readVersion(rootMap),
+            readRequiredString(rootMap, "name", "pipeline composition"),
+            readPipelines(rootMap));
+    }
+
+    public PipelineCompositionIr loadIr(Path manifestPath) {
+        PipelineCompositionConfig config = load(manifestPath);
+        Path baseDir = manifestPath.toAbsolutePath().normalize().getParent();
+        if (baseDir == null) {
+            baseDir = Path.of(".").toAbsolutePath().normalize();
+        }
+
+        List<PipelineCompositionNode> nodes = new ArrayList<>();
+        for (PipelineCompositionPipeline pipeline : config.pipelines()) {
+            Path pipelinePath = resolvePipelinePath(baseDir, pipeline);
+            PipelineTemplateConfig pipelineConfig = pipelineLoader.load(pipelinePath);
+            nodes.add(new PipelineCompositionNode(pipeline.id(), pipelinePath, pipelineConfig));
+        }
+        return validate(config, nodes);
+    }
+
+    private Object loadYaml(Path path) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(1_000_000);
+        loaderOptions.setMaxAliasesForCollections(50);
+        loaderOptions.setAllowDuplicateKeys(false);
+        Yaml yaml = new Yaml(new SafeConstructor(loaderOptions));
+        try (Reader reader = Files.newBufferedReader(path)) {
+            return yaml.load(reader);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read pipeline composition config: " + path, e);
+        }
+    }
+
+    private int readVersion(Map<?, ?> rootMap) {
+        Object rawVersion = rootMap.get("version");
+        if (rawVersion == null) {
+            throw new IllegalArgumentException("pipeline composition version must be declared");
+        }
+        if (!(rawVersion instanceof Number number)) {
+            throw new IllegalArgumentException("pipeline composition version must be numeric");
+        }
+        int version = number.intValue();
+        if (number.doubleValue() != version) {
+            throw new IllegalArgumentException("pipeline composition version must be an integer");
+        }
+        return version;
+    }
+
+    private List<PipelineCompositionPipeline> readPipelines(Map<?, ?> rootMap) {
+        Object pipelinesObj = rootMap.get("pipelines");
+        if (!(pipelinesObj instanceof Iterable<?> pipelineItems)) {
+            throw new IllegalArgumentException("pipeline composition pipelines must be declared as a YAML list");
+        }
+        List<PipelineCompositionPipeline> pipelines = new ArrayList<>();
+        int index = 0;
+        for (Object pipelineObj : pipelineItems) {
+            if (!(pipelineObj instanceof Map<?, ?> pipelineMap)) {
+                throw new IllegalArgumentException(
+                    "pipeline composition pipeline entry at index " + index + " must be a YAML map");
+            }
+            pipelines.add(new PipelineCompositionPipeline(
+                readRequiredString(pipelineMap, "id", "pipeline composition pipeline[" + index + "]"),
+                readRequiredString(pipelineMap, "path", "pipeline composition pipeline[" + index + "]")));
+            index++;
+        }
+        return pipelines;
+    }
+
+    private String readRequiredString(Map<?, ?> map, String key, String context) {
+        Object value = map.get(key);
+        if (value == null || String.valueOf(value).isBlank()) {
+            throw new IllegalArgumentException(context + "." + key + " must not be blank");
+        }
+        return String.valueOf(value).trim();
+    }
+
+    private Path resolvePipelinePath(Path baseDir, PipelineCompositionPipeline pipeline) {
+        Path authoredPath = Path.of(pipeline.path());
+        Path resolved = authoredPath.isAbsolute()
+            ? authoredPath.normalize()
+            : baseDir.resolve(authoredPath).normalize();
+        if (!Files.isRegularFile(resolved)) {
+            throw new IllegalArgumentException(
+                "Pipeline composition pipeline '" + pipeline.id() + "' file does not exist: " + resolved);
+        }
+        return resolved;
+    }
+
+    PipelineCompositionIr validate(PipelineCompositionConfig config, List<PipelineCompositionNode> nodes) {
+        Map<String, PipelineCompositionNode> producersByPublication = new LinkedHashMap<>();
+        Map<String, List<PipelineCompositionNode>> consumersByPublication = new LinkedHashMap<>();
+        List<String> entrypoints = new ArrayList<>();
+
+        for (PipelineCompositionNode node : nodes) {
+            if (node.config().steps().isEmpty()) {
+                throw new IllegalStateException("Pipeline '" + node.id() + "' must define at least one step");
+            }
+            node.checkpointPublication().ifPresent(publication -> registerProducer(producersByPublication, publication, node));
+            node.subscriptionPublication().ifPresentOrElse(
+                publication -> consumersByPublication.computeIfAbsent(publication, ignored -> new ArrayList<>()).add(node),
+                () -> entrypoints.add(node.id()));
+        }
+
+        List<PipelineCompositionHandoff> handoffs = new ArrayList<>();
+        Set<String> consumedPublications = new LinkedHashSet<>();
+        for (Map.Entry<String, List<PipelineCompositionNode>> entry : consumersByPublication.entrySet()) {
+            String publication = entry.getKey();
+            PipelineCompositionNode producer = producersByPublication.get(publication);
+            if (producer == null) {
+                throw new IllegalStateException(
+                    "Pipeline subscription for publication '" + publication + "' has no producer in composition");
+            }
+            consumedPublications.add(publication);
+            for (PipelineCompositionNode consumer : entry.getValue()) {
+                validateHandoff(publication, producer, consumer);
+                PipelineTemplateStep terminalStep = producer.terminalStep();
+                PipelineTemplateStep entryStep = consumer.entryStep();
+                handoffs.add(new PipelineCompositionHandoff(
+                    publication,
+                    producer.id(),
+                    consumer.id(),
+                    terminalStep.outputTypeName(),
+                    entryStep.inputTypeName()));
+            }
+        }
+
+        List<String> terminalPublications = producersByPublication.keySet().stream()
+            .filter(publication -> !consumedPublications.contains(publication))
+            .toList();
+
+        return new PipelineCompositionIr(config, nodes, handoffs, entrypoints, terminalPublications);
+    }
+
+    private void registerProducer(
+        Map<String, PipelineCompositionNode> producersByPublication,
+        String publication,
+        PipelineCompositionNode producer
+    ) {
+        PipelineCompositionNode previous = producersByPublication.putIfAbsent(publication, producer);
+        if (previous != null) {
+            throw new IllegalStateException(
+                "Duplicate checkpoint publication '" + publication + "' produced by pipelines '"
+                    + previous.id() + "' and '" + producer.id() + "'");
+        }
+    }
+
+    private void validateHandoff(String publication, PipelineCompositionNode producer, PipelineCompositionNode consumer) {
+        PipelineTemplateStep terminalStep = producer.terminalStep();
+        PipelineTemplateStep entryStep = consumer.entryStep();
+        if (!Objects.equals(terminalStep.outputTypeName(), entryStep.inputTypeName())) {
+            throw new IllegalStateException(
+                "Pipeline handoff type mismatch for publication '" + publication + "': producer '"
+                    + producer.id() + "' outputs '" + terminalStep.outputTypeName() + "' but consumer '"
+                    + consumer.id() + "' expects '" + entryStep.inputTypeName() + "'");
+        }
+        validateFieldCompatibility(publication, producer, consumer, terminalStep.outputFields(), entryStep.inputFields());
+    }
+
+    private void validateFieldCompatibility(
+        String publication,
+        PipelineCompositionNode producer,
+        PipelineCompositionNode consumer,
+        List<PipelineTemplateField> outputFields,
+        List<PipelineTemplateField> inputFields
+    ) {
+        Map<String, PipelineTemplateField> outputs = byFieldName(outputFields, producer.id(), "output");
+        Map<String, PipelineTemplateField> inputs = byFieldName(inputFields, consumer.id(), "input");
+        if (!outputs.keySet().equals(inputs.keySet())) {
+            throw new IllegalStateException(
+                "Pipeline handoff fields mismatch for publication '" + publication + "' from '"
+                    + producer.id() + "' to '" + consumer.id() + "': producer fields="
+                    + outputs.keySet() + ", consumer fields=" + inputs.keySet());
+        }
+        for (Map.Entry<String, PipelineTemplateField> entry : outputs.entrySet()) {
+            String fieldName = entry.getKey();
+            PipelineTemplateField output = entry.getValue();
+            PipelineTemplateField input = inputs.get(fieldName);
+            assertFieldValue(publication, producer, consumer, fieldName, "number", output.number(), input.number());
+            assertFieldValue(publication, producer, consumer, fieldName, "type", output.type(), input.type());
+            assertFieldValue(publication, producer, consumer, fieldName, "protoType", output.protoType(), input.protoType());
+        }
+    }
+
+    private Map<String, PipelineTemplateField> byFieldName(
+        List<PipelineTemplateField> fields,
+        String pipelineId,
+        String direction
+    ) {
+        Map<String, PipelineTemplateField> byName = new LinkedHashMap<>();
+        for (int i = 0; i < fields.size(); i++) {
+            PipelineTemplateField field = fields.get(i);
+            if (field == null || field.name() == null || field.name().isBlank()) {
+                throw new IllegalStateException(
+                    "Pipeline '" + pipelineId + "' has invalid " + direction + " field at index " + i);
+            }
+            PipelineTemplateField previous = byName.putIfAbsent(field.name(), field);
+            if (previous != null) {
+                throw new IllegalStateException(
+                    "Pipeline '" + pipelineId + "' has duplicate " + direction + " field '" + field.name() + "'");
+            }
+        }
+        return byName;
+    }
+
+    private void assertFieldValue(
+        String publication,
+        PipelineCompositionNode producer,
+        PipelineCompositionNode consumer,
+        String fieldName,
+        String attribute,
+        Object outputValue,
+        Object inputValue
+    ) {
+        if (!Objects.equals(outputValue, inputValue)) {
+            throw new IllegalStateException(
+                "Pipeline handoff field " + attribute + " mismatch for publication '" + publication
+                    + "' field '" + fieldName + "' from '" + producer.id() + "' to '" + consumer.id()
+                    + "': producer=" + outputValue + ", consumer=" + inputValue);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoader.java
@@ -111,10 +111,16 @@ public class PipelineCompositionConfigLoader {
 
     private String readRequiredString(Map<?, ?> map, String key, String context) {
         Object value = map.get(key);
-        if (value == null || String.valueOf(value).isBlank()) {
+        if (value == null) {
             throw new IllegalArgumentException(context + "." + key + " must not be blank");
         }
-        return String.valueOf(value).trim();
+        if (!(value instanceof String stringValue)) {
+            throw new IllegalArgumentException(context + "." + key + " must be a string");
+        }
+        if (stringValue.isBlank()) {
+            throw new IllegalArgumentException(context + "." + key + " must not be blank");
+        }
+        return stringValue.trim();
     }
 
     private Path resolvePipelinePath(Path baseDir, PipelineCompositionPipeline pipeline) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionHandoff.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionHandoff.java
@@ -1,0 +1,41 @@
+package org.pipelineframework.config.composition;
+
+/**
+ * Derived typed handoff from one pipeline checkpoint publication to one subscribed pipeline.
+ *
+ * @param publication checkpoint publication name
+ * @param producerPipelineId producer pipeline id
+ * @param consumerPipelineId consumer pipeline id
+ * @param outputTypeName producer terminal output type name
+ * @param inputTypeName consumer entry input type name
+ */
+public record PipelineCompositionHandoff(
+    String publication,
+    String producerPipelineId,
+    String consumerPipelineId,
+    String outputTypeName,
+    String inputTypeName
+) {
+    public PipelineCompositionHandoff {
+        if (publication == null || publication.isBlank()) {
+            throw new IllegalArgumentException("composition handoff publication must not be blank");
+        }
+        if (producerPipelineId == null || producerPipelineId.isBlank()) {
+            throw new IllegalArgumentException("composition handoff producerPipelineId must not be blank");
+        }
+        if (consumerPipelineId == null || consumerPipelineId.isBlank()) {
+            throw new IllegalArgumentException("composition handoff consumerPipelineId must not be blank");
+        }
+        if (outputTypeName == null || outputTypeName.isBlank()) {
+            throw new IllegalArgumentException("composition handoff outputTypeName must not be blank");
+        }
+        if (inputTypeName == null || inputTypeName.isBlank()) {
+            throw new IllegalArgumentException("composition handoff inputTypeName must not be blank");
+        }
+        publication = publication.trim();
+        producerPipelineId = producerPipelineId.trim();
+        consumerPipelineId = consumerPipelineId.trim();
+        outputTypeName = outputTypeName.trim();
+        inputTypeName = inputTypeName.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionIr.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionIr.java
@@ -1,0 +1,30 @@
+package org.pipelineframework.config.composition;
+
+import java.util.List;
+
+/**
+ * Validated typed-tree composition model derived from pipeline boundary declarations.
+ *
+ * @param config source composition manifest
+ * @param nodes resolved pipeline nodes in manifest order
+ * @param handoffs derived publication handoffs
+ * @param entrypointPipelineIds pipeline ids with no input subscription
+ * @param terminalPublications checkpoint publications with no composed consumer
+ */
+public record PipelineCompositionIr(
+    PipelineCompositionConfig config,
+    List<PipelineCompositionNode> nodes,
+    List<PipelineCompositionHandoff> handoffs,
+    List<String> entrypointPipelineIds,
+    List<String> terminalPublications
+) {
+    public PipelineCompositionIr {
+        if (config == null) {
+            throw new IllegalArgumentException("composition config must not be null");
+        }
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
+        handoffs = handoffs == null ? List.of() : List.copyOf(handoffs);
+        entrypointPipelineIds = entrypointPipelineIds == null ? List.of() : List.copyOf(entrypointPipelineIds);
+        terminalPublications = terminalPublications == null ? List.of() : List.copyOf(terminalPublications);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionNode.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionNode.java
@@ -1,0 +1,56 @@
+package org.pipelineframework.config.composition;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateStep;
+
+/**
+ * Resolved pipeline node in a composition IR.
+ *
+ * @param id pipeline id from the composition manifest
+ * @param path resolved pipeline YAML path
+ * @param config parsed pipeline template config
+ */
+public record PipelineCompositionNode(
+    String id,
+    Path path,
+    PipelineTemplateConfig config
+) {
+    public PipelineCompositionNode {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("composition node id must not be blank");
+        }
+        if (path == null) {
+            throw new IllegalArgumentException("composition node path must not be null");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("composition node config must not be null");
+        }
+        id = id.trim();
+        path = path.toAbsolutePath().normalize();
+    }
+
+    public PipelineTemplateStep entryStep() {
+        return config.steps().getFirst();
+    }
+
+    public PipelineTemplateStep terminalStep() {
+        return config.steps().getLast();
+    }
+
+    public Optional<String> subscriptionPublication() {
+        if (config.input() == null || config.input().subscription() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(config.input().subscription().publication());
+    }
+
+    public Optional<String> checkpointPublication() {
+        if (config.output() == null || config.output().checkpoint() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(config.output().checkpoint().publication());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionPipeline.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionPipeline.java
@@ -1,0 +1,20 @@
+package org.pipelineframework.config.composition;
+
+/**
+ * One pipeline entry in a composition manifest.
+ *
+ * @param id stable pipeline id within the composition
+ * @param path path to the pipeline YAML, resolved relative to the composition manifest
+ */
+public record PipelineCompositionPipeline(String id, String path) {
+    public PipelineCompositionPipeline {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("pipeline composition pipeline id must not be blank");
+        }
+        if (path == null || path.isBlank()) {
+            throw new IllegalArgumentException("pipeline composition pipeline path must not be blank");
+        }
+        id = id.trim();
+        path = path.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionPipeline.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/composition/PipelineCompositionPipeline.java
@@ -1,5 +1,7 @@
 package org.pipelineframework.config.composition;
 
+import java.util.regex.Pattern;
+
 /**
  * One pipeline entry in a composition manifest.
  *
@@ -7,6 +9,8 @@ package org.pipelineframework.config.composition;
  * @param path path to the pipeline YAML, resolved relative to the composition manifest
  */
 public record PipelineCompositionPipeline(String id, String path) {
+    private static final Pattern ID_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9._-]*$");
+
     public PipelineCompositionPipeline {
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("pipeline composition pipeline id must not be blank");
@@ -15,6 +19,10 @@ public record PipelineCompositionPipeline(String id, String path) {
             throw new IllegalArgumentException("pipeline composition pipeline path must not be blank");
         }
         id = id.trim();
+        if (!ID_PATTERN.matcher(id).matches()) {
+            throw new IllegalArgumentException(
+                "pipeline composition pipeline id must match ^[a-zA-Z][a-zA-Z0-9._-]*$: " + id);
+        }
         path = path.trim();
     }
 }

--- a/framework/runtime/src/main/resources/META-INF/pipeline/pipeline-composition-schema.json
+++ b/framework/runtime/src/main/resources/META-INF/pipeline/pipeline-composition-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pipelineframework.org/schemas/pipeline-composition.schema.json",
+  "title": "Pipeline Composition Manifest",
+  "description": "Companion manifest that groups pipeline YAML files into a typed checkpoint-handoff composition.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pipelines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9._-]*$"
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "version",
+    "name",
+    "pipelines"
+  ],
+  "additionalProperties": false
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoaderTest.java
@@ -1,0 +1,422 @@
+package org.pipelineframework.config.composition;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.config.boundary.PipelineCheckpointConfig;
+import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
+import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
+import org.pipelineframework.config.boundary.PipelineSubscriptionConfig;
+import org.pipelineframework.config.template.PipelinePlatform;
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateField;
+import org.pipelineframework.config.template.PipelineTemplateMaterialization;
+import org.pipelineframework.config.template.PipelineTemplateStep;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PipelineCompositionConfigLoaderTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadIrResolvesPipelinePathsRelativeToManifest() throws Exception {
+        Path configs = Files.createDirectories(tempDir.resolve("configs"));
+        writePipeline(configs.resolve("producer.yaml"), "Input", fields(field(1, "id", "uuid")), "Output",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        Path manifest = writeManifest(configs,
+            """
+              - id: producer
+                path: producer.yaml
+            """);
+
+        PipelineCompositionIr ir = new PipelineCompositionConfigLoader().loadIr(manifest);
+
+        assertEquals(1, ir.nodes().size());
+        assertEquals(configs.resolve("producer.yaml").toAbsolutePath().normalize(), ir.nodes().getFirst().path());
+        assertEquals(List.of("producer"), ir.entrypointPipelineIds());
+        assertEquals(List.of("orders-ready"), ir.terminalPublications());
+    }
+
+    @Test
+    void duplicatePipelineIdsFail() throws Exception {
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: duplicate
+                path: a.yaml
+              - id: duplicate
+                path: b.yaml
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().load(manifest));
+
+        assertTrue(exception.getMessage().contains("Duplicate pipeline id"));
+    }
+
+    @Test
+    void missingPipelineFileFailsClearly() throws Exception {
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: missing
+                path: missing.yaml
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().loadIr(manifest));
+
+        assertTrue(exception.getMessage().contains("Pipeline composition pipeline 'missing' file does not exist"));
+    }
+
+    @Test
+    void invalidManifestShapeFailsClearly() throws Exception {
+        Path manifest = tempDir.resolve("pipeline-composition.yaml");
+        Files.writeString(manifest,
+            """
+            version: 1
+            name: invalid
+            pipelines:
+              id: not-a-list
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().load(manifest));
+
+        assertEquals("pipeline composition pipelines must be declared as a YAML list", exception.getMessage());
+    }
+
+    @Test
+    void allowsFanOutFromOneCheckpointPublicationToMultipleSubscribers() throws Exception {
+        writePipeline(tempDir.resolve("producer.yaml"), "Input", fields(field(1, "id", "uuid")), "OrderReady",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        writePipeline(tempDir.resolve("consumer-a.yaml"), "OrderReady", fields(field(1, "id", "uuid")), "DoneA",
+            fields(field(1, "id", "uuid")), "orders-ready", "done-a");
+        writePipeline(tempDir.resolve("consumer-b.yaml"), "OrderReady", fields(field(1, "id", "uuid")), "DoneB",
+            fields(field(1, "id", "uuid")), "orders-ready", "done-b");
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: producer
+                path: producer.yaml
+              - id: consumer-a
+                path: consumer-a.yaml
+              - id: consumer-b
+                path: consumer-b.yaml
+            """);
+
+        PipelineCompositionIr ir = new PipelineCompositionConfigLoader().loadIr(manifest);
+
+        assertEquals(3, ir.nodes().size());
+        assertEquals(2, ir.handoffs().size());
+        assertEquals(List.of("producer"), ir.entrypointPipelineIds());
+        assertEquals(List.of("done-a", "done-b"), ir.terminalPublications());
+    }
+
+    @Test
+    void rejectsSubscriptionWithoutProducer() throws Exception {
+        writePipeline(tempDir.resolve("consumer.yaml"), "OrderReady", fields(field(1, "id", "uuid")), "Done",
+            fields(field(1, "id", "uuid")), "orders-ready", "done");
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: consumer
+                path: consumer.yaml
+            """);
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineCompositionConfigLoader().loadIr(manifest));
+
+        assertEquals("Pipeline subscription for publication 'orders-ready' has no producer in composition",
+            exception.getMessage());
+    }
+
+    @Test
+    void rejectsDuplicatePublicationProducers() throws Exception {
+        writePipeline(tempDir.resolve("producer-a.yaml"), "InputA", fields(field(1, "id", "uuid")), "OrderReady",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        writePipeline(tempDir.resolve("producer-b.yaml"), "InputB", fields(field(1, "id", "uuid")), "OrderReady",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: producer-a
+                path: producer-a.yaml
+              - id: producer-b
+                path: producer-b.yaml
+            """);
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineCompositionConfigLoader().loadIr(manifest));
+
+        assertTrue(exception.getMessage().contains("Duplicate checkpoint publication 'orders-ready'"));
+    }
+
+    @Test
+    void rejectsHandoffTypeNameMismatch() throws Exception {
+        writePipeline(tempDir.resolve("producer.yaml"), "Input", fields(field(1, "id", "uuid")), "OrderReady",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        writePipeline(tempDir.resolve("consumer.yaml"), "DifferentOrder", fields(field(1, "id", "uuid")), "Done",
+            fields(field(1, "id", "uuid")), "orders-ready", "done");
+        Path manifest = producerConsumerManifest();
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineCompositionConfigLoader().loadIr(manifest));
+
+        assertTrue(exception.getMessage().contains("Pipeline handoff type mismatch for publication 'orders-ready'"));
+    }
+
+    @Test
+    void rejectsHandoffFieldNumberMismatch() throws Exception {
+        writePipeline(tempDir.resolve("producer.yaml"), "OrderReady", fields(field(1, "id", "uuid")), "OrderReady",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        writePipeline(tempDir.resolve("consumer.yaml"), "OrderReady", fields(field(2, "id", "uuid")), "Done",
+            fields(field(1, "id", "uuid")), "orders-ready", "done");
+        Path manifest = producerConsumerManifest();
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineCompositionConfigLoader().loadIr(manifest));
+
+        assertTrue(exception.getMessage().contains("field number mismatch"));
+    }
+
+    @Test
+    void rejectsHandoffFieldSemanticTypeMismatch() throws Exception {
+        writePipeline(tempDir.resolve("producer.yaml"), "OrderReady", fields(field(1, "id", "uuid")), "OrderReady",
+            fields(field(1, "id", "uuid")), null, "orders-ready");
+        writePipeline(tempDir.resolve("consumer.yaml"), "OrderReady", fields(field(1, "id", "string")), "Done",
+            fields(field(1, "id", "uuid")), "orders-ready", "done");
+        Path manifest = producerConsumerManifest();
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineCompositionConfigLoader().loadIr(manifest));
+
+        assertTrue(exception.getMessage().contains("field type mismatch"));
+    }
+
+    @Test
+    void rejectsHandoffFieldProtoTypeMismatch() throws Exception {
+        PipelineCompositionConfig config = new PipelineCompositionConfig(1, "test",
+            List.of(
+                new PipelineCompositionPipeline("producer", "producer.yaml"),
+                new PipelineCompositionPipeline("consumer", "consumer.yaml")));
+        PipelineTemplateField outputField = normalizedField(1, "id", "uuid", "string");
+        PipelineTemplateField inputField = normalizedField(1, "id", "uuid", "bytes");
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineCompositionConfigLoader().validate(config, List.of(
+                node("producer", null, "orders-ready", "Input", List.of(outputField), "OrderReady", List.of(outputField)),
+                node("consumer", "orders-ready", "done", "OrderReady", List.of(inputField), "Done", List.of(inputField)))));
+
+        assertTrue(exception.getMessage().contains("field protoType mismatch"));
+    }
+
+    @Test
+    void acceptsKitchenFanOutFanInInsideSinglePipeline() throws Exception {
+        Files.writeString(tempDir.resolve("kitchen.yaml"),
+            """
+            version: 2
+            appName: Kitchen
+            basePackage: com.example.kitchen
+            transport: GRPC
+            messages:
+              OrderAccepted:
+                fields:
+                  - number: 1
+                    name: id
+                    type: uuid
+              KitchenTask:
+                fields:
+                  - number: 1
+                    name: id
+                    type: uuid
+                  - number: 2
+                    name: task
+                    type: string
+              OrderReady:
+                fields:
+                  - number: 1
+                    name: id
+                    type: uuid
+            steps:
+              - name: Expand Tasks
+                cardinality: ONE_TO_MANY
+                inputTypeName: OrderAccepted
+                outputTypeName: KitchenTask
+              - name: Reduce Tasks
+                cardinality: MANY_TO_ONE
+                inputTypeName: KitchenTask
+                outputTypeName: OrderReady
+            output:
+              checkpoint:
+                publication: orders-ready
+                idempotencyKeyFields: [id]
+            """);
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: kitchen
+                path: kitchen.yaml
+            """);
+
+        PipelineCompositionIr ir = new PipelineCompositionConfigLoader().loadIr(manifest);
+
+        assertEquals(1, ir.nodes().size());
+        assertEquals("MANY_TO_ONE", ir.nodes().getFirst().terminalStep().cardinality());
+        assertEquals(List.of("orders-ready"), ir.terminalPublications());
+    }
+
+    @Test
+    void compositionSchemaResourceIsPackaged() {
+        assertNotNull(Thread.currentThread().getContextClassLoader()
+            .getResource("META-INF/pipeline/pipeline-composition-schema.json"));
+    }
+
+    private Path producerConsumerManifest() throws Exception {
+        return writeManifest(tempDir,
+            """
+              - id: producer
+                path: producer.yaml
+              - id: consumer
+                path: consumer.yaml
+            """);
+    }
+
+    private Path writeManifest(Path directory, String pipelineEntries) throws Exception {
+        Path manifest = directory.resolve("pipeline-composition.yaml");
+        Files.writeString(manifest,
+            """
+            version: 1
+            name: test-composition
+            pipelines:
+            %s
+            """.formatted(pipelineEntries));
+        return manifest;
+    }
+
+    private void writePipeline(
+        Path path,
+        String inputType,
+        String inputFields,
+        String outputType,
+        String outputFields,
+        String subscriptionPublication,
+        String checkpointPublication
+    ) throws Exception {
+        String inputBoundary = subscriptionPublication == null ? "" : """
+            input:
+              subscription:
+                publication: %s
+            """.formatted(subscriptionPublication);
+        String outputBoundary = checkpointPublication == null ? "" : """
+            output:
+              checkpoint:
+                publication: %s
+                idempotencyKeyFields: [id]
+            """.formatted(checkpointPublication);
+        String messages = inputType.equals(outputType)
+            ? message(inputType, inputFields)
+            : message(inputType, inputFields) + message(outputType, outputFields);
+        Files.writeString(path,
+            """
+            version: 2
+            appName: Test
+            basePackage: com.example.test
+            transport: GRPC
+            messages:
+            %s
+            steps:
+              - name: Process
+                cardinality: ONE_TO_ONE
+                inputTypeName: %s
+                outputTypeName: %s
+            %s%s
+            """.formatted(messages, inputType, outputType, inputBoundary, outputBoundary));
+    }
+
+    private String message(String typeName, String fields) {
+        return """
+              %s:
+                fields:
+            %s
+            """.formatted(typeName, fields);
+    }
+
+    private String fields(String... fields) {
+        return String.join("", fields);
+    }
+
+    private String field(int number, String name, String type) {
+        return """
+                  - number: %d
+                    name: %s
+                    type: %s
+            """.formatted(number, name, type);
+    }
+
+    private PipelineCompositionNode node(
+        String id,
+        String subscriptionPublication,
+        String checkpointPublication,
+        String inputTypeName,
+        List<PipelineTemplateField> inputFields,
+        String outputTypeName,
+        List<PipelineTemplateField> outputFields
+    ) {
+        PipelineInputBoundaryConfig input = subscriptionPublication == null
+            ? null
+            : new PipelineInputBoundaryConfig(new PipelineSubscriptionConfig(subscriptionPublication, null));
+        PipelineOutputBoundaryConfig output = checkpointPublication == null
+            ? null
+            : new PipelineOutputBoundaryConfig(new PipelineCheckpointConfig(checkpointPublication, List.of("id")));
+        PipelineTemplateConfig config = new PipelineTemplateConfig(
+            2,
+            id,
+            "com.example." + id.replace('-', '.'),
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            Map.of(),
+            Map.of(),
+            List.of(new PipelineTemplateStep(
+                "Process",
+                "ONE_TO_ONE",
+                inputTypeName,
+                inputFields,
+                outputTypeName,
+                outputFields)),
+            Map.of(),
+            input,
+            output,
+            new PipelineTemplateMaterialization(List.of()));
+        return new PipelineCompositionNode(id, tempDir.resolve(id + ".yaml"), config);
+    }
+
+    private PipelineTemplateField normalizedField(int number, String name, String type, String protoType) {
+        return new PipelineTemplateField(
+            number,
+            name,
+            type,
+            type,
+            null,
+            "UUID",
+            protoType,
+            null,
+            null,
+            false,
+            false,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/composition/PipelineCompositionConfigLoaderTest.java
@@ -93,6 +93,79 @@ class PipelineCompositionConfigLoaderTest {
     }
 
     @Test
+    void nonStringCompositionNameFailsClearly() throws Exception {
+        Path manifest = tempDir.resolve("pipeline-composition.yaml");
+        Files.writeString(manifest,
+            """
+            version: 1
+            name: 123
+            pipelines:
+              - id: producer
+                path: producer.yaml
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().load(manifest));
+
+        assertEquals("pipeline composition.name must be a string", exception.getMessage());
+    }
+
+    @Test
+    void nonStringPipelineIdFailsClearly() throws Exception {
+        Path manifest = tempDir.resolve("pipeline-composition.yaml");
+        Files.writeString(manifest,
+            """
+            version: 1
+            name: test-composition
+            pipelines:
+              - id: 123
+                path: producer.yaml
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().load(manifest));
+
+        assertEquals("pipeline composition pipeline[0].id must be a string", exception.getMessage());
+    }
+
+    @Test
+    void nonStringPipelinePathFailsClearly() throws Exception {
+        Path manifest = tempDir.resolve("pipeline-composition.yaml");
+        Files.writeString(manifest,
+            """
+            version: 1
+            name: test-composition
+            pipelines:
+              - id: producer
+                path: 123
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().load(manifest));
+
+        assertEquals("pipeline composition pipeline[0].path must be a string", exception.getMessage());
+    }
+
+    @Test
+    void pipelineIdMustMatchSchemaPattern() throws Exception {
+        Path manifest = writeManifest(tempDir,
+            """
+              - id: 1producer
+                path: producer.yaml
+            """);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineCompositionConfigLoader().load(manifest));
+
+        assertTrue(exception.getMessage().contains(
+            "pipeline composition pipeline id must match ^[a-zA-Z][a-zA-Z0-9._-]*$"));
+    }
+
+    @Test
     void allowsFanOutFromOneCheckpointPublicationToMultipleSubscribers() throws Exception {
         writePipeline(tempDir.resolve("producer.yaml"), "Input", fields(field(1, "id", "uuid")), "OrderReady",
             fields(field(1, "id", "uuid")), null, "orders-ready");

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/CheckoutReferenceContractTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/CheckoutReferenceContractTest.java
@@ -2,73 +2,54 @@ package org.pipelineframework.config.template;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.composition.PipelineCompositionHandoff;
+import org.pipelineframework.config.composition.PipelineCompositionIr;
+import org.pipelineframework.config.composition.PipelineCompositionConfigLoader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CheckoutReferenceContractTest {
 
-    private static final String CHECKOUT_CONFIG = "examples/checkout/checkout-orchestrator-svc/pipeline.yaml";
-    private static final String CONSUMER_VALIDATION_CONFIG =
-        "examples/checkout/consumer-validation-orchestrator-svc/pipeline.yaml";
+    private static final String CHECKOUT_COMPOSITION =
+        "examples/checkout/config/canonical/pipeline-composition.yaml";
 
     @Test
-    void checkpointOutputMatchesNextPipelineInputContract() {
-        PipelineTemplateConfigLoader loader = new PipelineTemplateConfigLoader();
+    void canonicalCheckoutCompositionResolvesTypedHandoffs() {
+        PipelineCompositionIr ir = new PipelineCompositionConfigLoader()
+            .loadIr(resolveFromWorkspaceRoot(CHECKOUT_COMPOSITION));
 
-        PipelineTemplateConfig checkout = loader.load(resolveFromWorkspaceRoot(CHECKOUT_CONFIG));
-        PipelineTemplateConfig consumerValidation =
-            loader.load(resolveFromWorkspaceRoot(CONSUMER_VALIDATION_CONFIG));
-
-        assertEquals("GRPC", checkout.transport(), "Checkout transport should be GRPC.");
-        assertEquals("GRPC", consumerValidation.transport(), "Consumer-validation transport should be GRPC.");
-        assertFalse(checkout.steps().isEmpty(), "Checkout pipeline must define steps.");
-        assertFalse(consumerValidation.steps().isEmpty(), "Consumer-validation pipeline must define steps.");
-
-        PipelineTemplateStep checkoutTerminalStep = checkout.steps().getLast();
-        PipelineTemplateStep consumerValidationEntryStep = consumerValidation.steps().getFirst();
-
-        assertEquals(checkoutTerminalStep.outputTypeName(), consumerValidationEntryStep.inputTypeName(),
-            "Pipeline handoff type mismatch between checkout output and consumer-validation input.");
-
-        Map<String, PipelineTemplateField> checkoutOutputFields = byFieldName(checkoutTerminalStep.outputFields());
-        Map<String, PipelineTemplateField> consumerValidationInputFields =
-            byFieldName(consumerValidationEntryStep.inputFields());
-
-        assertEquals(checkoutOutputFields.keySet(), consumerValidationInputFields.keySet(),
-            "Pipeline handoff fields mismatch between checkout output and consumer-validation input.");
-
-        for (Map.Entry<String, PipelineTemplateField> entry : checkoutOutputFields.entrySet()) {
-            String fieldName = entry.getKey();
-            PipelineTemplateField outputField = entry.getValue();
-            PipelineTemplateField inputField = consumerValidationInputFields.get(fieldName);
-            assertEquals(outputField.number(), inputField.number(),
-                "Semantic-v2 field number mismatch for handoff field: " + fieldName);
-            assertEquals(outputField.type(), inputField.type(),
-                "Java type mismatch for handoff field: " + fieldName);
-            assertEquals(outputField.protoType(), inputField.protoType(),
-                "Proto type mismatch for handoff field: " + fieldName);
-        }
+        assertEquals("tpfgo-checkout", ir.config().name());
+        assertEquals(8, ir.nodes().size());
+        assertEquals(7, ir.handoffs().size());
+        assertEquals(List.of("checkout"), ir.entrypointPipelineIds());
+        assertEquals(List.of("tpfgo.compensation.terminal-state.v1"), ir.terminalPublications());
+        assertTrue(ir.nodes().stream().allMatch(node -> "GRPC".equals(node.config().transport())),
+            "Canonical checkout pipelines should use GRPC transport.");
+        assertEquals(
+            List.of(
+                "checkout->consumer-validation:tpfgo.checkout.order-pending.v1",
+                "consumer-validation->restaurant-acceptance:tpfgo.consumer.order-approved.v1",
+                "restaurant-acceptance->kitchen-preparation:tpfgo.restaurant.order-accepted.v1",
+                "kitchen-preparation->dispatch:tpfgo.kitchen.order-ready.v1",
+                "dispatch->delivery-execution:tpfgo.dispatch.delivery-assigned.v1",
+                "delivery-execution->payment-capture:tpfgo.delivery.order-delivered.v1",
+                "payment-capture->compensation-failure:tpfgo.payment.capture-result.v1"),
+            ir.handoffs().stream().map(this::describe).toList());
+        assertEquals("MANY_TO_ONE",
+            ir.nodes().stream()
+                .filter(node -> "kitchen-preparation".equals(node.id()))
+                .findFirst()
+                .orElseThrow()
+                .terminalStep()
+                .cardinality());
     }
 
-    private Map<String, PipelineTemplateField> byFieldName(List<PipelineTemplateField> fields) {
-        Map<String, PipelineTemplateField> byName = new LinkedHashMap<>();
-        for (int i = 0; i < fields.size(); i++) {
-            PipelineTemplateField field = fields.get(i);
-            if (field == null || field.name() == null || field.name().isBlank()) {
-                throw new IllegalStateException("Invalid field definition at index " + i + ": " + field);
-            }
-            if (byName.containsKey(field.name())) {
-                throw new IllegalStateException("Duplicate field name: " + field.name());
-            }
-            byName.put(field.name(), field);
-        }
-        return byName;
+    private String describe(PipelineCompositionHandoff handoff) {
+        return handoff.producerPipelineId() + "->" + handoff.consumerPipelineId() + ":" + handoff.publication();
     }
 
     private Path resolveFromWorkspaceRoot(String relativePath) {


### PR DESCRIPTION
## Summary

Adds a runtime-side composition manifest loader/IR for typed checkpoint-handoff compositions.

This PR includes:
- `pipeline-composition.yaml` for the canonical checkout chain.
- Runtime composition manifest records, loader, derived handoff IR, and packaged JSON schema.
- Validation for producer/subscriber publication matching, duplicate publications, missing producers, and handoff field compatibility.
- Checkout reference contract coverage updated to validate all eight canonical handoffs through the composition IR.
- Checkout README updates for the composition manifest and targeted validation command.

## Scope

In scope:
- Static composition manifest parsing and typed handoff validation.
- Canonical checkout composition proof.

Out of scope:
- Runtime execution of compositions.
- Broker/Kafka transport behavior.
- Template generator or Canvas/UI integration.

## Validation

Passed:
- `git diff --cached --check`
- `./mvnw -f framework/pom.xml -pl runtime '-Dtest=PipelineComposition*Test,CheckoutReferenceContractTest' test`

## Review notes

Local CodeRabbit prompt-only review was attempted but blocked by local CLI authentication. This PR is opened ready so normal GitHub review/check automation can run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pipeline composition manifests enabling multiple pipelines to be connected via typed checkpoint handoffs with automatic validation of compatibility between connected pipelines.

* **Documentation**
  * Updated checkout examples documentation to clarify the pipeline composition structure and validation requirements.

* **Tests**
  * Added comprehensive test coverage for pipeline composition loading, validation, and handoff compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->