### PR TITLE
Add SQS await CSV self-host HA reference

### DIFF
--- a/docs/guide/build/configuration/index.md
+++ b/docs/guide/build/configuration/index.md
@@ -225,7 +225,7 @@ Prefix: `pipeline.orchestrator`
 | `pipeline.orchestrator.dlq-provider` | string | `log` | Dead-letter publisher provider for terminal execution failures. |
 | `pipeline.orchestrator.dlq-url` | string | none | Dead-letter queue URL when `dlq-provider=sqs`. |
 | `pipeline.orchestrator.queue-url` | string | none | Queue URL for external dispatcher providers. |
-| `pipeline.orchestrator.resume-token-secret` | string | none | HMAC secret used to sign and verify await resume tokens for webhook-based await steps. Required when using the webhook transport adapter for await boundary steps. Use a high-entropy value, preferably at least 32 random bytes encoded as base64 or hex. If this property is missing, the orchestrator fails with a clear error when webhook dispatch attempts to generate a token. See [Await Boundaries](/guide/development/orchestrator-runtime/await). |
+| `pipeline.orchestrator.resume-token-secret` | string | none | HMAC secret used to sign and verify await resume tokens. Required for signed webhook, Kafka, and SQS await dispatch/completion. Use a high-entropy value, preferably at least 32 random bytes encoded as base64 or hex. If this property is missing, signed await dispatch fails with a clear error rather than allowing unsigned resumptions. See [Await Boundaries](/guide/development/orchestrator-runtime/await). |
 | `pipeline.orchestrator.control-plane.enabled` | boolean | `false` | Enables the internal hosted-control-plane REST surface under `/tpf/control-plane/tenants/{tenantId}` for local/dev coordinator proofs. |
 | `pipeline.orchestrator.control-plane.admin-token` | string | none | Bearer token accepted by the hosted-control-plane REST surface. Configure exactly one of `admin-token` or `admin-token-ref` when the surface is enabled. |
 | `pipeline.orchestrator.control-plane.admin-token-ref` | string | none | Local secret reference for the hosted-control-plane bearer token. Supports `env:NAME`, `sys:property.name`, and `config:some.config.key`. |
@@ -275,7 +275,7 @@ Background execution notes:
 3. In queue mode, strict startup also requires `pipeline.orchestrator.idempotency-policy` to be explicitly set to a non-default value.
 4. In-memory providers are for local/dev only; use providers backed by external storage/queues for crash recovery.
 5. For dead-letter handling that survives restarts, set both `pipeline.orchestrator.dlq-provider=sqs` and `pipeline.orchestrator.dlq-url`.
-6. For webhook await steps using signed resume tokens, configure a stable `pipeline.orchestrator.resume-token-secret`; rotating it invalidates outstanding resume tokens.
+6. For webhook, Kafka, or SQS await steps using signed resume tokens, configure a stable `pipeline.orchestrator.resume-token-secret`; rotating it invalidates outstanding resume tokens.
 7. Remote transition worker selection is inferred from configured targets: REST uses `pipeline.orchestrator.worker.rest.base-url`, gRPC uses `pipeline.orchestrator.worker.grpc.endpoint`, SQS uses `pipeline.orchestrator.worker.sqs.request-queue-url`, and no remote target uses the local in-process worker.
 8. Configure at most one remote worker target. Multiple remote targets fail startup as ambiguous; there is no `worker.provider` selector.
 9. `pipeline.platform` remains orthogonal and does not select worker invocation.
@@ -295,6 +295,36 @@ pipeline.orchestrator.queue-url=https://sqs.eu-west-1.amazonaws.com/123456789012
 pipeline.orchestrator.dlq-url=https://sqs.eu-west-1.amazonaws.com/123456789012/tpf-dlq
 pipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
 ```
+
+### Await Transports
+
+Await transport selection is authored per `kind: await` step in pipeline YAML. These runtime properties enable the concrete adapter plumbing for broker-backed await providers.
+
+#### Kafka Await
+
+Prefix: `tpf.await.kafka`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `tpf.await.kafka.reactive-messaging.enabled` | boolean | `false` | Enables the Quarkus Reactive Messaging Kafka await publisher and completion consumer. |
+
+Kafka await also requires SmallRye channel configuration for the framework-owned `tpf-await-kafka-requests` outgoing channel and `tpf-await-kafka-responses` incoming channel. See [Await Boundaries](/guide/development/orchestrator-runtime/await).
+
+#### SQS Await
+
+Prefix: `tpf.await.sqs`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `tpf.await.sqs.poller.enabled` | boolean | `false` | Enables the coordinator-side SQS await completion poller. |
+| `tpf.await.sqs.response-queue-url` | string | none | SQS response queue URL consumed by the completion poller. Required when the poller is enabled. |
+| `tpf.await.sqs.poll-start-delay` | duration | `PT0S` | Optional delay before the completion poller starts. |
+| `tpf.await.sqs.visibility-timeout` | duration | `PT30S` | Visibility timeout for claimed completion messages. |
+| `tpf.await.sqs.completion-timeout` | duration | `PT5M` | Timeout while admitting one completion through the await coordinator. |
+| `tpf.await.sqs.wait-time-seconds` | int | `1` | Long-poll wait time for SQS receive calls. Values are clamped to the SQS range `1..20`. |
+| `tpf.await.sqs.max-messages` | int | `1` | Maximum messages received per poll. Values are clamped to the SQS range `1..10`. |
+
+SQS await dispatch uses the `request.queueUrl` and `response.queueUrl` authored on the await step. The completion poller uses the runtime `response-queue-url` so the hosting coordinator can decide which queue it consumes. Region and endpoint override reuse `pipeline.orchestrator.sqs.region` and `pipeline.orchestrator.sqs.endpoint-override`.
 
 ### Item Reject Sink
 

--- a/docs/guide/development/orchestrator-runtime/await.md
+++ b/docs/guide/development/orchestrator-runtime/await.md
@@ -16,9 +16,9 @@ For production operation, see [Await Boundary Operations](/guide/operations/awai
 
 `csv-payments` uses authored `ONE_TO_ONE` await over a stream of `PaymentRecord` items. That is a stream of unary await interactions, not a hidden dispatch mode.
 
-The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope. The built-in `kafka` adapter publishes a request envelope to Kafka and admits response envelopes from a configured response channel.
+The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope. The built-in `kafka` adapter publishes a request envelope to Kafka and admits response envelopes from a configured response channel. The built-in `sqs` adapter does the same request/completion pattern with SQS queues.
 
-For runnable examples, use [`examples/restaurant-approval`](https://github.com/The-Pipeline-Framework/pipelineframework/tree/main/examples/restaurant-approval) for human/UI await and [`examples/csv-payments`](https://github.com/The-Pipeline-Framework/pipelineframework/tree/main/examples/csv-payments) for Kafka unary await over a stream.
+For runnable examples, use [`examples/restaurant-approval`](https://github.com/The-Pipeline-Framework/pipelineframework/tree/main/examples/restaurant-approval) for human/UI await and [`examples/csv-payments`](https://github.com/The-Pipeline-Framework/pipelineframework/tree/main/examples/csv-payments) for brokered unary await over a stream.
 
 ## Await Versus Operator
 
@@ -64,7 +64,7 @@ The runtime also enforces aggregate materialization guardrails:
 
 Set either value to `0` only when the application has its own upstream size control and storage budget. Prefer stable business limits at the API/file/broker boundary rather than relying on these guards as the first line of defense.
 
-Transport choice changes operational responsibility. `interaction-api` requires an API consumer to query and complete pending work. `webhook` requires stable resume-token signing and callback reachability. `kafka` requires broker channel configuration, consumer health, and response-envelope monitoring. The operational checklist is covered in [Await Boundary Operations](/guide/operations/await-boundaries).
+Transport choice changes operational responsibility. `interaction-api` requires an API consumer to query and complete pending work. `webhook` requires stable resume-token signing and callback reachability. `kafka` requires broker channel configuration, consumer health, and response-envelope monitoring. `sqs` requires request/response queue configuration, poller health, visibility-timeout sizing, and queue DLQ policy. The operational checklist is covered in [Await Boundary Operations](/guide/operations/await-boundaries).
 
 That matters for plugin-style side effects after an await boundary. A resumed queue-async execution can replay the remainder of the pipeline after a downstream retry, so once-only side-effect checkpointing is a separate concern from await durability itself.
 
@@ -142,7 +142,7 @@ steps:
           topic: "csv-payments.payment.results"
 ```
 
-Add the Quarkus Kafka messaging extension to the application that hosts the orchestrator, enable the default Kafka bridge with `pipeline.await.kafka.reactive-messaging.enabled=true`, then configure the SmallRye channels:
+Add the Quarkus Kafka messaging extension to the application that hosts the orchestrator, enable the default Kafka bridge with `tpf.await.kafka.reactive-messaging.enabled=true`, then configure the SmallRye channels:
 
 ```properties
 mp.messaging.outgoing.tpf-await-kafka-requests.connector=smallrye-kafka
@@ -152,4 +152,34 @@ mp.messaging.incoming.tpf-await-kafka-responses.topic=csv-payments.payment.resul
 mp.messaging.incoming.tpf-await-kafka-responses.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 ```
 
-`pipeline.orchestrator.resume-token-secret` must be stable for the lifetime of outstanding webhook and Kafka interactions. If `pipeline.orchestrator.resume-token-secret` is missing, signed dispatch and token validation fail with a clear error rather than allowing insecure or unsigned resumptions.
+## SQS Example
+
+```yaml
+steps:
+  - name: "Brokered Fraud Check"
+    kind: "await"
+    cardinality: "ONE_TO_ONE"
+    input: "com.example.FraudCheckRequest"
+    output: "com.example.FraudCheckDecision"
+    timeout: "PT10M"
+    idempotencyKeyFields: ["orderId"]
+    await:
+      correlation:
+        strategy: "signedResumeToken"
+      transport:
+        type: "sqs"
+        request:
+          queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/fraud-check-requests"
+        response:
+          queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/fraud-check-decisions"
+```
+
+SQS dispatch sends a framework-owned JSON envelope with the same interaction identity and resume token fields as Kafka. The coordinator-side SQS completion poller consumes the response queue and admits completions through the await coordinator. This is separate from SQS work dispatch, SQS DLQ publication, and the SQS transition-worker request/reply protocol.
+
+```properties
+tpf.await.sqs.poller.enabled=true
+tpf.await.sqs.response-queue-url=https://sqs.us-east-1.amazonaws.com/123456789012/fraud-check-decisions
+pipeline.orchestrator.sqs.region=us-east-1
+```
+
+`pipeline.orchestrator.resume-token-secret` must be stable for the lifetime of outstanding webhook, Kafka, and SQS interactions. If `pipeline.orchestrator.resume-token-secret` is missing, signed dispatch and token validation fail with a clear error rather than allowing insecure or unsigned resumptions.

--- a/docs/guide/development/orchestrator-runtime/await.md
+++ b/docs/guide/development/orchestrator-runtime/await.md
@@ -16,7 +16,7 @@ For production operation, see [Await Boundary Operations](/guide/operations/awai
 
 `csv-payments` uses authored `ONE_TO_ONE` await over a stream of `PaymentRecord` items. That is a stream of unary await interactions, not a hidden dispatch mode.
 
-The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope. The built-in `kafka` adapter publishes a request envelope to Kafka and admits response envelopes from a configured response channel. The built-in `sqs` adapter does the same request/completion pattern with SQS queues.
+The built-in `interaction-api` adapter is for human/UI inboxes and mock-provider style flows where another client queries pending interactions and later calls the generated completion API. The built-in `webhook` adapter dispatches an HTTP request to an external system and includes a signed resume token in the envelope. The built-in `kafka` adapter publishes a request envelope to Kafka and admits completion envelopes from a configured response channel. The built-in `sqs` adapter does the same request/completion pattern with SQS standard queues.
 
 For runnable examples, use [`examples/restaurant-approval`](https://github.com/The-Pipeline-Framework/pipelineframework/tree/main/examples/restaurant-approval) for human/UI await and [`examples/csv-payments`](https://github.com/The-Pipeline-Framework/pipelineframework/tree/main/examples/csv-payments) for brokered unary await over a stream.
 
@@ -174,7 +174,7 @@ steps:
           queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/fraud-check-decisions"
 ```
 
-SQS dispatch sends a framework-owned JSON envelope with the same interaction identity and resume token fields as Kafka. The coordinator-side SQS completion poller consumes the response queue and admits completions through the await coordinator. This is separate from SQS work dispatch, SQS DLQ publication, and the SQS transition-worker request/reply protocol.
+SQS dispatch sends a framework-owned JSON envelope with the same interaction identity and resume token fields as Kafka. The coordinator-side SQS completion poller consumes the response queue and admits completions through the await coordinator. SQS await v1 supports standard queues, not FIFO queue URLs. This is separate from SQS work dispatch, SQS DLQ publication, and the SQS transition-worker request/reply protocol.
 
 ```properties
 tpf.await.sqs.poller.enabled=true

--- a/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
+++ b/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
@@ -4,16 +4,18 @@ This page captures the product value and implementation ordering for brokered bo
 
 ## Value Proposition
 
-Brokered boundaries are attractive because many organisations already trust Kafka operationally. They have teams, dashboards, retention policies, ACLs, incident playbooks, and scaling patterns around it.
+Brokered boundaries are attractive because many organisations already trust brokers operationally. They have teams, dashboards, retention policies, queue policies, ACLs, incident playbooks, and scaling patterns around Kafka, SQS, or both.
 
 The TPF value proposition is not "you no longer need brokers." It is:
 
 - Application teams do not have to encode pipeline semantics as topic naming, offset handling, Redis key conventions, and sidecar logic.
-- Platform teams can keep trusted broker infrastructure where it is useful.
-- TPF keeps the execution model explicit: authored steps, typed or envelope contracts, deterministic lineage, replay topology, and generated/runtime validation.
+- Platform teams can choose Kafka, SQS, REST, gRPC, or local substrates per boundary.
+- TPF keeps the execution model explicit: authored steps, declared DTO/envelope contracts, deterministic lineage, replay topology, and generated/runtime validation.
 - Self-hosted TPF deployments can keep backing broker/cache choices explicit while preserving one TPF model for application code.
 
 This lowers adoption risk for enterprise users without weakening the core TPF model.
+
+Kafka/MSK is the stronger fit when the platform already needs a Kafka estate: topic fan-out, retained streams, partition-aware throughput, Kafka-native consumers, and stream observability. SQS is the simpler AWS-shaped fit for queue/request-reply/DLQ-oriented workloads, especially when the goal is an await request/completion queue rather than a retained event stream.
 
 ## Adoption Ramp
 
@@ -33,14 +35,15 @@ Platform teams can start with a loose envelope where adoption matters, then move
 
 Prefer these implementation slices if this work becomes active:
 
-1. Kafka-backed checkpoint publication/subscription.
-2. Kafka-backed await transport.
-3. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
-4. Protobuf-backed external step-host contract generation for non-Java implementations.
-5. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
-6. Brokered step-host dispatch only after the earlier boundary types are proven.
+1. SQS-backed await transport for AWS-shaped self-host HA. Implemented by the CSV container reference.
+2. Kafka await provider for event-stream await proofs. Implemented by the default CSV topology.
+3. Kafka-backed checkpoint publication/subscription.
+4. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
+5. Protobuf-backed external step-host contract generation for non-Java implementations.
+6. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
+7. Brokered step-host dispatch only after the earlier boundary types are proven.
 
-Avoid starting with a broad "Kafka transport" PR. That would mix unrelated risks and blur TPF semantics.
+Avoid starting with broad "Kafka transport" or "SQS transport" PRs. They mix unrelated risks and blur TPF semantics.
 
 ## Non-Goals
 
@@ -49,7 +52,7 @@ Envelope and brokered boundary work should not:
 1. replace typed TPF as the default,
 2. make mapper pair validation irrelevant for typed paths,
 3. hide drift by treating all payloads as arbitrary objects,
-4. turn Kafka offsets into TPF replay state,
+4. turn Kafka offsets, SQS visibility timeouts, or broker redelivery into TPF replay state,
 5. force users to operate Kafka when local, REST, gRPC, or SQS runtime boundaries are enough,
 6. introduce a second workflow engine inside TPF.
 

--- a/docs/guide/evolve/brokered-boundaries/boundary-taxonomy.md
+++ b/docs/guide/evolve/brokered-boundaries/boundary-taxonomy.md
@@ -8,16 +8,16 @@ Use TPF terms when discussing brokered designs:
 
 | Broker term | TPF meaning |
 | --- | --- |
-| Topic | Step inbox, await request/response channel, checkpoint publication channel, or transition dispatch queue |
-| Consumer group | Scaled step-host group for one boundary |
-| Partition key | Item key, lineage key, document id, fan-in key, or await correlation key |
-| Offset | Delivery cursor, not the TPF replay pointer |
-| Retention | Transport-level redelivery window, not business persistence |
-| Lag | Boundary pressure signal |
-| DLQ topic | Item reject sink or failed execution lane |
-| Record | TPF envelope carrying typed payload, serialized payload, payload reference, or controlled loose payload |
+| Topic/queue/channel | Step inbox, await request/completion channel, checkpoint publication channel, or transition dispatch queue |
+| Consumer/worker group | Scaled step-host or provider group for one boundary |
+| Partition key/message group | Item key, lineage key, document id, fan-in key, or await correlation key |
+| Offset/visibility timeout | Delivery cursor or redelivery lease, not the TPF replay pointer |
+| Retention/redrive window | Transport-level redelivery window, not business persistence |
+| Lag/queue depth | Boundary pressure signal |
+| DLQ topic/queue | Item reject sink or failed execution lane |
+| Record/message | TPF envelope carrying typed payload, serialized payload, payload reference, or controlled loose payload |
 
-Kafka replay means re-reading records from a log. TPF replay means re-running or reusing a known pipeline boundary with step identity, lineage, cache/persistence policy, and replay metadata.
+Kafka replay means re-reading records from a log. SQS redrive means making queued messages visible again from a queue or DLQ. TPF replay means re-running or reusing a known pipeline boundary with step identity, lineage, cache/persistence policy, and replay metadata.
 
 ## Boundary Types
 
@@ -25,7 +25,7 @@ Kafka replay means re-reading records from a log. TPF replay means re-running or
 | --- | --- | --- |
 | Local step boundary | Same process, direct invocation | Usually no |
 | Remote operator boundary | Immediate request/response external step host | Usually REST/gRPC/LOCAL transport first |
-| Await boundary | Execution parks and resumes after correlated completion | Strong fit for request/response topics |
+| Await boundary | Execution parks and resumes after correlated completion | Strong fit for request/completion channels |
 | Checkpoint handoff | One pipeline publishes work to another owner | Strong fit for publication/subscription |
 | Transition-worker boundary | Durable coordinator dispatches one bounded continuation | Possible dispatcher provider |
 | Brokered step-host boundary | A step is executed by a scaled step-host group | Future design candidate |
@@ -41,17 +41,17 @@ flowchart TB
     Transition["Transition-worker dispatch<br/>coordinator continuation"]
     StepHost["Brokered step host<br/>future scaled step execution"]
 
-    Kafka["Kafka/SQS/etc.<br/>durable dispatch substrate"]
+    Broker["Kafka/SQS/etc.<br/>durable dispatch substrate"]
 
     Runtime --> Await
     Runtime --> Checkpoint
     Runtime --> Transition
     Runtime --> StepHost
 
-    Await -. request/response topics .-> Kafka
-    Checkpoint -. publication channel .-> Kafka
-    Transition -. command/result queue .-> Kafka
-    StepHost -. step inbox .-> Kafka
+    Await -. request/completion channel .-> Broker
+    Checkpoint -. publication channel .-> Broker
+    Transition -. command/result queue .-> Broker
+    StepHost -. step inbox .-> Broker
 ```
 
 ## Ownership
@@ -69,9 +69,9 @@ TPF should own:
 The dispatch substrate should own:
 
 1. durable delivery,
-2. queue depth and lag,
-3. partition-local ordering,
-4. consumer group distribution,
+2. queue depth, lag, and message age,
+3. partition-local ordering or queue visibility/redrive behavior,
+4. consumer/worker distribution,
 5. broker-level redelivery,
 6. retention and substrate ACLs.
 

--- a/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
+++ b/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
@@ -11,14 +11,14 @@ It is not the same decision as transport mode, platform mode, runtime layout, or
 | Local | tests, demos, monoliths, low-friction adoption | no crash-surviving handoff by itself |
 | REST | simple request/response step hosts and transition workers | immediate call semantics; not durable buffering |
 | gRPC | efficient typed request/response and protobuf contracts | still immediate unless paired with await/checkpoint semantics |
-| SQS | durable coordinator dispatch and DLQ-oriented cloud deployments | weaker ordering/grouping model than Kafka |
-| Kafka | enterprise broker backbone, durable fan-out/fan-in pressure boundaries, checkpoint streams | do not treat offsets as TPF replay semantics |
+| SQS | AWS-shaped durable coordinator dispatch, await request/completion queues, DLQ/re-drive, and queue-style self-host HA | standard queues only for SQS await v1; weaker ordering/grouping model than Kafka |
+| Kafka | enterprise broker backbone, Kafka await, stream pressure boundaries, topic fan-out, retained event streams, and Kafka-native estates | do not treat offsets as TPF replay semantics |
 
-## Not `transport: KAFKA`
+## Not `transport: KAFKA` Or `transport: SQS`
 
-Do not flatten Kafka into the same top-level decision as REST or gRPC.
+Do not flatten Kafka or SQS into the same top-level decision as REST or gRPC.
 
-REST and gRPC are immediate call transports. Kafka is a brokered dispatch substrate with different timing, correlation, retry, and ownership implications.
+REST and gRPC are immediate call transports. Kafka and SQS are brokered dispatch substrates with different timing, correlation, retry, and ownership implications.
 
 Prefer boundary-specific configuration shapes:
 
@@ -27,6 +27,13 @@ kind: await
 await:
   transport:
     type: kafka
+```
+
+```yaml
+kind: await
+await:
+  transport:
+    type: sqs
 ```
 
 ```yaml
@@ -39,10 +46,10 @@ checkpoint:
 The checkpoint snippet is illustrative only. Current supported checkpoint handoff target configuration uses `pipeline.handoff.bindings.<publication>.targets.<target>.*`, and broker-backed `KAFKA` publication targets are not supported yet.
 
 ```properties
-pipeline.orchestrator.dispatcher-provider=kafka
+pipeline.orchestrator.dispatcher-provider=sqs
 ```
 
-These examples are design direction, not committed public API.
+Kafka and SQS await are supported runtime adapters. `pipeline.orchestrator.dispatcher-provider=sqs` is supported for queue-async work dispatch. Kafka checkpoint publication and Kafka dispatcher-provider examples remain design direction, not committed public API.
 
 ## Relationship To Existing Work
 
@@ -54,7 +61,7 @@ This guide extends existing boundary seams:
 - [Checkpoint Handoff](/guide/development/orchestrator-runtime/checkpoint-handoff) is the natural user-facing shape for pipeline-to-pipeline publication.
 - [Runtime Core Decoupling](/guide/evolve/runtime-core-decoupling) keeps runtime-adapter concerns out of core semantics.
 
-Kafka should extend these seams. It should not introduce an independent workflow engine inside TPF.
+Broker-backed await providers should extend these seams. They should not introduce an independent workflow engine inside TPF.
 
 ## Pressure And Replay
 

--- a/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
@@ -4,7 +4,7 @@ This page describes the current production-ish self-host shape for the durable c
 
 The runnable starting point remains `examples/restaurant-approval/self-host`. That example proves the same control-plane, release, await, result, and failure/DLQ paths in one local process. The containerized HA reference in `examples/restaurant-approval/self-host/container` runs the same flow with a coordinator container, REST worker container, and LocalStack-backed DynamoDB/SQS/S3-compatible services.
 
-`examples/csv-payments/self-host/container` is the advanced container reference. It adds Kafka-backed await completions, stream input, app persistence, a REST transition worker, and a grouped `pipeline-runtime-svc` gRPC step runtime on top of the same durable coordinator pattern.
+`examples/csv-payments/self-host/container` is the advanced container reference. It adds SQS-backed await completions, stream input, app persistence, a REST transition worker, and a grouped `pipeline-runtime-svc` gRPC step runtime on top of the same durable coordinator pattern. The default CSV application still keeps Kafka as the event-stream await proof; the container HA reference uses SQS to stay within the LocalStack-backed AWS-shaped substrate.
 
 ## Deployment Shapes
 
@@ -133,7 +133,7 @@ The restaurant container reference demonstrates this baseline locally:
 
 It uses LocalStack to create the required DynamoDB tables, SQS work/DLQ queues, and S3-compatible release artifact bucket. Treat that as local verification of the topology, not production AWS provisioning.
 
-The CSV Payments container reference demonstrates the same baseline with Kafka await completions and the example persistence path:
+The CSV Payments container reference demonstrates the same baseline with SQS await completions and the example persistence path:
 
 ```bash
 ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci

--- a/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
+++ b/docs/guide/evolve/durable-coordinator/self-hosted-deployment.md
@@ -4,7 +4,7 @@ This page describes the current production-ish self-host shape for the durable c
 
 The runnable starting point remains `examples/restaurant-approval/self-host`. That example proves the same control-plane, release, await, result, and failure/DLQ paths in one local process. The containerized HA reference in `examples/restaurant-approval/self-host/container` runs the same flow with a coordinator container, REST worker container, and LocalStack-backed DynamoDB/SQS/S3-compatible services.
 
-`examples/csv-payments/self-host/container` is the advanced container reference. It adds SQS-backed await completions, stream input, app persistence, a REST transition worker, and a grouped `pipeline-runtime-svc` gRPC step runtime on top of the same durable coordinator pattern. The default CSV application still keeps Kafka as the event-stream await proof; the container HA reference uses SQS to stay within the LocalStack-backed AWS-shaped substrate.
+`examples/csv-payments/self-host/container` is the advanced container reference. It adds stream input, app persistence, a REST transition worker, and a grouped `pipeline-runtime-svc` gRPC step runtime on top of the same durable coordinator pattern. The default lane uses SQS to stay within the LocalStack-backed AWS-shaped substrate; `TPF_CSV_AWAIT_TRANSPORT=kafka` runs the same self-host topology with Kafka await completions.
 
 ## Deployment Shapes
 
@@ -133,10 +133,16 @@ The restaurant container reference demonstrates this baseline locally:
 
 It uses LocalStack to create the required DynamoDB tables, SQS work/DLQ queues, and S3-compatible release artifact bucket. Treat that as local verification of the topology, not production AWS provisioning.
 
-The CSV Payments container reference demonstrates the same baseline with SQS await completions and the example persistence path:
+The CSV Payments container reference demonstrates the same baseline with broker-backed await completions and the example persistence path:
 
 ```bash
 ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci
+```
+
+The SQS lane is the default AWS-shaped proof. The Kafka lane proves the same await abstraction against a second provider:
+
+```bash
+TPF_CSV_AWAIT_TRANSPORT=kafka ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci
 ```
 
 CSV await item continuations use the same bounded transition-worker seam as normal queue-async work. The worker executes each item continuation segment up to the aggregate boundary, while generated step clients target the runtime and persistence containers.

--- a/docs/guide/evolve/template-generator.md
+++ b/docs/guide/evolve/template-generator.md
@@ -102,7 +102,7 @@ You can determine that version with `template-generator --version`, by checking 
 
 The generator copies the authored config into `config/pipeline.yaml` so the build can recreate `.proto` definitions during `generate-sources`.
 
-Await steps are part of the v2 template schema so CI and automation can validate authored `kind: await` pipeline configs. The generator now scaffolds await-aware projects for `interaction-api` and `webhook` transports. It still rejects `kafka` await scaffolding explicitly because the generated project does not yet include the required messaging dependencies and channel configuration.
+Await steps are part of the v2 template schema so CI and automation can validate authored `kind: await` pipeline configs. The generator scaffolding surface lives in the `tpf-mcp-bridge` repository and must keep runtime support separate from generated dependency wiring. Runtime supports `interaction-api`, `webhook`, Kafka await, and SQS await; scaffold support for Kafka and SQS must emit the matching Quarkus dependencies, channel or poller properties, and queue/topic configuration rather than assuming generic await wiring is enough.
 
 ## Semantic Types and Derived Bindings
 

--- a/docs/guide/operations/await-boundaries.md
+++ b/docs/guide/operations/await-boundaries.md
@@ -32,8 +32,9 @@ The state transition that parks or resumes the execution is guarded by the orche
 | `interaction-api` | A UI or client must list pending interactions and call the generated completion API. |
 | `webhook` | Configure a stable resume-token secret, reachable callback URLs, and partner retry/idempotency handling. |
 | `kafka` | Configure request and response channels, monitor broker/consumer health, and keep correlation ids stable. |
+| `sqs` | Configure request and response queues, monitor poller health, size visibility timeouts, and attach queue DLQ policy. |
 
-Kafka await uses framework-owned request and response envelopes. The external provider is not a pipeline step; it is the actor that completes the await interaction.
+Kafka and SQS await use framework-owned request and response envelopes. The external provider is not a pipeline step; it is the actor that completes the await interaction.
 
 ## Idempotency And Completion
 

--- a/docs/guide/operations/await-boundaries.md
+++ b/docs/guide/operations/await-boundaries.md
@@ -34,7 +34,7 @@ The state transition that parks or resumes the execution is guarded by the orche
 | `kafka` | Configure request and response channels, monitor broker/consumer health, and keep correlation ids stable. |
 | `sqs` | Configure request and response queues, monitor poller health, size visibility timeouts, and attach queue DLQ policy. |
 
-Kafka and SQS await use framework-owned request and response envelopes. The external provider is not a pipeline step; it is the actor that completes the await interaction.
+Kafka and SQS await use framework-owned request and completion envelopes. The external provider is not a pipeline step; it is the actor that completes the await interaction.
 
 ## Idempotency And Completion
 

--- a/examples/csv-payments/README.md
+++ b/examples/csv-payments/README.md
@@ -53,13 +53,13 @@ csv-payments.payment.results
 
 ## Containerized Self-Hosted HA Reference
 
-For a compute-first self-hosted HA reference with a durable coordinator, REST transition worker, Kafka await completions, Postgres persistence, and LocalStack-backed DynamoDB/SQS/S3-compatible coordinator stores:
+For a compute-first self-hosted HA reference with a durable coordinator, REST transition worker, SQS await completions, Postgres persistence, and LocalStack-backed DynamoDB/SQS/S3-compatible coordinator stores:
 
 ```bash
 ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci
 ```
 
-This is the advanced Kafka/stream-await reference. The smaller human-await reference remains `examples/restaurant-approval/self-host/container`.
+This is the advanced stream-await self-host HA reference. It uses SQS for the await request/completion loop to keep the local AWS-shaped stack on LocalStack; the default CSV pipeline remains the Kafka await reference.
 
 ## Running End-to-End Tests
 

--- a/examples/csv-payments/README.md
+++ b/examples/csv-payments/README.md
@@ -53,13 +53,13 @@ csv-payments.payment.results
 
 ## Containerized Self-Hosted HA Reference
 
-For a compute-first self-hosted HA reference with a durable coordinator, REST transition worker, SQS await completions, Postgres persistence, and LocalStack-backed DynamoDB/SQS/S3-compatible coordinator stores:
+For a compute-first self-hosted HA reference with a durable coordinator, REST transition worker, broker-backed await completions, Postgres persistence, and LocalStack-backed DynamoDB/SQS/S3-compatible coordinator stores:
 
 ```bash
 ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci
 ```
 
-This is the advanced stream-await self-host HA reference. It uses SQS for the await request/completion loop to keep the local AWS-shaped stack on LocalStack; the default CSV pipeline remains the Kafka await reference.
+This is the advanced stream-await self-host HA reference. It uses SQS by default for the AWS-shaped LocalStack lane. Run `TPF_CSV_AWAIT_TRANSPORT=kafka ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci` to prove the same coordinator/worker topology with Kafka await completions.
 
 ## Running End-to-End Tests
 

--- a/examples/csv-payments/build-pipeline-runtime.sh
+++ b/examples/csv-payments/build-pipeline-runtime.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CSV_DIR="$ROOT_DIR/examples/csv-payments"
 ACTIVE_MAPPING="$CSV_DIR/config/pipeline.runtime.yaml"
+ACTIVE_PIPELINE_CONFIG="$CSV_DIR/config/pipeline.yaml"
 PIPELINE_RUNTIME_MAPPING="$CSV_DIR/config/runtime-mapping/pipeline-runtime.yaml"
 MVN_BIN="${MVN_BIN:-$ROOT_DIR/mvnw}"
 
@@ -23,16 +24,32 @@ if [[ -f "$ACTIVE_MAPPING" ]]; then
   backup_file="$(mktemp "${TMPDIR:-/tmp}/pipeline-runtime.XXXXXX")"
   cp "$ACTIVE_MAPPING" "$backup_file"
 fi
+pipeline_config_backup_file=""
+if [[ -n "${PIPELINE_CONFIG:-}" ]]; then
+  if [[ ! -f "${PIPELINE_CONFIG}" ]]; then
+    echo "Pipeline config file not found: ${PIPELINE_CONFIG}" >&2
+    exit 1
+  fi
+  pipeline_config_backup_file="$(mktemp "${TMPDIR:-/tmp}/pipeline-config.XXXXXX")"
+  cp "$ACTIVE_PIPELINE_CONFIG" "$pipeline_config_backup_file"
+fi
 
 cleanup() {
   if [[ -n "$backup_file" ]]; then
     cp "$backup_file" "$ACTIVE_MAPPING"
     rm -f "$backup_file"
   fi
+  if [[ -n "$pipeline_config_backup_file" ]]; then
+    cp "$pipeline_config_backup_file" "$ACTIVE_PIPELINE_CONFIG"
+    rm -f "$pipeline_config_backup_file"
+  fi
 }
 trap cleanup EXIT
 
 cp "$PIPELINE_RUNTIME_MAPPING" "$ACTIVE_MAPPING"
+if [[ -n "${PIPELINE_CONFIG:-}" ]]; then
+  cp "$PIPELINE_CONFIG" "$ACTIVE_PIPELINE_CONFIG"
+fi
 PIPELINE_TRANSPORT="${PIPELINE_TRANSPORT:-GRPC}"
 
 # Ensure module parent POM is available in local repository for Quarkus bootstrap/codegen.

--- a/examples/csv-payments/config/pipeline.container-sqs.yaml
+++ b/examples/csv-payments/config/pipeline.container-sqs.yaml
@@ -1,0 +1,188 @@
+version: 2
+appName: csv-payments
+basePackage: org.pipelineframework.csv
+transport: GRPC
+aspects:
+  persistence:
+    enabled: true
+    scope: STEPS
+    position: AFTER_STEP
+    config:
+      # Queue-async resume is at-least-once from the await boundary onward. Persisted CSV entities
+      # use stable business IDs and duplicate-key=ignore so replayed side effects stay idempotent.
+      targetSteps:
+        - ProcessFolderService
+        - ProcessCsvPaymentsInputService
+        - ProcessPaymentStatusService
+        - ProcessCsvPaymentsOutputFileService
+      pluginImplementationClass: org.pipelineframework.plugin.persistence.PersistenceService
+      enabledTargets:
+        - GRPC_SERVICE
+        - CLIENT_STEP
+messages:
+  CsvFolder:
+    fields:
+      - number: 1
+        name: path
+        type: path
+  CsvPaymentsInputFile:
+    fields:
+      - number: 1
+        name: id
+        type: uuid
+      - number: 2
+        name: filepath
+        type: path
+      - number: 3
+        name: csvFolderPath
+        type: path
+  PaymentRecord:
+    fields:
+      - number: 1
+        name: id
+        type: uuid
+      - number: 2
+        name: csvId
+        type: string
+      - number: 3
+        name: recipient
+        type: string
+      - number: 4
+        name: amount
+        type: decimal
+      - number: 5
+        name: currency
+        type: currency
+      - number: 6
+        name: csvPaymentsInputFilePath
+        type: path
+  PaymentStatus:
+    fields:
+      - number: 1
+        name: id
+        type: uuid
+      - number: 2
+        name: reference
+        type: string
+      - number: 3
+        name: status
+        type: string
+      - number: 4
+        name: message
+        type: string
+      - number: 5
+        name: fee
+        type: decimal
+      - number: 6
+        name: conversationId
+        type: uuid
+      - number: 7
+        name: statusCode
+        type: int64
+      - number: 8
+        name: paymentRecordId
+        type: uuid
+      - number: 9
+        name: paymentRecord
+        type: PaymentRecord
+  PaymentOutput:
+    fields:
+      - number: 1
+        name: id
+        type: uuid
+      - number: 2
+        name: csvPaymentsOutputFilename
+        type: string
+      - number: 3
+        name: csvId
+        type: string
+      - number: 4
+        name: recipient
+        type: string
+      - number: 5
+        name: amount
+        type: decimal
+      - number: 6
+        name: currency
+        type: currency
+      - number: 7
+        name: conversationId
+        type: uuid
+      - number: 8
+        name: status
+        type: int64
+      - number: 9
+        name: message
+        type: string
+      - number: 10
+        name: fee
+        type: decimal
+      - number: 11
+        name: paymentStatus
+        type: PaymentStatus
+  CsvPaymentsOutputFile:
+    fields:
+      - number: 1
+        name: id
+        type: uuid
+      - number: 2
+        name: filepath
+        type: path
+      - number: 3
+        name: csvFolderPath
+        type: path
+steps:
+  - name: Process Folder
+    service: org.pipelineframework.csv.service.ProcessFolderService
+    cardinality: EXPANSION
+    input: org.pipelineframework.csv.common.domain.CsvFolder
+    inputTypeName: CsvFolder
+    inboundMapper: org.pipelineframework.csv.common.mapper.CsvFolderMapper
+    output: org.pipelineframework.csv.common.domain.CsvPaymentsInputFile
+    outputTypeName: CsvPaymentsInputFile
+    outboundMapper: org.pipelineframework.csv.common.mapper.CsvPaymentsInputFileMapper
+  - name: Process Csv Payments Input
+    service: org.pipelineframework.csv.service.ProcessCsvPaymentsInputService
+    cardinality: EXPANSION
+    input: org.pipelineframework.csv.common.domain.CsvPaymentsInputFile
+    inputTypeName: CsvPaymentsInputFile
+    inboundMapper: org.pipelineframework.csv.common.mapper.CsvPaymentsInputFileMapper
+    output: org.pipelineframework.csv.common.domain.PaymentRecord
+    outputTypeName: PaymentRecord
+    outboundMapper: org.pipelineframework.csv.common.mapper.PaymentRecordMapper
+  - name: Await Payment Provider
+    kind: await
+    cardinality: ONE_TO_ONE
+    input: org.pipelineframework.csv.common.domain.PaymentRecord
+    inputTypeName: PaymentRecord
+    output: org.pipelineframework.csv.common.domain.PaymentStatus
+    outputTypeName: PaymentStatus
+    timeout: PT5M
+    idempotencyKeyFields: ["csvId", "recipient", "amount", "currency"]
+    await:
+      correlation:
+        strategy: signedResumeToken
+      transport:
+        type: sqs
+        request:
+          queueUrl: http://localstack:4566/000000000000/csv-payment-await-requests
+        response:
+          queueUrl: http://localstack:4566/000000000000/csv-payment-await-results
+  - name: Process Payment Status
+    service: org.pipelineframework.csv.service.ProcessPaymentStatusService
+    cardinality: ONE_TO_ONE
+    input: org.pipelineframework.csv.common.domain.PaymentStatus
+    inputTypeName: PaymentStatus
+    inboundMapper: org.pipelineframework.csv.common.mapper.PaymentStatusMapper
+    output: org.pipelineframework.csv.common.domain.PaymentOutput
+    outputTypeName: PaymentOutput
+    outboundMapper: org.pipelineframework.csv.common.mapper.PaymentOutputMapper
+  - name: Process Csv Payments Output File
+    service: org.pipelineframework.csv.service.ProcessCsvPaymentsOutputFileService
+    cardinality: MANY_TO_MANY
+    input: org.pipelineframework.csv.common.domain.PaymentOutput
+    inputTypeName: PaymentOutput
+    inboundMapper: org.pipelineframework.csv.common.mapper.PaymentOutputMapper
+    output: org.pipelineframework.csv.common.domain.CsvPaymentsOutputFile
+    outputTypeName: CsvPaymentsOutputFile
+    outboundMapper: org.pipelineframework.csv.common.mapper.CsvPaymentsOutputFileMapper

--- a/examples/csv-payments/orchestrator-svc/pom.xml
+++ b/examples/csv-payments/orchestrator-svc/pom.xml
@@ -241,6 +241,7 @@
                 <pipeline.runtime.source.dir.output>${pipeline.runtime.source.root}/output-csv-file-processing-svc/src/main/java</pipeline.runtime.source.dir.output>
                 <pipeline.runtime.source.exclude.executor>org/pipelineframework/csv/service/ExecutorProducer.java</pipeline.runtime.source.exclude.executor>
                 <pipeline.runtime.source.exclude.payment-provider-kafka-mock>org/pipelineframework/csv/service/PaymentProviderKafkaAwaitMock.java</pipeline.runtime.source.exclude.payment-provider-kafka-mock>
+                <pipeline.runtime.source.exclude.payment-provider-sqs-mock>org/pipelineframework/csv/service/PaymentProviderSqsAwaitMock.java</pipeline.runtime.source.exclude.payment-provider-sqs-mock>
                 <pipeline.runtime.source.exclude.payment-provider-mock>org/pipelineframework/csv/service/PaymentProviderServiceMock.java</pipeline.runtime.source.exclude.payment-provider-mock>
                 <pipeline.runtime.duplicate.check.script>${pipeline.runtime.source.root}/build-tools/check-duplicate-sources.sh</pipeline.runtime.duplicate.check.script>
             </properties>
@@ -281,6 +282,7 @@
                                             <fileset dir="${pipeline.runtime.source.dir.payments}">
                                                 <exclude name="${pipeline.runtime.source.exclude.executor}" />
                                                 <exclude name="${pipeline.runtime.source.exclude.payment-provider-kafka-mock}" />
+                                                <exclude name="${pipeline.runtime.source.exclude.payment-provider-sqs-mock}" />
                                                 <exclude name="${pipeline.runtime.source.exclude.payment-provider-mock}" />
                                             </fileset>
                                         </copy>

--- a/examples/csv-payments/payments-processing-svc/README.md
+++ b/examples/csv-payments/payments-processing-svc/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The Payments Processing Service is a Quarkus-based mock provider for the CSV payment processing system. It consumes one awaited `PaymentRecord` request and returns one `PaymentStatus` completion through the Kafka await transport.
+The Payments Processing Service is a Quarkus-based mock provider for the CSV payment processing system. It consumes one awaited `PaymentRecord` request and returns one `PaymentStatus` completion through the configured broker-backed await transport.
 
 This service is part of the [CSV Payments POC](../README.md) project, which processes CSV files containing payment information through a series of microservices.
 
@@ -13,14 +13,14 @@ This service is part of the [CSV Payments POC](../README.md) project, which proc
 - Process one payment record at a time through the mock provider
 - Publish direct `PaymentStatus` await completions
 - Handle rate limiting and timeout scenarios
-- Provide the Kafka-backed external boundary used by the await step
+- Provide the external payment-provider boundary used by Kafka and SQS await examples
 
 ## Architecture
 
 ```mermaid
 graph LR
-    A[Kafka Await Dispatch: PaymentRecord] --> B[Mock Payment Provider]
-    B --> C[Kafka Await Completion: PaymentStatus]
+    A[Await Dispatch: PaymentRecord] --> B[Mock Payment Provider]
+    B --> C[Await Completion: PaymentStatus]
     
     subgraph "Payments Processing Service"
         B
@@ -50,7 +50,7 @@ The service processes several key domain objects:
 
 ## Service Interfaces
 
-The service implements the example-local provider contract used by the Kafka await mock:
+The service implements the example-local provider contract used by the broker-backed await mocks:
 
 ### PaymentProviderService
 
@@ -58,7 +58,7 @@ The service implements the example-local provider contract used by the Kafka awa
 PaymentStatus processPayment(PaymentRecord paymentRecord);
 ```
 
-`PaymentProviderKafkaAwaitMock` adapts Kafka await dispatch envelopes to this contract and publishes Kafka await completion envelopes.
+`PaymentProviderKafkaAwaitMock` adapts Kafka await dispatch envelopes to this contract and publishes Kafka await completion envelopes. `PaymentProviderSqsAwaitMock` does the same for the CSV containerized self-host HA reference by polling SQS request messages and publishing SQS completion messages.
 
 ## Performance Features
 
@@ -115,14 +115,19 @@ The service uses the following configuration properties:
 - `csv-payments.payment-provider.timeout-millis`: Timeout for acquiring permits (default: 2000)
 - `csv-payments.payment-provider.provider-timeout-probability`: Deterministic fraction of provider calls that time out
 - `csv-payments.payment-provider.provider-reject-probability`: Deterministic fraction of provider calls that return `PaymentStatus.status=Rejected`
+- `csv-payments.payment-provider.sqs.enabled`: Enables the example-local SQS await mock provider
+- `csv-payments.payment-provider.sqs.request-queue-url`: SQS await request queue consumed by the mock provider
+- `csv-payments.payment-provider.sqs.response-queue-url`: SQS await completion queue published by the mock provider
+- `csv-payments.payment-provider.sqs.region`: Optional SQS region override
+- `csv-payments.payment-provider.sqs.endpoint-override`: Optional LocalStack/SQS-compatible endpoint override
 
 ## Integration with Other Services
 
 This service is typically invoked by the Orchestrator Service as part of the payment processing workflow:
 
 1. Orchestrator receives payment records from the Input CSV File Processing Service
-2. The await step publishes one Kafka dispatch per payment record
-3. The mock provider processes each record and publishes one `PaymentStatus` completion
+2. The await step publishes one broker dispatch per payment record
+3. The mock provider processes each record and publishes one `PaymentStatus` completion through Kafka or SQS
 4. The orchestrator resumes the stream and forwards payment statuses to the Payment Status Service
 
 ## Related Services

--- a/examples/csv-payments/payments-processing-svc/pom.xml
+++ b/examples/csv-payments/payments-processing-svc/pom.xml
@@ -77,6 +77,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-sqs</artifactId>
+        </dependency>
         <!-- Health check dependency -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/examples/csv-payments/payments-processing-svc/src/main/java/org/pipelineframework/csv/service/PaymentProviderConfig.java
+++ b/examples/csv-payments/payments-processing-svc/src/main/java/org/pipelineframework/csv/service/PaymentProviderConfig.java
@@ -16,6 +16,9 @@
 
 package org.pipelineframework.csv.service;
 
+import java.time.Duration;
+import java.util.Optional;
+
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -48,4 +51,43 @@ public interface PaymentProviderConfig {
    */
   @WithDefault("0")
   long responseDelayMillis();
+
+  /** SQS await mock provider configuration. */
+  Sqs sqs();
+
+  /** SQS await mock provider settings for the container self-host reference. */
+  interface Sqs {
+
+    /** Whether the SQS await mock provider poller starts with the application. */
+    @WithDefault("false")
+    boolean enabled();
+
+    /** SQS queue URL that receives payment-provider await requests. */
+    Optional<String> requestQueueUrl();
+
+    /** SQS queue URL that receives payment-provider await completion responses. */
+    Optional<String> responseQueueUrl();
+
+    /** AWS region used by the SQS client. */
+    Optional<String> region();
+
+    /** Optional SQS endpoint override, used by LocalStack in the self-host reference. */
+    Optional<String> endpointOverride();
+
+    /** Delay before the provider starts polling the request queue. */
+    @WithDefault("PT0S")
+    Duration pollStartDelay();
+
+    /** SQS visibility timeout used while processing provider requests. */
+    @WithDefault("PT30S")
+    Duration visibilityTimeout();
+
+    /** Long-poll wait time in seconds for request queue receives. */
+    @WithDefault("1")
+    int waitTimeSeconds();
+
+    /** Maximum number of request messages to receive per poll. */
+    @WithDefault("1")
+    int maxMessages();
+  }
 }

--- a/examples/csv-payments/payments-processing-svc/src/main/java/org/pipelineframework/csv/service/PaymentProviderKafkaAwaitMock.java
+++ b/examples/csv-payments/payments-processing-svc/src/main/java/org/pipelineframework/csv/service/PaymentProviderKafkaAwaitMock.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletionStage;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import io.quarkus.arc.properties.IfBuildProperty;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.MutinyEmitter;
@@ -39,6 +40,7 @@ import org.pipelineframework.csv.common.domain.PaymentStatus;
  * External mock provider for the CSV await/Kafka example.
  */
 @ApplicationScoped
+@IfBuildProperty(name = "csv-payments.payment-provider.kafka.enabled", stringValue = "true", enableIfMissing = true)
 public class PaymentProviderKafkaAwaitMock {
 
   static final String REQUEST_CHANNEL = "csv-payment-provider-requests";

--- a/examples/csv-payments/payments-processing-svc/src/main/java/org/pipelineframework/csv/service/PaymentProviderSqsAwaitMock.java
+++ b/examples/csv-payments/payments-processing-svc/src/main/java/org/pipelineframework/csv/service/PaymentProviderSqsAwaitMock.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2023-2025 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.csv.service;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.sqs.SqsAwaitCompletionEnvelope;
+import org.pipelineframework.awaitable.sqs.SqsAwaitDispatchEnvelope;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.csv.common.domain.PaymentRecord;
+import org.pipelineframework.csv.common.domain.PaymentStatus;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+/**
+ * External mock provider for the CSV await/SQS self-host example.
+ */
+@ApplicationScoped
+public class PaymentProviderSqsAwaitMock {
+
+  private static final Logger LOG = Logger.getLogger(PaymentProviderSqsAwaitMock.class);
+  private static final Duration DEFAULT_POLL_START_DELAY = Duration.ZERO;
+  private static final Duration DEFAULT_VISIBILITY_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration EXECUTOR_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration INITIAL_FAILURE_BACKOFF = Duration.ofSeconds(1);
+  private static final Duration MAX_FAILURE_BACKOFF = Duration.ofSeconds(30);
+
+  @Inject
+  PaymentProviderServiceMock paymentProvider;
+
+  @Inject
+  PaymentProviderConfig paymentProviderConfig;
+
+  private volatile SqsClient client;
+  private volatile ExecutorService pollExecutor;
+  private volatile Future<?> pollFuture;
+  private volatile boolean running;
+  private final AtomicInteger consecutivePollFailures = new AtomicInteger();
+
+  public PaymentProviderSqsAwaitMock() {
+  }
+
+  PaymentProviderSqsAwaitMock(
+      PaymentProviderServiceMock paymentProvider,
+      PaymentProviderConfig paymentProviderConfig,
+      SqsClient client) {
+    this.paymentProvider = paymentProvider;
+    this.paymentProviderConfig = paymentProviderConfig;
+    this.client = client;
+  }
+
+  void onStartup(@Observes StartupEvent event) {
+    SqsProviderConfig config = SqsProviderConfig.fromRuntime();
+    if (!config.enabled()) {
+      return;
+    }
+    String requestQueueUrl = requiredQueueUrl(config.requestQueueUrl(),
+        "csv-payments.payment-provider.sqs.request-queue-url");
+    String responseQueueUrl = requiredQueueUrl(config.responseQueueUrl(),
+        "csv-payments.payment-provider.sqs.response-queue-url");
+    ensureExecutor();
+    running = true;
+    pollFuture = pollExecutor.submit(() -> {
+      sleep(config.pollStartDelay());
+      pollLoop();
+    });
+    LOG.infof("CSV SQS await mock provider enabled requestQueueUrl=%s responseQueueUrl=%s",
+        requestQueueUrl,
+        responseQueueUrl);
+  }
+
+  @PreDestroy
+  void shutdown() {
+    running = false;
+    Future<?> activePollFuture = pollFuture;
+    if (activePollFuture != null) {
+      activePollFuture.cancel(true);
+    }
+    shutdownExecutor(pollExecutor);
+    pollExecutor = null;
+    SqsClient activeClient = client;
+    if (activeClient == null) {
+      return;
+    }
+    try {
+      activeClient.close();
+    } catch (Exception e) {
+      LOG.debug("Failed closing SQS client for CSV await mock provider.", e);
+    } finally {
+      client = null;
+    }
+  }
+
+  boolean pollOnce(SqsProviderConfig config) {
+    if (!config.enabled()) {
+      return true;
+    }
+    String requestQueueUrl = config.requestQueueUrl()
+        .filter(url -> !url.isBlank())
+        .orElseThrow(() -> new IllegalStateException(
+            "csv-payments.payment-provider.sqs.request-queue-url must be configured when SQS provider is enabled."));
+    int visibilityTimeoutSeconds = visibilityTimeoutSeconds(config);
+    List<Message> messages;
+    try {
+      messages = sqsClient(config).receiveMessage(ReceiveMessageRequest.builder()
+          .queueUrl(requestQueueUrl)
+          .maxNumberOfMessages(config.maxMessages())
+          .waitTimeSeconds(config.waitTimeSeconds())
+          .visibilityTimeout(visibilityTimeoutSeconds)
+          .build()).messages();
+    } catch (RuntimeException e) {
+      LOG.errorf(e, "Failed receiving CSV SQS await requests from queueUrl=%s", requestQueueUrl);
+      sleepFailureBackoff();
+      return false;
+    }
+    for (Message message : messages) {
+      handleMessage(requestQueueUrl, message, config);
+    }
+    return true;
+  }
+
+  private static int visibilityTimeoutSeconds(SqsProviderConfig config) {
+    long seconds = config.visibilityTimeout().toSeconds();
+    if (seconds < 0 || seconds > 43_200) {
+      throw new IllegalArgumentException(
+          "csv-payments.payment-provider.sqs.visibility-timeout must be between PT0S and PT43200S.");
+    }
+    return (int) seconds;
+  }
+
+  private static String requiredQueueUrl(Optional<String> value, String configKey) {
+    return value
+        .filter(url -> !url.isBlank())
+        .orElseThrow(() -> new IllegalStateException(configKey + " must be configured when SQS provider is enabled."));
+  }
+
+  private void pollLoop() {
+    while (running && !Thread.currentThread().isInterrupted()) {
+      try {
+        if (pollOnce(SqsProviderConfig.fromRuntime())) {
+          consecutivePollFailures.set(0);
+        }
+      } catch (Exception e) {
+        LOG.error("CSV SQS await provider poll failed.", e);
+        sleepFailureBackoff();
+      }
+    }
+  }
+
+  private void handleMessage(String requestQueueUrl, Message message, SqsProviderConfig config) {
+    if (message == null || message.receiptHandle() == null) {
+      return;
+    }
+    if (message.body() == null) {
+      LOG.warnf("Leaving CSV SQS await request with null body for queue redrive id=%s", message.messageId());
+      return;
+    }
+    SqsAwaitCompletionEnvelope completion;
+    try {
+      completion = handle(PipelineJson.mapper().readValue(message.body(), SqsAwaitDispatchEnvelope.class));
+    } catch (Exception e) {
+      LOG.errorf(e, "Failed processing CSV SQS await request id=%s", message.messageId());
+      return;
+    }
+    try {
+      delayCompletion();
+      sqsClient(config).sendMessage(SendMessageRequest.builder()
+          .queueUrl(config.responseQueueUrl()
+              .filter(url -> !url.isBlank())
+              .orElseThrow(() -> new IllegalStateException(
+                  "csv-payments.payment-provider.sqs.response-queue-url must be configured when SQS provider is enabled.")))
+          .messageBody(serialize(completion))
+          .build());
+      deleteMessage(requestQueueUrl, message.receiptHandle(), config);
+    } catch (RuntimeException e) {
+      LOG.errorf(e, "Failed sending CSV SQS await completion id=%s", message.messageId());
+    }
+  }
+
+  private SqsAwaitCompletionEnvelope handle(SqsAwaitDispatchEnvelope dispatch) {
+    PaymentRecord paymentRecord = PipelineJson.mapper().convertValue(dispatch.requestPayload(), PaymentRecord.class);
+    validatePaymentRecord(paymentRecord);
+    PaymentStatus status = paymentProvider.processPayment(paymentRecord);
+    return new SqsAwaitCompletionEnvelope(
+        dispatch.tenantId(),
+        dispatch.interactionId(),
+        dispatch.correlationId(),
+        dispatch.resumeToken(),
+        dispatch.interactionId(),
+        status,
+        "csv-payments-sqs-mock-provider");
+  }
+
+  private void delayCompletion() {
+    long delayMillis = paymentProviderConfig.responseDelayMillis();
+    if (delayMillis <= 0) {
+      return;
+    }
+    sleep(Duration.ofMillis(delayMillis));
+  }
+
+  private void deleteMessage(String queueUrl, String receiptHandle, SqsProviderConfig config) {
+    sqsClient(config).deleteMessage(DeleteMessageRequest.builder()
+        .queueUrl(queueUrl)
+        .receiptHandle(receiptHandle)
+        .build());
+  }
+
+  private SqsClient sqsClient(SqsProviderConfig config) {
+    SqsClient active = client;
+    if (active != null) {
+      return active;
+    }
+    synchronized (this) {
+      if (client == null) {
+        var builder = SqsClient.builder();
+        builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+        config.region()
+            .filter(region -> !region.isBlank())
+            .ifPresent(region -> builder.region(Region.of(region)));
+        config.endpointOverride()
+            .filter(endpoint -> !endpoint.isBlank())
+            .ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
+        client = builder.build();
+      }
+      return client;
+    }
+  }
+
+  private void ensureExecutor() {
+    if (pollExecutor == null) {
+      pollExecutor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "csv-sqs-await-provider");
+        thread.setDaemon(true);
+        return thread;
+      });
+    }
+  }
+
+  private void sleepFailureBackoff() {
+    int failures = consecutivePollFailures.incrementAndGet();
+    long delayMillis = Math.min(
+        INITIAL_FAILURE_BACKOFF.toMillis() * (1L << Math.min(10, Math.max(0, failures - 1))),
+        MAX_FAILURE_BACKOFF.toMillis());
+    sleep(Duration.ofMillis(delayMillis));
+  }
+
+  private static void shutdownExecutor(ExecutorService executor) {
+    if (executor == null) {
+      return;
+    }
+    executor.shutdownNow();
+    try {
+      if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+        LOG.warnf("CSV SQS await provider executor did not terminate within %s", EXECUTOR_SHUTDOWN_TIMEOUT);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warnf(e, "Interrupted while shutting down CSV SQS await provider executor");
+    }
+  }
+
+  private static void validatePaymentRecord(PaymentRecord paymentRecord) {
+    if (paymentRecord == null) {
+      throw new IllegalArgumentException("SQS await payment request payload must contain a PaymentRecord");
+    }
+    if (paymentRecord.getAmount() == null || paymentRecord.getRecipient() == null || paymentRecord.getRecipient().isBlank()
+        || paymentRecord.getCurrency() == null || paymentRecord.getId() == null) {
+      throw new IllegalArgumentException("PaymentRecord must include id, amount, recipient, and currency");
+    }
+  }
+
+  private static String serialize(SqsAwaitCompletionEnvelope envelope) {
+    try {
+      return PipelineJson.mapper().writeValueAsString(envelope);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed serializing SQS await completion envelope", e);
+    }
+  }
+
+  private static void sleep(Duration duration) {
+    if (duration == null || duration.isZero() || duration.isNegative()) {
+      return;
+    }
+    try {
+      Thread.sleep(duration.toMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  record SqsProviderConfig(
+      boolean enabled,
+      Optional<String> requestQueueUrl,
+      Optional<String> responseQueueUrl,
+      Optional<String> region,
+      Optional<String> endpointOverride,
+      Duration pollStartDelay,
+      Duration visibilityTimeout,
+      int waitTimeSeconds,
+      int maxMessages
+  ) {
+    static SqsProviderConfig fromRuntime() {
+      var config = ConfigProvider.getConfig();
+      return new SqsProviderConfig(
+          config.getOptionalValue("csv-payments.payment-provider.sqs.enabled", Boolean.class).orElse(false),
+          config.getOptionalValue("csv-payments.payment-provider.sqs.request-queue-url", String.class),
+          config.getOptionalValue("csv-payments.payment-provider.sqs.response-queue-url", String.class),
+          config.getOptionalValue("csv-payments.payment-provider.sqs.region", String.class),
+          config.getOptionalValue("csv-payments.payment-provider.sqs.endpoint-override", String.class),
+          config.getOptionalValue("csv-payments.payment-provider.sqs.poll-start-delay", Duration.class)
+              .orElse(DEFAULT_POLL_START_DELAY),
+          config.getOptionalValue("csv-payments.payment-provider.sqs.visibility-timeout", Duration.class)
+              .orElse(DEFAULT_VISIBILITY_TIMEOUT),
+          Math.max(1, Math.min(20,
+              config.getOptionalValue("csv-payments.payment-provider.sqs.wait-time-seconds", Integer.class).orElse(1))),
+          Math.max(1, Math.min(10,
+              config.getOptionalValue("csv-payments.payment-provider.sqs.max-messages", Integer.class).orElse(1))));
+    }
+  }
+}

--- a/examples/csv-payments/payments-processing-svc/src/test/java/org/pipelineframework/csv/service/PaymentProviderConfigTest.java
+++ b/examples/csv-payments/payments-processing-svc/src/test/java/org/pipelineframework/csv/service/PaymentProviderConfigTest.java
@@ -18,6 +18,9 @@ package org.pipelineframework.csv.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +56,11 @@ class PaymentProviderConfigTest {
                     public long responseDelayMillis() {
                         return 0L;
                     }
+
+                    @Override
+                    public Sqs sqs() {
+                        return disabledSqs();
+                    }
                 };
     }
 
@@ -79,5 +87,54 @@ class PaymentProviderConfigTest {
     @Test
     void testDefaultResponseDelayMillis() {
         assertThat(config.responseDelayMillis()).isZero();
+    }
+
+    private static PaymentProviderConfig.Sqs disabledSqs() {
+        return new PaymentProviderConfig.Sqs() {
+            @Override
+            public boolean enabled() {
+                return false;
+            }
+
+            @Override
+            public Optional<String> requestQueueUrl() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<String> responseQueueUrl() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<String> region() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<String> endpointOverride() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Duration pollStartDelay() {
+                return Duration.ZERO;
+            }
+
+            @Override
+            public Duration visibilityTimeout() {
+                return Duration.ofSeconds(30);
+            }
+
+            @Override
+            public int waitTimeSeconds() {
+                return 1;
+            }
+
+            @Override
+            public int maxMessages() {
+                return 1;
+            }
+        };
     }
 }

--- a/examples/csv-payments/payments-processing-svc/src/test/java/org/pipelineframework/csv/service/PaymentProviderServiceMockTest.java
+++ b/examples/csv-payments/payments-processing-svc/src/test/java/org/pipelineframework/csv/service/PaymentProviderServiceMockTest.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.Currency;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -123,6 +125,60 @@ class PaymentProviderServiceMockTest {
     public long responseDelayMillis() {
       return 0L;
     }
+
+    @Override
+    public Sqs sqs() {
+      return disabledSqs();
+    }
+  }
+
+  private static PaymentProviderConfig.Sqs disabledSqs() {
+    return new PaymentProviderConfig.Sqs() {
+      @Override
+      public boolean enabled() {
+        return false;
+      }
+
+      @Override
+      public Optional<String> requestQueueUrl() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<String> responseQueueUrl() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<String> region() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<String> endpointOverride() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Duration pollStartDelay() {
+        return Duration.ZERO;
+      }
+
+      @Override
+      public Duration visibilityTimeout() {
+        return Duration.ofSeconds(30);
+      }
+
+      @Override
+      public int waitTimeSeconds() {
+        return 1;
+      }
+
+      @Override
+      public int maxMessages() {
+        return 1;
+      }
+    };
   }
 
   private static final class NegativeTimeoutPaymentProviderConfig extends FakePaymentProviderConfig {

--- a/examples/csv-payments/payments-processing-svc/src/test/java/org/pipelineframework/csv/service/PaymentProviderSqsAwaitMockTest.java
+++ b/examples/csv-payments/payments-processing-svc/src/test/java/org/pipelineframework/csv/service/PaymentProviderSqsAwaitMockTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2023-2025 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.csv.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Currency;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.pipelineframework.awaitable.sqs.SqsAwaitCompletionEnvelope;
+import org.pipelineframework.awaitable.sqs.SqsAwaitDispatchEnvelope;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.csv.common.domain.PaymentRecord;
+import org.pipelineframework.csv.common.domain.PaymentStatus;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+class PaymentProviderSqsAwaitMockTest {
+
+  private SqsClient client;
+  private PaymentProviderServiceMock paymentProvider;
+  private PaymentProviderSqsAwaitMock mockProvider;
+
+  @BeforeEach
+  void setUp() {
+    client = mock(SqsClient.class);
+    paymentProvider = mock(PaymentProviderServiceMock.class);
+    mockProvider = new PaymentProviderSqsAwaitMock(
+        paymentProvider,
+        new FakePaymentProviderConfig(),
+        client);
+  }
+
+  @Test
+  void pollOnceProcessesRequestSendsCompletionAndDeletesRequest() throws Exception {
+    PaymentRecord paymentRecord = validPaymentRecord();
+    PaymentStatus status = validPaymentStatus(paymentRecord);
+    when(paymentProvider.processPayment(any(PaymentRecord.class))).thenReturn(status);
+    when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+        .messages(message("receipt-1", dispatchJson(paymentRecord)))
+        .build());
+
+    assertDoesNotThrow(() -> mockProvider.pollOnce(enabledConfig()));
+
+    ArgumentCaptor<PaymentRecord> requestCaptor = ArgumentCaptor.forClass(PaymentRecord.class);
+    verify(paymentProvider).processPayment(requestCaptor.capture());
+    assertEquals(paymentRecord.getAmount(), requestCaptor.getValue().getAmount());
+    assertEquals(paymentRecord.getRecipient(), requestCaptor.getValue().getRecipient());
+    assertEquals(paymentRecord.getCurrency(), requestCaptor.getValue().getCurrency());
+
+    verify(client).sendMessage(argThat((SendMessageRequest request) -> {
+      try {
+        SqsAwaitCompletionEnvelope completion = PipelineJson.mapper()
+            .readValue(request.messageBody(), SqsAwaitCompletionEnvelope.class);
+        return request.queueUrl().equals("http://sqs.local/responses")
+            && completion.tenantId().equals("tenant-1")
+            && completion.interactionId().equals("interaction-1")
+            && completion.correlationId().equals("corr-1")
+            && completion.resumeToken().equals("resume-token")
+            && completion.idempotencyKey().equals("interaction-1")
+            && completion.actor().equals("csv-payments-sqs-mock-provider");
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
+    }));
+    verify(client).deleteMessage(argThat((DeleteMessageRequest request) ->
+        request.queueUrl().equals("http://sqs.local/requests")
+            && request.receiptHandle().equals("receipt-1")));
+  }
+
+  @Test
+  void pollOnceLeavesRequestWhenProviderFails() throws Exception {
+    PaymentRecord paymentRecord = validPaymentRecord();
+    when(paymentProvider.processPayment(any(PaymentRecord.class))).thenThrow(new IllegalStateException("provider down"));
+    when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+        .messages(message("receipt-2", dispatchJson(paymentRecord)))
+        .build());
+
+    assertDoesNotThrow(() -> mockProvider.pollOnce(enabledConfig()));
+
+    verify(client, never()).sendMessage(any(SendMessageRequest.class));
+    verify(client, never()).deleteMessage(any(DeleteMessageRequest.class));
+  }
+
+  @Test
+  void pollOnceLeavesRequestWhenResponseSendFails() throws Exception {
+    PaymentRecord paymentRecord = validPaymentRecord();
+    when(paymentProvider.processPayment(any(PaymentRecord.class))).thenReturn(validPaymentStatus(paymentRecord));
+    when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+        .messages(message("receipt-3", dispatchJson(paymentRecord)))
+        .build());
+    when(client.sendMessage(any(SendMessageRequest.class))).thenThrow(new IllegalStateException("sqs down"));
+
+    assertDoesNotThrow(() -> mockProvider.pollOnce(enabledConfig()));
+
+    verify(client, never()).deleteMessage(any(DeleteMessageRequest.class));
+  }
+
+  @Test
+  void pollOnceKeepsMalformedRequestForQueueRedrive() {
+    when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+        .messages(message("receipt-4", "{not-json"))
+        .build());
+
+    assertDoesNotThrow(() -> mockProvider.pollOnce(enabledConfig()));
+
+    verify(paymentProvider, never()).processPayment(any(PaymentRecord.class));
+    verify(client, never()).sendMessage(any(SendMessageRequest.class));
+    verify(client, never()).deleteMessage(any(DeleteMessageRequest.class));
+  }
+
+  @Test
+  void pollOnceSkipsWhenDisabled() {
+    assertDoesNotThrow(() -> mockProvider.pollOnce(config(false)));
+
+    verify(client, never()).receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
+  @Test
+  void pollOnceRejectsVisibilityTimeoutAboveSqsLimit() {
+    PaymentProviderSqsAwaitMock.SqsProviderConfig tooLarge = new PaymentProviderSqsAwaitMock.SqsProviderConfig(
+        true,
+        Optional.of("http://sqs.local/requests"),
+        Optional.of("http://sqs.local/responses"),
+        Optional.empty(),
+        Optional.empty(),
+        Duration.ZERO,
+        Duration.ofSeconds(43_201),
+        1,
+        1);
+
+    IllegalArgumentException failure = assertThrows(IllegalArgumentException.class, () -> mockProvider.pollOnce(tooLarge));
+
+    assertEquals("csv-payments.payment-provider.sqs.visibility-timeout must be between PT0S and PT43200S.",
+        failure.getMessage());
+    verify(client, never()).receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
+  @Test
+  void onStartupFailsFastWhenEnabledWithoutResponseQueue() {
+    assertStartupFails(
+        Optional.of("http://sqs.local/requests"),
+        Optional.empty(),
+        "csv-payments.payment-provider.sqs.response-queue-url must be configured when SQS provider is enabled.");
+  }
+
+  @Test
+  void onStartupFailsFastWhenEnabledWithoutRequestQueue() {
+    assertStartupFails(
+        Optional.empty(),
+        Optional.of("http://sqs.local/responses"),
+        "csv-payments.payment-provider.sqs.request-queue-url must be configured when SQS provider is enabled.");
+  }
+
+  private void assertStartupFails(
+      Optional<String> requestQueueUrl,
+      Optional<String> responseQueueUrl,
+      String expectedMessage) {
+    System.setProperty("csv-payments.payment-provider.sqs.enabled", "true");
+    setOrClear("csv-payments.payment-provider.sqs.request-queue-url", requestQueueUrl);
+    setOrClear("csv-payments.payment-provider.sqs.response-queue-url", responseQueueUrl);
+    try {
+      IllegalStateException failure = assertThrows(IllegalStateException.class, () -> mockProvider.onStartup(null));
+      assertEquals(expectedMessage, failure.getMessage());
+    } finally {
+      System.clearProperty("csv-payments.payment-provider.sqs.enabled");
+      System.clearProperty("csv-payments.payment-provider.sqs.request-queue-url");
+      System.clearProperty("csv-payments.payment-provider.sqs.response-queue-url");
+    }
+  }
+
+  private static void setOrClear(String key, Optional<String> value) {
+    if (value.isPresent()) {
+      System.setProperty(key, value.get());
+    } else {
+      System.clearProperty(key);
+    }
+  }
+
+  private static PaymentProviderSqsAwaitMock.SqsProviderConfig enabledConfig() {
+    return config(true);
+  }
+
+  private static PaymentProviderSqsAwaitMock.SqsProviderConfig config(boolean enabled) {
+    return new PaymentProviderSqsAwaitMock.SqsProviderConfig(
+        enabled,
+        Optional.of("http://sqs.local/requests"),
+        Optional.of("http://sqs.local/responses"),
+        Optional.empty(),
+        Optional.empty(),
+        Duration.ZERO,
+        Duration.ofSeconds(30),
+        1,
+        1);
+  }
+
+  private static Message message(String receiptHandle, String body) {
+    return Message.builder()
+        .messageId(receiptHandle)
+        .receiptHandle(receiptHandle)
+        .body(body)
+        .build();
+  }
+
+  private static String dispatchJson(PaymentRecord paymentRecord) throws Exception {
+    SqsAwaitDispatchEnvelope dispatch = new SqsAwaitDispatchEnvelope(
+        "tenant-1",
+        "exec-1",
+        "interaction-1",
+        "corr-1",
+        "AwaitPaymentProvider",
+        System.currentTimeMillis() + 60_000L,
+        PaymentRecord.class.getName(),
+        PaymentStatus.class.getName(),
+        "resume-token",
+        paymentRecord,
+        Map.of("queue", "requests"));
+    return PipelineJson.mapper().writeValueAsString(dispatch);
+  }
+
+  private static PaymentRecord validPaymentRecord() {
+    PaymentRecord paymentRecord = new PaymentRecord()
+        .setCsvId("csv-1")
+        .setRecipient("alice")
+        .setAmount(new BigDecimal("12.34"))
+        .setCurrency(Currency.getInstance("EUR"));
+    paymentRecord.setId(UUID.randomUUID());
+    return paymentRecord;
+  }
+
+  private static PaymentStatus validPaymentStatus(PaymentRecord paymentRecord) {
+    return new PaymentStatus()
+        .setReference("provider-ref")
+        .setStatus("Completed")
+        .setMessage("settled")
+        .setFee(new BigDecimal("0.12"))
+        .setConversationId(UUID.randomUUID())
+        .setStatusCode(1000L)
+        .setPaymentRecord(paymentRecord)
+        .setPaymentRecordId(paymentRecord.getId());
+  }
+
+  private static final class FakePaymentProviderConfig implements PaymentProviderConfig {
+    @Override
+    public double permitsPerSecond() {
+      return 1000.0;
+    }
+
+    @Override
+    public long timeoutMillis() {
+      return 5000;
+    }
+
+    @Override
+    public double providerTimeoutProbability() {
+      return 0.0;
+    }
+
+    @Override
+    public double providerRejectProbability() {
+      return 0.0;
+    }
+
+    @Override
+    public long responseDelayMillis() {
+      return 0L;
+    }
+
+    @Override
+    public Sqs sqs() {
+      return new Sqs() {
+        @Override
+        public boolean enabled() {
+          return false;
+        }
+
+        @Override
+        public Optional<String> requestQueueUrl() {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> responseQueueUrl() {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> region() {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> endpointOverride() {
+          return Optional.empty();
+        }
+
+        @Override
+        public Duration pollStartDelay() {
+          return Duration.ZERO;
+        }
+
+        @Override
+        public Duration visibilityTimeout() {
+          return Duration.ofSeconds(30);
+        }
+
+        @Override
+        public int waitTimeSeconds() {
+          return 1;
+        }
+
+        @Override
+        public int maxMessages() {
+          return 1;
+        }
+      };
+    }
+  }
+}

--- a/examples/csv-payments/persistence-svc/pom.xml
+++ b/examples/csv-payments/persistence-svc/pom.xml
@@ -140,6 +140,7 @@
                 <pipeline.runtime.source.dir.output>${pipeline.runtime.source.root}/output-csv-file-processing-svc/src/main/java</pipeline.runtime.source.dir.output>
                 <pipeline.runtime.source.exclude.executor>org/pipelineframework/csv/service/ExecutorProducer.java</pipeline.runtime.source.exclude.executor>
                 <pipeline.runtime.source.exclude.kafka-mock>org/pipelineframework/csv/service/PaymentProviderKafkaAwaitMock.java</pipeline.runtime.source.exclude.kafka-mock>
+                <pipeline.runtime.source.exclude.sqs-mock>org/pipelineframework/csv/service/PaymentProviderSqsAwaitMock.java</pipeline.runtime.source.exclude.sqs-mock>
                 <pipeline.runtime.duplicate.check.script>${pipeline.runtime.source.root}/build-tools/check-duplicate-sources.sh</pipeline.runtime.duplicate.check.script>
             </properties>
             <build>
@@ -179,6 +180,7 @@
                                             <fileset dir="${pipeline.runtime.source.dir.payments}">
                                                 <exclude name="${pipeline.runtime.source.exclude.executor}" />
                                                 <exclude name="${pipeline.runtime.source.exclude.kafka-mock}" />
+                                                <exclude name="${pipeline.runtime.source.exclude.sqs-mock}" />
                                             </fileset>
                                         </copy>
                                         <copy todir="${project.build.directory}/pipeline-runtime-sources">

--- a/examples/csv-payments/pipeline-runtime-svc/pom.xml
+++ b/examples/csv-payments/pipeline-runtime-svc/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-sqs</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
         </dependency>

--- a/examples/csv-payments/pom.xml
+++ b/examples/csv-payments/pom.xml
@@ -48,6 +48,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <enablePreview>true</enablePreview>
         <quarkus.platform.version>3.33.1</quarkus.platform.version>
+        <quarkus.amazon.services.bom.version>3.19.0</quarkus.amazon.services.bom.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <grpc.version>1.63.0</grpc.version>
@@ -77,6 +78,13 @@
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-services-bom</artifactId>
+                <version>${quarkus.amazon.services.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/csv-payments/self-host/container/README.md
+++ b/examples/csv-payments/self-host/container/README.md
@@ -3,13 +3,13 @@
 This directory runs the CSV Payments example as the advanced compute-first self-host HA reference:
 
 1. LocalStack provides DynamoDB, SQS, and S3-compatible coordinator stores.
-2. Kafka carries the await request/completion flow for the mock payment provider.
+2. SQS carries the await request/completion flow for the mock payment provider.
 3. Postgres backs the CSV example persistence plugin path.
 4. One coordinator container owns control-plane APIs, release admin APIs, execution/await state, SQS dispatch, DLQ publication, release metadata, artifact storage, and worker lifecycle.
 5. One REST transition worker container hosts the canonical `orchestrator-svc` pipeline order and delegates generated step calls to the grouped runtime and persistence services.
-6. One `pipeline-runtime-svc` container hosts the grouped gRPC step services and Kafka mock provider.
+6. One `pipeline-runtime-svc` container hosts the grouped gRPC step services and SQS mock provider.
 
-Restaurant approval remains the smaller human-await reference. This stack proves the same coordinator model against stream input plus Kafka-backed await completions.
+Restaurant approval remains the smaller human-await reference. This stack proves the same coordinator model against stream input plus SQS-backed await completions. The default CSV example still uses Kafka as the event-stream await proof; this container path is the AWS-shaped self-host HA reference.
 
 ## Run The Demo
 
@@ -22,13 +22,13 @@ From the repository root:
 The script:
 
 1. builds the current framework,
-2. builds CSV `orchestrator-svc`, `pipeline-runtime-svc`, and `persistence-svc` Jib images with gRPC step transport,
-3. starts LocalStack, Kafka, Postgres, persistence, worker, and coordinator containers,
-4. creates DynamoDB tables, SQS queues, and an S3 release bucket; the local Kafka broker creates await topics on first use,
+2. builds CSV `orchestrator-svc`, `pipeline-runtime-svc`, and `persistence-svc` Jib images with gRPC step transport and the SQS await pipeline config,
+3. starts LocalStack, Postgres, persistence, runtime, worker, and coordinator containers,
+4. creates DynamoDB tables, SQS work/DLQ/await queues, and an S3 release bucket,
 5. registers and activates a release from the `orchestrator-svc` artifact,
 6. registers a healthy REST worker for the active release,
 7. submits `payments_12.csv` through `/tpf/control-plane/...`,
-8. waits for Kafka await completions and verifies generated `.out` files.
+8. waits for SQS await completions and verifies generated `.out` files.
 
 Set `TPF_SKIP_FRAMEWORK_INSTALL=true` or `TPF_SKIP_CONTAINER_BUILD=true` for faster reruns after local artifacts/images are current.
 
@@ -46,7 +46,6 @@ Set `TPF_SKIP_FRAMEWORK_INSTALL=true` or `TPF_SKIP_CONTAINER_BUILD=true` for fas
 | `TPF_WORKER_PORT` | `8182` |
 | `TPF_PERSISTENCE_PORT` | `8282` |
 | `TPF_LOCALSTACK_PORT` | `4567` |
-| `TPF_KAFKA_PORT` | `9093` |
 | `TPF_CONTROL_PLANE_TOKEN` | `csv-control-plane-admin-token` |
 | `TPF_ADMIN_TOKEN` | `csv-control-plane-admin-token` |
 | `TPF_WORKER_SECRET` | `csv-transition-worker-secret` |
@@ -57,11 +56,11 @@ These defaults are for local verification only. Real deployments should use secr
 
 1. The durable coordinator can submit and observe a stream-shaped CSV pipeline through the generic control-plane API.
 2. A separated REST worker can execute the grouped pipeline runtime while the coordinator owns durable execution, await, release, worker lifecycle, work queue, and DLQ state.
-3. Kafka await dispatch/completion works in the self-host shape.
+3. SQS await dispatch/completion works in the self-host shape.
 4. The example persistence path can run beside the durable coordinator substrates.
 
 This is still a local reference stack, not a production deployment package.
 
 ## Runtime Boundary Note
 
-Kafka await completions resume item continuations through the same bounded transition-worker seam used for normal queue-async work. The REST transition worker executes the continuation segment up to the aggregate boundary, while generated gRPC step calls target the runtime and persistence containers.
+SQS await completions resume item continuations through the same bounded transition-worker seam used for normal queue-async work. The REST transition worker executes the continuation segment up to the aggregate boundary, while generated gRPC step calls target the runtime and persistence containers.

--- a/examples/csv-payments/self-host/container/README.md
+++ b/examples/csv-payments/self-host/container/README.md
@@ -3,13 +3,13 @@
 This directory runs the CSV Payments example as the advanced compute-first self-host HA reference:
 
 1. LocalStack provides DynamoDB, SQS, and S3-compatible coordinator stores.
-2. SQS carries the await request/completion flow for the mock payment provider.
+2. SQS or Kafka carries the await request/completion flow for the mock payment provider.
 3. Postgres backs the CSV example persistence plugin path.
 4. One coordinator container owns control-plane APIs, release admin APIs, execution/await state, SQS dispatch, DLQ publication, release metadata, artifact storage, and worker lifecycle.
 5. One REST transition worker container hosts the canonical `orchestrator-svc` pipeline order and delegates generated step calls to the grouped runtime and persistence services.
-6. One `pipeline-runtime-svc` container hosts the grouped gRPC step services and SQS mock provider.
+6. One `pipeline-runtime-svc` container hosts the grouped gRPC step services and the selected mock provider.
 
-Restaurant approval remains the smaller human-await reference. This stack proves the same coordinator model against stream input plus SQS-backed await completions. The default CSV example still uses Kafka as the event-stream await proof; this container path is the AWS-shaped self-host HA reference.
+Restaurant approval remains the smaller human-await reference. This stack proves the same coordinator model against stream input plus broker-backed await completions. SQS is the default AWS-shaped self-host HA lane; Kafka is an explicit second lane that proves the await abstraction is not tied to one provider.
 
 ## Run The Demo
 
@@ -19,16 +19,22 @@ From the repository root:
 ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci
 ```
 
+Run the Kafka lane with the same coordinator/worker topology:
+
+```bash
+TPF_CSV_AWAIT_TRANSPORT=kafka ./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci
+```
+
 The script:
 
 1. builds the current framework,
-2. builds CSV `orchestrator-svc`, `pipeline-runtime-svc`, and `persistence-svc` Jib images with gRPC step transport and the SQS await pipeline config,
+2. builds CSV `orchestrator-svc`, `pipeline-runtime-svc`, and `persistence-svc` Jib images with gRPC step transport and the selected await pipeline config,
 3. starts LocalStack, Postgres, persistence, runtime, worker, and coordinator containers,
-4. creates DynamoDB tables, SQS work/DLQ/await queues, and an S3 release bucket,
+4. creates DynamoDB tables, SQS work/DLQ queues, an S3 release bucket, and the selected await substrate resources,
 5. registers and activates a release from the `orchestrator-svc` artifact,
 6. registers a healthy REST worker for the active release,
 7. submits `payments_12.csv` through `/tpf/control-plane/...`,
-8. waits for SQS await completions and verifies generated `.out` files.
+8. waits for await completions and verifies generated `.out` files.
 
 Set `TPF_SKIP_FRAMEWORK_INSTALL=true` or `TPF_SKIP_CONTAINER_BUILD=true` for faster reruns after local artifacts/images are current.
 
@@ -40,12 +46,14 @@ Set `TPF_SKIP_FRAMEWORK_INSTALL=true` or `TPF_SKIP_CONTAINER_BUILD=true` for fas
 | `TPF_CSV_WORKER_IMAGE` | `localhost/csv-payments/orchestrator-svc:latest` |
 | `TPF_CSV_RUNTIME_IMAGE` | `localhost/csv-payments/pipeline-runtime-svc:latest` |
 | `TPF_CSV_PERSISTENCE_IMAGE` | `localhost/csv-payments/persistence-svc:latest` |
+| `TPF_CSV_AWAIT_TRANSPORT` | `sqs` |
 | `TPF_TENANT_ID` | `csv-demo` |
 | `TPF_PIPELINE_ID` | `org.pipelineframework.csv` |
 | `TPF_COORDINATOR_PORT` | `8082` |
 | `TPF_WORKER_PORT` | `8182` |
 | `TPF_PERSISTENCE_PORT` | `8282` |
 | `TPF_LOCALSTACK_PORT` | `4567` |
+| `TPF_KAFKA_PORT` | `9093` when `TPF_CSV_AWAIT_TRANSPORT=kafka` |
 | `TPF_CONTROL_PLANE_TOKEN` | `csv-control-plane-admin-token` |
 | `TPF_ADMIN_TOKEN` | `csv-control-plane-admin-token` |
 | `TPF_WORKER_SECRET` | `csv-transition-worker-secret` |
@@ -56,11 +64,11 @@ These defaults are for local verification only. Real deployments should use secr
 
 1. The durable coordinator can submit and observe a stream-shaped CSV pipeline through the generic control-plane API.
 2. A separated REST worker can execute the grouped pipeline runtime while the coordinator owns durable execution, await, release, worker lifecycle, work queue, and DLQ state.
-3. SQS await dispatch/completion works in the self-host shape.
+3. SQS and Kafka await dispatch/completion can run through the same self-host shape.
 4. The example persistence path can run beside the durable coordinator substrates.
 
 This is still a local reference stack, not a production deployment package.
 
 ## Runtime Boundary Note
 
-SQS await completions resume item continuations through the same bounded transition-worker seam used for normal queue-async work. The REST transition worker executes the continuation segment up to the aggregate boundary, while generated gRPC step calls target the runtime and persistence containers.
+SQS and Kafka await completions resume item continuations through the same bounded transition-worker seam used for normal queue-async work. The REST transition worker executes the continuation segment up to the aggregate boundary, while generated gRPC step calls target the runtime and persistence containers.

--- a/examples/csv-payments/self-host/container/bootstrap-kafka.sh
+++ b/examples/csv-payments/self-host/container/bootstrap-kafka.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/compose.yaml"
+COMPOSE_KAFKA_FILE="${SCRIPT_DIR}/compose.kafka.yaml"
+
+export TPF_REPO_ROOT="${TPF_REPO_ROOT:-${REPO_ROOT}}"
+export TPF_KAFKA_PORT="${TPF_KAFKA_PORT:-9093}"
+
+compose() {
+  docker compose -f "${COMPOSE_FILE}" -f "${COMPOSE_KAFKA_FILE}" "$@"
+}
+
+wait_for_kafka() {
+  local timeout_seconds="${KAFKA_WAIT_SECONDS:-180}"
+  echo "Waiting for Kafka..."
+  for _ in $(seq 1 "${timeout_seconds}"); do
+    if compose exec -T kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:19092 --list >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for Kafka after ${timeout_seconds}s." >&2
+  compose logs kafka >&2 || true
+  exit 1
+}
+
+create_topic_if_missing() {
+  local topic="$1"
+  if compose exec -T kafka /opt/kafka/bin/kafka-topics.sh \
+      --bootstrap-server localhost:19092 \
+      --describe \
+      --topic "${topic}" >/dev/null 2>&1; then
+    echo "Kafka topic exists: ${topic}"
+    return
+  fi
+  echo "Creating Kafka topic: ${topic}"
+  compose exec -T kafka /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server localhost:19092 \
+    --create \
+    --if-not-exists \
+    --topic "${topic}" \
+    --partitions 1 \
+    --replication-factor 1 >/dev/null
+}
+
+compose up -d kafka
+wait_for_kafka
+create_topic_if_missing csv-payments.payment.requests
+create_topic_if_missing csv-payments.payment.results
+
+echo "CSV Kafka bootstrap complete."

--- a/examples/csv-payments/self-host/container/bootstrap-localstack.sh
+++ b/examples/csv-payments/self-host/container/bootstrap-localstack.sh
@@ -31,20 +31,6 @@ wait_for_localstack() {
   exit 1
 }
 
-wait_for_kafka() {
-  local timeout_seconds="${KAFKA_WAIT_SECONDS:-120}"
-  echo "Waiting for Kafka..."
-  for _ in $(seq 1 "${timeout_seconds}"); do
-    if compose exec -T kafka nc -z localhost 19092 >/dev/null 2>&1; then
-      return
-    fi
-    sleep 1
-  done
-  echo "Timed out waiting for Kafka after ${timeout_seconds}s." >&2
-  compose logs kafka >&2 || true
-  exit 1
-}
-
 create_table_if_missing() {
   local table_name="$1"
   shift
@@ -77,9 +63,8 @@ create_bucket_if_missing() {
   awslocal s3api create-bucket --bucket "${bucket}" >/dev/null
 }
 
-compose up -d localstack kafka postgres
+compose up -d localstack postgres
 wait_for_localstack
-wait_for_kafka
 
 create_table_if_missing tpf_execution \
   --attribute-definitions \
@@ -154,6 +139,8 @@ create_table_if_missing tpf_worker_registry \
 
 create_queue_if_missing tpf-work
 create_queue_if_missing tpf-execution-dlq
+create_queue_if_missing csv-payment-await-requests
+create_queue_if_missing csv-payment-await-results
 create_bucket_if_missing tpf-release-artifacts
 
-echo "CSV LocalStack/Kafka bootstrap complete. Kafka topics are created by the local broker on first use."
+echo "CSV LocalStack bootstrap complete."

--- a/examples/csv-payments/self-host/container/build-container-images.sh
+++ b/examples/csv-payments/self-host/container/build-container-images.sh
@@ -15,6 +15,7 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-localhost}"
 IMAGE_GROUP="${IMAGE_GROUP:-csv-payments}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 PIPELINE_TRANSPORT="${PIPELINE_TRANSPORT:-GRPC}"
+TPF_CSV_PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG:-${EXAMPLE_DIR}/config/pipeline.container-sqs.yaml}"
 expected_coordinator_image="${IMAGE_REGISTRY}/${IMAGE_GROUP}/orchestrator-svc:${IMAGE_TAG}"
 expected_worker_image="${expected_coordinator_image}"
 expected_runtime_image="${IMAGE_REGISTRY}/${IMAGE_GROUP}/pipeline-runtime-svc:${IMAGE_TAG}"
@@ -46,12 +47,25 @@ if [[ "${TPF_SKIP_FRAMEWORK_INSTALL}" != "true" ]]; then
   "${MVN_BIN}" -f "${REPO_ROOT}/framework/pom.xml" clean install
 fi
 
-echo "Building CSV pipeline-runtime topology images with gRPC step transport..."
+COMMON_BUILD_PROPS=(
+  -Dpipeline.config="${TPF_CSV_PIPELINE_CONFIG}"
+  -Dtpf.await.kafka.reactive-messaging.enabled=false
+  -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
+  -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=false
+  -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=false
+  -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=false
+  -Dcsv-payments.payment-provider.kafka.enabled=false
+  -Dcsv-payments.payment-provider.sqs.enabled=true
+)
+
+echo "Building CSV pipeline-runtime topology images with gRPC step transport and SQS await config..."
 IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
 IMAGE_GROUP="${IMAGE_GROUP}" \
 IMAGE_TAG="${IMAGE_TAG}" \
 PIPELINE_TRANSPORT="${PIPELINE_TRANSPORT}" \
+PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG}" \
 "${EXAMPLE_DIR}/build-pipeline-runtime.sh" \
+  "${COMMON_BUILD_PROPS[@]}" \
   -DskipTests \
   -Dquarkus.container-image.build=true \
   -Dquarkus.container-image.push=false
@@ -61,8 +75,10 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
 IMAGE_GROUP="${IMAGE_GROUP}" \
 IMAGE_TAG="${IMAGE_TAG}" \
 PIPELINE_TRANSPORT="${PIPELINE_TRANSPORT}" \
+PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG}" \
 "${EXAMPLE_DIR}/build-pipeline-runtime.sh" \
   -pl orchestrator-svc \
+  "${COMMON_BUILD_PROPS[@]}" \
   -DskipTests \
   -Dquarkus.container-image.build=true \
   -Dquarkus.container-image.push=false \

--- a/examples/csv-payments/self-host/container/build-container-images.sh
+++ b/examples/csv-payments/self-host/container/build-container-images.sh
@@ -15,7 +15,19 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-localhost}"
 IMAGE_GROUP="${IMAGE_GROUP:-csv-payments}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 PIPELINE_TRANSPORT="${PIPELINE_TRANSPORT:-GRPC}"
-TPF_CSV_PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG:-${EXAMPLE_DIR}/config/pipeline.container-sqs.yaml}"
+TPF_CSV_AWAIT_TRANSPORT="${TPF_CSV_AWAIT_TRANSPORT:-sqs}"
+case "${TPF_CSV_AWAIT_TRANSPORT}" in
+  sqs)
+    TPF_CSV_PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG:-${EXAMPLE_DIR}/config/pipeline.container-sqs.yaml}"
+    ;;
+  kafka)
+    TPF_CSV_PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG:-${EXAMPLE_DIR}/config/pipeline.yaml}"
+    ;;
+  *)
+    echo "ERROR: TPF_CSV_AWAIT_TRANSPORT must be 'sqs' or 'kafka'." >&2
+    exit 1
+    ;;
+esac
 expected_coordinator_image="${IMAGE_REGISTRY}/${IMAGE_GROUP}/orchestrator-svc:${IMAGE_TAG}"
 expected_worker_image="${expected_coordinator_image}"
 expected_runtime_image="${IMAGE_REGISTRY}/${IMAGE_GROUP}/pipeline-runtime-svc:${IMAGE_TAG}"
@@ -49,16 +61,31 @@ fi
 
 COMMON_BUILD_PROPS=(
   -Dpipeline.config="${TPF_CSV_PIPELINE_CONFIG}"
-  -Dtpf.await.kafka.reactive-messaging.enabled=false
-  -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
-  -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=false
-  -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=false
-  -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=false
-  -Dcsv-payments.payment-provider.kafka.enabled=false
-  -Dcsv-payments.payment-provider.sqs.enabled=true
 )
 
-echo "Building CSV pipeline-runtime topology images with gRPC step transport and SQS await config..."
+if [[ "${TPF_CSV_AWAIT_TRANSPORT}" == "sqs" ]]; then
+  COMMON_BUILD_PROPS+=(
+    -Dtpf.await.kafka.reactive-messaging.enabled=false
+    -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
+    -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=false
+    -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=false
+    -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=false
+    -Dcsv-payments.payment-provider.kafka.enabled=false
+    -Dcsv-payments.payment-provider.sqs.enabled=true
+  )
+else
+  COMMON_BUILD_PROPS+=(
+    -Dtpf.await.kafka.reactive-messaging.enabled=true
+    -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=true
+    -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=true
+    -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=true
+    -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=true
+    -Dcsv-payments.payment-provider.kafka.enabled=true
+    -Dcsv-payments.payment-provider.sqs.enabled=false
+  )
+fi
+
+echo "Building CSV pipeline-runtime topology images with gRPC step transport and ${TPF_CSV_AWAIT_TRANSPORT} await config..."
 IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
 IMAGE_GROUP="${IMAGE_GROUP}" \
 IMAGE_TAG="${IMAGE_TAG}" \

--- a/examples/csv-payments/self-host/container/compose.kafka.yaml
+++ b/examples/csv-payments/self-host/container/compose.kafka.yaml
@@ -1,0 +1,34 @@
+services:
+  kafka:
+    image: apache/kafka-native:3.8.0
+    ports:
+      - "${TPF_KAFKA_PORT:-9093}:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_LISTENERS: PLAINTEXT://:19092,CONTROLLER://:9093,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:19092,PLAINTEXT_HOST://localhost:${TPF_KAFKA_PORT:-9093}
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:19092 --list >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  runtime:
+    depends_on:
+      kafka:
+        condition: service_healthy
+
+  coordinator:
+    depends_on:
+      kafka:
+        condition: service_healthy

--- a/examples/csv-payments/self-host/container/compose.yaml
+++ b/examples/csv-payments/self-host/container/compose.yaml
@@ -75,7 +75,7 @@ services:
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
       AWS_REGION: "${AWS_REGION:-us-east-1}"
-      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml"
+      PIPELINE_CONFIG: "${TPF_CSV_PIPELINE_CONFIG:-${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml}"
       SERVER_KEYSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/pipeline-runtime-svc/server-keystore.jks"
       SERVER_KEYSTORE_PASSWORD: secret
       SERVER_TRUSTSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/pipeline-runtime-svc/client-truststore.jks"
@@ -99,11 +99,13 @@ services:
         -Dpipeline.orchestrator.mode=QUEUE_ASYNC
         -Dpipeline.orchestrator.resume-token-secret=csv-payments-container-resume-token-secret
         -Dpipeline.orchestrator.strict-startup=false
-        -Dtpf.await.kafka.reactive-messaging.enabled=false
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
-        -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=false
-        -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=false
-        -Dcsv-payments.payment-provider.sqs.enabled=true
+        -Dkafka.bootstrap.servers=${TPF_KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
+        -Dtpf.await.kafka.reactive-messaging.enabled=${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-false}
+        -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-false}
+        -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-false}
+        -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-false}
+        -Dcsv-payments.payment-provider.kafka.enabled=${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-false}
+        -Dcsv-payments.payment-provider.sqs.enabled=${TPF_RUNTIME_AWAIT_SQS_PROVIDER_ENABLED:-true}
         -Dcsv-payments.payment-provider.sqs.request-queue-url=http://localstack:4566/000000000000/csv-payment-await-requests
         -Dcsv-payments.payment-provider.sqs.response-queue-url=http://localstack:4566/000000000000/csv-payment-await-results
         -Dcsv-payments.payment-provider.sqs.region=${AWS_REGION:-us-east-1}
@@ -144,7 +146,7 @@ services:
       AWS_SECRET_ACCESS_KEY: test
       AWS_REGION: "${AWS_REGION:-us-east-1}"
       TPF_WORKER_SECRET: "${TPF_WORKER_SECRET:-csv-transition-worker-secret}"
-      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml"
+      PIPELINE_CONFIG: "${TPF_CSV_PIPELINE_CONFIG:-${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml}"
       SERVER_KEYSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/server-keystore.jks"
       SERVER_KEYSTORE_PASSWORD: secret
       SERVER_TRUSTSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/client-truststore.jks"
@@ -240,7 +242,7 @@ services:
       TPF_CONTROL_PLANE_TOKEN: "${TPF_CONTROL_PLANE_TOKEN:-csv-control-plane-admin-token}"
       TPF_ADMIN_TOKEN: "${TPF_ADMIN_TOKEN:-csv-control-plane-admin-token}"
       TPF_WORKER_SECRET: "${TPF_WORKER_SECRET:-csv-transition-worker-secret}"
-      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml"
+      PIPELINE_CONFIG: "${TPF_CSV_PIPELINE_CONFIG:-${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml}"
       SERVER_KEYSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/server-keystore.jks"
       CLIENT_TRUSTSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/client-truststore.jks"
       JAVA_OPTS_APPEND: >-
@@ -260,9 +262,10 @@ services:
         -Dpipeline.orchestrator.mode=QUEUE_ASYNC
         -Dpipeline.orchestrator.resume-token-secret=csv-payments-container-resume-token-secret
         -Dpipeline.orchestrator.strict-startup=true
-        -Dtpf.await.kafka.reactive-messaging.enabled=false
+        -Dkafka.bootstrap.servers=${TPF_KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
+        -Dtpf.await.kafka.reactive-messaging.enabled=${TPF_COORDINATOR_AWAIT_KAFKA_ENABLED:-false}
         -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=false
+        -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=${TPF_COORDINATOR_AWAIT_KAFKA_ENABLED:-false}
         -Dpipeline.health.enabled=false
         -Dpipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
         -Dpipeline.orchestrator.state-provider=dynamo
@@ -301,7 +304,7 @@ services:
         -Dpipeline.orchestrator.worker.rest.base-url=http://worker:8182
         -Dpipeline.orchestrator.worker.rest.request-timeout=PT180S
         -Dpipeline.orchestrator.worker.rest.shared-secret-ref=env:TPF_WORKER_SECRET
-        -Dtpf.await.sqs.poller.enabled=true
+        -Dtpf.await.sqs.poller.enabled=${TPF_COORDINATOR_AWAIT_SQS_POLLER_ENABLED:-true}
         -Dtpf.await.sqs.response-queue-url=http://localstack:4566/000000000000/csv-payment-await-results
         -Dtpf.await.sqs.visibility-timeout=PT30S
         -Dtpf.await.sqs.wait-time-seconds=1

--- a/examples/csv-payments/self-host/container/compose.yaml
+++ b/examples/csv-payments/self-host/container/compose.yaml
@@ -17,29 +17,6 @@ services:
       timeout: 3s
       retries: 30
 
-  kafka:
-    image: apache/kafka-native:3.8.0
-    ports:
-      - "${TPF_KAFKA_PORT:-9093}:9092"
-    environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9094
-      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092,CONTROLLER://:9094
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:19092,PLAINTEXT_HOST://localhost:${TPF_KAFKA_PORT:-9093}
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "19092"]
-      interval: 5s
-      timeout: 5s
-      retries: 30
-
   postgres:
     image: postgres:17
     environment:
@@ -86,7 +63,7 @@ services:
   runtime:
     image: "${TPF_CSV_RUNTIME_IMAGE:-localhost/csv-payments/pipeline-runtime-svc:latest}"
     depends_on:
-      kafka:
+      localstack:
         condition: service_healthy
       persistence:
         condition: service_started
@@ -95,8 +72,10 @@ services:
     volumes:
       - "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}:${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}"
     environment:
-      KAFKA_BOOTSTRAP_SERVERS: kafka:19092
-      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.yaml"
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: "${AWS_REGION:-us-east-1}"
+      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml"
       SERVER_KEYSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/pipeline-runtime-svc/server-keystore.jks"
       SERVER_KEYSTORE_PASSWORD: secret
       SERVER_TRUSTSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/pipeline-runtime-svc/client-truststore.jks"
@@ -120,18 +99,15 @@ services:
         -Dpipeline.orchestrator.mode=QUEUE_ASYNC
         -Dpipeline.orchestrator.resume-token-secret=csv-payments-container-resume-token-secret
         -Dpipeline.orchestrator.strict-startup=false
-        -Dtpf.await.kafka.reactive-messaging.enabled=true
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.connector=smallrye-kafka
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.topic=csv-payments.payment.requests
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-        -Dmp.messaging.incoming.csv-payment-provider-requests.connector=smallrye-kafka
-        -Dmp.messaging.incoming.csv-payment-provider-requests.topic=csv-payments.payment.requests
-        -Dmp.messaging.incoming.csv-payment-provider-requests.group.id=csv-payments-container-mock-provider
-        -Dmp.messaging.incoming.csv-payment-provider-requests.auto.offset.reset=earliest
-        -Dmp.messaging.incoming.csv-payment-provider-requests.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-        -Dmp.messaging.outgoing.csv-payment-provider-results.connector=smallrye-kafka
-        -Dmp.messaging.outgoing.csv-payment-provider-results.topic=csv-payments.payment.results
-        -Dmp.messaging.outgoing.csv-payment-provider-results.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+        -Dtpf.await.kafka.reactive-messaging.enabled=false
+        -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
+        -Dmp.messaging.incoming.csv-payment-provider-requests.enabled=false
+        -Dmp.messaging.outgoing.csv-payment-provider-results.enabled=false
+        -Dcsv-payments.payment-provider.sqs.enabled=true
+        -Dcsv-payments.payment-provider.sqs.request-queue-url=http://localstack:4566/000000000000/csv-payment-await-requests
+        -Dcsv-payments.payment-provider.sqs.response-queue-url=http://localstack:4566/000000000000/csv-payment-await-results
+        -Dcsv-payments.payment-provider.sqs.region=${AWS_REGION:-us-east-1}
+        -Dcsv-payments.payment-provider.sqs.endpoint-override=http://localstack:4566
         -Dcsv-payments.reader-demand-pacer.rows-per-period=20
         -Dcsv-payments.reader-demand-pacer.millis-period=100
         -Dcsv-payments.payment-provider.permits-per-second=250.0
@@ -153,7 +129,7 @@ services:
   worker:
     image: "${TPF_CSV_WORKER_IMAGE:-localhost/csv-payments/orchestrator-svc:latest}"
     depends_on:
-      kafka:
+      localstack:
         condition: service_healthy
       runtime:
         condition: service_started
@@ -164,9 +140,11 @@ services:
     volumes:
       - "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}:${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}"
     environment:
-      KAFKA_BOOTSTRAP_SERVERS: kafka:19092
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: "${AWS_REGION:-us-east-1}"
       TPF_WORKER_SECRET: "${TPF_WORKER_SECRET:-csv-transition-worker-secret}"
-      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.yaml"
+      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml"
       SERVER_KEYSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/server-keystore.jks"
       SERVER_KEYSTORE_PASSWORD: secret
       SERVER_TRUSTSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/client-truststore.jks"
@@ -192,16 +170,12 @@ services:
         -Dpipeline.orchestrator.worker.rest.server-enabled=true
         -Dpipeline.orchestrator.worker.rest.shared-secret-ref=env:TPF_WORKER_SECRET
         -Dpipeline.orchestrator.strict-startup=false
+        -Dtpf.await.kafka.reactive-messaging.enabled=false
+        -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
+        -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=false
+        -Dpipeline.orchestrator.sqs.region=${AWS_REGION:-us-east-1}
+        -Dpipeline.orchestrator.sqs.endpoint-override=http://localstack:4566
         -Dpipeline.health.enabled=false
-        -Dtpf.await.kafka.reactive-messaging.enabled=true
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.connector=smallrye-kafka
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.topic=csv-payments.payment.requests
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.connector=smallrye-kafka
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.topic=csv-payments.worker.ignored-results
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.group.id=csv-payments-container-worker-ignored
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.auto.offset.reset=earliest
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
         -Dquarkus.grpc.clients.process-folder.host=runtime
         -Dquarkus.grpc.clients.process-folder.port=8183
         -Dquarkus.grpc.clients.process-folder.plain-text=true
@@ -253,8 +227,6 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
-      kafka:
-        condition: service_healthy
       worker:
         condition: service_started
     ports:
@@ -265,11 +237,10 @@ services:
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
       AWS_REGION: "${AWS_REGION:-us-east-1}"
-      KAFKA_BOOTSTRAP_SERVERS: kafka:19092
       TPF_CONTROL_PLANE_TOKEN: "${TPF_CONTROL_PLANE_TOKEN:-csv-control-plane-admin-token}"
       TPF_ADMIN_TOKEN: "${TPF_ADMIN_TOKEN:-csv-control-plane-admin-token}"
       TPF_WORKER_SECRET: "${TPF_WORKER_SECRET:-csv-transition-worker-secret}"
-      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.yaml"
+      PIPELINE_CONFIG: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/config/pipeline.container-sqs.yaml"
       SERVER_KEYSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/server-keystore.jks"
       CLIENT_TRUSTSTORE_PATH: "${TPF_REPO_ROOT:?TPF_REPO_ROOT must be set}/examples/csv-payments/target/dev-certs/orchestrator-svc/client-truststore.jks"
       JAVA_OPTS_APPEND: >-
@@ -289,6 +260,9 @@ services:
         -Dpipeline.orchestrator.mode=QUEUE_ASYNC
         -Dpipeline.orchestrator.resume-token-secret=csv-payments-container-resume-token-secret
         -Dpipeline.orchestrator.strict-startup=true
+        -Dtpf.await.kafka.reactive-messaging.enabled=false
+        -Dmp.messaging.outgoing.tpf-await-kafka-requests.enabled=false
+        -Dmp.messaging.incoming.tpf-await-kafka-responses.enabled=false
         -Dpipeline.health.enabled=false
         -Dpipeline.orchestrator.idempotency-policy=CLIENT_KEY_REQUIRED
         -Dpipeline.orchestrator.state-provider=dynamo
@@ -327,15 +301,10 @@ services:
         -Dpipeline.orchestrator.worker.rest.base-url=http://worker:8182
         -Dpipeline.orchestrator.worker.rest.request-timeout=PT180S
         -Dpipeline.orchestrator.worker.rest.shared-secret-ref=env:TPF_WORKER_SECRET
-        -Dtpf.await.kafka.reactive-messaging.enabled=true
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.connector=smallrye-kafka
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.topic=csv-payments.payment.requests
-        -Dmp.messaging.outgoing.tpf-await-kafka-requests.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.connector=smallrye-kafka
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.topic=csv-payments.payment.results
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.group.id=csv-payments-container-coordinator
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.auto.offset.reset=earliest
-        -Dmp.messaging.incoming.tpf-await-kafka-responses.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+        -Dtpf.await.sqs.poller.enabled=true
+        -Dtpf.await.sqs.response-queue-url=http://localstack:4566/000000000000/csv-payment-await-results
+        -Dtpf.await.sqs.visibility-timeout=PT30S
+        -Dtpf.await.sqs.wait-time-seconds=1
         -Dquarkus.grpc.clients.process-folder.host=runtime
         -Dquarkus.grpc.clients.process-folder.port=8183
         -Dquarkus.grpc.clients.process-folder.plain-text=true

--- a/examples/csv-payments/self-host/container/run-container-ha-demo.sh
+++ b/examples/csv-payments/self-host/container/run-container-ha-demo.sh
@@ -21,7 +21,6 @@ export TPF_WORKER_PORT="${TPF_WORKER_PORT:-8182}"
 export TPF_RUNTIME_PORT="${TPF_RUNTIME_PORT:-8283}"
 export TPF_PERSISTENCE_PORT="${TPF_PERSISTENCE_PORT:-8282}"
 export TPF_LOCALSTACK_PORT="${TPF_LOCALSTACK_PORT:-4567}"
-export TPF_KAFKA_PORT="${TPF_KAFKA_PORT:-9093}"
 export TPF_CONTROL_PLANE_TOKEN="${TPF_CONTROL_PLANE_TOKEN:-csv-control-plane-admin-token}"
 export TPF_ADMIN_TOKEN="${TPF_ADMIN_TOKEN:-csv-control-plane-admin-token}"
 export TPF_WORKER_SECRET="${TPF_WORKER_SECRET:-csv-transition-worker-secret}"
@@ -91,7 +90,6 @@ require_free_port "WORKER" "${TPF_WORKER_PORT}"
 require_free_port "RUNTIME" "${TPF_RUNTIME_PORT}"
 require_free_port "PERSISTENCE" "${TPF_PERSISTENCE_PORT}"
 require_free_port "LOCALSTACK" "${TPF_LOCALSTACK_PORT}"
-require_free_port "KAFKA" "${TPF_KAFKA_PORT}"
 
 if [[ "${TPF_SKIP_CONTAINER_BUILD}" != "true" ]]; then
   "${SCRIPT_DIR}/build-container-images.sh"
@@ -162,5 +160,5 @@ if [[ "${CI_MODE}" == "true" ]]; then
   echo "CSV containerized self-host HA demo completed in CI mode."
 else
   echo "CSV containerized self-host HA demo completed."
-  echo "Logs: docker compose -f ${COMPOSE_FILE} logs coordinator worker persistence kafka localstack"
+  echo "Logs: docker compose -f ${COMPOSE_FILE} logs coordinator worker runtime persistence localstack"
 fi

--- a/examples/csv-payments/self-host/container/run-container-ha-demo.sh
+++ b/examples/csv-payments/self-host/container/run-container-ha-demo.sh
@@ -7,9 +7,33 @@ REPO_ROOT="$(cd "${EXAMPLE_DIR}/../.." && pwd)"
 PIPELINE_RUNTIME_DIR="${EXAMPLE_DIR}/pipeline-runtime-svc"
 ORCHESTRATOR_DIR="${EXAMPLE_DIR}/orchestrator-svc"
 COMPOSE_FILE="${SCRIPT_DIR}/compose.yaml"
+COMPOSE_KAFKA_FILE="${SCRIPT_DIR}/compose.kafka.yaml"
 CLIENT="${SCRIPT_DIR}/demo-client.py"
 
 export TPF_REPO_ROOT="${TPF_REPO_ROOT:-${REPO_ROOT}}"
+export TPF_CSV_AWAIT_TRANSPORT="${TPF_CSV_AWAIT_TRANSPORT:-sqs}"
+case "${TPF_CSV_AWAIT_TRANSPORT}" in
+  sqs)
+    export TPF_CSV_PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG:-${EXAMPLE_DIR}/config/pipeline.container-sqs.yaml}"
+    export TPF_RUNTIME_AWAIT_KAFKA_ENABLED="${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-false}"
+    export TPF_RUNTIME_AWAIT_SQS_PROVIDER_ENABLED="${TPF_RUNTIME_AWAIT_SQS_PROVIDER_ENABLED:-true}"
+    export TPF_COORDINATOR_AWAIT_KAFKA_ENABLED="${TPF_COORDINATOR_AWAIT_KAFKA_ENABLED:-false}"
+    export TPF_COORDINATOR_AWAIT_SQS_POLLER_ENABLED="${TPF_COORDINATOR_AWAIT_SQS_POLLER_ENABLED:-true}"
+    ;;
+  kafka)
+    export TPF_CSV_PIPELINE_CONFIG="${TPF_CSV_PIPELINE_CONFIG:-${EXAMPLE_DIR}/config/pipeline.yaml}"
+    export TPF_KAFKA_PORT="${TPF_KAFKA_PORT:-9093}"
+    export TPF_KAFKA_BOOTSTRAP_SERVERS="${TPF_KAFKA_BOOTSTRAP_SERVERS:-kafka:19092}"
+    export TPF_RUNTIME_AWAIT_KAFKA_ENABLED="${TPF_RUNTIME_AWAIT_KAFKA_ENABLED:-true}"
+    export TPF_RUNTIME_AWAIT_SQS_PROVIDER_ENABLED="${TPF_RUNTIME_AWAIT_SQS_PROVIDER_ENABLED:-false}"
+    export TPF_COORDINATOR_AWAIT_KAFKA_ENABLED="${TPF_COORDINATOR_AWAIT_KAFKA_ENABLED:-true}"
+    export TPF_COORDINATOR_AWAIT_SQS_POLLER_ENABLED="${TPF_COORDINATOR_AWAIT_SQS_POLLER_ENABLED:-false}"
+    ;;
+  *)
+    echo "ERROR: TPF_CSV_AWAIT_TRANSPORT must be 'sqs' or 'kafka'." >&2
+    exit 1
+    ;;
+esac
 export TPF_CSV_COORDINATOR_IMAGE="${TPF_CSV_COORDINATOR_IMAGE:-localhost/csv-payments/orchestrator-svc:latest}"
 export TPF_CSV_WORKER_IMAGE="${TPF_CSV_WORKER_IMAGE:-localhost/csv-payments/orchestrator-svc:latest}"
 export TPF_CSV_RUNTIME_IMAGE="${TPF_CSV_RUNTIME_IMAGE:-localhost/csv-payments/pipeline-runtime-svc:latest}"
@@ -39,6 +63,10 @@ if [[ "${1:-}" == "--ci" ]]; then
 fi
 
 compose() {
+  if [[ "${TPF_CSV_AWAIT_TRANSPORT}" == "kafka" ]]; then
+    docker compose -f "${COMPOSE_FILE}" -f "${COMPOSE_KAFKA_FILE}" "$@"
+    return
+  fi
   docker compose -f "${COMPOSE_FILE}" "$@"
 }
 
@@ -90,6 +118,9 @@ require_free_port "WORKER" "${TPF_WORKER_PORT}"
 require_free_port "RUNTIME" "${TPF_RUNTIME_PORT}"
 require_free_port "PERSISTENCE" "${TPF_PERSISTENCE_PORT}"
 require_free_port "LOCALSTACK" "${TPF_LOCALSTACK_PORT}"
+if [[ "${TPF_CSV_AWAIT_TRANSPORT}" == "kafka" ]]; then
+  require_free_port "KAFKA" "${TPF_KAFKA_PORT}"
+fi
 
 if [[ "${TPF_SKIP_CONTAINER_BUILD}" != "true" ]]; then
   "${SCRIPT_DIR}/build-container-images.sh"
@@ -98,8 +129,11 @@ fi
 "${EXAMPLE_DIR}/generate-dev-certs.sh" >/dev/null
 
 "${SCRIPT_DIR}/bootstrap-localstack.sh"
+if [[ "${TPF_CSV_AWAIT_TRANSPORT}" == "kafka" ]]; then
+  "${SCRIPT_DIR}/bootstrap-kafka.sh"
+fi
 
-echo "Starting CSV persistence, runtime, worker, and coordinator containers..."
+echo "Starting CSV persistence, runtime, worker, and coordinator containers with ${TPF_CSV_AWAIT_TRANSPORT} await..."
 compose up -d persistence runtime worker coordinator
 
 python3 "${CLIENT}" wait-health \
@@ -157,8 +191,8 @@ python3 "${CLIENT}" run-flow \
   --timeout-seconds 300
 
 if [[ "${CI_MODE}" == "true" ]]; then
-  echo "CSV containerized self-host HA demo completed in CI mode."
+  echo "CSV containerized self-host HA demo (${TPF_CSV_AWAIT_TRANSPORT}) completed in CI mode."
 else
-  echo "CSV containerized self-host HA demo completed."
+  echo "CSV containerized self-host HA demo (${TPF_CSV_AWAIT_TRANSPORT}) completed."
   echo "Logs: docker compose -f ${COMPOSE_FILE} logs coordinator worker runtime persistence localstack"
 fi

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -521,6 +521,9 @@ public class StepDefinitionParser {
         if ("kafka".equalsIgnoreCase(transportType) && !validateKafkaAwaitTransport(transportMap, stepName)) {
             return null;
         }
+        if ("sqs".equalsIgnoreCase(transportType) && !validateSqsAwaitTransport(transportMap, stepName)) {
+            return null;
+        }
         Object correlationObj = awaitMap.get("correlation");
         if (!(correlationObj instanceof Map<?, ?> correlationMap)) {
             String message = "Skipping step '" + stepName + "': await.correlation.strategy must be declared";
@@ -581,6 +584,59 @@ public class StepDefinitionParser {
             return false;
         }
         return true;
+    }
+
+    private boolean validateSqsAwaitTransport(Map<?, ?> transportMap, String stepName) {
+        Object requestObj = transportMap.get("request");
+        if (!(requestObj instanceof Map<?, ?> requestMap) || isBlank(stringValue(requestMap.get("queueUrl")))) {
+            String message = "Skipping step '" + stepName + "': sqs await transport must declare request.queueUrl";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        String requestQueueUrl = stringValue(requestMap.get("queueUrl"));
+        if (isFifoQueueUrl(requestQueueUrl)) {
+            String message = "Skipping step '" + stepName + "': sqs await transport supports standard queues only in v1";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        Object responseObj = transportMap.get("response");
+        if (!(responseObj instanceof Map<?, ?> responseMap) || isBlank(stringValue(responseMap.get("queueUrl")))) {
+            String message = "Skipping step '" + stepName + "': sqs await transport must declare response.queueUrl";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        String responseQueueUrl = stringValue(responseMap.get("queueUrl"));
+        if (isFifoQueueUrl(responseQueueUrl)) {
+            String message = "Skipping step '" + stepName + "': sqs await transport supports standard queues only in v1";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isFifoQueueUrl(String queueUrl) {
+        return normalizedQueueUrlForTypeCheck(queueUrl).endsWith(".fifo");
+    }
+
+    private String normalizedQueueUrlForTypeCheck(String queueUrl) {
+        if (queueUrl == null) {
+            return "";
+        }
+        String normalized = queueUrl.trim();
+        int queryIndex = normalized.indexOf('?');
+        int fragmentIndex = normalized.indexOf('#');
+        int endIndex = normalized.length();
+        if (queryIndex >= 0) {
+            endIndex = Math.min(endIndex, queryIndex);
+        }
+        if (fragmentIndex >= 0) {
+            endIndex = Math.min(endIndex, fragmentIndex);
+        }
+        return normalized.substring(0, endIndex);
     }
 
     private List<String> parseStringList(Object value, String stepName, String fieldName) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -440,6 +440,156 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void parsesSqsAwaitStepDefinition() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Sqs Fraud Check"
+                kind: "await"
+                input: "com.example.FraudCheckRequest"
+                output: "com.example.FraudCheckDecision"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "signedResumeToken"
+                  transport:
+                    type: "sqs"
+                    request:
+                      queueUrl: "http://localhost:4566/000000000000/fraud-check-requests"
+                    response:
+                      queueUrl: "http://localhost:4566/000000000000/fraud-check-decisions"
+            """, diagnostics);
+
+        assertEquals(1, steps.size());
+        StepDefinition step = steps.getFirst();
+        assertEquals(StepKind.AWAIT, step.kind());
+        java.util.Map<?, ?> transport = (java.util.Map<?, ?>) step.awaitConfig().get("transport");
+        assertEquals("sqs", transport.get("type"));
+        assertEquals("http://localhost:4566/000000000000/fraud-check-requests",
+            ((java.util.Map<?, ?>) transport.get("request")).get("queueUrl"));
+        assertEquals("http://localhost:4566/000000000000/fraud-check-decisions",
+            ((java.util.Map<?, ?>) transport.get("response")).get("queueUrl"));
+        assertTrue(diagnostics.stream().noneMatch(message -> message.contains(Diagnostic.Kind.ERROR.name())));
+    }
+
+    @Test
+    void rejectsSqsAwaitStepWithoutRequestQueueUrl() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Sqs Missing Request Queue"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "signedResumeToken"
+                  transport:
+                    type: "sqs"
+                    request: {}
+                    response:
+                      queueUrl: "http://localhost:4566/000000000000/responses"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("request.queueUrl")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsSqsAwaitStepWithoutResponseQueueUrl() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Sqs Missing Response Queue"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "signedResumeToken"
+                  transport:
+                    type: "sqs"
+                    request:
+                      queueUrl: "http://localhost:4566/000000000000/requests"
+                    response: {}
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("response.queueUrl")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsSqsAwaitStepWithFifoQueueUrl() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Sqs Fifo Queue"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "signedResumeToken"
+                  transport:
+                    type: "sqs"
+                    request:
+                      queueUrl: "http://localhost:4566/000000000000/requests.fifo"
+                    response:
+                      queueUrl: "http://localhost:4566/000000000000/responses"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("standard queues only")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsSqsAwaitStepWithNormalizedFifoQueueUrl() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Sqs Fifo Queue"
+                kind: "await"
+                input: "com.example.Input"
+                output: "com.example.Output"
+                timeout: "PT10M"
+                await:
+                  correlation:
+                    strategy: "signedResumeToken"
+                  transport:
+                    type: "sqs"
+                    request:
+                      queueUrl: "http://localhost:4566/000000000000/requests.fifo?ignored=true "
+                    response:
+                      queueUrl: "http://localhost:4566/000000000000/responses"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("standard queues only")),
+            diagnostics.toString());
+    }
+
+    @Test
     void rejectsAwaitStepWithoutCorrelationStrategy() throws IOException {
         List<String> diagnostics = new ArrayList<>();
         List<StepDefinition> steps = parse("""

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactory.java
@@ -60,9 +60,7 @@ public class AwaitStepDescriptorFactory {
     }
 
     private AwaitStepDescriptor loadDescriptor(String serviceName, String inputType, String outputType) {
-        Path base = resolveConfigBase();
-        Path configPath = new PipelineYamlConfigLocator().locate(base)
-            .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for await step " + serviceName));
+        Path configPath = resolveConfigPath(serviceName);
         PipelineYamlConfig config = new PipelineYamlConfigLoader().load(configPath);
         PipelineYamlStep step = config.steps().stream()
             .filter(candidate -> serviceName.equals(toServiceName(candidate.name())))
@@ -105,15 +103,13 @@ public class AwaitStepDescriptorFactory {
         return descriptor;
     }
 
-    private static Path resolveConfigBase() {
+    private static Path resolveConfigPath(String serviceName) {
         String explicit = firstNonBlank(System.getProperty("pipeline.config"), System.getenv("PIPELINE_CONFIG"));
         if (explicit != null) {
-            Path candidate = Path.of(explicit);
-            if (candidate.isAbsolute()) {
-                return candidate.getParent() != null ? candidate.getParent() : candidate;
-            }
+            return Path.of(explicit).toAbsolutePath().normalize();
         }
-        return Path.of("").toAbsolutePath();
+        return new PipelineYamlConfigLocator().locate(Path.of("").toAbsolutePath())
+            .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for await step " + serviceName));
     }
 
     private static String firstNonBlank(String... values) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapter.java
@@ -169,9 +169,23 @@ public class SqsAwaitTransportAdapter implements AwaitTransportAdapter<Object> {
         }
 
         public SqsConfig {
-            if (requestQueueUrl.endsWith(".fifo") || responseQueueUrl.endsWith(".fifo")) {
+            if (normalizedQueueUrlForTypeCheck(requestQueueUrl).endsWith(".fifo")
+                || normalizedQueueUrlForTypeCheck(responseQueueUrl).endsWith(".fifo")) {
                 throw new IllegalArgumentException("sqs await transport supports standard queues only in v1");
             }
+        }
+
+        private static String normalizedQueueUrlForTypeCheck(String queueUrl) {
+            String normalized = queueUrl.trim();
+            int queryIndex = normalized.indexOf('?');
+            if (queryIndex >= 0) {
+                normalized = normalized.substring(0, queryIndex);
+            }
+            int fragmentIndex = normalized.indexOf('#');
+            if (fragmentIndex >= 0) {
+                normalized = normalized.substring(0, fragmentIndex);
+            }
+            return normalized;
         }
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapter.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapter.java
@@ -1,0 +1,177 @@
+package org.pipelineframework.awaitable;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
+import org.pipelineframework.awaitable.sqs.SqsAwaitDispatchEnvelope;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+/**
+ * Await transport adapter that publishes one interaction request to SQS.
+ */
+@ApplicationScoped
+public class SqsAwaitTransportAdapter implements AwaitTransportAdapter<Object> {
+
+    @Inject
+    AwaitResumeTokenService resumeTokenService;
+
+    @Inject
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    private volatile SqsClient client;
+    private final SqsClient explicitClient;
+
+    public SqsAwaitTransportAdapter() {
+        this.explicitClient = null;
+    }
+
+    SqsAwaitTransportAdapter(SqsClient explicitClient, PipelineOrchestratorConfig orchestratorConfig) {
+        this.explicitClient = explicitClient;
+        this.client = explicitClient;
+        this.orchestratorConfig = orchestratorConfig;
+    }
+
+    @Override
+    public String type() {
+        return "sqs";
+    }
+
+    @Override
+    public Uni<AwaitDispatchResult> dispatch(AwaitDispatchRequest<Object> request) {
+        Objects.requireNonNull(request, "request must not be null");
+        AwaitStepDescriptor descriptor = request.descriptor();
+        AwaitInteractionRecord interaction = request.interaction();
+        SqsConfig config = SqsConfig.from(descriptor.transportConfig());
+        String resumeToken = resumeTokenService.sign(interaction, System.currentTimeMillis());
+        Map<String, Object> metadata = dispatchMetadata(config);
+        Object normalizedPayload = AwaitPayloadSupport.normalize(request.payload());
+        SqsAwaitDispatchEnvelope envelope = SqsAwaitDispatchEnvelope.from(
+            descriptor,
+            interaction,
+            normalizedPayload,
+            resumeToken,
+            metadata);
+        return blocking(() -> serializeEnvelope(envelope))
+            .onItem().transformToUni(body -> blocking(() -> {
+                sqsClient().sendMessage(SendMessageRequest.builder()
+                    .queueUrl(config.requestQueueUrl())
+                    .messageBody(body)
+                    .build());
+                return new AwaitDispatchResult(metadata);
+            }));
+    }
+
+    @PreDestroy
+    void closeClient() {
+        if (explicitClient != null) {
+            return;
+        }
+        SqsClient active = client;
+        if (active == null) {
+            return;
+        }
+        synchronized (this) {
+            active = client;
+            if (active == null) {
+                return;
+            }
+            try {
+                active.close();
+            } finally {
+                client = null;
+            }
+        }
+    }
+
+    private SqsClient sqsClient() {
+        SqsClient active = client;
+        if (active != null) {
+            return active;
+        }
+        synchronized (this) {
+            if (client == null) {
+                var builder = SqsClient.builder();
+                builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+                if (orchestratorConfig != null) {
+                    orchestratorConfig.sqs().region()
+                        .filter(region -> !region.isBlank())
+                        .ifPresent(region -> builder.region(Region.of(region)));
+                    orchestratorConfig.sqs().endpointOverride()
+                        .filter(endpoint -> !endpoint.isBlank())
+                        .ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
+                }
+                client = builder.build();
+            }
+            return client;
+        }
+    }
+
+    private static Map<String, Object> dispatchMetadata(SqsConfig config) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("adapter", "sqs");
+        metadata.put("requestQueueUrl", config.requestQueueUrl());
+        metadata.put("responseQueueUrl", config.responseQueueUrl());
+        metadata.put("dispatchedAtEpochMs", System.currentTimeMillis());
+        return metadata;
+    }
+
+    private static String serializeEnvelope(SqsAwaitDispatchEnvelope envelope) {
+        try {
+            return PipelineJson.mapper().writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed serializing SQS await dispatch envelope", e);
+        }
+    }
+
+    private static <T> Uni<T> blocking(Supplier<T> supplier) {
+        return Uni.createFrom().item(supplier).runSubscriptionOn(Infrastructure.getDefaultExecutor());
+    }
+
+    record SqsConfig(String requestQueueUrl, String responseQueueUrl) {
+        static SqsConfig from(Map<String, Object> transportConfig) {
+            if (transportConfig == null) {
+                throw new IllegalArgumentException("transportConfig must not be null");
+            }
+            Map<?, ?> request = requiredMap(transportConfig.get("request"), "sqs await transport requires request.queueUrl");
+            Map<?, ?> response = requiredMap(transportConfig.get("response"), "sqs await transport requires response.queueUrl");
+            return new SqsConfig(
+                requiredString(request.get("queueUrl"), "sqs await transport requires request.queueUrl"),
+                requiredString(response.get("queueUrl"), "sqs await transport requires response.queueUrl"));
+        }
+
+        private static Map<?, ?> requiredMap(Object value, String message) {
+            if (value instanceof Map<?, ?> map) {
+                return map;
+            }
+            throw new IllegalArgumentException(message);
+        }
+
+        private static String requiredString(Object value, String message) {
+            if (value == null || value.toString().isBlank()) {
+                throw new IllegalArgumentException(message);
+            }
+            return value.toString().trim();
+        }
+
+        public SqsConfig {
+            if (requestQueueUrl.endsWith(".fifo") || responseQueueUrl.endsWith(".fifo")) {
+                throw new IllegalArgumentException("sqs await transport supports standard queues only in v1");
+            }
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/sqs/SqsAwaitCompletionEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/sqs/SqsAwaitCompletionEnvelope.java
@@ -1,0 +1,41 @@
+package org.pipelineframework.awaitable.sqs;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Framework-owned SQS await response envelope.
+ */
+public record SqsAwaitCompletionEnvelope(
+    String tenantId,
+    String interactionId,
+    String correlationId,
+    String resumeToken,
+    String idempotencyKey,
+    Object responsePayload,
+    String actor
+) {
+    public SqsAwaitCompletionEnvelope {
+        Optional<String> normalizedTenantId = normalize(tenantId);
+        if (normalizedTenantId.isEmpty()) {
+            throw new IllegalArgumentException("tenantId must not be blank");
+        }
+        tenantId = normalizedTenantId.orElseThrow();
+        interactionId = normalize(interactionId).orElse(null);
+        correlationId = normalize(correlationId).orElse(null);
+        resumeToken = normalize(resumeToken).orElse(null);
+        idempotencyKey = normalize(idempotencyKey).orElse(null);
+        actor = normalize(actor).orElse(null);
+        if (interactionId == null && correlationId == null) {
+            throw new IllegalArgumentException("interactionId or correlationId must be supplied");
+        }
+        responsePayload = Objects.requireNonNull(responsePayload, "responsePayload must not be null");
+    }
+
+    private static Optional<String> normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(value.trim());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/sqs/SqsAwaitCompletionPoller.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/sqs/SqsAwaitCompletionPoller.java
@@ -1,0 +1,304 @@
+package org.pipelineframework.awaitable.sqs;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.pipelineframework.PipelineExecutionService;
+import org.pipelineframework.awaitable.AwaitCompletionAdmissionFailures;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionMetrics;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+/**
+ * Polls an SQS response queue and admits await completions.
+ */
+@ApplicationScoped
+public class SqsAwaitCompletionPoller {
+
+    private static final Logger LOG = Logger.getLogger(SqsAwaitCompletionPoller.class);
+    private static final Duration DEFAULT_POLL_START_DELAY = Duration.ZERO;
+    private static final Duration DEFAULT_VISIBILITY_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration DEFAULT_COMPLETION_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration INITIAL_FAILURE_BACKOFF = Duration.ofSeconds(1);
+    private static final Duration MAX_FAILURE_BACKOFF = Duration.ofSeconds(30);
+    private static final Duration EXECUTOR_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
+    private static final int DEFAULT_WAIT_TIME_SECONDS = 1;
+    private static final int DEFAULT_MAX_MESSAGES = 1;
+
+    @Inject
+    PipelineOrchestratorConfig orchestratorConfig;
+
+    @Inject
+    PipelineExecutionService executionService;
+
+    private volatile SqsClient client;
+    private volatile ExecutorService pollExecutor;
+    private volatile Future<?> pollFuture;
+    private volatile boolean running;
+    private final AtomicInteger consecutivePollFailures = new AtomicInteger();
+
+    public SqsAwaitCompletionPoller() {
+    }
+
+    SqsAwaitCompletionPoller(
+        PipelineOrchestratorConfig orchestratorConfig,
+        PipelineExecutionService executionService,
+        SqsClient client
+    ) {
+        this.orchestratorConfig = orchestratorConfig;
+        this.executionService = executionService;
+        this.client = client;
+    }
+
+    void onStartup(@Observes StartupEvent event) {
+        SqsAwaitPollerConfig config = SqsAwaitPollerConfig.fromRuntime();
+        if (!config.enabled()) {
+            return;
+        }
+        ensureExecutor();
+        running = true;
+        pollFuture = pollExecutor.submit(() -> {
+            sleep(config.pollStartDelay());
+            pollLoop();
+        });
+        LOG.infof("SQS await completion poller enabled for responseQueueUrl=%s", config.responseQueueUrl().orElse("<missing>"));
+    }
+
+    @PreDestroy
+    void shutdown() {
+        running = false;
+        Future<?> activePollFuture = pollFuture;
+        if (activePollFuture != null) {
+            activePollFuture.cancel(true);
+        }
+        shutdownExecutor(pollExecutor);
+        pollExecutor = null;
+        SqsClient activeClient = client;
+        if (activeClient == null) {
+            return;
+        }
+        try {
+            activeClient.close();
+        } catch (Exception e) {
+            LOG.debug("Failed closing SQS client for await completion poller.", e);
+        } finally {
+            client = null;
+        }
+    }
+
+    boolean pollOnce(SqsAwaitPollerConfig config) {
+        if (!config.enabled()) {
+            return true;
+        }
+        String responseQueueUrl = config.responseQueueUrl()
+            .filter(url -> !url.isBlank())
+            .orElseThrow(() -> new IllegalStateException(
+                "tpf.await.sqs.response-queue-url must be configured when tpf.await.sqs.poller.enabled=true."));
+
+        ReceiveMessageRequest request = ReceiveMessageRequest.builder()
+            .queueUrl(responseQueueUrl)
+            .maxNumberOfMessages(config.maxMessages())
+            .waitTimeSeconds(config.waitTimeSeconds())
+            .visibilityTimeout(visibilityTimeoutSeconds(config.visibilityTimeout(), "tpf.await.sqs.visibility-timeout"))
+            .build();
+        List<Message> messages;
+        try {
+            messages = sqsClient().receiveMessage(request).messages();
+        } catch (RuntimeException e) {
+            LOG.errorf(e, "Failed receiving SQS await completions from queueUrl=%s", responseQueueUrl);
+            sleepFailureBackoff();
+            return false;
+        }
+        for (Message message : messages) {
+            handleMessage(responseQueueUrl, message, config);
+        }
+        return true;
+    }
+
+    private void pollLoop() {
+        while (running && !Thread.currentThread().isInterrupted()) {
+            try {
+                if (pollOnce(SqsAwaitPollerConfig.fromRuntime())) {
+                    consecutivePollFailures.set(0);
+                }
+            } catch (Exception e) {
+                LOG.error("SQS await completion poll failed.", e);
+                sleepFailureBackoff();
+            }
+        }
+    }
+
+    private void handleMessage(String queueUrl, Message message, SqsAwaitPollerConfig config) {
+        if (message == null || message.receiptHandle() == null) {
+            return;
+        }
+        if (message.body() == null) {
+            LOG.warnf("Leaving SQS await completion message with null body for queue redrive id=%s", message.messageId());
+            return;
+        }
+        SqsAwaitCompletionEnvelope envelope;
+        try {
+            envelope = PipelineJson.mapper().readValue(message.body(), SqsAwaitCompletionEnvelope.class);
+        } catch (Exception e) {
+            LOG.warnf(e, "Leaving malformed SQS await completion message for queue redrive id=%s", message.messageId());
+            return;
+        }
+
+        try {
+            executionService.completeAwaitInteraction(new AwaitCompletionCommand(
+                envelope.tenantId(),
+                envelope.interactionId(),
+                envelope.correlationId(),
+                envelope.resumeToken(),
+                envelope.idempotencyKey(),
+                envelope.responsePayload(),
+                envelope.actor(),
+                System.currentTimeMillis()))
+                .await().atMost(config.completionTimeout());
+            deleteMessageSafely(queueUrl, message.receiptHandle(), "processed");
+        } catch (RuntimeException e) {
+            if (AwaitCompletionAdmissionFailures.isDeterministic(e)) {
+                String reason = AwaitCompletionAdmissionFailures.reason(e);
+                AwaitCompletionMetrics.recordDroppedCompletion("sqs", reason);
+                LOG.warnf(e, "Dropping deterministic SQS await completion message: reason=%s", reason);
+                deleteMessageSafely(queueUrl, message.receiptHandle(), "deterministic-" + reason);
+                return;
+            }
+            LOG.errorf(e, "Failed admitting SQS await completion interactionId=%s correlationId=%s",
+                envelope.interactionId(),
+                envelope.correlationId());
+        }
+    }
+
+    private void deleteMessageSafely(String queueUrl, String receiptHandle, String disposition) {
+        try {
+            sqsClient().deleteMessage(DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .build());
+        } catch (RuntimeException e) {
+            LOG.warnf(e, "Failed deleting SQS await completion message after %s disposition", disposition);
+        }
+    }
+
+    private SqsClient sqsClient() {
+        SqsClient active = client;
+        if (active != null) {
+            return active;
+        }
+        synchronized (this) {
+            if (client == null) {
+                var builder = SqsClient.builder();
+                builder.httpClientBuilder(UrlConnectionHttpClient.builder());
+                if (orchestratorConfig != null) {
+                    orchestratorConfig.sqs().region()
+                        .filter(region -> !region.isBlank())
+                        .ifPresent(region -> builder.region(Region.of(region)));
+                    orchestratorConfig.sqs().endpointOverride()
+                        .filter(endpoint -> !endpoint.isBlank())
+                        .ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
+                }
+                client = builder.build();
+            }
+            return client;
+        }
+    }
+
+    private void ensureExecutor() {
+        if (pollExecutor == null) {
+            pollExecutor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "tpf-sqs-await-completion-poller");
+                thread.setDaemon(true);
+                return thread;
+            });
+        }
+    }
+
+    private void sleepFailureBackoff() {
+        int failures = consecutivePollFailures.incrementAndGet();
+        long delayMillis = Math.min(
+            INITIAL_FAILURE_BACKOFF.toMillis() * (1L << Math.min(10, Math.max(0, failures - 1))),
+            MAX_FAILURE_BACKOFF.toMillis());
+        sleep(Duration.ofMillis(delayMillis));
+    }
+
+    private static void shutdownExecutor(ExecutorService executor) {
+        if (executor == null) {
+            return;
+        }
+        executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                LOG.warnf("SQS await completion poller executor did not terminate within %s", EXECUTOR_SHUTDOWN_TIMEOUT);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warnf(e, "Interrupted while shutting down SQS await completion poller executor");
+        }
+    }
+
+    private static void sleep(Duration duration) {
+        if (duration == null || duration.isZero() || duration.isNegative()) {
+            return;
+        }
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static int visibilityTimeoutSeconds(Duration visibilityTimeout, String configKey) {
+        long seconds = visibilityTimeout.toSeconds();
+        if (seconds < 0 || seconds > 43_200) {
+            throw new IllegalArgumentException(configKey + " must be between PT0S and PT43200S.");
+        }
+        return (int) seconds;
+    }
+
+    record SqsAwaitPollerConfig(
+        boolean enabled,
+        Optional<String> responseQueueUrl,
+        Duration pollStartDelay,
+        Duration visibilityTimeout,
+        Duration completionTimeout,
+        int waitTimeSeconds,
+        int maxMessages
+    ) {
+        static SqsAwaitPollerConfig fromRuntime() {
+            var config = ConfigProvider.getConfig();
+            return new SqsAwaitPollerConfig(
+                config.getOptionalValue("tpf.await.sqs.poller.enabled", Boolean.class).orElse(false),
+                config.getOptionalValue("tpf.await.sqs.response-queue-url", String.class),
+                config.getOptionalValue("tpf.await.sqs.poll-start-delay", Duration.class).orElse(DEFAULT_POLL_START_DELAY),
+                config.getOptionalValue("tpf.await.sqs.visibility-timeout", Duration.class).orElse(DEFAULT_VISIBILITY_TIMEOUT),
+                config.getOptionalValue("tpf.await.sqs.completion-timeout", Duration.class).orElse(DEFAULT_COMPLETION_TIMEOUT),
+                Math.max(1, Math.min(20,
+                    config.getOptionalValue("tpf.await.sqs.wait-time-seconds", Integer.class).orElse(DEFAULT_WAIT_TIME_SECONDS))),
+                Math.max(1, Math.min(10,
+                    config.getOptionalValue("tpf.await.sqs.max-messages", Integer.class).orElse(DEFAULT_MAX_MESSAGES))));
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/sqs/SqsAwaitDispatchEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/sqs/SqsAwaitDispatchEnvelope.java
@@ -1,0 +1,47 @@
+package org.pipelineframework.awaitable.sqs;
+
+import java.util.Map;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitStepDescriptor;
+
+/**
+ * Framework-owned SQS await request envelope.
+ */
+public record SqsAwaitDispatchEnvelope(
+    String tenantId,
+    String executionId,
+    String interactionId,
+    String correlationId,
+    String stepId,
+    long deadlineEpochMs,
+    String inputType,
+    String outputType,
+    String resumeToken,
+    Object requestPayload,
+    Map<String, Object> transportMetadata
+) {
+    public SqsAwaitDispatchEnvelope {
+        transportMetadata = transportMetadata == null ? Map.of() : Map.copyOf(transportMetadata);
+    }
+
+    public static SqsAwaitDispatchEnvelope from(
+        AwaitStepDescriptor descriptor,
+        AwaitInteractionRecord interaction,
+        Object payload,
+        String resumeToken,
+        Map<String, Object> transportMetadata) {
+        return new SqsAwaitDispatchEnvelope(
+            interaction.tenantId(),
+            interaction.executionId(),
+            interaction.interactionId(),
+            interaction.correlationId(),
+            interaction.stepId(),
+            interaction.deadlineEpochMs(),
+            descriptor.inputType(),
+            descriptor.outputType(),
+            resumeToken,
+            payload,
+            transportMetadata);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionResultShapeResolver.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/ExecutionResultShapeResolver.java
@@ -34,9 +34,7 @@ public class ExecutionResultShapeResolver {
     }
 
     private ExecutionResultShape loadShape() {
-        Path base = resolveConfigBase();
-        Path configPath = new PipelineYamlConfigLocator().locate(base)
-            .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for queue-async result-shape resolution"));
+        Path configPath = resolveConfigPath();
         PipelineYamlConfig config = new PipelineYamlConfigLoader().load(configPath);
         PipelineYamlStep step = config.steps().isEmpty()
             ? null
@@ -51,15 +49,13 @@ public class ExecutionResultShapeResolver {
         };
     }
 
-    private static Path resolveConfigBase() {
+    private static Path resolveConfigPath() {
         String explicit = firstNonBlank(System.getProperty("pipeline.config"), System.getenv("PIPELINE_CONFIG"));
         if (explicit != null) {
-            Path candidate = Path.of(explicit);
-            if (candidate.isAbsolute()) {
-                return candidate.getParent() != null ? candidate.getParent() : candidate;
-            }
+            return Path.of(explicit).toAbsolutePath().normalize();
         }
-        return Path.of("").toAbsolutePath();
+        return new PipelineYamlConfigLocator().locate(Path.of("").toAbsolutePath())
+            .orElseThrow(() -> new IllegalStateException("No pipeline YAML found for queue-async result-shape resolution"));
     }
 
     private static String firstNonBlank(String... values) {

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactoryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepDescriptorFactoryTest.java
@@ -1,0 +1,76 @@
+package org.pipelineframework.awaitable;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class AwaitStepDescriptorFactoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearPipelineConfigProperty() {
+        System.clearProperty("pipeline.config");
+    }
+
+    @Test
+    void descriptorUsesExplicitPipelineConfigFileNotSiblingDefault() throws Exception {
+        Files.writeString(tempDir.resolve("pipeline.yaml"), pipelineYaml("kafka", """
+                    request:
+                      topic: default.requests
+                    response:
+                      topic: default.responses
+            """));
+        Path explicit = tempDir.resolve("pipeline.container-sqs.yaml");
+        Files.writeString(explicit, pipelineYaml("sqs", """
+                    request:
+                      queueUrl: http://localhost:4566/000000000000/requests
+                    response:
+                      queueUrl: http://localhost:4566/000000000000/responses
+            """));
+        System.setProperty("pipeline.config", explicit.toString());
+
+        AwaitStepDescriptorFactory factory = new AwaitStepDescriptorFactory();
+        try {
+            AwaitStepDescriptor descriptor = factory.descriptor(
+                "ProcessAwaitPaymentProviderService",
+                "org.example.PaymentRecord",
+                "org.example.PaymentStatus").await().indefinitely();
+
+            assertEquals("sqs", descriptor.transportType());
+            @SuppressWarnings("unchecked")
+            var request = assertInstanceOf(java.util.Map.class, descriptor.transportConfig().get("request"));
+            assertEquals(
+                "http://localhost:4566/000000000000/requests",
+                request.get("queueUrl"));
+        } finally {
+            factory.shutdown();
+        }
+    }
+
+    private static String pipelineYaml(String transportType, String transportConfig) {
+        return """
+            basePackage: org.example
+            transport: GRPC
+            steps:
+              - name: Await Payment Provider
+                kind: await
+                cardinality: ONE_TO_ONE
+                input: org.example.PaymentRecord
+                output: org.example.PaymentStatus
+                timeout: PT5M
+                await:
+                  correlation:
+                    strategy: signedResumeToken
+                  transport:
+                    type: %s
+            %s
+            """.formatted(transportType, transportConfig);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapterTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapterTest.java
@@ -1,0 +1,158 @@
+package org.pipelineframework.awaitable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.spi.AwaitTransportAdapter;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+class SqsAwaitTransportAdapterTest {
+
+    @Test
+    void dispatchPublishesFrameworkEnvelope() throws Exception {
+        SqsClient client = mock(SqsClient.class);
+        SqsAwaitTransportAdapter adapter = adapter(client);
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("queueUrl", "http://sqs.local/requests"),
+            "response", Map.of("queueUrl", "http://sqs.local/responses")));
+
+        var result = adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+            descriptor,
+            interaction(),
+            Map.of("paymentId", "p-1"))).await().atMost(Duration.ofSeconds(5));
+
+        verify(client).sendMessage(argThat((SendMessageRequest request) -> {
+            try {
+                JsonNode body = PipelineJson.mapper().readTree(request.messageBody());
+                return request.queueUrl().equals("http://sqs.local/requests")
+                    && body.get("tenantId").asText().equals("tenant-1")
+                    && body.get("executionId").asText().equals("exec-1")
+                    && body.get("interactionId").asText().equals("interaction-1")
+                    && body.get("correlationId").asText().equals("corr-1")
+                    && body.get("stepId").asText().equals("PaymentProvider")
+                    && body.hasNonNull("resumeToken")
+                    && body.get("requestPayload").get("paymentId").asText().equals("p-1");
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }));
+        assertEquals("sqs", result.metadata().get("adapter"));
+        assertEquals("http://sqs.local/requests", result.metadata().get("requestQueueUrl"));
+        assertEquals("http://sqs.local/responses", result.metadata().get("responseQueueUrl"));
+    }
+
+    @Test
+    void dispatchRejectsMissingRequestQueueUrl() {
+        SqsAwaitTransportAdapter adapter = adapter(mock(SqsClient.class));
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of(),
+            "response", Map.of("queueUrl", "http://sqs.local/responses")));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(exception.getMessage().contains("request.queueUrl"));
+    }
+
+    @Test
+    void dispatchRejectsMissingResponseQueueUrl() {
+        SqsAwaitTransportAdapter adapter = adapter(mock(SqsClient.class));
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("queueUrl", "http://sqs.local/requests"),
+            "response", Map.of()));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(exception.getMessage().contains("response.queueUrl"));
+    }
+
+    @Test
+    void dispatchRejectsFifoQueueUrl() {
+        SqsAwaitTransportAdapter adapter = adapter(mock(SqsClient.class));
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("queueUrl", "http://sqs.local/requests.fifo"),
+            "response", Map.of("queueUrl", "http://sqs.local/responses")));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(exception.getMessage().contains("standard queues only"));
+    }
+
+    private static SqsAwaitTransportAdapter adapter(SqsClient client) {
+        SqsAwaitTransportAdapter adapter = new SqsAwaitTransportAdapter(client, config());
+        adapter.resumeTokenService = new AwaitResumeTokenService("secret-value-for-tests");
+        return adapter;
+    }
+
+    private static PipelineOrchestratorConfig config() {
+        PipelineOrchestratorConfig config = mock(PipelineOrchestratorConfig.class);
+        PipelineOrchestratorConfig.SqsConfig sqs = mock(PipelineOrchestratorConfig.SqsConfig.class);
+        when(config.sqs()).thenReturn(sqs);
+        when(sqs.region()).thenReturn(Optional.empty());
+        when(sqs.endpointOverride()).thenReturn(Optional.empty());
+        return config;
+    }
+
+    private static AwaitStepDescriptor descriptor(Map<String, Object> config) {
+        return new AwaitStepDescriptor(
+            "PaymentProvider",
+            "com.example.PaymentRecord",
+            "com.example.PaymentStatus",
+            Duration.ofMinutes(10),
+            "signedResumeToken",
+            "sqs",
+            config,
+            java.util.List.of("paymentId"));
+    }
+
+    private static AwaitInteractionRecord interaction() {
+        return new AwaitInteractionRecord(
+            "tenant-1",
+            "exec-1",
+            "PaymentProvider",
+            1,
+            "com.example.PaymentStatus",
+            "interaction-1",
+            "corr-1",
+            "cause-1",
+            "idem-1",
+            1L,
+            AwaitInteractionStatus.DISPATCHING,
+            Map.of("paymentId", "p-1"),
+            null,
+            null,
+            null,
+            null,
+            "sqs",
+            Map.of(),
+            99_999_999_999L,
+            1_000L,
+            2_000L,
+            99_999L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapterTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/SqsAwaitTransportAdapterTest.java
@@ -103,6 +103,22 @@ class SqsAwaitTransportAdapterTest {
         assertTrue(exception.getMessage().contains("standard queues only"));
     }
 
+    @Test
+    void dispatchRejectsNormalizedFifoQueueUrl() {
+        SqsAwaitTransportAdapter adapter = adapter(mock(SqsClient.class));
+        AwaitStepDescriptor descriptor = descriptor(Map.of(
+            "request", Map.of("queueUrl", "http://sqs.local/requests.fifo?ignored=true#fragment"),
+            "response", Map.of("queueUrl", "http://sqs.local/responses")));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            adapter.dispatch(new AwaitTransportAdapter.AwaitDispatchRequest<>(
+                descriptor,
+                interaction(),
+                Map.of())).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(exception.getMessage().contains("standard queues only"));
+    }
+
     private static SqsAwaitTransportAdapter adapter(SqsClient client) {
         SqsAwaitTransportAdapter adapter = new SqsAwaitTransportAdapter(client, config());
         adapter.resumeTokenService = new AwaitResumeTokenService("secret-value-for-tests");

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/sqs/SqsAwaitCompletionPollerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/sqs/SqsAwaitCompletionPollerTest.java
@@ -1,0 +1,226 @@
+package org.pipelineframework.awaitable.sqs;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.PipelineExecutionService;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitInteractionNotFoundException;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+class SqsAwaitCompletionPollerTest {
+
+    private SqsClient client;
+    private PipelineExecutionService executionService;
+    private SqsAwaitCompletionPoller poller;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(SqsClient.class);
+        executionService = mock(PipelineExecutionService.class);
+        poller = new SqsAwaitCompletionPoller(config(), executionService, client);
+    }
+
+    @Test
+    void pollOnceDeletesMessageAfterSuccessfulCompletion() throws Exception {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+            .messages(message("receipt-1", completionJson()))
+            .build());
+        when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(null, false)));
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(executionService).completeAwaitInteraction(argThat(command ->
+            command.tenantId().equals("tenant-1")
+                && command.interactionId().equals("interaction-1")
+                && command.correlationId().equals("corr-1")
+                && command.resumeToken().equals("resume-token")
+                && command.idempotencyKey().equals("idem-1")
+                && command.actor().equals("csv-payments-sqs-provider")));
+        verify(client).deleteMessage(argThat((DeleteMessageRequest request) ->
+            request.queueUrl().equals("http://sqs.local/responses")
+                && request.receiptHandle().equals("receipt-1")));
+    }
+
+    @Test
+    void pollOnceDoesNotRetryCompletionWhenDeleteFailsAfterSuccessfulCompletion() throws Exception {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+            .messages(message("receipt-1", completionJson()))
+            .build());
+        when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(null, false)));
+        when(client.deleteMessage(any(DeleteMessageRequest.class))).thenThrow(new IllegalStateException("sqs down"));
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(executionService).completeAwaitInteraction(any(AwaitCompletionCommand.class));
+        verify(client).deleteMessage(any(DeleteMessageRequest.class));
+    }
+
+    @Test
+    void pollOnceDeletesDeterministicAdmissionFailure() throws Exception {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+            .messages(message("receipt-2", completionJson()))
+            .build());
+        when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().failure(new AwaitInteractionNotFoundException("missing")));
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(client).deleteMessage(argThat((DeleteMessageRequest request) ->
+            request.queueUrl().equals("http://sqs.local/responses")
+                && request.receiptHandle().equals("receipt-2")));
+    }
+
+    @Test
+    void pollOnceDoesNotRetryDeterministicAdmissionFailureWhenDeleteFails() throws Exception {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+            .messages(message("receipt-2", completionJson()))
+            .build());
+        when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().failure(new AwaitInteractionNotFoundException("missing")));
+        when(client.deleteMessage(any(DeleteMessageRequest.class))).thenThrow(new IllegalStateException("sqs down"));
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(client).deleteMessage(any(DeleteMessageRequest.class));
+    }
+
+    @Test
+    void pollOnceKeepsMessageWhenCompletionFailsTransiently() throws Exception {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+            .messages(message("receipt-3", completionJson()))
+            .build());
+        when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
+            .thenReturn(Uni.createFrom().failure(new IllegalStateException("store down")));
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(client, never()).deleteMessage(any(DeleteMessageRequest.class));
+    }
+
+    @Test
+    void pollOnceKeepsMalformedMessageForQueueRedrive() {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder()
+            .messages(message("receipt-4", "{not-json"))
+            .build());
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(client, never()).deleteMessage(any(DeleteMessageRequest.class));
+        verify(executionService, never()).completeAwaitInteraction(any(AwaitCompletionCommand.class));
+    }
+
+    @Test
+    void pollOnceSkipsWhenDisabled() {
+        assertDoesNotThrow(() -> poller.pollOnce(disabledConfig()));
+
+        verify(client, never()).receiveMessage(any(ReceiveMessageRequest.class));
+        verify(executionService, never()).completeAwaitInteraction(any(AwaitCompletionCommand.class));
+    }
+
+    @Test
+    void pollOnceUsesConfiguredReceiveSettings() {
+        when(client.receiveMessage(any(ReceiveMessageRequest.class)))
+            .thenReturn(ReceiveMessageResponse.builder().messages(List.of()).build());
+
+        assertDoesNotThrow(() -> poller.pollOnce(enabledConfig()));
+
+        verify(client).receiveMessage(argThat((ReceiveMessageRequest request) ->
+            request.queueUrl().equals("http://sqs.local/responses")
+                && request.visibilityTimeout().equals(45)
+                && request.waitTimeSeconds().equals(2)
+                && request.maxNumberOfMessages().equals(3)));
+    }
+
+    @Test
+    void pollOnceRejectsVisibilityTimeoutAboveSqsLimit() {
+        SqsAwaitCompletionPoller.SqsAwaitPollerConfig tooLarge = new SqsAwaitCompletionPoller.SqsAwaitPollerConfig(
+            true,
+            Optional.of("http://sqs.local/responses"),
+            Duration.ZERO,
+            Duration.ofSeconds(43_201),
+            Duration.ofSeconds(5),
+            2,
+            3);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class, () -> poller.pollOnce(tooLarge));
+
+        assertEquals("tpf.await.sqs.visibility-timeout must be between PT0S and PT43200S.", failure.getMessage());
+        verify(client, never()).receiveMessage(any(ReceiveMessageRequest.class));
+    }
+
+    private static PipelineOrchestratorConfig config() {
+        PipelineOrchestratorConfig config = mock(PipelineOrchestratorConfig.class);
+        PipelineOrchestratorConfig.SqsConfig sqs = mock(PipelineOrchestratorConfig.SqsConfig.class);
+        when(config.sqs()).thenReturn(sqs);
+        when(sqs.region()).thenReturn(Optional.empty());
+        when(sqs.endpointOverride()).thenReturn(Optional.empty());
+        return config;
+    }
+
+    private static SqsAwaitCompletionPoller.SqsAwaitPollerConfig enabledConfig() {
+        return new SqsAwaitCompletionPoller.SqsAwaitPollerConfig(
+            true,
+            Optional.of("http://sqs.local/responses"),
+            Duration.ZERO,
+            Duration.ofSeconds(45),
+            Duration.ofSeconds(5),
+            2,
+            3);
+    }
+
+    private static SqsAwaitCompletionPoller.SqsAwaitPollerConfig disabledConfig() {
+        return new SqsAwaitCompletionPoller.SqsAwaitPollerConfig(
+            false,
+            Optional.of("http://sqs.local/responses"),
+            Duration.ZERO,
+            Duration.ofSeconds(45),
+            Duration.ofSeconds(5),
+            2,
+            3);
+    }
+
+    private static Message message(String receiptHandle, String body) {
+        return Message.builder()
+            .messageId(receiptHandle)
+            .receiptHandle(receiptHandle)
+            .body(body)
+            .build();
+    }
+
+    private static String completionJson() throws Exception {
+        SqsAwaitCompletionEnvelope envelope = new SqsAwaitCompletionEnvelope(
+            "tenant-1",
+            "interaction-1",
+            "corr-1",
+            "resume-token",
+            "idem-1",
+            Map.of("status", "Completed"),
+            "csv-payments-sqs-provider");
+        return PipelineJson.mapper().writeValueAsString(envelope);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/CheckoutReferenceContractTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/CheckoutReferenceContractTest.java
@@ -43,7 +43,7 @@ class CheckoutReferenceContractTest {
             ir.nodes().stream()
                 .filter(node -> "kitchen-preparation".equals(node.id()))
                 .findFirst()
-                .orElseThrow()
+                .orElseThrow(() -> new AssertionError("Expected kitchen-preparation node in checkout composition"))
                 .terminalStep()
                 .cardinality());
     }

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/ExecutionResultShapeResolverTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/ExecutionResultShapeResolverTest.java
@@ -1,0 +1,48 @@
+package org.pipelineframework.orchestrator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExecutionResultShapeResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearPipelineConfigProperty() {
+        System.clearProperty("pipeline.config");
+    }
+
+    @Test
+    void resolveUsesExplicitPipelineConfigFileNotSiblingDefault() throws Exception {
+        Files.writeString(tempDir.resolve("pipeline.yaml"), pipelineYaml("ONE_TO_MANY"));
+        Path explicit = tempDir.resolve("pipeline.container-sqs.yaml");
+        Files.writeString(explicit, pipelineYaml("ONE_TO_ONE"));
+        System.setProperty("pipeline.config", explicit.toString());
+
+        ExecutionResultShapeResolver resolver = new ExecutionResultShapeResolver();
+
+        assertEquals(ExecutionResultShape.SINGLE, resolver.resolve());
+    }
+
+    private static String pipelineYaml(String terminalCardinality) {
+        return """
+            basePackage: org.example
+            transport: GRPC
+            steps:
+              - name: Process Input
+                cardinality: ONE_TO_ONE
+                input: org.example.Input
+                output: org.example.Intermediate
+              - name: Process Output
+                cardinality: %s
+                input: org.example.Intermediate
+                output: org.example.Output
+            """.formatted(terminalCardinality);
+    }
+}

--- a/plugins/foundational/persistence/src/main/java/org/pipelineframework/plugin/persistence/PersistenceService.java
+++ b/plugins/foundational/persistence/src/main/java/org/pipelineframework/plugin/persistence/PersistenceService.java
@@ -17,6 +17,10 @@
 package org.pipelineframework.plugin.persistence;
 
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import jakarta.inject.Inject;
 
@@ -357,39 +361,74 @@ public class PersistenceService<T> implements ReactiveSideEffectService<T>, Para
     }
 
     private boolean isDuplicateKeyError(Throwable failure) {
-        Throwable current = failure;
-        while (current != null) {
-            if (current instanceof java.sql.SQLException sqlException) {
-                if ("23505".equals(sqlException.getSQLState())) {
-                    return true;
-                }
-            } else {
-                try {
-                    java.lang.reflect.Method getSqlState = current.getClass().getMethod("getSQLState");
-                    Object result = getSqlState.invoke(current);
-                    if (result != null && "23505".equals(result.toString())) {
-                        return true;
-                    }
-                } catch (Exception ignored) {
-                    // ignore reflection failures
-                }
+        if (failure == null) {
+            return false;
+        }
+        ArrayDeque<Throwable> pending = new ArrayDeque<>();
+        Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        pending.add(failure);
+        while (!pending.isEmpty()) {
+            Throwable current = pending.removeFirst();
+            if (!seen.add(current)) {
+                continue;
             }
-
-            String msg = current.getMessage();
-            if (msg != null) {
-                String lowerMsg = msg.toLowerCase();
-                if (lowerMsg.contains("duplicate key") || lowerMsg.contains("unique constraint")) {
-                    return true;
-                }
+            if (isDuplicateKeyThrowable(current)) {
+                return true;
             }
-
-            current = current.getCause();
-            if (current == failure) {
-                break;
+            Throwable cause = current.getCause();
+            if (cause != null) {
+                pending.add(cause);
+            }
+            for (Throwable suppressed : current.getSuppressed()) {
+                if (suppressed != null) {
+                    pending.add(suppressed);
+                }
             }
         }
 
         return false;
+    }
+
+    private boolean isDuplicateKeyThrowable(Throwable throwable) {
+        if (throwable instanceof java.sql.SQLException sqlException
+            && isDuplicateKeySqlState(sqlException.getSQLState())) {
+            return true;
+        }
+        if (hasDuplicateKeySqlState(throwable, "getSQLState")
+            || hasDuplicateKeySqlState(throwable, "getSqlState")
+            || hasDuplicateKeySqlState(throwable, "getCode")) {
+            return true;
+        }
+        return hasDuplicateKeyText(throwable.getMessage())
+            || hasDuplicateKeyText(invokeStringGetter(throwable, "getErrorMessage"))
+            || hasDuplicateKeyText(invokeStringGetter(throwable, "getConstraint"));
+    }
+
+    private boolean hasDuplicateKeySqlState(Throwable throwable, String methodName) {
+        String value = invokeStringGetter(throwable, methodName);
+        return isDuplicateKeySqlState(value);
+    }
+
+    private boolean isDuplicateKeySqlState(String value) {
+        return "23505".equals(value) || "23000".equals(value);
+    }
+
+    private String invokeStringGetter(Throwable throwable, String methodName) {
+        try {
+            java.lang.reflect.Method method = throwable.getClass().getMethod(methodName);
+            Object value = method.invoke(throwable);
+            return value == null ? "" : value.toString();
+        } catch (ReflectiveOperationException ignored) {
+            return "";
+        }
+    }
+
+    private boolean hasDuplicateKeyText(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        String lowerValue = value.toLowerCase();
+        return lowerValue.contains("duplicate key") || lowerValue.contains("unique constraint");
     }
 
     @Override

--- a/plugins/foundational/persistence/src/main/java/org/pipelineframework/plugin/persistence/PersistenceService.java
+++ b/plugins/foundational/persistence/src/main/java/org/pipelineframework/plugin/persistence/PersistenceService.java
@@ -410,7 +410,7 @@ public class PersistenceService<T> implements ReactiveSideEffectService<T>, Para
     }
 
     private boolean isDuplicateKeySqlState(String value) {
-        return "23505".equals(value) || "23000".equals(value);
+        return "23505".equals(value);
     }
 
     private String invokeStringGetter(Throwable throwable, String methodName) {

--- a/plugins/foundational/persistence/src/test/java/org/pipelineframework/plugin/persistence/PersistenceServiceDuplicateKeyTest.java
+++ b/plugins/foundational/persistence/src/test/java/org/pipelineframework/plugin/persistence/PersistenceServiceDuplicateKeyTest.java
@@ -81,12 +81,12 @@ class PersistenceServiceDuplicateKeyTest {
     }
 
     @Test
-    void ignoreDuplicateKeyPolicyRecognizesGenericIntegritySqlState() {
+    void ignoreDuplicateKeyPolicyRecognizesGenericIntegritySqlStateWithDuplicateText() {
         PersistenceManager manager = mock(PersistenceManager.class);
         PersistenceService<TestEntity> service = service(manager, ignorePolicyConfig());
 
         TestEntity entity = new TestEntity();
-        SQLException duplicate = new SQLException("constraint violation", "23000");
+        SQLException duplicate = new SQLException("duplicate key violates unique constraint", "23000");
         when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(duplicate));
 
         UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
@@ -94,6 +94,25 @@ class PersistenceServiceDuplicateKeyTest {
         subscriber.awaitItem();
 
         assertSame(entity, subscriber.getItem());
+        verify(manager).persist(entity);
+    }
+
+    @Test
+    void ignoreDuplicateKeyPolicyDoesNotTreatGenericIntegritySqlStateAsDuplicateKey() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceService<TestEntity> service = service(manager, ignorePolicyConfig());
+
+        TestEntity entity = new TestEntity();
+        SQLException constraintViolation = new SQLException("foreign key constraint violation", "23000");
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(constraintViolation));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitFailure();
+
+        Throwable thrown = subscriber.getFailure();
+        assertTrue(thrown instanceof NonRetryableException);
+        assertSame(constraintViolation, thrown.getCause());
         verify(manager).persist(entity);
     }
 

--- a/plugins/foundational/persistence/src/test/java/org/pipelineframework/plugin/persistence/PersistenceServiceDuplicateKeyTest.java
+++ b/plugins/foundational/persistence/src/test/java/org/pipelineframework/plugin/persistence/PersistenceServiceDuplicateKeyTest.java
@@ -1,0 +1,160 @@
+package org.pipelineframework.plugin.persistence;
+
+import java.sql.SQLException;
+import java.util.Optional;
+import jakarta.persistence.PersistenceException;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.vertx.pgclient.PgException;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.step.NonRetryableException;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PersistenceServiceDuplicateKeyTest {
+
+    @Test
+    void ignoreDuplicateKeyPolicyHandlesSuppressedPostgresFailure() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceConfig config = ignorePolicyConfig();
+        PersistenceService<TestEntity> service = service(manager, config);
+
+        TestEntity entity = new TestEntity();
+        PersistenceException wrapper = new PersistenceException("Failed to persist entity");
+        wrapper.addSuppressed(new PgException(
+            "duplicate key value violates unique constraint \"paymentrecord_pkey\"",
+            "ERROR",
+            "23505",
+            "paymentrecord_pkey"));
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(wrapper));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitItem();
+
+        assertSame(entity, subscriber.getItem());
+        verify(manager).persist(entity);
+    }
+
+    @Test
+    void ignoreDuplicateKeyPolicyHandlesCauseChainPostgresFailure() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceService<TestEntity> service = service(manager, ignorePolicyConfig());
+
+        TestEntity entity = new TestEntity();
+        PersistenceException wrapper = new PersistenceException("Failed to persist entity",
+            new PgException(
+                "duplicate key value violates unique constraint \"paymentrecord_pkey\"",
+                "ERROR",
+                "23505",
+                "paymentrecord_pkey"));
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(wrapper));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitItem();
+
+        assertSame(entity, subscriber.getItem());
+        verify(manager).persist(entity);
+    }
+
+    @Test
+    void ignoreDuplicateKeyPolicyFallsBackToDuplicateKeyText() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceService<TestEntity> service = service(manager, ignorePolicyConfig());
+
+        TestEntity entity = new TestEntity();
+        SQLException duplicate = new SQLException("duplicate key value violates unique constraint", "99999");
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(duplicate));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitItem();
+
+        assertSame(entity, subscriber.getItem());
+        verify(manager).persist(entity);
+    }
+
+    @Test
+    void ignoreDuplicateKeyPolicyRecognizesGenericIntegritySqlState() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceService<TestEntity> service = service(manager, ignorePolicyConfig());
+
+        TestEntity entity = new TestEntity();
+        SQLException duplicate = new SQLException("constraint violation", "23000");
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(duplicate));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitItem();
+
+        assertSame(entity, subscriber.getItem());
+        verify(manager).persist(entity);
+    }
+
+    @Test
+    void upsertDuplicateKeyPolicyPersistsOrUpdates() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceConfig config = config("upsert");
+        PersistenceService<TestEntity> service = service(manager, config);
+
+        TestEntity entity = new TestEntity();
+        SQLException duplicate = new SQLException("duplicate key", "23505");
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(duplicate));
+        when(manager.persistOrUpdate(entity)).thenReturn(Uni.createFrom().item(entity));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitItem();
+
+        assertSame(entity, subscriber.getItem());
+        verify(manager).persist(entity);
+        verify(manager).persistOrUpdate(entity);
+    }
+
+    @Test
+    void failDuplicateKeyPolicyPropagatesThroughNonTransientWrapper() {
+        PersistenceManager manager = mock(PersistenceManager.class);
+        PersistenceConfig config = config("fail");
+        PersistenceService<TestEntity> service = service(manager, config);
+
+        TestEntity entity = new TestEntity();
+        SQLException duplicate = new SQLException("duplicate key", "23505");
+        when(manager.persist(entity)).thenReturn(Uni.createFrom().failure(duplicate));
+
+        UniAssertSubscriber<TestEntity> subscriber = service.process(entity)
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.awaitFailure();
+
+        Throwable thrown = subscriber.getFailure();
+        assertTrue(thrown instanceof NonRetryableException);
+        assertSame(duplicate, thrown.getCause());
+        verify(manager).persist(entity);
+    }
+
+    private static PersistenceService<TestEntity> service(PersistenceManager manager, PersistenceConfig config) {
+        PersistenceService<TestEntity> service = new PersistenceService<>();
+        service.persistenceManager = manager;
+        service.config = config;
+        return service;
+    }
+
+    private static PersistenceConfig ignorePolicyConfig() {
+        return config("ignore");
+    }
+
+    private static PersistenceConfig config(String duplicateKeyPolicy) {
+        PersistenceConfig config = mock(PersistenceConfig.class);
+        when(config.duplicateKey()).thenReturn(duplicateKeyPolicy);
+        when(config.providerClass()).thenReturn(Optional.empty());
+        return config;
+    }
+
+    static final class TestEntity {
+    }
+}


### PR DESCRIPTION
## Summary
- adds first-class SQS await dispatch/completion support as a runtime await transport
- switches the CSV containerized self-host HA reference from Kafka to LocalStack SQS await queues while keeping the default CSV Kafka topology intact
- adds an example-local SQS payment provider mock and hardens duplicate-key persistence handling needed by durable retry/replay in the container flow
- documents Kafka await as the event-stream proof and SQS await as the AWS-shaped self-host HA path

## Scope
- no Lambda/FUNCTION work
- no FIFO queue support
- no SQS transition-worker protocol changes
- no replacement of the default Kafka CSV pipeline/E2E surfaces

## Validation
- `./examples/csv-payments/self-host/container/run-container-ha-demo.sh --ci` with isolated ports, because local port 8082 is occupied by an unrelated Java process
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=AwaitStepDescriptorFactoryTest,ExecutionResultShapeResolverTest,SqsAwaitTransportAdapterTest,SqsAwaitCompletionPollerTest test`
- `./mvnw -f framework/pom.xml -pl deployment -Dtest=StepDefinitionParserTest test`
- `./mvnw -f examples/csv-payments/pom.xml -pl payments-processing-svc -Dtest=PaymentProviderKafkaAwaitMockTest,PaymentProviderSqsAwaitMockTest test`
- `./mvnw -f plugins/foundational/persistence/pom.xml -Dtest=PersistenceServiceDuplicateKeyTest test`
- `./examples/csv-payments/build-pipeline-runtime.sh -pl pipeline-runtime-svc,orchestrator-svc -am -DskipTests`
- `npm --prefix docs run build`
- `git diff --check`

## Local Review
Ran local CodeRabbit twice against `main`. Fixed in-scope findings: persistence test mock/coverage, SQS timeout narrowing, duplicated build flags, generic duplicate-key SQL state, and redundant SQS URL trims. Rejected/deferred unrelated runtime-spring/runtime-core/Dynamo findings as outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SQS-based await completions alongside Kafka, including request/response queue handling and completion polling for await interactions.
  * CSV Payments self-hosting stack updated to use SQS-based await request/completion flow (with LocalStack queue provisioning).

* **Documentation**
  * Refreshed await-boundaries and development/deployment guides with SQS operational responsibilities and updated examples/config requirements.

* **Bug Fixes**
  * Improved duplicate-key detection to recognize more Postgres error patterns and constraint text.

* **Chores**
  * Added/adjusted SQS-related build configuration and optional pipeline config override for container builds/runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->