### PR TITLE
[codex] Add Kafka checkpoint handoff

### DIFF
--- a/docs/guide/development/orchestrator-runtime/checkpoint-handoff.md
+++ b/docs/guide/development/orchestrator-runtime/checkpoint-handoff.md
@@ -8,6 +8,7 @@ Supported in this release:
 2. target: downstream orchestrator background admission bound by a named logical publication,
 3. idempotency: preserve incoming dispatch identifiers when present, otherwise derive a repeat-safe handoff key from configured checkpoint fields,
 4. ownership: downstream retry/DLQ remains orchestrator-owned after background admission.
+5. broker substrate: Kafka publication/subscription through framework-owned handoff envelopes when configured at runtime.
 
 Declare reliable handoff in `pipeline.yaml`:
 
@@ -30,12 +31,44 @@ output:
 3. Publication is generated into existing orchestrator ownership; no separate connector runtime or deployment role is introduced.
 4. Subscriber admission is handled by framework-owned HTTP and gRPC checkpoint publication endpoints instead of runtime subscription discovery.
 5. Protobuf-over-HTTP and gRPC use the same framework-owned checkpoint protobuf envelope for transport-native admission.
-6. Reliable handoff is supported only for `QUEUE_ASYNC` orchestrators and is rejected for `FUNCTION` pipelines.
-7. Live `Subscribe` remains a weaker observer/tap API and is not the reliable checkpoint handoff path.
+6. Kafka checkpoint handoff uses a strict JSON envelope over a configured publication topic and routes into the same subscriber admission service.
+7. Reliable handoff is supported only for `QUEUE_ASYNC` orchestrators and is rejected for `FUNCTION` pipelines.
+8. Live `Subscribe` remains a weaker observer/tap API and is not the reliable checkpoint handoff path.
+
+## Kafka Handoff Targets
+
+Configure a Kafka checkpoint publication target with the same logical publication binding shape:
+
+```properties
+pipeline.handoff.bindings."checkout.orders.ready.v1".targets.next.kind=KAFKA
+pipeline.handoff.bindings."checkout.orders.ready.v1".targets.next.topic=checkout.orders.ready.v1
+```
+
+Enable the Kafka checkpoint publisher on the source orchestrator:
+
+```properties
+tpf.checkpoint.kafka.publisher.enabled=true
+kafka.bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+mp.messaging.outgoing.tpf-checkpoint-kafka-publications.connector=smallrye-kafka
+mp.messaging.outgoing.tpf-checkpoint-kafka-publications.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+```
+
+Enable the Kafka checkpoint consumer on the subscriber orchestrator:
+
+```properties
+tpf.checkpoint.kafka.consumer.enabled=true
+kafka.bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+mp.messaging.incoming.tpf-checkpoint-kafka-publications.connector=smallrye-kafka
+mp.messaging.incoming.tpf-checkpoint-kafka-publications.topic=checkout.orders.ready.v1
+mp.messaging.incoming.tpf-checkpoint-kafka-publications.group.id=checkout-orders-ready-subscriber
+mp.messaging.incoming.tpf-checkpoint-kafka-publications.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+```
+
+The Kafka record carries TPF-owned control metadata plus the checkpoint payload. Kafka offsets remain broker delivery cursors, not TPF replay state.
 
 ## Not Yet Supported
 
 1. generic broker-message re-drive,
 2. a separate durable checkpoint-publication service or publication-specific DLQ,
 3. dynamic runtime publication discovery or runtime subscription registration,
-4. broker-backed publication targets such as `SQS` or `KAFKA`.
+4. SQS-backed checkpoint publication targets.

--- a/docs/guide/development/orchestrator-runtime/checkpoint-handoff.md
+++ b/docs/guide/development/orchestrator-runtime/checkpoint-handoff.md
@@ -65,10 +65,3 @@ mp.messaging.incoming.tpf-checkpoint-kafka-publications.value.deserializer=org.a
 ```
 
 The Kafka record carries TPF-owned control metadata plus the checkpoint payload. Kafka offsets remain broker delivery cursors, not TPF replay state.
-
-## Not Yet Supported
-
-1. generic broker-message re-drive,
-2. a separate durable checkpoint-publication service or publication-specific DLQ,
-3. dynamic runtime publication discovery or runtime subscription registration,
-4. SQS-backed checkpoint publication targets.

--- a/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
+++ b/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
@@ -46,6 +46,15 @@ Prefer these implementation slices if this work becomes active:
 
 Avoid starting with broad "Kafka transport" or "SQS transport" PRs. They mix unrelated risks and blur TPF semantics.
 
+## Checkpoint Handoff Follow-Ups
+
+Track these as brokered-boundary follow-ups, not user-facing runtime behaviour:
+
+1. generic broker-message re-drive,
+2. a separate durable checkpoint-publication service or publication-specific DLQ,
+3. dynamic runtime publication discovery or runtime subscription registration,
+4. SQS-backed checkpoint publication targets.
+
 ## Non-Goals
 
 Envelope and brokered boundary work should not:

--- a/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
+++ b/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
@@ -37,11 +37,12 @@ Prefer these implementation slices if this work becomes active:
 
 1. SQS-backed await transport for AWS-shaped self-host HA. Implemented by the CSV container reference.
 2. Kafka await provider for event-stream await proofs. Implemented by the default CSV topology.
-3. Kafka-backed checkpoint publication/subscription.
-4. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
-5. Protobuf-backed external step-host contract generation for non-Java implementations.
-6. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
-7. Brokered step-host dispatch only after the earlier boundary types are proven.
+3. Kafka-backed checkpoint publication/subscription. Implemented as the first broker-backed checkpoint handoff provider.
+4. SQS-backed checkpoint publication/subscription for AWS queue-shaped handoff.
+5. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
+6. Protobuf-backed external step-host contract generation for non-Java implementations.
+7. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
+8. Brokered step-host dispatch only after the earlier boundary types are proven.
 
 Avoid starting with broad "Kafka transport" or "SQS transport" PRs. They mix unrelated risks and blur TPF semantics.
 

--- a/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
+++ b/docs/guide/evolve/brokered-boundaries/dispatch-substrates.md
@@ -43,13 +43,13 @@ checkpoint:
       kind: kafka
 ```
 
-The checkpoint snippet is illustrative only. Current supported checkpoint handoff target configuration uses `pipeline.handoff.bindings.<publication>.targets.<target>.*`, and broker-backed `KAFKA` publication targets are not supported yet.
+The checkpoint snippet is illustrative. Supported runtime configuration uses `pipeline.handoff.bindings.<publication>.targets.<target>.*` with `kind=KAFKA` and `topic=<topic>`.
 
 ```properties
 pipeline.orchestrator.dispatcher-provider=sqs
 ```
 
-Kafka and SQS await are supported runtime adapters. `pipeline.orchestrator.dispatcher-provider=sqs` is supported for queue-async work dispatch. Kafka checkpoint publication and Kafka dispatcher-provider examples remain design direction, not committed public API.
+Kafka and SQS await are supported runtime adapters. Kafka checkpoint publication/subscription is supported as a broker-backed handoff provider. `pipeline.orchestrator.dispatcher-provider=sqs` is supported for queue-async work dispatch. Kafka dispatcher-provider examples remain design direction, not committed public API.
 
 ## Relationship To Existing Work
 

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationEnvelope.java
@@ -1,0 +1,52 @@
+package org.pipelineframework.checkpoint;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Strict framework-owned checkpoint publication envelope for brokered dispatch.
+ *
+ * @param publication logical publication name
+ * @param tenantId tenant identifier
+ * @param idempotencyKey stable handoff idempotency key
+ * @param payload serialized checkpoint payload
+ * @param publishedAtEpochMs publication timestamp
+ */
+public record CheckpointPublicationEnvelope(
+    String publication,
+    String tenantId,
+    String idempotencyKey,
+    JsonNode payload,
+    long publishedAtEpochMs
+) {
+    public CheckpointPublicationEnvelope {
+        publication = normalizeRequired(publication, "publication");
+        tenantId = normalizeOptional(tenantId);
+        idempotencyKey = normalizeOptional(idempotencyKey);
+        if (payload == null || payload.isNull()) {
+            throw new IllegalArgumentException("payload must not be null");
+        }
+        if (publishedAtEpochMs <= 0L) {
+            throw new IllegalArgumentException("publishedAtEpochMs must be positive");
+        }
+    }
+
+    public CheckpointPublicationRequest toRequest() {
+        return new CheckpointPublicationRequest(publication, payload);
+    }
+
+    private static String normalizeRequired(String value, String field) {
+        String normalized = normalizeOptional(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationService.java
@@ -123,10 +123,9 @@ public class CheckpointPublicationService {
         if (binding == null || binding.targets() == null || binding.targets().isEmpty()) {
             return java.util.List.of();
         }
-        java.util.Set<PublicationTargetKind> supportedKinds = dispatcherByKind.keySet();
         java.util.List<ResolvedCheckpointPublicationTarget> targets = new java.util.ArrayList<>();
         for (java.util.Map.Entry<String, PipelineHandoffConfig.TargetConfig> entry : binding.targets().entrySet()) {
-            targets.add(resolveTarget(publication, entry.getKey(), entry.getValue(), supportedKinds));
+            targets.add(resolveTarget(publication, entry.getKey(), entry.getValue()));
         }
         return java.util.List.copyOf(targets);
     }
@@ -134,8 +133,7 @@ public class CheckpointPublicationService {
     private ResolvedCheckpointPublicationTarget resolveTarget(
         String publication,
         String targetId,
-        PipelineHandoffConfig.TargetConfig target,
-        java.util.Set<PublicationTargetKind> supportedKinds
+        PipelineHandoffConfig.TargetConfig target
     ) {
         if (targetId == null || targetId.isBlank()) {
             throw new IllegalStateException(
@@ -145,102 +143,12 @@ public class CheckpointPublicationService {
             throw new IllegalStateException(
                 "Checkpoint publication '" + publication + "' target '" + targetId + "' must declare kind");
         }
-        if (!supportedKinds.contains(target.kind())) {
+        CheckpointPublicationTargetDispatcher dispatcher = dispatcherByKind.get(target.kind());
+        if (dispatcher == null) {
             throw new IllegalStateException(
                 "Checkpoint publication '" + publication + "' target '" + targetId
                     + "' uses unsupported kind " + target.kind());
         }
-        return switch (target.kind()) {
-            case GRPC -> resolveGrpcTarget(publication, targetId, target);
-            case HTTP -> resolveHttpTarget(publication, targetId, target);
-            case KAFKA -> resolveKafkaTarget(publication, targetId, target);
-        };
-    }
-
-    private ResolvedCheckpointPublicationTarget resolveGrpcTarget(
-        String publication,
-        String targetId,
-        PipelineHandoffConfig.TargetConfig target
-    ) {
-        String host = target.host()
-            .map(String::trim)
-            .filter(value -> !value.isBlank())
-            .orElseThrow(() -> new IllegalStateException(
-                "Checkpoint publication '" + publication + "' target '" + targetId
-                    + "' requires host for GRPC delivery"));
-        int port = target.port()
-            .filter(value -> value > 0)
-            .orElseThrow(() -> new IllegalStateException(
-                "Checkpoint publication '" + publication + "' target '" + targetId
-                    + "' requires port for GRPC delivery"));
-        return new ResolvedCheckpointPublicationTarget(
-            publication,
-            targetId,
-            PublicationTargetKind.GRPC,
-            PublicationEncoding.PROTO,
-            null,
-            null,
-            host + ":" + port,
-            target.plaintext() ? "PLAINTEXT" : "TLS");
-    }
-
-    private ResolvedCheckpointPublicationTarget resolveHttpTarget(
-        String publication,
-        String targetId,
-        PipelineHandoffConfig.TargetConfig target
-    ) {
-        String baseUrl = target.baseUrl()
-            .map(String::trim)
-            .filter(value -> !value.isBlank())
-            .orElseThrow(() -> new IllegalStateException(
-                "Checkpoint publication '" + publication + "' target '" + targetId
-                    + "' requires base-url for HTTP delivery"));
-        String path = target.path()
-            .map(String::trim)
-            .filter(value -> !value.isBlank())
-            .orElse(CheckpointPublicationResource.DEFAULT_PATH);
-        String method = target.method() == null ? "POST" : target.method().trim().toUpperCase(java.util.Locale.ROOT);
-        if (!"POST".equals(method)) {
-            throw new IllegalStateException(
-                "Checkpoint publication '" + publication + "' target '" + targetId
-                    + "' only supports HTTP method POST");
-        }
-        PublicationEncoding encoding = target.encoding().orElse(PublicationEncoding.PROTO);
-        String normalizedBase = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-        String normalizedPath = path.startsWith("/") ? path : "/" + path;
-        return new ResolvedCheckpointPublicationTarget(
-            publication,
-            targetId,
-            PublicationTargetKind.HTTP,
-            encoding,
-            target.contentType().filter(value -> !value.isBlank()).orElse(
-                encoding == PublicationEncoding.PROTO
-                    ? org.pipelineframework.transport.http.ProtobufHttpContentTypes.APPLICATION_X_PROTOBUF
-                    : org.pipelineframework.transport.http.ProtobufHttpContentTypes.APPLICATION_JSON),
-            target.idempotencyHeader().orElse("Idempotency-Key"),
-            normalizedBase + normalizedPath,
-            method);
-    }
-
-    private ResolvedCheckpointPublicationTarget resolveKafkaTarget(
-        String publication,
-        String targetId,
-        PipelineHandoffConfig.TargetConfig target
-    ) {
-        String topic = target.topic()
-            .map(String::trim)
-            .filter(value -> !value.isBlank())
-            .orElseThrow(() -> new IllegalStateException(
-                "Checkpoint publication '" + publication + "' target '" + targetId
-                    + "' requires topic for KAFKA delivery"));
-        return new ResolvedCheckpointPublicationTarget(
-            publication,
-            targetId,
-            PublicationTargetKind.KAFKA,
-            PublicationEncoding.JSON,
-            null,
-            null,
-            topic,
-            "PUBLISH");
+        return dispatcher.resolveTarget(publication, targetId, target);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationService.java
@@ -153,6 +153,7 @@ public class CheckpointPublicationService {
         return switch (target.kind()) {
             case GRPC -> resolveGrpcTarget(publication, targetId, target);
             case HTTP -> resolveHttpTarget(publication, targetId, target);
+            case KAFKA -> resolveKafkaTarget(publication, targetId, target);
         };
     }
 
@@ -219,5 +220,27 @@ public class CheckpointPublicationService {
             target.idempotencyHeader().orElse("Idempotency-Key"),
             normalizedBase + normalizedPath,
             method);
+    }
+
+    private ResolvedCheckpointPublicationTarget resolveKafkaTarget(
+        String publication,
+        String targetId,
+        PipelineHandoffConfig.TargetConfig target
+    ) {
+        String topic = target.topic()
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .orElseThrow(() -> new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' requires topic for KAFKA delivery"));
+        return new ResolvedCheckpointPublicationTarget(
+            publication,
+            targetId,
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            topic,
+            "PUBLISH");
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationTargetDispatcher.java
@@ -15,6 +15,20 @@ public interface CheckpointPublicationTargetDispatcher {
     PublicationTargetKind kind();
 
     /**
+     * Resolve one configured target for this dispatcher kind.
+     *
+     * @param publication logical publication name
+     * @param targetId configured target id
+     * @param target target configuration
+     * @return resolved target configuration
+     */
+    ResolvedCheckpointPublicationTarget resolveTarget(
+        String publication,
+        String targetId,
+        PipelineHandoffConfig.TargetConfig target
+    );
+
+    /**
      * Dispatch one published checkpoint to the resolved target.
      *
      * @param target resolved target configuration

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcher.java
@@ -34,6 +34,34 @@ public class GrpcCheckpointPublicationTargetDispatcher implements CheckpointPubl
     }
 
     @Override
+    public ResolvedCheckpointPublicationTarget resolveTarget(
+        String publication,
+        String targetId,
+        PipelineHandoffConfig.TargetConfig target
+    ) {
+        String host = target.host()
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .orElseThrow(() -> new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' requires host for GRPC delivery"));
+        int port = target.port()
+            .filter(value -> value > 0)
+            .orElseThrow(() -> new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' requires port for GRPC delivery"));
+        return new ResolvedCheckpointPublicationTarget(
+            publication,
+            targetId,
+            PublicationTargetKind.GRPC,
+            PublicationEncoding.PROTO,
+            null,
+            null,
+            host + ":" + port,
+            target.plaintext() ? "PLAINTEXT" : "TLS");
+    }
+
+    @Override
     public Uni<Void> dispatch(
         ResolvedCheckpointPublicationTarget target,
         CheckpointPublicationRequest request,

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcher.java
@@ -45,6 +45,11 @@ public class GrpcCheckpointPublicationTargetDispatcher implements CheckpointPubl
             .orElseThrow(() -> new IllegalStateException(
                 "Checkpoint publication '" + publication + "' target '" + targetId
                     + "' requires host for GRPC delivery"));
+        if (host.contains(":")) {
+            throw new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' does not support colon-containing GRPC hosts; use a DNS name or IPv4 address");
+        }
         int port = target.port()
             .filter(value -> value > 0)
             .orElseThrow(() -> new IllegalStateException(

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/HttpCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/HttpCheckpointPublicationTargetDispatcher.java
@@ -37,6 +37,45 @@ public class HttpCheckpointPublicationTargetDispatcher implements CheckpointPubl
     }
 
     @Override
+    public ResolvedCheckpointPublicationTarget resolveTarget(
+        String publication,
+        String targetId,
+        PipelineHandoffConfig.TargetConfig target
+    ) {
+        String baseUrl = target.baseUrl()
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .orElseThrow(() -> new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' requires base-url for HTTP delivery"));
+        String path = target.path()
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .orElse(CheckpointPublicationResource.DEFAULT_PATH);
+        String method = target.method() == null ? "POST" : target.method().trim().toUpperCase(java.util.Locale.ROOT);
+        if (!"POST".equals(method)) {
+            throw new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' only supports HTTP method POST");
+        }
+        PublicationEncoding encoding = target.encoding().orElse(PublicationEncoding.PROTO);
+        String normalizedBase = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        String normalizedPath = path.startsWith("/") ? path : "/" + path;
+        return new ResolvedCheckpointPublicationTarget(
+            publication,
+            targetId,
+            PublicationTargetKind.HTTP,
+            encoding,
+            target.contentType().filter(value -> !value.isBlank()).orElse(
+                encoding == PublicationEncoding.PROTO
+                    ? org.pipelineframework.transport.http.ProtobufHttpContentTypes.APPLICATION_X_PROTOBUF
+                    : org.pipelineframework.transport.http.ProtobufHttpContentTypes.APPLICATION_JSON),
+            target.idempotencyHeader().orElse(DEFAULT_IDEMPOTENCY_HEADER),
+            normalizedBase + normalizedPath,
+            method);
+    }
+
+    @Override
     public Uni<Void> dispatch(
         ResolvedCheckpointPublicationTarget target,
         CheckpointPublicationRequest request,

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/PipelineHandoffConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/PipelineHandoffConfig.java
@@ -43,6 +43,7 @@ public interface PipelineHandoffConfig {
      * {@code HTTP} targets require {@code base-url}; {@code path}, {@code method},
      * {@code content-type}, and {@code idempotency-header} are optional.
      * {@code GRPC} targets require {@code host} and {@code port}; {@code plaintext} is optional.
+     * {@code KAFKA} targets require {@code topic}.
      */
     interface TargetConfig {
 
@@ -122,5 +123,12 @@ public interface PipelineHandoffConfig {
          */
         @WithDefault("POST")
         String method();
+
+        /**
+         * Kafka topic for {@link PublicationTargetKind#KAFKA} targets (required).
+         *
+         * @return topic when configured
+         */
+        Optional<String> topic();
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/PublicationTargetKind.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/PublicationTargetKind.java
@@ -5,5 +5,6 @@ package org.pipelineframework.checkpoint;
  */
 public enum PublicationTargetKind {
     GRPC,
-    HTTP
+    HTTP,
+    KAFKA
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/ResolvedCheckpointPublicationTarget.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/ResolvedCheckpointPublicationTarget.java
@@ -46,5 +46,8 @@ public record ResolvedCheckpointPublicationTarget(
         if (kind == PublicationTargetKind.GRPC && !"PLAINTEXT".equals(method) && !"TLS".equals(method)) {
             throw new IllegalArgumentException("GRPC checkpoint publication targets must use method PLAINTEXT or TLS");
         }
+        if (kind == PublicationTargetKind.KAFKA && !"PUBLISH".equals(method)) {
+            throw new IllegalArgumentException("KAFKA checkpoint publication targets must use method PUBLISH");
+        }
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationConsumer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationConsumer.java
@@ -1,0 +1,79 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.logging.Logger;
+import org.pipelineframework.checkpoint.CheckpointPublicationAdmissionService;
+import org.pipelineframework.checkpoint.CheckpointPublicationEnvelope;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+/**
+ * SmallRye Reactive Messaging consumer that admits Kafka checkpoint handoffs.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "tpf.checkpoint.kafka.consumer.enabled", stringValue = "true")
+public class KafkaCheckpointPublicationConsumer {
+
+    public static final String INCOMING_CHANNEL = "tpf-checkpoint-kafka-publications";
+    private static final Logger LOG = Logger.getLogger(KafkaCheckpointPublicationConsumer.class);
+
+    @Inject
+    CheckpointPublicationAdmissionService admissionService;
+
+    public KafkaCheckpointPublicationConsumer() {
+    }
+
+    KafkaCheckpointPublicationConsumer(CheckpointPublicationAdmissionService admissionService) {
+        this.admissionService = admissionService;
+    }
+
+    @Incoming(INCOMING_CHANNEL)
+    public CompletionStage<Void> consume(Message<String> message) {
+        Objects.requireNonNull(message, "message must not be null");
+        return Uni.createFrom().item(() -> parseEnvelope(message.getPayload()))
+            .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+            .onItem().transformToUni(envelope -> admissionService.admit(
+                envelope.toRequest(),
+                envelope.tenantId(),
+                envelope.idempotencyKey()))
+            .replaceWithVoid()
+            .subscribeAsCompletionStage()
+            .thenCompose(ignored -> message.ack())
+            .exceptionallyCompose(failure -> {
+                Throwable cause = unwrap(failure);
+                if (cause instanceof NotFoundException) {
+                    LOG.warnf("Dropping Kafka checkpoint handoff without local subscriber: %s", cause.getMessage());
+                    return message.ack();
+                }
+                return message.nack(cause);
+            });
+    }
+
+    private static CheckpointPublicationEnvelope parseEnvelope(String payload) {
+        try {
+            return PipelineJson.mapper().readValue(payload, CheckpointPublicationEnvelope.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Kafka checkpoint publication envelope", e);
+        }
+    }
+
+    private static Throwable unwrap(Throwable failure) {
+        Throwable current = failure;
+        while ((current instanceof CompletionException || current instanceof java.util.concurrent.ExecutionException)
+            && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationRequest.java
@@ -1,0 +1,36 @@
+package org.pipelineframework.checkpoint.kafka;
+
+/**
+ * Kafka publish request for one checkpoint handoff envelope.
+ *
+ * @param topic Kafka topic
+ * @param key Kafka record key
+ * @param body serialized envelope body
+ */
+public record KafkaCheckpointPublicationRequest(
+    String topic,
+    String key,
+    String body
+) {
+    public KafkaCheckpointPublicationRequest {
+        topic = required(topic, "topic");
+        key = normalize(key);
+        body = required(body, "body");
+    }
+
+    private static String required(String value, String field) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationTargetDispatcher.java
@@ -90,10 +90,17 @@ public class KafkaCheckpointPublicationTargetDispatcher implements CheckpointPub
         if (explicitPublisher != null) {
             return explicitPublisher;
         }
-        return publishers.stream()
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException(
+        java.util.List<KafkaCheckpointPublisher> candidates = publishers.stream().toList();
+        if (candidates.isEmpty()) {
+            throw new IllegalStateException(
                 "Kafka checkpoint handoff requires a KafkaCheckpointPublisher provider. "
-                    + "Enable tpf.checkpoint.kafka.publisher.enabled=true and configure the TPF checkpoint Kafka channel."));
+                    + "Enable tpf.checkpoint.kafka.publisher.enabled=true and configure the TPF checkpoint Kafka channel.");
+        }
+        if (candidates.size() > 1) {
+            throw new IllegalStateException(
+                "Ambiguous KafkaCheckpointPublisher providers configured for Kafka checkpoint handoff: "
+                    + candidates.size());
+        }
+        return candidates.get(0);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationTargetDispatcher.java
@@ -9,6 +9,8 @@ import io.smallrye.mutiny.Uni;
 import org.pipelineframework.checkpoint.CheckpointPublicationEnvelope;
 import org.pipelineframework.checkpoint.CheckpointPublicationRequest;
 import org.pipelineframework.checkpoint.CheckpointPublicationTargetDispatcher;
+import org.pipelineframework.checkpoint.PipelineHandoffConfig;
+import org.pipelineframework.checkpoint.PublicationEncoding;
 import org.pipelineframework.checkpoint.PublicationTargetKind;
 import org.pipelineframework.checkpoint.ResolvedCheckpointPublicationTarget;
 import org.pipelineframework.config.pipeline.PipelineJson;
@@ -36,6 +38,29 @@ public class KafkaCheckpointPublicationTargetDispatcher implements CheckpointPub
     @Override
     public PublicationTargetKind kind() {
         return PublicationTargetKind.KAFKA;
+    }
+
+    @Override
+    public ResolvedCheckpointPublicationTarget resolveTarget(
+        String publication,
+        String targetId,
+        PipelineHandoffConfig.TargetConfig target
+    ) {
+        String topic = target.topic()
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .orElseThrow(() -> new IllegalStateException(
+                "Checkpoint publication '" + publication + "' target '" + targetId
+                    + "' requires topic for KAFKA delivery"));
+        return new ResolvedCheckpointPublicationTarget(
+            publication,
+            targetId,
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            topic,
+            "PUBLISH");
     }
 
     @Override

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationTargetDispatcher.java
@@ -1,0 +1,74 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import io.quarkus.arc.Unremovable;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.checkpoint.CheckpointPublicationEnvelope;
+import org.pipelineframework.checkpoint.CheckpointPublicationRequest;
+import org.pipelineframework.checkpoint.CheckpointPublicationTargetDispatcher;
+import org.pipelineframework.checkpoint.PublicationTargetKind;
+import org.pipelineframework.checkpoint.ResolvedCheckpointPublicationTarget;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+/**
+ * Kafka dispatcher for runtime checkpoint publication targets.
+ */
+@ApplicationScoped
+@Unremovable
+public class KafkaCheckpointPublicationTargetDispatcher implements CheckpointPublicationTargetDispatcher {
+
+    @Inject
+    Instance<KafkaCheckpointPublisher> publishers;
+
+    private final KafkaCheckpointPublisher explicitPublisher;
+
+    public KafkaCheckpointPublicationTargetDispatcher() {
+        this.explicitPublisher = null;
+    }
+
+    KafkaCheckpointPublicationTargetDispatcher(KafkaCheckpointPublisher publisher) {
+        this.explicitPublisher = publisher;
+    }
+
+    @Override
+    public PublicationTargetKind kind() {
+        return PublicationTargetKind.KAFKA;
+    }
+
+    @Override
+    public Uni<Void> dispatch(
+        ResolvedCheckpointPublicationTarget target,
+        CheckpointPublicationRequest request,
+        String tenantId,
+        String idempotencyKey
+    ) {
+        String key = idempotencyKey == null || idempotencyKey.isBlank() ? request.publication() : idempotencyKey.trim();
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            request.publication(),
+            tenantId,
+            idempotencyKey,
+            request.payload(),
+            System.currentTimeMillis());
+        String body;
+        try {
+            body = PipelineJson.mapper().writeValueAsString(envelope);
+        } catch (Exception e) {
+            return Uni.createFrom().failure(new IllegalStateException("Failed serializing Kafka checkpoint envelope", e));
+        }
+        return publisher().publish(new KafkaCheckpointPublicationRequest(target.endpoint(), key, body));
+    }
+
+    private KafkaCheckpointPublisher publisher() {
+        if (explicitPublisher != null) {
+            return explicitPublisher;
+        }
+        return publishers.stream()
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(
+                "Kafka checkpoint handoff requires a KafkaCheckpointPublisher provider. "
+                    + "Enable tpf.checkpoint.kafka.publisher.enabled=true and configure the TPF checkpoint Kafka channel."));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublisher.java
@@ -1,0 +1,17 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Broker boundary used by the Kafka checkpoint handoff dispatcher.
+ */
+public interface KafkaCheckpointPublisher {
+
+    /**
+     * Publishes one checkpoint handoff envelope.
+     *
+     * @param request publish request
+     * @return completion signal
+     */
+    Uni<Void> publish(KafkaCheckpointPublicationRequest request);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/ReactiveMessagingKafkaCheckpointPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/kafka/ReactiveMessagingKafkaCheckpointPublisher.java
@@ -1,0 +1,35 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * SmallRye Reactive Messaging backed Kafka publisher for checkpoint handoff.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "tpf.checkpoint.kafka.publisher.enabled", stringValue = "true")
+public class ReactiveMessagingKafkaCheckpointPublisher implements KafkaCheckpointPublisher {
+
+    public static final String OUTGOING_CHANNEL = "tpf-checkpoint-kafka-publications";
+
+    @Inject
+    @Channel(OUTGOING_CHANNEL)
+    MutinyEmitter<String> emitter;
+
+    @Override
+    public Uni<Void> publish(KafkaCheckpointPublicationRequest request) {
+        OutgoingKafkaRecordMetadata<String> metadata = OutgoingKafkaRecordMetadata.<String>builder()
+            .withTopic(request.topic())
+            .withKey(request.key())
+            .build();
+        Message<String> message = Message.of(request.body()).addMetadata(metadata);
+        return emitter.sendMessage(message);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/CheckpointPublicationEnvelopeTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/CheckpointPublicationEnvelopeTest.java
@@ -1,0 +1,139 @@
+package org.pipelineframework.checkpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+class CheckpointPublicationEnvelopeTest {
+
+    @Test
+    void constructsWithAllFields() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode().put("orderId", "o-1");
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            "orders-ready", "tenant-1", "idem-1", payload, 1000L);
+
+        assertEquals("orders-ready", envelope.publication());
+        assertEquals("tenant-1", envelope.tenantId());
+        assertEquals("idem-1", envelope.idempotencyKey());
+        assertEquals("o-1", envelope.payload().get("orderId").asText());
+        assertEquals(1000L, envelope.publishedAtEpochMs());
+    }
+
+    @Test
+    void constructsWithNullOptionalFields() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode().put("orderId", "o-1");
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            "orders-ready", null, null, payload, 1L);
+
+        assertEquals("orders-ready", envelope.publication());
+        assertNull(envelope.tenantId());
+        assertNull(envelope.idempotencyKey());
+    }
+
+    @Test
+    void nullPublicationThrows() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope(null, "tenant-1", "idem-1", payload, 1L));
+    }
+
+    @Test
+    void blankPublicationThrows() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope("   ", "tenant-1", "idem-1", payload, 1L));
+    }
+
+    @Test
+    void emptyPublicationThrows() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope("", "tenant-1", "idem-1", payload, 1L));
+    }
+
+    @Test
+    void nullPayloadThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope("orders-ready", "tenant-1", "idem-1", null, 1L));
+    }
+
+    @Test
+    void jsonNullPayloadThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope(
+                "orders-ready", "tenant-1", "idem-1",
+                JsonNodeFactory.instance.nullNode(), 1L));
+    }
+
+    @Test
+    void zeroTimestampThrows() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope("orders-ready", "tenant-1", "idem-1", payload, 0L));
+    }
+
+    @Test
+    void negativeTimestampThrows() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        assertThrows(IllegalArgumentException.class, () ->
+            new CheckpointPublicationEnvelope("orders-ready", "tenant-1", "idem-1", payload, -1L));
+    }
+
+    @Test
+    void publicationIsTrimmerd() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            "  orders-ready  ", "tenant-1", "idem-1", payload, 1L);
+        assertEquals("orders-ready", envelope.publication());
+    }
+
+    @Test
+    void blankTenantIdNormalizesToNull() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            "orders-ready", "   ", "idem-1", payload, 1L);
+        assertNull(envelope.tenantId());
+    }
+
+    @Test
+    void blankIdempotencyKeyNormalizesToNull() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            "orders-ready", "tenant-1", "   ", payload, 1L);
+        assertNull(envelope.idempotencyKey());
+    }
+
+    @Test
+    void toRequestReturnsPublicationAndPayload() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode().put("orderId", "o-1");
+        CheckpointPublicationEnvelope envelope = new CheckpointPublicationEnvelope(
+            "orders-ready", "tenant-1", "idem-1", payload, 1L);
+
+        CheckpointPublicationRequest request = envelope.toRequest();
+
+        assertEquals("orders-ready", request.publication());
+        assertEquals("o-1", request.payload().get("orderId").asText());
+    }
+
+    @Test
+    void roundTripsThroughJsonSerialization() throws Exception {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode().put("orderId", "o-1");
+        CheckpointPublicationEnvelope original = new CheckpointPublicationEnvelope(
+            "orders-ready", "tenant-1", "idem-1", payload, 1000L);
+
+        String json = PipelineJson.mapper().writeValueAsString(original);
+        CheckpointPublicationEnvelope deserialized = PipelineJson.mapper()
+            .readValue(json, CheckpointPublicationEnvelope.class);
+
+        assertEquals(original.publication(), deserialized.publication());
+        assertEquals(original.tenantId(), deserialized.tenantId());
+        assertEquals(original.idempotencyKey(), deserialized.idempotencyKey());
+        assertEquals(original.publishedAtEpochMs(), deserialized.publishedAtEpochMs());
+        assertEquals("o-1", deserialized.payload().get("orderId").asText());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/CheckpointPublicationServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/CheckpointPublicationServiceTest.java
@@ -3,9 +3,7 @@ package org.pipelineframework.checkpoint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.enterprise.inject.Instance;
@@ -173,6 +171,25 @@ class CheckpointPublicationServiceTest {
         @Override
         public PublicationTargetKind kind() {
             return kind;
+        }
+
+        @Override
+        public ResolvedCheckpointPublicationTarget resolveTarget(
+            String publication,
+            String targetId,
+            PipelineHandoffConfig.TargetConfig target
+        ) {
+            return new ResolvedCheckpointPublicationTarget(
+                publication,
+                targetId,
+                kind,
+                kind == PublicationTargetKind.KAFKA ? PublicationEncoding.JSON : PublicationEncoding.PROTO,
+                kind == PublicationTargetKind.HTTP
+                    ? org.pipelineframework.transport.http.ProtobufHttpContentTypes.APPLICATION_X_PROTOBUF
+                    : null,
+                null,
+                kind == PublicationTargetKind.KAFKA ? target.topic().orElseThrow() : target.baseUrl().orElseThrow(),
+                kind == PublicationTargetKind.KAFKA ? "PUBLISH" : "POST");
         }
 
         @Override

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/CheckpointPublicationServiceTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/CheckpointPublicationServiceTest.java
@@ -40,7 +40,7 @@ class CheckpointPublicationServiceTest {
     void publishFansOutToConfiguredTargets() {
         CheckpointPublicationService service = new CheckpointPublicationService();
         service.publicationDescriptors = descriptors(new TestDescriptor("orders-ready", List.of("orderId")));
-        TestDispatcher dispatcher = new TestDispatcher();
+        TestDispatcher dispatcher = new TestDispatcher(PublicationTargetKind.HTTP);
         service.targetDispatchers = dispatchers(dispatcher);
         service.orchestratorConfig = orchestratorConfig();
         service.handoffConfig = handoffConfig(Map.of(
@@ -55,6 +55,26 @@ class CheckpointPublicationServiceTest {
         assertEquals(2, dispatcher.targetIds.size());
         assertTrue(dispatcher.targetIds.containsAll(List.of("deliver", "audit")));
         assertEquals(List.of("o-1", "o-1"), dispatcher.idempotencyKeys);
+    }
+
+    @Test
+    void publishDispatchesKafkaTarget() {
+        CheckpointPublicationService service = new CheckpointPublicationService();
+        service.publicationDescriptors = descriptors(new TestDescriptor("orders-ready", List.of("orderId")));
+        TestDispatcher dispatcher = new TestDispatcher(PublicationTargetKind.KAFKA);
+        service.targetDispatchers = dispatchers(dispatcher);
+        service.orchestratorConfig = orchestratorConfig();
+        service.handoffConfig = handoffConfig(Map.of(
+            "orders-ready",
+            publicationBinding(Map.of(
+                "deliver", kafkaTarget("checkout.orders.ready.v1")))));
+        service.initialize();
+
+        service.publishIfConfigured(record(), new PublishedOrder("o-1", "c-1")).await().indefinitely();
+
+        assertEquals(List.of("deliver"), dispatcher.targetIds);
+        assertEquals(List.of("checkout.orders.ready.v1"), dispatcher.endpoints);
+        assertEquals(List.of("o-1"), dispatcher.idempotencyKeys);
     }
 
     @SuppressWarnings("unchecked")
@@ -102,6 +122,13 @@ class CheckpointPublicationServiceTest {
         return target;
     }
 
+    private PipelineHandoffConfig.TargetConfig kafkaTarget(String topic) {
+        PipelineHandoffConfig.TargetConfig target = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(target.kind()).thenReturn(PublicationTargetKind.KAFKA);
+        when(target.topic()).thenReturn(java.util.Optional.of(topic));
+        return target;
+    }
+
     private ExecutionRecord<Object, Object> record() {
         return new ExecutionRecord<>(
             "tenant-1",
@@ -135,11 +162,17 @@ class CheckpointPublicationServiceTest {
 
     private static final class TestDispatcher implements CheckpointPublicationTargetDispatcher {
         private final java.util.List<String> targetIds = new java.util.ArrayList<>();
+        private final java.util.List<String> endpoints = new java.util.ArrayList<>();
         private final java.util.List<String> idempotencyKeys = new java.util.ArrayList<>();
+        private final PublicationTargetKind kind;
+
+        private TestDispatcher(PublicationTargetKind kind) {
+            this.kind = kind;
+        }
 
         @Override
         public PublicationTargetKind kind() {
-            return PublicationTargetKind.HTTP;
+            return kind;
         }
 
         @Override
@@ -150,6 +183,7 @@ class CheckpointPublicationServiceTest {
             String idempotencyKey
         ) {
             targetIds.add(target.targetId());
+            endpoints.add(target.endpoint());
             idempotencyKeys.add(idempotencyKey);
             return Uni.createFrom().voidItem();
         }

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcherTest.java
@@ -64,6 +64,21 @@ class GrpcCheckpointPublicationTargetDispatcherTest {
     }
 
     @Test
+    void resolveTargetRejectsColonContainingHosts() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig target = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(target.host()).thenReturn(Optional.of("::1"));
+        when(target.port()).thenReturn(Optional.of(9000));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", target));
+
+        assertEquals(
+            "Checkpoint publication 'orders-ready' target 'deliver' does not support colon-containing GRPC hosts; use a DNS name or IPv4 address",
+            error.getMessage());
+    }
+
+    @Test
     void resolveTargetFailsWhenHostBlank() {
         GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
         PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcherTest.java
@@ -1,10 +1,14 @@
 package org.pipelineframework.checkpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.checkpoint.grpc.CheckpointPublishAcceptedResponse;
@@ -13,6 +17,93 @@ import org.pipelineframework.checkpoint.grpc.MutinyCheckpointPublicationServiceG
 import org.pipelineframework.config.pipeline.PipelineJson;
 
 class GrpcCheckpointPublicationTargetDispatcherTest {
+
+    @Test
+    void resolveTargetBuildsEndpointFromHostAndPort() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.host()).thenReturn(Optional.of("downstream-host"));
+        when(config.port()).thenReturn(Optional.of(9090));
+        when(config.plaintext()).thenReturn(false);
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("orders-ready", target.publication());
+        assertEquals("deliver", target.targetId());
+        assertEquals(PublicationTargetKind.GRPC, target.kind());
+        assertEquals(PublicationEncoding.PROTO, target.encoding());
+        assertEquals("downstream-host:9090", target.endpoint());
+        assertEquals("TLS", target.method());
+    }
+
+    @Test
+    void resolveTargetUsesPlaintextWhenConfigured() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.host()).thenReturn(Optional.of("localhost"));
+        when(config.port()).thenReturn(Optional.of(9000));
+        when(config.plaintext()).thenReturn(true);
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("PLAINTEXT", target.method());
+    }
+
+    @Test
+    void resolveTargetFailsWhenHostAbsent() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.host()).thenReturn(Optional.empty());
+        when(config.port()).thenReturn(Optional.of(9000));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+        assertEquals(
+            "Checkpoint publication 'orders-ready' target 'deliver' requires host for GRPC delivery",
+            error.getMessage());
+    }
+
+    @Test
+    void resolveTargetFailsWhenHostBlank() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.host()).thenReturn(Optional.of("   "));
+        when(config.port()).thenReturn(Optional.of(9000));
+
+        assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+    }
+
+    @Test
+    void resolveTargetFailsWhenPortAbsent() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.host()).thenReturn(Optional.of("localhost"));
+        when(config.port()).thenReturn(Optional.empty());
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+        assertEquals(
+            "Checkpoint publication 'orders-ready' target 'deliver' requires port for GRPC delivery",
+            error.getMessage());
+    }
+
+    @Test
+    void resolveTargetFailsWhenPortIsZero() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.host()).thenReturn(Optional.of("localhost"));
+        when(config.port()).thenReturn(Optional.of(0));
+
+        assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+    }
+
+    @Test
+    void resolveTargetKindIsGrpc() {
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        assertEquals(PublicationTargetKind.GRPC, dispatcher.kind());
+    }
 
     @Test
     void dispatchSendsCanonicalProtoRequest() throws Exception {

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/HttpCheckpointPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/HttpCheckpointPublicationTargetDispatcherTest.java
@@ -1,6 +1,9 @@
 package org.pipelineframework.checkpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.net.httpserver.HttpExchange;
@@ -8,6 +11,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.checkpoint.grpc.CheckpointPublishRequest;
@@ -15,6 +19,172 @@ import org.pipelineframework.config.pipeline.PipelineJson;
 import org.pipelineframework.transport.http.ProtobufHttpContentTypes;
 
 class HttpCheckpointPublicationTargetDispatcherTest {
+
+    @Test
+    void resolveTargetBuildsFullUrlFromBaseUrlAndPath() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.of("/pipeline/checkpoints/publish"));
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.of(PublicationEncoding.PROTO));
+        when(config.contentType()).thenReturn(Optional.empty());
+        when(config.idempotencyHeader()).thenReturn(Optional.empty());
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("orders-ready", target.publication());
+        assertEquals("deliver", target.targetId());
+        assertEquals(PublicationTargetKind.HTTP, target.kind());
+        assertEquals(PublicationEncoding.PROTO, target.encoding());
+        assertEquals("http://localhost:8081/pipeline/checkpoints/publish", target.endpoint());
+        assertEquals("POST", target.method());
+        assertEquals(ProtobufHttpContentTypes.APPLICATION_X_PROTOBUF, target.contentType());
+        assertEquals("Idempotency-Key", target.idempotencyHeader());
+    }
+
+    @Test
+    void resolveTargetStripsTrailingSlashFromBaseUrl() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081/"));
+        when(config.path()).thenReturn(Optional.of("/pipeline/checkpoints/publish"));
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.of(PublicationEncoding.PROTO));
+        when(config.contentType()).thenReturn(Optional.empty());
+        when(config.idempotencyHeader()).thenReturn(Optional.empty());
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("http://localhost:8081/pipeline/checkpoints/publish", target.endpoint());
+    }
+
+    @Test
+    void resolveTargetPrefixesPathWithSlashIfMissing() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.of("pipeline/checkpoints/publish"));
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.of(PublicationEncoding.PROTO));
+        when(config.contentType()).thenReturn(Optional.empty());
+        when(config.idempotencyHeader()).thenReturn(Optional.empty());
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("http://localhost:8081/pipeline/checkpoints/publish", target.endpoint());
+    }
+
+    @Test
+    void resolveTargetUsesJsonEncodingWithJsonContentType() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.empty());
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.of(PublicationEncoding.JSON));
+        when(config.contentType()).thenReturn(Optional.empty());
+        when(config.idempotencyHeader()).thenReturn(Optional.empty());
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals(PublicationEncoding.JSON, target.encoding());
+        assertEquals(ProtobufHttpContentTypes.APPLICATION_JSON, target.contentType());
+    }
+
+    @Test
+    void resolveTargetUsesExplicitContentTypeWhenProvided() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.empty());
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.of(PublicationEncoding.PROTO));
+        when(config.contentType()).thenReturn(Optional.of("application/x-custom-proto"));
+        when(config.idempotencyHeader()).thenReturn(Optional.empty());
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("application/x-custom-proto", target.contentType());
+    }
+
+    @Test
+    void resolveTargetUsesExplicitIdempotencyHeaderWhenProvided() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.empty());
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.empty());
+        when(config.contentType()).thenReturn(Optional.empty());
+        when(config.idempotencyHeader()).thenReturn(Optional.of("X-Custom-Idempotency"));
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("X-Custom-Idempotency", target.idempotencyHeader());
+    }
+
+    @Test
+    void resolveTargetDefaultsEncodingToProto() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.empty());
+        when(config.method()).thenReturn("POST");
+        when(config.encoding()).thenReturn(Optional.empty());
+        when(config.contentType()).thenReturn(Optional.empty());
+        when(config.idempotencyHeader()).thenReturn(Optional.empty());
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals(PublicationEncoding.PROTO, target.encoding());
+    }
+
+    @Test
+    void resolveTargetFailsWhenBaseUrlAbsent() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.empty());
+        when(config.method()).thenReturn("POST");
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+        assertEquals(
+            "Checkpoint publication 'orders-ready' target 'deliver' requires base-url for HTTP delivery",
+            error.getMessage());
+    }
+
+    @Test
+    void resolveTargetFailsWhenBaseUrlBlank() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("   "));
+        when(config.method()).thenReturn("POST");
+
+        assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+    }
+
+    @Test
+    void resolveTargetFailsForNonPostMethod() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.baseUrl()).thenReturn(Optional.of("http://localhost:8081"));
+        when(config.path()).thenReturn(Optional.empty());
+        when(config.method()).thenReturn("PUT");
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+        assertEquals(
+            "Checkpoint publication 'orders-ready' target 'deliver' only supports HTTP method POST",
+            error.getMessage());
+    }
+
+    @Test
+    void resolveTargetKindIsHttp() {
+        HttpCheckpointPublicationTargetDispatcher dispatcher = new HttpCheckpointPublicationTargetDispatcher();
+        assertEquals(PublicationTargetKind.HTTP, dispatcher.kind());
+    }
 
     @Test
     void dispatchSendsProtobufWrappedCheckpointRequest() throws Exception {

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/PipelineHandoffConfigTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/PipelineHandoffConfigTest.java
@@ -45,6 +45,17 @@ class PipelineHandoffConfigTest {
         assertTrue(target.plaintext());
     }
 
+    @Test
+    void configReadsKafkaBindingShape() {
+        PipelineHandoffConfig config = buildConfig(Map.of(
+            "pipeline.handoff.bindings.orders-ready.targets.deliver.kind", "KAFKA",
+            "pipeline.handoff.bindings.orders-ready.targets.deliver.topic", "checkout.orders.ready.v1"));
+
+        PipelineHandoffConfig.TargetConfig target = config.bindings().get("orders-ready").targets().get("deliver");
+        assertEquals(PublicationTargetKind.KAFKA, target.kind());
+        assertEquals("checkout.orders.ready.v1", target.topic().orElseThrow());
+    }
+
     private PipelineHandoffConfig buildConfig(Map<String, String> properties) {
         SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
         builder.withMapping(PipelineHandoffConfig.class);

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/ResolvedCheckpointPublicationTargetTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/ResolvedCheckpointPublicationTargetTest.java
@@ -1,0 +1,128 @@
+package org.pipelineframework.checkpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.transport.http.ProtobufHttpContentTypes;
+
+class ResolvedCheckpointPublicationTargetTest {
+
+    @Test
+    void kafkaTargetRequiresPublishMethod() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready",
+                "deliver",
+                PublicationTargetKind.KAFKA,
+                PublicationEncoding.JSON,
+                null,
+                null,
+                "checkout.orders.ready.v1",
+                "POST"));
+        assertEquals("KAFKA checkpoint publication targets must use method PUBLISH", error.getMessage());
+    }
+
+    @Test
+    void kafkaTargetAcceptsPublishMethod() {
+        ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+            "orders-ready",
+            "deliver",
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            "checkout.orders.ready.v1",
+            "PUBLISH");
+
+        assertEquals(PublicationTargetKind.KAFKA, target.kind());
+        assertEquals("PUBLISH", target.method());
+        assertEquals("checkout.orders.ready.v1", target.endpoint());
+    }
+
+    @Test
+    void grpcTargetAcceptsPlaintext() {
+        ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+            "orders-ready", "deliver", PublicationTargetKind.GRPC,
+            PublicationEncoding.PROTO, null, null, "localhost:9000", "PLAINTEXT");
+
+        assertEquals("PLAINTEXT", target.method());
+    }
+
+    @Test
+    void grpcTargetAcceptsTls() {
+        ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+            "orders-ready", "deliver", PublicationTargetKind.GRPC,
+            PublicationEncoding.PROTO, null, null, "downstream:9000", "TLS");
+
+        assertEquals("TLS", target.method());
+    }
+
+    @Test
+    void grpcTargetRejectsInvalidMethod() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready", "deliver", PublicationTargetKind.GRPC,
+                PublicationEncoding.PROTO, null, null, "localhost:9000", "POST"));
+        assertEquals("GRPC checkpoint publication targets must use method PLAINTEXT or TLS", error.getMessage());
+    }
+
+    @Test
+    void httpTargetRequiresPostMethod() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready", "deliver", PublicationTargetKind.HTTP,
+                PublicationEncoding.PROTO,
+                ProtobufHttpContentTypes.APPLICATION_X_PROTOBUF,
+                "Idempotency-Key",
+                "http://localhost:8081/path", "PUT"));
+        assertEquals("HTTP checkpoint publication targets must use method POST", error.getMessage());
+    }
+
+    @Test
+    void httpTargetRequiresContentType() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready", "deliver", PublicationTargetKind.HTTP,
+                PublicationEncoding.PROTO,
+                null,
+                "Idempotency-Key",
+                "http://localhost:8081/path", "POST"));
+    }
+
+    @Test
+    void blankPublicationThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "", "deliver", PublicationTargetKind.KAFKA,
+                PublicationEncoding.JSON, null, null,
+                "checkout.orders.ready.v1", "PUBLISH"));
+    }
+
+    @Test
+    void nullKindThrows() {
+        assertThrows(NullPointerException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready", "deliver", null,
+                PublicationEncoding.JSON, null, null,
+                "checkout.orders.ready.v1", "PUBLISH"));
+    }
+
+    @Test
+    void blankEndpointThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready", "deliver", PublicationTargetKind.KAFKA,
+                PublicationEncoding.JSON, null, null,
+                "", "PUBLISH"));
+    }
+
+    @Test
+    void blankMethodThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new ResolvedCheckpointPublicationTarget(
+                "orders-ready", "deliver", PublicationTargetKind.KAFKA,
+                PublicationEncoding.JSON, null, null,
+                "checkout.orders.ready.v1", ""));
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationConsumerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationConsumerTest.java
@@ -1,0 +1,125 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.ws.rs.NotFoundException;
+
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.pipelineframework.checkpoint.CheckpointPublicationAdmissionService;
+import org.pipelineframework.checkpoint.CheckpointPublicationEnvelope;
+import org.pipelineframework.checkpoint.CheckpointPublicationRequest;
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+
+class CheckpointKafkaPublicationConsumerTest {
+
+    @Test
+    void consumesCheckpointEnvelopeThroughAdmissionService() throws Exception {
+        CheckpointPublicationAdmissionService admissionService = mock(CheckpointPublicationAdmissionService.class);
+        when(admissionService.admit(any(CheckpointPublicationRequest.class), eq("tenant-1"), eq("idem-1")))
+            .thenReturn(Uni.createFrom().item(new RunAsyncAcceptedDto("exec-1", false, "/status/exec-1", 1L)));
+        KafkaCheckpointPublicationConsumer consumer = new KafkaCheckpointPublicationConsumer(admissionService);
+        AtomicReference<Boolean> acked = new AtomicReference<>(false);
+
+        consumer.consume(message(body("orders-ready"), acked, new AtomicReference<>()))
+            .toCompletableFuture()
+            .orTimeout(5, TimeUnit.SECONDS)
+            .join();
+
+        assertEquals(Boolean.TRUE, acked.get());
+        ArgumentCaptor<CheckpointPublicationRequest> captor = ArgumentCaptor.forClass(CheckpointPublicationRequest.class);
+        verify(admissionService).admit(captor.capture(), eq("tenant-1"), eq("idem-1"));
+        assertEquals("orders-ready", captor.getValue().publication());
+        assertEquals("o-1", captor.getValue().payload().get("orderId").asText());
+    }
+
+    @Test
+    void invalidEnvelopeNacksMessage() {
+        KafkaCheckpointPublicationConsumer consumer = new KafkaCheckpointPublicationConsumer(
+            mock(CheckpointPublicationAdmissionService.class));
+        AtomicReference<Throwable> nacked = new AtomicReference<>();
+
+        consumer.consume(message("not-json", new AtomicReference<>(), nacked))
+            .toCompletableFuture()
+            .orTimeout(5, TimeUnit.SECONDS)
+            .join();
+
+        assertNotNull(nacked.get());
+    }
+
+    @Test
+    void missingSubscriberAcksMessage() throws Exception {
+        CheckpointPublicationAdmissionService admissionService = mock(CheckpointPublicationAdmissionService.class);
+        when(admissionService.admit(any(CheckpointPublicationRequest.class), eq("tenant-1"), eq("idem-1")))
+            .thenReturn(Uni.createFrom().failure(new NotFoundException("missing publication")));
+        KafkaCheckpointPublicationConsumer consumer = new KafkaCheckpointPublicationConsumer(admissionService);
+        AtomicReference<Boolean> acked = new AtomicReference<>(false);
+        AtomicReference<Throwable> nacked = new AtomicReference<>();
+
+        consumer.consume(message(body("orders-ready"), acked, nacked))
+            .toCompletableFuture()
+            .orTimeout(5, TimeUnit.SECONDS)
+            .join();
+
+        assertEquals(Boolean.TRUE, acked.get());
+        assertEquals(null, nacked.get());
+    }
+
+    @Test
+    void admissionFailureNacksMessage() throws Exception {
+        CheckpointPublicationAdmissionService admissionService = mock(CheckpointPublicationAdmissionService.class);
+        when(admissionService.admit(any(CheckpointPublicationRequest.class), eq("tenant-1"), eq("idem-1")))
+            .thenReturn(Uni.createFrom().failure(new IllegalStateException("transient")));
+        KafkaCheckpointPublicationConsumer consumer = new KafkaCheckpointPublicationConsumer(admissionService);
+        AtomicReference<Throwable> nacked = new AtomicReference<>();
+
+        consumer.consume(message(body("orders-ready"), new AtomicReference<>(), nacked))
+            .toCompletableFuture()
+            .orTimeout(5, TimeUnit.SECONDS)
+            .join();
+
+        assertNotNull(nacked.get());
+    }
+
+    private static String body(String publication) throws Exception {
+        return PipelineJson.mapper().writeValueAsString(new CheckpointPublicationEnvelope(
+            publication,
+            "tenant-1",
+            "idem-1",
+            PipelineJson.mapper().valueToTree(new PublishedOrder("o-1")),
+            1L));
+    }
+
+    private static Message<String> message(
+        String payload,
+        AtomicReference<Boolean> acked,
+        AtomicReference<Throwable> nacked
+    ) {
+        return Message.of(
+            payload,
+            () -> {
+                acked.set(true);
+                return CompletableFuture.completedFuture(null);
+            },
+            failure -> {
+                nacked.set(failure);
+                return CompletableFuture.completedFuture(null);
+            });
+    }
+
+    private record PublishedOrder(String orderId) {
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationTargetDispatcherTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import jakarta.enterprise.inject.Instance;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import io.smallrye.mutiny.Uni;
 import org.junit.jupiter.api.Test;
@@ -162,6 +164,46 @@ class CheckpointKafkaPublicationTargetDispatcherTest {
             null).await().indefinitely();
 
         assertEquals("orders-ready", captured.get().key());
+    }
+
+    @Test
+    void dispatchFailsWhenMultiplePublishersAreConfigured() {
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher();
+        dispatcher.publishers = publishers(
+            request -> Uni.createFrom().voidItem(),
+            request -> Uni.createFrom().voidItem());
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.dispatch(
+                target(),
+                new CheckpointPublicationRequest(
+                    "orders-ready",
+                    PipelineJson.mapper().valueToTree(new PublishedOrder("o-1", "c-1"))),
+                "tenant-1",
+                "idem-1"));
+
+        assertEquals(
+            "Ambiguous KafkaCheckpointPublisher providers configured for Kafka checkpoint handoff: 2",
+            error.getMessage());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Instance<KafkaCheckpointPublisher> publishers(KafkaCheckpointPublisher... publishers) {
+        Instance<KafkaCheckpointPublisher> instance = mock(Instance.class);
+        when(instance.stream()).thenReturn(Stream.of(publishers));
+        return instance;
+    }
+
+    private ResolvedCheckpointPublicationTarget target() {
+        return new ResolvedCheckpointPublicationTarget(
+            "orders-ready",
+            "deliver",
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            "checkout.orders.ready.v1",
+            "PUBLISH");
     }
 
     private record PublishedOrder(String orderId, String customerId) {

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationTargetDispatcherTest.java
@@ -1,0 +1,86 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.checkpoint.CheckpointPublicationEnvelope;
+import org.pipelineframework.checkpoint.CheckpointPublicationRequest;
+import org.pipelineframework.checkpoint.PublicationEncoding;
+import org.pipelineframework.checkpoint.PublicationTargetKind;
+import org.pipelineframework.checkpoint.ResolvedCheckpointPublicationTarget;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+class CheckpointKafkaPublicationTargetDispatcherTest {
+
+    @Test
+    void dispatchPublishesStrictEnvelopeToConfiguredTopic() throws Exception {
+        AtomicReference<KafkaCheckpointPublicationRequest> captured = new AtomicReference<>();
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> {
+                captured.set(request);
+                return Uni.createFrom().voidItem();
+            });
+        ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+            "orders-ready",
+            "deliver",
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            "checkout.orders.ready.v1",
+            "PUBLISH");
+
+        dispatcher.dispatch(
+            target,
+            new CheckpointPublicationRequest(
+                "orders-ready",
+                PipelineJson.mapper().valueToTree(new PublishedOrder("o-1", "c-1"))),
+            "tenant-1",
+            "idem-1").await().indefinitely();
+
+        KafkaCheckpointPublicationRequest request = captured.get();
+        assertEquals("checkout.orders.ready.v1", request.topic());
+        assertEquals("idem-1", request.key());
+        CheckpointPublicationEnvelope envelope = PipelineJson.mapper()
+            .readValue(request.body(), CheckpointPublicationEnvelope.class);
+        assertEquals("orders-ready", envelope.publication());
+        assertEquals("tenant-1", envelope.tenantId());
+        assertEquals("idem-1", envelope.idempotencyKey());
+        assertEquals("o-1", envelope.payload().get("orderId").asText());
+    }
+
+    @Test
+    void dispatchUsesPublicationAsKafkaKeyWhenIdempotencyKeyIsAbsent() {
+        AtomicReference<KafkaCheckpointPublicationRequest> captured = new AtomicReference<>();
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> {
+                captured.set(request);
+                return Uni.createFrom().voidItem();
+            });
+        ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+            "orders-ready",
+            "deliver",
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            "checkout.orders.ready.v1",
+            "PUBLISH");
+
+        dispatcher.dispatch(
+            target,
+            new CheckpointPublicationRequest(
+                "orders-ready",
+                PipelineJson.mapper().valueToTree(new PublishedOrder("o-1", "c-1"))),
+            "tenant-1",
+            null).await().indefinitely();
+
+        assertEquals("orders-ready", captured.get().key());
+    }
+
+    private record PublishedOrder(String orderId, String customerId) {
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/CheckpointKafkaPublicationTargetDispatcherTest.java
@@ -1,19 +1,102 @@
 package org.pipelineframework.checkpoint.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.mutiny.Uni;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.checkpoint.CheckpointPublicationEnvelope;
 import org.pipelineframework.checkpoint.CheckpointPublicationRequest;
+import org.pipelineframework.checkpoint.PipelineHandoffConfig;
 import org.pipelineframework.checkpoint.PublicationEncoding;
 import org.pipelineframework.checkpoint.PublicationTargetKind;
 import org.pipelineframework.checkpoint.ResolvedCheckpointPublicationTarget;
 import org.pipelineframework.config.pipeline.PipelineJson;
 
 class CheckpointKafkaPublicationTargetDispatcherTest {
+
+    @Test
+    void resolveTargetBuildskafkaTargetWithTopic() {
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> Uni.createFrom().voidItem());
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.topic()).thenReturn(Optional.of("checkout.orders.ready.v1"));
+
+        ResolvedCheckpointPublicationTarget target = dispatcher.resolveTarget("orders-ready", "deliver", config);
+
+        assertEquals("orders-ready", target.publication());
+        assertEquals("deliver", target.targetId());
+        assertEquals(PublicationTargetKind.KAFKA, target.kind());
+        assertEquals(PublicationEncoding.JSON, target.encoding());
+        assertEquals("checkout.orders.ready.v1", target.endpoint());
+        assertEquals("PUBLISH", target.method());
+    }
+
+    @Test
+    void resolveTargetFailsWhenTopicAbsent() {
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> Uni.createFrom().voidItem());
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.topic()).thenReturn(Optional.empty());
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+        assertEquals(
+            "Checkpoint publication 'orders-ready' target 'deliver' requires topic for KAFKA delivery",
+            error.getMessage());
+    }
+
+    @Test
+    void resolveTargetFailsWhenTopicBlank() {
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> Uni.createFrom().voidItem());
+        PipelineHandoffConfig.TargetConfig config = mock(PipelineHandoffConfig.TargetConfig.class);
+        when(config.topic()).thenReturn(Optional.of("   "));
+
+        assertThrows(IllegalStateException.class,
+            () -> dispatcher.resolveTarget("orders-ready", "deliver", config));
+    }
+
+    @Test
+    void resolveTargetKindIsKafka() {
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> Uni.createFrom().voidItem());
+        assertEquals(PublicationTargetKind.KAFKA, dispatcher.kind());
+    }
+
+    @Test
+    void dispatchUsesBlankIdempotencyKeyAsPublicationKey() {
+        AtomicReference<KafkaCheckpointPublicationRequest> captured = new AtomicReference<>();
+        KafkaCheckpointPublicationTargetDispatcher dispatcher = new KafkaCheckpointPublicationTargetDispatcher(
+            request -> {
+                captured.set(request);
+                return Uni.createFrom().voidItem();
+            });
+        ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+            "orders-ready",
+            "deliver",
+            PublicationTargetKind.KAFKA,
+            PublicationEncoding.JSON,
+            null,
+            null,
+            "checkout.orders.ready.v1",
+            "PUBLISH");
+
+        dispatcher.dispatch(
+            target,
+            new CheckpointPublicationRequest(
+                "orders-ready",
+                PipelineJson.mapper().valueToTree(new PublishedOrder("o-1", "c-1"))),
+            "tenant-1",
+            "   ").await().indefinitely();
+
+        assertEquals("orders-ready", captured.get().key());
+    }
 
     @Test
     void dispatchPublishesStrictEnvelopeToConfiguredTopic() throws Exception {

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationRequestTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/kafka/KafkaCheckpointPublicationRequestTest.java
@@ -1,0 +1,90 @@
+package org.pipelineframework.checkpoint.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaCheckpointPublicationRequestTest {
+
+    @Test
+    void constructsWithAllFields() {
+        KafkaCheckpointPublicationRequest request = new KafkaCheckpointPublicationRequest(
+            "checkout.orders.ready.v1", "idem-1", "{\"orderId\":\"o-1\"}");
+
+        assertEquals("checkout.orders.ready.v1", request.topic());
+        assertEquals("idem-1", request.key());
+        assertEquals("{\"orderId\":\"o-1\"}", request.body());
+    }
+
+    @Test
+    void constructsWithNullKey() {
+        KafkaCheckpointPublicationRequest request = new KafkaCheckpointPublicationRequest(
+            "checkout.orders.ready.v1", null, "{\"orderId\":\"o-1\"}");
+
+        assertNull(request.key());
+    }
+
+    @Test
+    void nullTopicThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new KafkaCheckpointPublicationRequest(null, "idem-1", "{\"orderId\":\"o-1\"}"));
+    }
+
+    @Test
+    void blankTopicThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new KafkaCheckpointPublicationRequest("   ", "idem-1", "{\"orderId\":\"o-1\"}"));
+    }
+
+    @Test
+    void emptyTopicThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new KafkaCheckpointPublicationRequest("", "idem-1", "{\"orderId\":\"o-1\"}"));
+    }
+
+    @Test
+    void nullBodyThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new KafkaCheckpointPublicationRequest("checkout.orders.ready.v1", "idem-1", null));
+    }
+
+    @Test
+    void blankBodyThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new KafkaCheckpointPublicationRequest("checkout.orders.ready.v1", "idem-1", "   "));
+    }
+
+    @Test
+    void topicIsTrimmerd() {
+        KafkaCheckpointPublicationRequest request = new KafkaCheckpointPublicationRequest(
+            "  checkout.orders.ready.v1  ", "idem-1", "{}");
+
+        assertEquals("checkout.orders.ready.v1", request.topic());
+    }
+
+    @Test
+    void bodyIsTrimmerd() {
+        KafkaCheckpointPublicationRequest request = new KafkaCheckpointPublicationRequest(
+            "checkout.orders.ready.v1", "idem-1", "  {}  ");
+
+        assertEquals("{}", request.body());
+    }
+
+    @Test
+    void blankKeyNormalizesToNull() {
+        KafkaCheckpointPublicationRequest request = new KafkaCheckpointPublicationRequest(
+            "checkout.orders.ready.v1", "   ", "{}");
+
+        assertNull(request.key());
+    }
+
+    @Test
+    void keyIsTrimmerd() {
+        KafkaCheckpointPublicationRequest request = new KafkaCheckpointPublicationRequest(
+            "checkout.orders.ready.v1", "  idem-1  ", "{}");
+
+        assertEquals("idem-1", request.key());
+    }
+}


### PR DESCRIPTION
## Summary
- add Kafka as a runtime checkpoint handoff target kind using `pipeline.handoff.bindings.<publication>.targets.<target>.kind=KAFKA`
- add framework-owned Kafka checkpoint envelopes plus SmallRye publisher/consumer adapters behind explicit build properties
- route Kafka checkpoint messages into the existing `CheckpointPublicationAdmissionService` while preserving TPF-owned publication, tenant, idempotency, and payload metadata
- update brokered-boundary and checkpoint handoff docs to mark Kafka checkpoint handoff as supported and leave SQS checkpoint handoff deferred

## Validation
- `./mvnw -f framework/pom.xml -pl runtime,runtime-core -Dtest='*Checkpoint*Kafka*,CheckpointPublicationServiceTest,PipelineHandoffConfigTest' -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipTests compile`
- `./mvnw -f framework/pom.xml -pl runtime spotless:check`
- `npm --prefix docs run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded checkpoint handoff guidance with explicit Kafka configuration details, binding shapes, and implementation ordering.
  * Clarified support status for Kafka checkpoint publication/subscription with updated configuration path documentation.

* **New Features**
  * Added Kafka-backed checkpoint publication/subscription target support for brokered checkpoint handoff.
  * Enhanced checkpoint configuration to support Kafka topic specification and runtime target resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->