### PR TITLE
Fix release-blocking await and native lanes

### DIFF
--- a/examples/search/common/pom.xml
+++ b/examples/search/common/pom.xml
@@ -314,7 +314,7 @@
         <profile>
             <id>native</id>
             <properties>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
+                <quarkus.build.skip>true</quarkus.build.skip>
                 <skipITs>false</skipITs>
             </properties>
         </profile>

--- a/framework/runtime/pom.xml
+++ b/framework/runtime/pom.xml
@@ -222,6 +222,17 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.40.3</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumer.java
@@ -1,5 +1,6 @@
 package org.pipelineframework.awaitable.kafka;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
@@ -11,9 +12,11 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.pipelineframework.awaitable.AwaitInteractionNotFoundException;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
 import org.pipelineframework.awaitable.AwaitCompletionAdmissionFailures;
 import org.pipelineframework.awaitable.AwaitCompletionMetrics;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.PipelineExecutionService;
 import org.jboss.logging.Logger;
 import org.pipelineframework.config.pipeline.PipelineJson;
@@ -27,9 +30,13 @@ public class KafkaAwaitCompletionConsumer {
 
     public static final String INCOMING_CHANNEL = "tpf-await-kafka-responses";
     private static final Logger LOG = Logger.getLogger(KafkaAwaitCompletionConsumer.class);
+    private static final Duration DEFAULT_NOT_FOUND_RETRY_DELAY = Duration.ofMillis(100);
+    private static final int DEFAULT_NOT_FOUND_RETRY_ATTEMPTS = 30;
 
     @Inject
     PipelineExecutionService executionService;
+    Duration notFoundRetryDelay = DEFAULT_NOT_FOUND_RETRY_DELAY;
+    int notFoundRetryAttempts = DEFAULT_NOT_FOUND_RETRY_ATTEMPTS;
 
     public KafkaAwaitCompletionConsumer() {
     }
@@ -38,24 +45,33 @@ public class KafkaAwaitCompletionConsumer {
         this.executionService = executionService;
     }
 
+    KafkaAwaitCompletionConsumer(
+        PipelineExecutionService executionService,
+        Duration notFoundRetryDelay,
+        int notFoundRetryAttempts
+    ) {
+        this.executionService = executionService;
+        this.notFoundRetryDelay = notFoundRetryDelay == null ? DEFAULT_NOT_FOUND_RETRY_DELAY : notFoundRetryDelay;
+        this.notFoundRetryAttempts = Math.max(0, notFoundRetryAttempts);
+    }
+
     @Incoming(INCOMING_CHANNEL)
     public CompletionStage<Void> consume(Message<String> message) {
         Objects.requireNonNull(message, "message must not be null");
         return Uni.createFrom().item(() -> parseEnvelope(message.getPayload()))
             .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-            .onItem().transformToUni(envelope -> executionService.completeAwaitInteraction(new AwaitCompletionCommand(
-                envelope.tenantId(),
-                envelope.interactionId(),
-                envelope.correlationId(),
-                envelope.resumeToken(),
-                envelope.idempotencyKey(),
-                envelope.responsePayload(),
-                envelope.actor(),
-                System.currentTimeMillis())))
+            .onItem().transformToUni(this::admitCompletion)
             .replaceWithVoid()
             .subscribeAsCompletionStage()
             .thenCompose(ignored -> message.ack())
             .exceptionallyCompose(failure -> {
+                if (isNotFoundFailure(failure)) {
+                    AwaitCompletionMetrics.recordDroppedCompletion("kafka", "not_found");
+                    LOG.warnf(
+                        failure,
+                        "Dropping unresolved Kafka await completion after interaction lookup retries");
+                    return message.ack();
+                }
                 if (AwaitCompletionAdmissionFailures.isDeterministic(failure)) {
                     String reason = AwaitCompletionAdmissionFailures.reason(failure);
                     AwaitCompletionMetrics.recordDroppedCompletion("kafka", reason);
@@ -64,6 +80,34 @@ public class KafkaAwaitCompletionConsumer {
                 }
                 return message.nack(failure);
             });
+    }
+
+    private Uni<AwaitCompletionResult> admitCompletion(KafkaAwaitCompletionEnvelope envelope) {
+        Uni<AwaitCompletionResult> admission = Uni.createFrom().deferred(() -> executionService.completeAwaitInteraction(new AwaitCompletionCommand(
+                envelope.tenantId(),
+                envelope.interactionId(),
+                envelope.correlationId(),
+                envelope.resumeToken(),
+                envelope.idempotencyKey(),
+                envelope.responsePayload(),
+                envelope.actor(),
+                System.currentTimeMillis())));
+        if (notFoundRetryAttempts <= 0) {
+            return admission;
+        }
+        return admission
+            .onFailure(KafkaAwaitCompletionConsumer::isNotFoundFailure)
+            .retry()
+            .withBackOff(notFoundRetryDelay, notFoundRetryDelay)
+            .atMost(notFoundRetryAttempts);
+    }
+
+    private static boolean isNotFoundFailure(Throwable failure) {
+        Throwable current = failure;
+        while (current != null && current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current instanceof AwaitInteractionNotFoundException;
     }
 
     private static KafkaAwaitCompletionEnvelope parseEnvelope(String payload) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseArtifactStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseArtifactStore.java
@@ -4,9 +4,13 @@ import java.nio.file.Path;
 
 import org.pipelineframework.orchestrator.release.PipelineReleaseRecord;
 
-public interface PipelineReleaseArtifactStore {
+public interface PipelineReleaseArtifactStore extends AutoCloseable {
 
     PipelineReleaseStoredArtifact store(Path sourcePath);
 
     void verify(PipelineReleaseRecord record);
+
+    @Override
+    default void close() {
+    }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseRuntimeBeans.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/PipelineReleaseRuntimeBeans.java
@@ -12,10 +12,8 @@ import java.time.Duration;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;
-import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
-import software.amazon.awssdk.services.s3.S3Client;
 
 /**
  * Selects local/dev release runtime collaborators from orchestrator config.
@@ -27,9 +25,6 @@ public class PipelineReleaseRuntimeBeans {
 
     @Inject
     PipelineOrchestratorConfig orchestratorConfig;
-
-    @Inject
-    Instance<S3Client> s3Clients;
 
     @Produces
     @ApplicationScoped
@@ -44,7 +39,7 @@ public class PipelineReleaseRuntimeBeans {
         }
         if ("s3".equalsIgnoreCase(provider)) {
             return new S3PipelineReleaseArtifactStore(
-                s3Clients.get(),
+                S3PipelineReleaseArtifactStore.newClient(orchestratorConfig),
                 S3PipelineReleaseArtifactStore.bucket(orchestratorConfig),
                 S3PipelineReleaseArtifactStore.prefix(orchestratorConfig));
         }
@@ -52,16 +47,8 @@ public class PipelineReleaseRuntimeBeans {
             "Unsupported pipeline.orchestrator.releases.storage.provider '" + provider + "'");
     }
 
-    @Produces
-    @ApplicationScoped
-    S3Client s3Client() {
-        return S3PipelineReleaseArtifactStore.newClient(orchestratorConfig);
-    }
-
-    void closeS3Client(@Disposes S3Client client) {
-        if (client != null) {
-            client.close();
-        }
+    void closePipelineReleaseArtifactStore(@Disposes PipelineReleaseArtifactStore store) {
+        store.close();
     }
 
     @Produces

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStore.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/S3PipelineReleaseArtifactStore.java
@@ -110,6 +110,11 @@ public class S3PipelineReleaseArtifactStore implements PipelineReleaseArtifactSt
         return prefix;
     }
 
+    @Override
+    public void close() {
+        client.close();
+    }
+
     private String objectKey(String checksum, Path sourcePath) {
         String filename = stripChecksumPrefix(checksum);
         String sourceName = sourcePath.getFileName() == null ? "" : sourcePath.getFileName().toString();

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/kafka/KafkaAwaitCompletionConsumerTest.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.mutiny.Uni;
@@ -98,11 +99,46 @@ class KafkaAwaitCompletionConsumerTest {
     }
 
     @Test
-    void deterministicNotFoundFailureAcksMessage() {
+    void notFoundFailureRetriesBeforeAckingMessage() {
+        PipelineExecutionService executionService = mock(PipelineExecutionService.class);
+        AtomicInteger attempts = new AtomicInteger();
+        when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
+            .thenAnswer(invocation -> attempts.incrementAndGet() < 3
+                ? Uni.createFrom().failure(new AwaitInteractionNotFoundException("missing"))
+                : Uni.createFrom().item(new AwaitCompletionResult(record(), false)));
+        KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(
+            executionService,
+            Duration.ofMillis(1),
+            3);
+        AtomicReference<Boolean> acked = new AtomicReference<>(false);
+        AtomicReference<Throwable> nacked = new AtomicReference<>();
+
+        consumer.consume(message("""
+            {
+              "tenantId": "tenant-1",
+              "interactionId": "interaction-1",
+              "idempotencyKey": "completion-1",
+              "responsePayload": {"decision": "approved"}
+            }
+            """, acked, nacked))
+            .toCompletableFuture()
+            .orTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+            .join();
+
+        assertEquals(3, attempts.get());
+        assertEquals(Boolean.TRUE, acked.get());
+        assertEquals(null, nacked.get());
+    }
+
+    @Test
+    void unresolvedNotFoundFailureAcksMessageAfterRetries() {
         PipelineExecutionService executionService = mock(PipelineExecutionService.class);
         when(executionService.completeAwaitInteraction(any(AwaitCompletionCommand.class)))
             .thenReturn(Uni.createFrom().failure(new AwaitInteractionNotFoundException("missing")));
-        KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(executionService);
+        KafkaAwaitCompletionConsumer consumer = new KafkaAwaitCompletionConsumer(
+            executionService,
+            Duration.ofMillis(1),
+            1);
         AtomicReference<Boolean> acked = new AtomicReference<>(false);
         AtomicReference<Throwable> nacked = new AtomicReference<>();
 


### PR DESCRIPTION
## Summary
- retry Kafka await completions that arrive before the owning interaction is visible, then ack/drop still-unresolved completions as stale or unowned instead of fail-stopping the Kafka channel
- keep Search common from running its own Quarkus native build in the native profile
- make release S3 artifact storage native-friendly by using the URL connection client, adding the AWS CRT runtime dependency, and creating the S3 client lazily only when the S3 store is selected

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -am -Dtest=KafkaAwaitCompletionConsumerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl runtime -am -Dtest='KafkaAwaitCompletionConsumerTest,S3PipelineReleaseArtifactStoreTest' -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl runtime spotless:check -DskipTests`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipTests install`
- `./examples/csv-payments/build-pipeline-runtime.sh -DskipTests -Dquarkus.container-image.build=true`
- `./mvnw -f examples/csv-payments/pom.pipeline-runtime.xml -pl orchestrator-svc -Dcsv.runtime.layout=pipeline-runtime -Dcsv.e2e.pipeline.wait.seconds=240 -Dtest=PipelineRuntimeTopologyTest -Dit.test=CsvPaymentsPipelineRuntimeEndToEndIT -Dquarkus.container-image.build=false verify`
- `JENV_VERSION=21.0.9 ./mvnw -f examples/search/pom.xml -pl crawl-source-svc -am -DskipTests -Dtpf.build.platform=FUNCTION -Dtpf.build.transport=REST -Dtpf.build.rest.naming.strategy=RESOURCEFUL -Dtpf.build.lambda.scope=compile -Dquarkus.profile=lambda -Dquarkus.container-image.build=false -Dquarkus.native.enabled=true -Pnative package`

## Release note
This PR only removes current `main` blockers for the planned `v26.6.1` release. Do not push `v26.6.1` until this PR is merged and the `main` workflows are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry logic for Kafka completion operations when lookups fail, improving reliability.

* **Improvements**
  * Enhanced resource cleanup for artifact storage operations.

* **Chores**
  * Updated AWS CRT dependency and Maven configuration.
  * Expanded test coverage for error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->