### PR TITLE
Add Spring Reactor unary authoring

### DIFF
--- a/docs/guide/evolve/runtime-core-decoupling.md
+++ b/docs/guide/evolve/runtime-core-decoupling.md
@@ -66,15 +66,17 @@ The `spring` renderer profile now has two narrow generated execution proofs:
 - reactive-authored `UNARY_UNARY` steps
 - generated Spring `@Component` local step beans
 
-Generated Spring local step beans implement the neutral `runtime-core` `PipelineUnaryStep<I, O>` contract and adapt the authored Mutiny service boundary to `CompletionStage` at the generated-code edge. `framework/runtime-spring` contributes `SpringPipelineRunner`, an adapter over the shared `PipelineRunnerCore`; the Quarkus `PipelineRunner` also delegates ordered step sequencing to that same core.
+Generated Spring local step beans implement the neutral `runtime-core` `PipelineUnaryStep<I, O>` contract and adapt authored `Uni<Out>` or Spring-profile `Mono<Out>` service boundaries to `CompletionStage` at the generated-code edge. `framework/runtime-spring` contributes `SpringPipelineRunner`, an adapter over the shared `PipelineRunnerCore`; the Quarkus `PipelineRunner` also delegates ordered step sequencing to that same core.
 
 The same profile also supports a constrained `pipeline.transport=REST`, `pipeline.platform=COMPUTE` unary smoke. Generation emits Spring WebFlux `@RestController` resources and the matching Spring unary step beans, then routes the HTTP request through `SpringPipelineRunner` and the shared runner core.
 
 `framework/api` now carries the tiny framework-neutral generated-code surface (`Mapper` and `GeneratedRole`) used by Spring generated applications. `framework/runtime` depends on that API module so existing Quarkus users remain source-compatible through the current runtime artifact.
 
-`framework/spring-smoke-tests` is the first real generated Spring Boot application smoke. It compiles a YAML-only `REST + COMPUTE` unary pipeline with `pipeline.codegen.rendererProfile=spring`, starts a Spring Boot WebFlux test context, invokes the generated REST endpoint, and verifies execution through `SpringPipelineRunner`. The authored service is a plain Spring component with `process(In): Uni<Out>` and no `@PipelineStep` or `ReactiveService` dependency.
+`framework/spring-smoke-tests` is the first real generated Spring Boot application smoke. It compiles a YAML-only `REST + COMPUTE` unary pipeline with `pipeline.codegen.rendererProfile=spring`, starts a Spring Boot WebFlux test context, invokes the generated REST endpoint, and verifies execution through `SpringPipelineRunner`. The authored service is a plain Spring component with `process(In): Mono<Out>` and no `@PipelineStep`, `ReactiveService`, or direct Mutiny dependency.
 
-Unsupported Spring profile combinations fail at build time instead of falling back to Quarkus generation. The unsupported set still includes Reactor-native generated service contracts, gRPC, function handlers, await/durable/checkpoint/broker paths, persistence, delegated/operator steps, side effects, REST client-step remote boundaries, and non-unary streaming shapes.
+Unsupported Spring profile combinations fail at build time instead of falling back to Quarkus generation. The unsupported set still includes public Reactor service interfaces, Reactor-native core execution, gRPC, function handlers, await/durable/checkpoint/broker paths, persistence, delegated/operator steps, side effects, REST client-step remote boundaries, and non-unary streaming shapes.
+
+`Mono<Out>` is currently supported only for YAML-declared Spring-profile unary services. Generated Spring local steps adapt `Mono` to the neutral `CompletionStage` runner boundary with `toFuture()`. Reactor context propagation, `Flux`, and Reactor-native core execution remain deferred.
 
 ## Vert.x seam and context propagation
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
@@ -32,6 +32,7 @@ import org.pipelineframework.parallelism.ThreadSafety;
  * @param mapperFallbackMode Gets mapper fallback mode used when no explicit/inferred mapper matches.
  * @param remoteExecution Gets remote operator execution metadata when the step is remote, otherwise null.
  * @param serviceApiKind Distinguishes reactive-authored from blocking-authored internal services.
+ * @param reactiveReturnKind Identifies the reactive return library used by unary reactive services.
  */
 public record PipelineStepModel(
         String serviceName,
@@ -52,7 +53,8 @@ public record PipelineStepModel(
         ClassName externalMapper,
         MapperFallbackMode mapperFallbackMode,
         PipelineTemplateStepExecution remoteExecution,
-        ServiceApiKind serviceApiKind
+        ServiceApiKind serviceApiKind,
+        ReactiveReturnKind reactiveReturnKind
 ) {
     /**
          * Creates a new PipelineStepModel with the supplied service identity, type mappings and generation configuration.
@@ -95,7 +97,8 @@ public record PipelineStepModel(
             ClassName externalMapper,
             MapperFallbackMode mapperFallbackMode,
             PipelineTemplateStepExecution remoteExecution,
-            ServiceApiKind serviceApiKind) {
+            ServiceApiKind serviceApiKind,
+            ReactiveReturnKind reactiveReturnKind) {
         // Validate non-null invariants
         if (serviceName == null)
             throw new IllegalArgumentException("serviceName cannot be null");
@@ -133,6 +136,52 @@ public record PipelineStepModel(
         this.mapperFallbackMode = mapperFallbackMode == null ? MapperFallbackMode.NONE : mapperFallbackMode;
         this.remoteExecution = remoteExecution;
         this.serviceApiKind = serviceApiKind == null ? ServiceApiKind.REACTIVE : serviceApiKind;
+        this.reactiveReturnKind = reactiveReturnKind == null ? ReactiveReturnKind.MUTINY_UNI : reactiveReturnKind;
+    }
+
+    /**
+     * @deprecated prefer {@link Builder} for construction.
+     */
+    @Deprecated
+    public PipelineStepModel(String serviceName,
+            String generatedName,
+            String servicePackage,
+            ClassName serviceClassName,
+            TypeMapping inputMapping,
+            TypeMapping outputMapping,
+            StreamingShape streamingShape,
+            Set<GenerationTarget> enabledTargets,
+            ExecutionMode executionMode,
+            DeploymentRole deploymentRole,
+            boolean sideEffect,
+            ClassName cacheKeyGenerator,
+            OrderingRequirement orderingRequirement,
+            ThreadSafety threadSafety,
+            ClassName delegateService,
+            ClassName externalMapper,
+            MapperFallbackMode mapperFallbackMode,
+            PipelineTemplateStepExecution remoteExecution,
+            ServiceApiKind serviceApiKind) {
+        this(serviceName,
+            generatedName,
+            servicePackage,
+            serviceClassName,
+            inputMapping,
+            outputMapping,
+            streamingShape,
+            enabledTargets,
+            executionMode,
+            deploymentRole,
+            sideEffect,
+            cacheKeyGenerator,
+            orderingRequirement,
+            threadSafety,
+            delegateService,
+            externalMapper,
+            mapperFallbackMode,
+            remoteExecution,
+            serviceApiKind,
+            ReactiveReturnKind.MUTINY_UNI);
     }
 
     /**
@@ -319,6 +368,7 @@ public record PipelineStepModel(
         private MapperFallbackMode mapperFallbackMode = MapperFallbackMode.NONE;
         private PipelineTemplateStepExecution remoteExecution;
         private ServiceApiKind serviceApiKind = ServiceApiKind.REACTIVE;
+        private ReactiveReturnKind reactiveReturnKind = ReactiveReturnKind.MUTINY_UNI;
 
         /**
          * Sets the service name.
@@ -541,6 +591,17 @@ public record PipelineStepModel(
         }
 
         /**
+         * Sets the reactive return library for unary reactive services.
+         *
+         * @param reactiveReturnKind reactive return library marker
+         * @return this {@link PipelineStepModel.Builder} for chaining
+         */
+        public Builder reactiveReturnKind(ReactiveReturnKind reactiveReturnKind) {
+            this.reactiveReturnKind = reactiveReturnKind;
+            return this;
+        }
+
+        /**
          * Create a PipelineStepModel populated from the builder's current state.
          *
          * @return a PipelineStepModel populated with the builder's state
@@ -584,7 +645,8 @@ public record PipelineStepModel(
                 externalMapper,
                 mapperFallbackMode,
                 remoteExecution,
-                serviceApiKind);
+                serviceApiKind,
+                reactiveReturnKind);
         }
     }
     
@@ -614,7 +676,8 @@ public record PipelineStepModel(
             externalMapper,
             mapperFallbackMode,
             remoteExecution,
-            serviceApiKind
+            serviceApiKind,
+            reactiveReturnKind
         );
     }
 
@@ -650,6 +713,7 @@ public record PipelineStepModel(
             .externalMapper(externalMapper)
             .mapperFallbackMode(mapperFallbackMode)
             .remoteExecution(remoteExecution)
-            .serviceApiKind(serviceApiKind);
+            .serviceApiKind(serviceApiKind)
+            .reactiveReturnKind(reactiveReturnKind);
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/ReactiveReturnKind.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/ReactiveReturnKind.java
@@ -1,0 +1,9 @@
+package org.pipelineframework.processor.ir;
+
+/**
+ * Identifies the reactive library used by an authored unary service boundary.
+ */
+public enum ReactiveReturnKind {
+    MUTINY_UNI,
+    REACTOR_MONO
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -1127,7 +1128,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return null;
         }
         if (combinedMatches.isEmpty()) {
-            return resolvePlainUnaryProcessSignature(ctx, serviceElement, messager);
+            return resolvePlainUnaryProcessSignature(ctx, serviceElement, messager).orElse(null);
         }
         SupportedServiceSignature match = combinedMatches.get(0);
         if (match.materializingWarning() != null) {
@@ -1139,7 +1140,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         return match;
     }
 
-    private SupportedServiceSignature resolvePlainUnaryProcessSignature(
+    private Optional<SupportedServiceSignature> resolvePlainUnaryProcessSignature(
             PipelineCompilationContext ctx,
             TypeElement serviceElement,
             javax.annotation.processing.Messager messager) {
@@ -1183,9 +1184,9 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                 "Internal service '" + serviceElement.getQualifiedName()
                     + "' declares multiple public process(In): Uni<Out>" + springPlainMonoHint(ctx)
                     + " methods. Please declare exactly one.");
-            return null;
+            return Optional.empty();
         }
-        return matches.isEmpty() ? null : matches.getFirst();
+        return matches.isEmpty() ? Optional.empty() : Optional.of(matches.getFirst());
     }
 
     private boolean isSpringRendererProfile(PipelineCompilationContext ctx) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -33,6 +33,7 @@ import org.pipelineframework.processor.ir.ExecutionMode;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.MapperFallbackMode;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ReactiveReturnKind;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TypeMapping;
@@ -330,6 +331,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         }
 
         SupportedServiceSignature serviceSignature = resolveSupportedInternalSignature(
+            ctx,
             serviceClass,
             ctx.getProcessingEnv().getTypeUtils(),
             ctx.getProcessingEnv().getMessager());
@@ -337,7 +339,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal step service '" + stepDef.executionClass().canonicalName()
-                    + "' must implement exactly one supported service interface or declare exactly one public process(In): Uni<Out> method for step '"
+                    + "' must implement exactly one supported service interface or declare exactly one public process(In): Uni<Out>"
+                    + springPlainMonoHint(ctx) + " method for step '"
                     + stepDef.name() + "'");
             return null;
         }
@@ -408,6 +411,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .outputMapping(new TypeMapping(outputType, outboundMapper, outboundMapper != null, outputType))
             .streamingShape(serviceSignature.shape())
             .serviceApiKind(serviceSignature.apiKind())
+            .reactiveReturnKind(serviceSignature.reactiveReturnKind())
             .build();
     }
 
@@ -454,6 +458,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .sideEffect(false)
             .cacheKeyGenerator(null)
             .serviceApiKind(serviceSignature.apiKind())
+            .reactiveReturnKind(serviceSignature.reactiveReturnKind())
             .build();
     }
 
@@ -1046,6 +1051,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
     }
 
     private SupportedServiceSignature resolveSupportedInternalSignature(
+            PipelineCompilationContext ctx,
             TypeElement serviceElement,
             Types typeUtils,
             javax.annotation.processing.Messager messager) {
@@ -1121,7 +1127,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return null;
         }
         if (combinedMatches.isEmpty()) {
-            return resolvePlainUniProcessSignature(serviceElement, messager);
+            return resolvePlainUnaryProcessSignature(ctx, serviceElement, messager);
         }
         SupportedServiceSignature match = combinedMatches.get(0);
         if (match.materializingWarning() != null) {
@@ -1133,10 +1139,12 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         return match;
     }
 
-    private SupportedServiceSignature resolvePlainUniProcessSignature(
+    private SupportedServiceSignature resolvePlainUnaryProcessSignature(
+            PipelineCompilationContext ctx,
             TypeElement serviceElement,
             javax.annotation.processing.Messager messager) {
         List<SupportedServiceSignature> matches = new ArrayList<>();
+        boolean springProfile = isSpringRendererProfile(ctx);
         for (Element enclosed : serviceElement.getEnclosedElements()) {
             if (!(enclosed instanceof ExecutableElement method)) {
                 continue;
@@ -1149,8 +1157,15 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             }
             TypeMirror returnType = method.getReturnType();
             if (!(returnType instanceof DeclaredType declaredReturn)
-                || !isDeclaredType(declaredReturn, "io.smallrye.mutiny.Uni")
                 || declaredReturn.getTypeArguments().size() != 1) {
+                continue;
+            }
+            ReactiveReturnKind reactiveReturnKind;
+            if (isDeclaredType(declaredReturn, "io.smallrye.mutiny.Uni")) {
+                reactiveReturnKind = ReactiveReturnKind.MUTINY_UNI;
+            } else if (springProfile && isDeclaredType(declaredReturn, "reactor.core.publisher.Mono")) {
+                reactiveReturnKind = ReactiveReturnKind.REACTOR_MONO;
+            } else {
                 continue;
             }
             matches.add(new SupportedServiceSignature(
@@ -1158,6 +1173,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                 StreamingShape.UNARY_UNARY,
                 TypeName.get(method.getParameters().getFirst().asType()),
                 TypeName.get(declaredReturn.getTypeArguments().getFirst()),
+                reactiveReturnKind,
                 null));
         }
 
@@ -1165,10 +1181,19 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             messager.printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal service '" + serviceElement.getQualifiedName()
-                    + "' declares multiple public process(In): Uni<Out> methods. Please declare exactly one.");
+                    + "' declares multiple public process(In): Uni<Out>" + springPlainMonoHint(ctx)
+                    + " methods. Please declare exactly one.");
             return null;
         }
         return matches.isEmpty() ? null : matches.getFirst();
+    }
+
+    private boolean isSpringRendererProfile(PipelineCompilationContext ctx) {
+        return ctx != null && "spring".equalsIgnoreCase(ctx.getRendererProfile());
+    }
+
+    private String springPlainMonoHint(PipelineCompilationContext ctx) {
+        return isSpringRendererProfile(ctx) ? " or process(In): Mono<Out>" : "";
     }
 
     private boolean isDeclaredType(DeclaredType declaredType, String qualifiedName) {
@@ -1219,6 +1244,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             shape,
             TypeName.get(declared.getTypeArguments().get(0)),
             TypeName.get(declared.getTypeArguments().get(1)),
+            ReactiveReturnKind.MUTINY_UNI,
             materializingWarning));
         matchNames.add(interfaceName);
     }
@@ -1422,6 +1448,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         StreamingShape shape,
         TypeName inputType,
         TypeName outputType,
+        ReactiveReturnKind reactiveReturnKind,
         String materializingWarning
     ) {
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
@@ -32,6 +32,7 @@ import org.pipelineframework.processor.PipelineStepProcessor;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.LocalBinding;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ReactiveReturnKind;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 
@@ -79,7 +80,7 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
             .addModifiers(Modifier.PUBLIC)
             .returns(completionStage)
             .addParameter(inputType, "input")
-            .addStatement("return this.$N.process(input).subscribeAsCompletionStage()", serviceFieldName)
+            .addStatement("return this.$N.process(input).$L", serviceFieldName, completionStageAdapter(model))
             .build();
 
         return TypeSpec.classBuilder(getClientStepClassName(model))
@@ -90,6 +91,12 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
             .addMethod(constructor)
             .addMethod(applyMethod)
             .build();
+    }
+
+    private String completionStageAdapter(PipelineStepModel model) {
+        return model.reactiveReturnKind() == ReactiveReturnKind.REACTOR_MONO
+            ? "toFuture()"
+            : "subscribeAsCompletionStage()";
     }
 
     private void validateSupported(PipelineStepModel model) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
@@ -94,9 +94,10 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
     }
 
     private String completionStageAdapter(PipelineStepModel model) {
-        return model.reactiveReturnKind() == ReactiveReturnKind.REACTOR_MONO
-            ? "toFuture()"
-            : "subscribeAsCompletionStage()";
+        return switch (model.reactiveReturnKind()) {
+            case MUTINY_UNI -> "subscribeAsCompletionStage()";
+            case REACTOR_MONO -> "toFuture()";
+        };
     }
 
     private void validateSupported(PipelineStepModel model) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
@@ -275,6 +275,209 @@ class YamlDrivenStepGenerationTest {
     }
 
     @Test
+    void generatesYamlInternalStepFromPlainMonoProcessMethodWithSpringProfile() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-plain-mono.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import reactor.core.publisher.Mono;
+
+            public class PaymentService {
+                public Mono<PaymentStatus> process(PaymentRecord input) {
+                    return Mono.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus, monoStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertTrue(result.success(), "Expected plain Mono process method compilation to succeed: " + result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepFromPlainMonoProcessMethodWithoutSpringProfile() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-plain-mono-quarkus.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import reactor.core.publisher.Mono;
+
+            public class PaymentService {
+                public Mono<PaymentStatus> process(PaymentRecord input) {
+                    return Mono.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(yamlFile, List.of(paymentService, paymentRecord, paymentStatus, monoStub));
+        assertFalse(result.success(), "Expected default renderer profile to reject plain Mono process methods");
+        assertTrue(
+            result.errorSummary().contains("must implement exactly one supported service interface or declare exactly one public process(In): Uni<Out> method"),
+            result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenPlainMonoProcessMethodIsRaw() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-raw-plain-mono.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import reactor.core.publisher.Mono;
+
+            public class PaymentService {
+                @SuppressWarnings("rawtypes")
+                public Mono process(PaymentRecord input) {
+                    return Mono.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus, monoStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected raw Mono process method compilation to fail");
+        assertTrue(
+            result.errorSummary().contains("process(In): Mono<Out>"),
+            result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenMultiplePlainReactiveProcessMethodsExist() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-multiple-plain-reactive.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import io.smallrye.mutiny.Uni;
+            import reactor.core.publisher.Mono;
+
+            public class PaymentService {
+                public Uni<PaymentStatus> process(PaymentRecord input) {
+                    return Uni.createFrom().item(new PaymentStatus());
+                }
+
+                public Mono<PaymentStatus> process(AlternatePaymentRecord input) {
+                    return Mono.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writeSource("PaymentRecord.java", """
+            package com.example.app;
+
+            public class PaymentRecord {
+            }
+            """);
+        Path alternatePaymentRecord = writeSource("AlternatePaymentRecord.java", """
+            package com.example.app;
+
+            public class AlternatePaymentRecord {
+            }
+            """);
+        Path paymentStatus = writeSource("PaymentStatus.java", """
+            package com.example.app;
+
+            public class PaymentStatus {
+            }
+            """);
+        Path uniStub = writeUniStub();
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, alternatePaymentRecord, paymentStatus, uniStub, monoStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected multiple plain reactive process methods to fail");
+        assertTrue(
+            result.errorSummary().contains("declares multiple public process(In): Uni<Out> or process(In): Mono<Out> methods"),
+            result.errorSummary());
+    }
+
+    @Test
     void failsYamlInternalStepWhenPlainUniProcessMethodIsStatic() throws IOException {
         Path yamlFile = tempDir.resolve("pipeline-internal-static-plain-uni.yaml");
         Files.writeString(yamlFile, """
@@ -944,6 +1147,18 @@ class YamlDrivenStepGenerationTest {
                     public <U> Uni<U> item(U value) {
                         return new Uni<>();
                     }
+                }
+            }
+            """);
+    }
+
+    private Path writeMonoStub() throws IOException {
+        return writeSource("Mono.java", """
+            package reactor.core.publisher;
+
+            public class Mono<T> {
+                public static <U> Mono<U> just(U value) {
+                    return new Mono<>();
                 }
             }
             """);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/ir/PipelineStepModelTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/ir/PipelineStepModelTest.java
@@ -380,13 +380,12 @@ class PipelineStepModelTest {
                 .build();
 
         PipelineStepModel modified = original.toBuilder()
-                .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
                 .reactiveReturnKind(ReactiveReturnKind.REACTOR_MONO)
                 .build();
 
         assertEquals(ServiceApiKind.REACTIVE, original.serviceApiKind());
         assertEquals(ReactiveReturnKind.MUTINY_UNI, original.reactiveReturnKind());
-        assertEquals(ServiceApiKind.BLOCKING_ITERATOR, modified.serviceApiKind());
+        assertEquals(ServiceApiKind.REACTIVE, modified.serviceApiKind());
         assertEquals(ReactiveReturnKind.REACTOR_MONO, modified.reactiveReturnKind());
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/ir/PipelineStepModelTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/ir/PipelineStepModelTest.java
@@ -281,6 +281,7 @@ class PipelineStepModelTest {
                 .build();
 
         assertEquals(ServiceApiKind.REACTIVE, model.serviceApiKind());
+        assertEquals(ReactiveReturnKind.MUTINY_UNI, model.reactiveReturnKind());
     }
 
     @Test
@@ -322,6 +323,25 @@ class PipelineStepModelTest {
     }
 
     @Test
+    void builderCanSetReactiveReturnKind() {
+        PipelineStepModel model = new PipelineStepModel.Builder()
+                .serviceName("TestService")
+                .generatedName("TestService")
+                .servicePackage("com.example")
+                .serviceClassName(ClassName.get("com.example", "TestService"))
+                .inputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .outputMapping(new TypeMapping(TypeName.INT, TypeName.INT, false))
+                .streamingShape(StreamingShape.UNARY_UNARY)
+                .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+                .executionMode(ExecutionMode.DEFAULT)
+                .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+                .reactiveReturnKind(ReactiveReturnKind.REACTOR_MONO)
+                .build();
+
+        assertEquals(ReactiveReturnKind.REACTOR_MONO, model.reactiveReturnKind());
+    }
+
+    @Test
     void toBuilderPreservesServiceApiKind() {
         PipelineStepModel original = new PipelineStepModel.Builder()
                 .serviceName("TestService")
@@ -340,6 +360,7 @@ class PipelineStepModelTest {
         PipelineStepModel rebuilt = original.toBuilder().build();
 
         assertEquals(ServiceApiKind.BLOCKING, rebuilt.serviceApiKind());
+        assertEquals(ReactiveReturnKind.MUTINY_UNI, rebuilt.reactiveReturnKind());
     }
 
     @Test
@@ -360,10 +381,13 @@ class PipelineStepModelTest {
 
         PipelineStepModel modified = original.toBuilder()
                 .serviceApiKind(ServiceApiKind.BLOCKING_ITERATOR)
+                .reactiveReturnKind(ReactiveReturnKind.REACTOR_MONO)
                 .build();
 
         assertEquals(ServiceApiKind.REACTIVE, original.serviceApiKind());
+        assertEquals(ReactiveReturnKind.MUTINY_UNI, original.reactiveReturnKind());
         assertEquals(ServiceApiKind.BLOCKING_ITERATOR, modified.serviceApiKind());
+        assertEquals(ReactiveReturnKind.REACTOR_MONO, modified.reactiveReturnKind());
     }
 
     @Test
@@ -390,6 +414,7 @@ class PipelineStepModelTest {
                 null /* serviceApiKind */);
 
         assertEquals(ServiceApiKind.REACTIVE, model.serviceApiKind());
+        assertEquals(ReactiveReturnKind.MUTINY_UNI, model.reactiveReturnKind());
     }
 
     @Test
@@ -411,6 +436,7 @@ class PipelineStepModelTest {
         PipelineStepModel modified = original.withDeploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT);
 
         assertEquals(ServiceApiKind.BLOCKING_ITERATOR, modified.serviceApiKind());
+        assertEquals(ReactiveReturnKind.MUTINY_UNI, modified.reactiveReturnKind());
         assertEquals(DeploymentRole.ORCHESTRATOR_CLIENT, modified.deploymentRole());
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
@@ -28,6 +28,7 @@ import org.pipelineframework.processor.ir.ExecutionMode;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.LocalBinding;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ReactiveReturnKind;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.TypeMapping;
@@ -56,9 +57,32 @@ class SpringLocalClientStepRendererTest {
         assertTrue(source.contains("private final PaymentService paymentService;"));
         assertTrue(source.contains("public PaymentLocalClientStep(PaymentService paymentService)"));
         assertTrue(source.contains("return this.paymentService.process(input).subscribeAsCompletionStage();"));
+        assertFalse(source.contains(".toFuture();"));
         assertFalse(source.contains("io.quarkus."));
         assertFalse(source.contains("jakarta.enterprise."));
         assertFalse(source.contains("jakarta.inject."));
+        assertFalse(source.contains("io.vertx."));
+        assertFalse(source.contains("org.jboss.resteasy."));
+        assertFalse(source.contains("jakarta.ws.rs."));
+    }
+
+    @Test
+    void rendersReactorMonoUnaryLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(model(
+                StreamingShape.UNARY_UNARY,
+                ServiceApiKind.REACTIVE,
+                ReactiveReturnKind.REACTOR_MONO)),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/PaymentLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("return this.paymentService.process(input).toFuture();"));
+        assertFalse(source.contains("subscribeAsCompletionStage"));
+        assertFalse(source.contains("io.smallrye.mutiny"));
+        assertFalse(source.contains("io.quarkus."));
+        assertFalse(source.contains("jakarta.enterprise."));
         assertFalse(source.contains("io.vertx."));
         assertFalse(source.contains("org.jboss.resteasy."));
         assertFalse(source.contains("jakarta.ws.rs."));
@@ -83,6 +107,10 @@ class SpringLocalClientStepRendererTest {
     }
 
     private PipelineStepModel model(StreamingShape shape, ServiceApiKind apiKind) {
+        return model(shape, apiKind, ReactiveReturnKind.MUTINY_UNI);
+    }
+
+    private PipelineStepModel model(StreamingShape shape, ServiceApiKind apiKind, ReactiveReturnKind reactiveReturnKind) {
         return new PipelineStepModel.Builder()
             .serviceName("PaymentService")
             .generatedName("PaymentService")
@@ -95,6 +123,7 @@ class SpringLocalClientStepRendererTest {
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
             .serviceApiKind(apiKind)
+            .reactiveReturnKind(reactiveReturnKind)
             .build();
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestResourceRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestResourceRendererTest.java
@@ -65,6 +65,7 @@ class SpringRestResourceRendererTest {
         assertFalse(source.contains("jakarta.enterprise."));
         assertFalse(source.contains("jakarta.inject."));
         assertFalse(source.contains("io.vertx."));
+        assertFalse(source.contains("io.smallrye.mutiny"));
         assertFalse(source.contains("org.jboss.resteasy."));
         assertFalse(source.contains("jakarta.ws.rs."));
     }

--- a/framework/spring-smoke-tests/pom.xml
+++ b/framework/spring-smoke-tests/pom.xml
@@ -79,10 +79,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>mutiny</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>

--- a/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentService.java
+++ b/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentService.java
@@ -2,15 +2,15 @@ package com.example.smoke.service;
 
 import com.example.smoke.domain.PaymentRecord;
 import com.example.smoke.domain.PaymentStatus;
-import io.smallrye.mutiny.Uni;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 @Component
 public class PaymentService {
-    public Uni<PaymentStatus> process(PaymentRecord input) {
+    public Mono<PaymentStatus> process(PaymentRecord input) {
         if (input == null) {
-            return Uni.createFrom().failure(new IllegalArgumentException("Payment input must not be null"));
+            return Mono.error(new IllegalArgumentException("Payment input must not be null"));
         }
-        return Uni.createFrom().item(new PaymentStatus(input.paymentId(), "APPROVED:" + input.cents()));
+        return Mono.just(new PaymentStatus(input.paymentId(), "APPROVED:" + input.cents()));
     }
 }

--- a/framework/spring-smoke-tests/src/test/java/com/example/smoke/SpringSmokeDependencyGuardTest.java
+++ b/framework/spring-smoke-tests/src/test/java/com/example/smoke/SpringSmokeDependencyGuardTest.java
@@ -16,6 +16,7 @@ class SpringSmokeDependencyGuardTest {
         "io.quarkus.",
         "jakarta.enterprise.",
         "io.vertx.",
+        "io.smallrye.mutiny",
         "org.jboss.resteasy.",
         "jakarta.ws.rs.");
 
@@ -24,6 +25,13 @@ class SpringSmokeDependencyGuardTest {
         assertThrows(
             ClassNotFoundException.class,
             () -> Class.forName("org.pipelineframework.service.ReactiveService"));
+    }
+
+    @Test
+    void springSmokePomDoesNotDeclareDirectMutinyDependency() throws IOException {
+        Path pom = Path.of(System.getProperty("user.dir"), "pom.xml");
+        String content = Files.readString(pom);
+        assertFalse(content.contains("<artifactId>mutiny</artifactId>"), "Spring smoke module must not declare Mutiny directly");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds the next Spring Boot portability leg: YAML-only `LOCAL/REST + COMPUTE` unary pipelines can author plain Spring services returning `Mono<Out>` when `pipeline.codegen.rendererProfile=spring`.

This keeps existing Mutiny `Uni<Out>` services and Quarkus/default-profile behavior unchanged. The slice adapts Reactor only at generated Spring local-step edges into the existing neutral `CompletionStage` runner boundary.

## Scope

- Add an internal `ReactiveReturnKind` marker for unary reactive service returns.
- Accept plain `process(In): Mono<Out>` only for the Spring renderer profile.
- Render Spring local unary steps with `.toFuture()` for Mono and keep `.subscribeAsCompletionStage()` for Uni.
- Update the generated Spring Boot REST smoke to use a plain Spring `@Component` returning Mono and no direct Mutiny dependency.
- Update Evolve docs to record the narrow Spring Mono authoring support.

## Out of scope

- No Reactor public service interfaces.
- No Reactor-native core runner/runtime migration.
- No `Flux`, streaming, Reactor context propagation, await/checkpoint/broker, gRPC, function, persistence, delegated/operator, or production Spring parity work.

## Validation

- `cr review --agent --base origin/main --config ./AGENTS.md` reported 0 findings.
- `./mvnw -f framework/pom.xml -pl deployment,spring-smoke-tests -am -Dtest=YamlDrivenStepGenerationTest,PipelineStepModelTest,SpringLocalClientStepRendererTest,SpringRestResourceRendererTest,GeneratedSpringRestSmokeTest,SpringSmokeDependencyGuardTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml verify`
- `npm --prefix docs run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Reactor `Mono` alongside Mutiny `Uni` for Spring service boundaries.
  * Generated code now intelligently adapts reactive types to neutral completion stage contracts.

* **Documentation**
  * Updated guides to clarify current Spring execution patterns and supported reactive library combinations.

* **Tests**
  * Expanded test coverage for Reactor Mono integration scenarios.

* **Chores**
  * Removed Mutiny dependency from Spring smoke test module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->