### PR TITLE
[codex] Add object publish connector boundary

### DIFF
--- a/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProvider.java
+++ b/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProvider.java
@@ -1,24 +1,41 @@
 package org.pipelineframework.connector.objectingest;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.pipelineframework.objectpublish.ObjectTargetProvider;
-import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteCloseRequest;
+import org.pipelineframework.objectpublish.ObjectWriteOpenRequest;
 import org.pipelineframework.objectpublish.ObjectWriteResult;
+import org.pipelineframework.objectpublish.ObjectWriteSession;
 import org.pipelineframework.repository.PayloadReference;
 
 /**
  * Filesystem object target provider for Object Publish.
  */
 public class FilesystemObjectTargetProvider implements ObjectTargetProvider {
+    private final Executor executor;
+
+    public FilesystemObjectTargetProvider() {
+        this(ForkJoinPool.commonPool());
+    }
+
+    FilesystemObjectTargetProvider(Executor executor) {
+        this.executor = executor;
+    }
 
     @Override
     public String providerName() {
@@ -26,44 +43,27 @@ public class FilesystemObjectTargetProvider implements ObjectTargetProvider {
     }
 
     @Override
-    public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
-        return Uni.createFrom().item(() -> writeBlocking(request))
-            .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+        return CompletableFuture.supplyAsync(() -> openBlocking(request), executor);
     }
 
-    private ObjectWriteResult writeBlocking(ObjectWriteRequest request) {
-        Path root = root(request);
-        Path path = requireUnderRoot(root, root.resolve(request.objectKey()).normalize());
+    private ObjectWriteSession openBlocking(ObjectWriteOpenRequest request) {
         try {
-            Path parent = path.getParent();
+            Path root = root(request);
+            Path finalPath = requireUnderRoot(root, root.resolve(request.objectKey()).normalize());
+            Path parent = finalPath.getParent();
             if (parent != null) {
                 Files.createDirectories(parent);
             }
-            Files.write(
-                path,
-                request.bytes(),
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING,
-                StandardOpenOption.WRITE);
-            Map<String, String> metadata = new LinkedHashMap<>(request.metadata());
-            metadata.put("target", request.targetName());
-            PayloadReference reference = new PayloadReference(
-                providerName(),
-                root.toString(),
-                request.objectKey(),
-                request.contentType(),
-                "raw",
-                request.checksum(),
-                request.bytes().length,
-                null,
-                metadata);
-            return new ObjectWriteResult(reference, request.bytes().length, request.checksum(), Instant.now());
+            Path tempPath = Files.createTempFile(parent == null ? root : parent, ".tpf-publish-", ".tmp");
+            OutputStream output = new BufferedOutputStream(Files.newOutputStream(tempPath));
+            return new FilesystemWriteSession(request, root, finalPath, tempPath, output, executor);
         } catch (IOException e) {
-            throw new IllegalStateException("Failed writing filesystem object: " + request.objectKey(), e);
+            throw new CompletionException(e);
         }
     }
 
-    private Path root(ObjectWriteRequest request) {
+    private Path root(ObjectWriteOpenRequest request) {
         Object root = request.target().location().get("root");
         if (root == null || root.toString().isBlank()) {
             throw new IllegalArgumentException("filesystem publish target '" + request.targetName() + "' requires location.root");
@@ -76,5 +76,98 @@ public class FilesystemObjectTargetProvider implements ObjectTargetProvider {
             throw new SecurityException("Filesystem object publish path escapes configured root: " + path);
         }
         return path;
+    }
+
+    private static final class FilesystemWriteSession implements ObjectWriteSession {
+        private final ObjectWriteOpenRequest request;
+        private final Path root;
+        private final Path finalPath;
+        private final Path tempPath;
+        private final OutputStream output;
+        private final Executor executor;
+        private boolean closed;
+
+        private FilesystemWriteSession(
+            ObjectWriteOpenRequest request,
+            Path root,
+            Path finalPath,
+            Path tempPath,
+            OutputStream output,
+            Executor executor
+        ) {
+            this.request = request;
+            this.root = root;
+            this.finalPath = finalPath;
+            this.tempPath = tempPath;
+            this.output = output;
+            this.executor = executor;
+        }
+
+        @Override
+        public CompletionStage<Void> write(ByteBuffer chunk) {
+            byte[] bytes = copy(chunk);
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    output.write(bytes);
+                } catch (IOException e) {
+                    throw new CompletionException(e);
+                }
+            }, executor);
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteResult> close(ObjectWriteCloseRequest closeRequest) {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    if (!closed) {
+                        output.flush();
+                        output.close();
+                        closed = true;
+                    }
+                    Files.move(tempPath, finalPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                    Map<String, String> metadata = new LinkedHashMap<>(request.metadata());
+                    metadata.putAll(closeRequest.metadata());
+                    metadata.put("target", request.targetName());
+                    PayloadReference reference = new PayloadReference(
+                        "filesystem",
+                        root.toString(),
+                        request.objectKey(),
+                        request.contentType(),
+                        "raw",
+                        closeRequest.checksum(),
+                        closeRequest.bytes(),
+                        null,
+                        metadata);
+                    return new ObjectWriteResult(reference, closeRequest.bytes(), closeRequest.checksum(), Instant.now());
+                } catch (IOException e) {
+                    throw new CompletionException(e);
+                }
+            }, executor);
+        }
+
+        @Override
+        public CompletionStage<Void> abort(Throwable cause) {
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    if (!closed) {
+                        output.close();
+                        closed = true;
+                    }
+                    Files.deleteIfExists(tempPath);
+                } catch (IOException e) {
+                    throw new CompletionException(e);
+                }
+            }, executor);
+        }
+
+        private static byte[] copy(ByteBuffer chunk) {
+            if (chunk == null) {
+                return new byte[0];
+            }
+            ByteBuffer duplicate = chunk.slice();
+            byte[] bytes = new byte[duplicate.remaining()];
+            duplicate.get(bytes);
+            return bytes;
+        }
     }
 }

--- a/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProvider.java
+++ b/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProvider.java
@@ -1,0 +1,80 @@
+package org.pipelineframework.connector.objectingest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.pipelineframework.objectpublish.ObjectTargetProvider;
+import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteResult;
+import org.pipelineframework.repository.PayloadReference;
+
+/**
+ * Filesystem object target provider for Object Publish.
+ */
+public class FilesystemObjectTargetProvider implements ObjectTargetProvider {
+
+    @Override
+    public String providerName() {
+        return "filesystem";
+    }
+
+    @Override
+    public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
+        return Uni.createFrom().item(() -> writeBlocking(request))
+            .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    }
+
+    private ObjectWriteResult writeBlocking(ObjectWriteRequest request) {
+        Path root = root(request);
+        Path path = requireUnderRoot(root, root.resolve(request.objectKey()).normalize());
+        try {
+            Path parent = path.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.write(
+                path,
+                request.bytes(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE);
+            Map<String, String> metadata = new LinkedHashMap<>(request.metadata());
+            metadata.put("target", request.targetName());
+            PayloadReference reference = new PayloadReference(
+                providerName(),
+                root.toString(),
+                request.objectKey(),
+                request.contentType(),
+                "raw",
+                request.checksum(),
+                request.bytes().length,
+                null,
+                metadata);
+            return new ObjectWriteResult(reference, request.bytes().length, request.checksum(), Instant.now());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed writing filesystem object: " + request.objectKey(), e);
+        }
+    }
+
+    private Path root(ObjectWriteRequest request) {
+        Object root = request.target().location().get("root");
+        if (root == null || root.toString().isBlank()) {
+            throw new IllegalArgumentException("filesystem publish target '" + request.targetName() + "' requires location.root");
+        }
+        return Path.of(root.toString()).toAbsolutePath().normalize();
+    }
+
+    private Path requireUnderRoot(Path root, Path path) {
+        if (!path.startsWith(root)) {
+            throw new SecurityException("Filesystem object publish path escapes configured root: " + path);
+        }
+        return path;
+    }
+}

--- a/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProvider.java
+++ b/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProvider.java
@@ -1,15 +1,24 @@
 package org.pipelineframework.connector.objectingest;
 
+import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
-import io.smallrye.mutiny.Uni;
 import org.pipelineframework.objectpublish.ObjectTargetProvider;
-import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteCloseRequest;
+import org.pipelineframework.objectpublish.ObjectWriteOpenRequest;
 import org.pipelineframework.objectpublish.ObjectWriteResult;
+import org.pipelineframework.objectpublish.ObjectWriteSession;
 import org.pipelineframework.repository.PayloadReference;
 
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -17,26 +26,47 @@ import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
  * Plain AWS SDK S3 object target provider for Object Publish.
  */
 public class S3ObjectTargetProvider implements ObjectTargetProvider, AutoCloseable {
+    static final int DEFAULT_PART_SIZE_BYTES = 8 * 1024 * 1024;
+    private static final int MIN_PART_SIZE_BYTES = 5 * 1024 * 1024;
 
     private final S3Client client;
     private final boolean ownsClient;
+    private final Executor executor;
+    private final int partSizeBytes;
     private volatile S3Client resolvedClient;
 
     public S3ObjectTargetProvider() {
-        this.client = null;
-        this.ownsClient = true;
+        this(null, true, ForkJoinPool.commonPool(), DEFAULT_PART_SIZE_BYTES);
     }
 
     S3ObjectTargetProvider(S3Client client) {
+        this(client, false, ForkJoinPool.commonPool(), DEFAULT_PART_SIZE_BYTES);
+    }
+
+    S3ObjectTargetProvider(S3Client client, Executor executor, int partSizeBytes) {
+        this(client, false, executor, partSizeBytes);
+    }
+
+    private S3ObjectTargetProvider(S3Client client, boolean ownsClient, Executor executor, int partSizeBytes) {
         this.client = client;
-        this.ownsClient = false;
+        this.ownsClient = ownsClient;
+        this.executor = executor;
+        this.partSizeBytes = Math.max(partSizeBytes, MIN_PART_SIZE_BYTES);
     }
 
     @Override
@@ -45,8 +75,19 @@ public class S3ObjectTargetProvider implements ObjectTargetProvider, AutoCloseab
     }
 
     @Override
-    public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
-        return Uni.createFrom().item(() -> writeBlocking(request));
+    public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            String bucket = required(request, "bucket");
+            String key = objectKey(request);
+            S3Client s3 = client(request);
+            CreateMultipartUploadResponse response = s3.createMultipartUpload(CreateMultipartUploadRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(request.contentType())
+                .metadata(request.metadata())
+                .build());
+            return new S3WriteSession(request, s3, bucket, key, response.uploadId(), executor, partSizeBytes);
+        }, executor);
     }
 
     @Override
@@ -56,31 +97,7 @@ public class S3ObjectTargetProvider implements ObjectTargetProvider, AutoCloseab
         }
     }
 
-    private ObjectWriteResult writeBlocking(ObjectWriteRequest request) {
-        String bucket = required(request, "bucket");
-        Map<String, String> metadata = new LinkedHashMap<>(request.metadata());
-        metadata.put("target", request.targetName());
-        PutObjectResponse response = client(request).putObject(PutObjectRequest.builder()
-            .bucket(bucket)
-            .key(request.objectKey())
-            .contentType(request.contentType())
-            .metadata(metadata)
-            .build(), RequestBody.fromBytes(request.bytes()));
-        String version = response.versionId();
-        PayloadReference reference = new PayloadReference(
-            providerName(),
-            bucket,
-            request.objectKey(),
-            request.contentType(),
-            "raw",
-            request.checksum(),
-            request.bytes().length,
-            version,
-            metadata);
-        return new ObjectWriteResult(reference, request.bytes().length, request.checksum(), Instant.now());
-    }
-
-    private S3Client client(ObjectWriteRequest request) {
+    private S3Client client(ObjectWriteOpenRequest request) {
         if (client != null) {
             return client;
         }
@@ -95,22 +112,172 @@ public class S3ObjectTargetProvider implements ObjectTargetProvider, AutoCloseab
             }
             S3ClientBuilder builder = S3Client.builder().httpClientBuilder(UrlConnectionHttpClient.builder());
             optional(request, "region").ifPresent(region -> builder.region(Region.of(region)));
-            optional(request, "endpoint").map(URI::create).ifPresent(builder::endpointOverride);
+            optional(request, "endpoint").or(() -> optional(request, "endpointOverride"))
+                .map(URI::create)
+                .ifPresent(builder::endpointOverride);
+            boolean pathStyle = Boolean.parseBoolean(optional(request, "pathStyleAccess").orElse("false"));
+            if (pathStyle) {
+                builder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build());
+            }
             resolvedClient = builder.build();
             return resolvedClient;
         }
     }
 
-    private String required(ObjectWriteRequest request, String key) {
+    private String objectKey(ObjectWriteOpenRequest request) {
+        String prefix = optional(request, "prefix").orElse("");
+        if (prefix.isBlank()) {
+            return request.objectKey();
+        }
+        String normalizedPrefix = prefix.endsWith("/") ? prefix.substring(0, prefix.length() - 1) : prefix;
+        String normalizedKey = request.objectKey().startsWith("/") ? request.objectKey().substring(1) : request.objectKey();
+        return normalizedPrefix + "/" + normalizedKey;
+    }
+
+    private String required(ObjectWriteOpenRequest request, String key) {
         return optional(request, key)
             .orElseThrow(() -> new IllegalArgumentException(
                 "s3 publish target '" + request.targetName() + "' requires location." + key));
     }
 
-    private Optional<String> optional(ObjectWriteRequest request, String key) {
+    private Optional<String> optional(ObjectWriteOpenRequest request, String key) {
         Object value = request.target().location().get(key);
         return value == null || value.toString().isBlank()
             ? Optional.empty()
             : Optional.of(value.toString().trim());
+    }
+
+    private static final class S3WriteSession implements ObjectWriteSession {
+        private final ObjectWriteOpenRequest request;
+        private final S3Client client;
+        private final String bucket;
+        private final String key;
+        private final String uploadId;
+        private final Executor executor;
+        private final int partSizeBytes;
+        private final List<CompletedPart> parts = new ArrayList<>();
+        private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        private int nextPartNumber = 1;
+        private boolean completed;
+
+        private S3WriteSession(
+            ObjectWriteOpenRequest request,
+            S3Client client,
+            String bucket,
+            String key,
+            String uploadId,
+            Executor executor,
+            int partSizeBytes
+        ) {
+            this.request = request;
+            this.client = client;
+            this.bucket = bucket;
+            this.key = key;
+            this.uploadId = uploadId;
+            this.executor = executor;
+            this.partSizeBytes = partSizeBytes;
+        }
+
+        @Override
+        public CompletionStage<Void> write(ByteBuffer chunk) {
+            byte[] bytes = copy(chunk);
+            return CompletableFuture.runAsync(() -> {
+                buffer.writeBytes(bytes);
+                while (buffer.size() >= partSizeBytes) {
+                    uploadBufferedPart(partSizeBytes);
+                }
+            }, executor);
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteResult> close(ObjectWriteCloseRequest closeRequest) {
+            return CompletableFuture.supplyAsync(() -> {
+                if (buffer.size() > 0) {
+                    uploadBufferedPart(buffer.size());
+                }
+                if (parts.isEmpty()) {
+                    client.abortMultipartUpload(abortRequest());
+                    client.putObject(
+                        PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .contentType(request.contentType())
+                            .metadata(request.metadata())
+                            .build(),
+                        RequestBody.empty());
+                } else {
+                    client.completeMultipartUpload(
+                        CompleteMultipartUploadRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .uploadId(uploadId)
+                            .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
+                            .build());
+                }
+                completed = true;
+                Map<String, String> metadata = new LinkedHashMap<>(request.metadata());
+                metadata.putAll(closeRequest.metadata());
+                metadata.put("target", request.targetName());
+                PayloadReference reference = new PayloadReference(
+                    "s3",
+                    bucket,
+                    key,
+                    request.contentType(),
+                    "raw",
+                    closeRequest.checksum(),
+                    closeRequest.bytes(),
+                    null,
+                    metadata);
+                return new ObjectWriteResult(reference, closeRequest.bytes(), closeRequest.checksum(), Instant.now());
+            }, executor);
+        }
+
+        @Override
+        public CompletionStage<Void> abort(Throwable cause) {
+            return CompletableFuture.runAsync(() -> {
+                if (!completed) {
+                    client.abortMultipartUpload(abortRequest());
+                    completed = true;
+                }
+            }, executor);
+        }
+
+        private void uploadBufferedPart(int size) {
+            byte[] payload = buffer.toByteArray();
+            byte[] part = java.util.Arrays.copyOf(payload, size);
+            buffer.reset();
+            if (payload.length > size) {
+                buffer.writeBytes(java.util.Arrays.copyOfRange(payload, size, payload.length));
+            }
+            int partNumber = nextPartNumber++;
+            UploadPartResponse response = client.uploadPart(
+                UploadPartRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .uploadId(uploadId)
+                    .partNumber(partNumber)
+                    .contentLength((long) part.length)
+                    .build(),
+                RequestBody.fromBytes(part));
+            parts.add(CompletedPart.builder().partNumber(partNumber).eTag(response.eTag()).build());
+        }
+
+        private AbortMultipartUploadRequest abortRequest() {
+            return AbortMultipartUploadRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .uploadId(uploadId)
+                .build();
+        }
+
+        private static byte[] copy(ByteBuffer chunk) {
+            if (chunk == null) {
+                return new byte[0];
+            }
+            ByteBuffer duplicate = chunk.slice();
+            byte[] bytes = new byte[duplicate.remaining()];
+            duplicate.get(bytes);
+            return bytes;
+        }
     }
 }

--- a/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProvider.java
+++ b/connectors/object-ingest/src/main/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProvider.java
@@ -1,0 +1,116 @@
+package org.pipelineframework.connector.objectingest;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.objectpublish.ObjectTargetProvider;
+import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteResult;
+import org.pipelineframework.repository.PayloadReference;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+/**
+ * Plain AWS SDK S3 object target provider for Object Publish.
+ */
+public class S3ObjectTargetProvider implements ObjectTargetProvider, AutoCloseable {
+
+    private final S3Client client;
+    private final boolean ownsClient;
+    private volatile S3Client resolvedClient;
+
+    public S3ObjectTargetProvider() {
+        this.client = null;
+        this.ownsClient = true;
+    }
+
+    S3ObjectTargetProvider(S3Client client) {
+        this.client = client;
+        this.ownsClient = false;
+    }
+
+    @Override
+    public String providerName() {
+        return "s3";
+    }
+
+    @Override
+    public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
+        return Uni.createFrom().item(() -> writeBlocking(request));
+    }
+
+    @Override
+    public void close() {
+        if (ownsClient && resolvedClient != null) {
+            resolvedClient.close();
+        }
+    }
+
+    private ObjectWriteResult writeBlocking(ObjectWriteRequest request) {
+        String bucket = required(request, "bucket");
+        Map<String, String> metadata = new LinkedHashMap<>(request.metadata());
+        metadata.put("target", request.targetName());
+        PutObjectResponse response = client(request).putObject(PutObjectRequest.builder()
+            .bucket(bucket)
+            .key(request.objectKey())
+            .contentType(request.contentType())
+            .metadata(metadata)
+            .build(), RequestBody.fromBytes(request.bytes()));
+        String version = response.versionId();
+        PayloadReference reference = new PayloadReference(
+            providerName(),
+            bucket,
+            request.objectKey(),
+            request.contentType(),
+            "raw",
+            request.checksum(),
+            request.bytes().length,
+            version,
+            metadata);
+        return new ObjectWriteResult(reference, request.bytes().length, request.checksum(), Instant.now());
+    }
+
+    private S3Client client(ObjectWriteRequest request) {
+        if (client != null) {
+            return client;
+        }
+        S3Client local = resolvedClient;
+        if (local != null) {
+            return local;
+        }
+        synchronized (this) {
+            local = resolvedClient;
+            if (local != null) {
+                return local;
+            }
+            S3ClientBuilder builder = S3Client.builder().httpClientBuilder(UrlConnectionHttpClient.builder());
+            optional(request, "region").ifPresent(region -> builder.region(Region.of(region)));
+            optional(request, "endpoint").map(URI::create).ifPresent(builder::endpointOverride);
+            resolvedClient = builder.build();
+            return resolvedClient;
+        }
+    }
+
+    private String required(ObjectWriteRequest request, String key) {
+        return optional(request, key)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "s3 publish target '" + request.targetName() + "' requires location." + key));
+    }
+
+    private Optional<String> optional(ObjectWriteRequest request, String key) {
+        Object value = request.target().location().get(key);
+        return value == null || value.toString().isBlank()
+            ? Optional.empty()
+            : Optional.of(value.toString().trim());
+    }
+}

--- a/connectors/object-ingest/src/main/resources/META-INF/services/org.pipelineframework.objectpublish.ObjectTargetProvider
+++ b/connectors/object-ingest/src/main/resources/META-INF/services/org.pipelineframework.objectpublish.ObjectTargetProvider
@@ -1,0 +1,2 @@
+org.pipelineframework.connector.objectingest.FilesystemObjectTargetProvider
+org.pipelineframework.connector.objectingest.S3ObjectTargetProvider

--- a/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProviderTest.java
+++ b/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProviderTest.java
@@ -1,0 +1,68 @@
+package org.pipelineframework.connector.objectingest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteResult;
+
+class FilesystemObjectTargetProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesObjectUnderConfiguredRoot() throws Exception {
+        PipelineObjectPublishConfig target = target(tempDir);
+        ObjectWriteRequest request = request(target, "results/payments.csv", "id,amount\n1,10\n");
+
+        ObjectWriteResult result = new FilesystemObjectTargetProvider().write(request).await().indefinitely();
+
+        assertEquals("id,amount\n1,10\n", Files.readString(tempDir.resolve("results/payments.csv")));
+        assertEquals("filesystem", result.reference().provider());
+        assertEquals(tempDir.toString(), result.reference().container());
+        assertEquals("results/payments.csv", result.reference().key());
+        assertEquals("text/csv", result.reference().contentType());
+        assertEquals(request.checksum(), result.checksum());
+        assertEquals(request.bytes().length, result.bytes());
+    }
+
+    @Test
+    void rejectsEscapedOutputPath() {
+        PipelineObjectPublishConfig target = target(tempDir);
+        ObjectWriteRequest request = request(target, "../outside.csv", "bad");
+
+        assertThrows(SecurityException.class, () ->
+            new FilesystemObjectTargetProvider().write(request).await().indefinitely());
+    }
+
+    private PipelineObjectPublishConfig target(Path root) {
+        return new PipelineObjectPublishConfig(
+            "results",
+            "object",
+            "filesystem",
+            Map.of("root", root.toString()),
+            null,
+            null);
+    }
+
+    private ObjectWriteRequest request(PipelineObjectPublishConfig target, String key, String body) {
+        return new ObjectWriteRequest(
+            target.name(),
+            target,
+            key,
+            body.getBytes(StandardCharsets.UTF_8),
+            "text/csv",
+            Map.of("kind", "test"),
+            "checksum",
+            "idempotency");
+    }
+}

--- a/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProviderTest.java
+++ b/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/FilesystemObjectTargetProviderTest.java
@@ -1,18 +1,24 @@
 package org.pipelineframework.connector.objectingest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
-import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteCloseRequest;
+import org.pipelineframework.objectpublish.ObjectWriteOpenRequest;
 import org.pipelineframework.objectpublish.ObjectWriteResult;
+import org.pipelineframework.objectpublish.ObjectWriteSession;
 
 class FilesystemObjectTargetProviderTest {
 
@@ -20,28 +26,51 @@ class FilesystemObjectTargetProviderTest {
     Path tempDir;
 
     @Test
-    void writesObjectUnderConfiguredRoot() throws Exception {
-        PipelineObjectPublishConfig target = target(tempDir);
-        ObjectWriteRequest request = request(target, "results/payments.csv", "id,amount\n1,10\n");
+    void streamsChunksAndMovesTempFileOnClose() throws Exception {
+        FilesystemObjectTargetProvider provider = new FilesystemObjectTargetProvider(Runnable::run);
+        ObjectWriteSession session = provider.open(openRequest(target(tempDir), "results/payments.csv"))
+            .toCompletableFuture().join();
 
-        ObjectWriteResult result = new FilesystemObjectTargetProvider().write(request).await().indefinitely();
+        session.write(ByteBuffer.wrap("id,amount\n".getBytes(StandardCharsets.UTF_8))).toCompletableFuture().join();
+        session.write(ByteBuffer.wrap("1,10\n".getBytes(StandardCharsets.UTF_8))).toCompletableFuture().join();
+        ObjectWriteResult result = session.close(new ObjectWriteCloseRequest(
+            "id,amount\n1,10\n".getBytes(StandardCharsets.UTF_8).length,
+            "checksum",
+            Map.of("recordCount", "1"))).toCompletableFuture().join();
 
         assertEquals("id,amount\n1,10\n", Files.readString(tempDir.resolve("results/payments.csv")));
         assertEquals("filesystem", result.reference().provider());
         assertEquals(tempDir.toString(), result.reference().container());
         assertEquals("results/payments.csv", result.reference().key());
         assertEquals("text/csv", result.reference().contentType());
-        assertEquals(request.checksum(), result.checksum());
-        assertEquals(request.bytes().length, result.bytes());
+        assertEquals("checksum", result.checksum());
+        assertEquals("1", result.reference().metadata().get("recordCount"));
+        assertTrue(Files.list(tempDir.resolve("results"))
+            .noneMatch(path -> path.getFileName().toString().contains(".tpf-publish-")));
+    }
+
+    @Test
+    void abortDeletesTempFile() throws Exception {
+        FilesystemObjectTargetProvider provider = new FilesystemObjectTargetProvider(Runnable::run);
+        ObjectWriteSession session = provider.open(openRequest(target(tempDir), "results/payments.csv"))
+            .toCompletableFuture().join();
+
+        session.write(ByteBuffer.wrap("partial".getBytes(StandardCharsets.UTF_8))).toCompletableFuture().join();
+        session.abort(new RuntimeException("failed")).toCompletableFuture().join();
+
+        assertFalse(Files.exists(tempDir.resolve("results/payments.csv")));
+        assertTrue(Files.list(tempDir.resolve("results"))
+            .noneMatch(path -> path.getFileName().toString().contains(".tpf-publish-")));
     }
 
     @Test
     void rejectsEscapedOutputPath() {
         PipelineObjectPublishConfig target = target(tempDir);
-        ObjectWriteRequest request = request(target, "../outside.csv", "bad");
 
-        assertThrows(SecurityException.class, () ->
-            new FilesystemObjectTargetProvider().write(request).await().indefinitely());
+        CompletionException exception = assertThrows(CompletionException.class, () ->
+            new FilesystemObjectTargetProvider(Runnable::run).open(openRequest(target, "../outside.csv"))
+                .toCompletableFuture().join());
+        assertTrue(exception.getCause() instanceof SecurityException);
     }
 
     private PipelineObjectPublishConfig target(Path root) {
@@ -54,15 +83,13 @@ class FilesystemObjectTargetProviderTest {
             null);
     }
 
-    private ObjectWriteRequest request(PipelineObjectPublishConfig target, String key, String body) {
-        return new ObjectWriteRequest(
+    private ObjectWriteOpenRequest openRequest(PipelineObjectPublishConfig target, String key) {
+        return new ObjectWriteOpenRequest(
             target.name(),
             target,
             key,
-            body.getBytes(StandardCharsets.UTF_8),
             "text/csv",
             Map.of("kind", "test"),
-            "checksum",
             "idempotency");
     }
 }

--- a/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProviderTest.java
+++ b/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProviderTest.java
@@ -6,57 +6,84 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
-import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteCloseRequest;
+import org.pipelineframework.objectpublish.ObjectWriteOpenRequest;
 import org.pipelineframework.objectpublish.ObjectWriteResult;
+import org.pipelineframework.objectpublish.ObjectWriteSession;
 
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 class S3ObjectTargetProviderTest {
 
     @Test
-    void writesObjectToConfiguredBucket() {
+    void streamsMultipartUploadAndCompletesOnClose() {
         S3Client client = mock(S3Client.class);
-        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenReturn(PutObjectResponse.builder().versionId("v1").build());
+        when(client.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+            .thenReturn(CreateMultipartUploadResponse.builder().uploadId("upload-1").build());
+        when(client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+            .thenReturn(UploadPartResponse.builder().eTag("etag-1").build());
+        S3ObjectTargetProvider provider = new S3ObjectTargetProvider(client, Runnable::run, 5 * 1024 * 1024);
+        ObjectWriteSession session = provider.open(openRequest()).toCompletableFuture().join();
+
+        session.write(ByteBuffer.wrap(new byte[5 * 1024 * 1024])).toCompletableFuture().join();
+        ObjectWriteResult result = session.close(new ObjectWriteCloseRequest(
+            5 * 1024 * 1024,
+            "checksum",
+            Map.of("recordCount", "1"))).toCompletableFuture().join();
+
+        ArgumentCaptor<CreateMultipartUploadRequest> createCaptor =
+            ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+        verify(client).createMultipartUpload(createCaptor.capture());
+        assertEquals("payments", createCaptor.getValue().bucket());
+        assertEquals("out/payments.csv", createCaptor.getValue().key());
+        verify(client).uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
+        verify(client).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+        assertEquals("s3", result.reference().provider());
+        assertEquals("payments", result.reference().container());
+        assertEquals("out/payments.csv", result.reference().key());
+        assertEquals("1", result.reference().metadata().get("recordCount"));
+    }
+
+    @Test
+    void abortCancelsMultipartUpload() {
+        S3Client client = mock(S3Client.class);
+        when(client.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+            .thenReturn(CreateMultipartUploadResponse.builder().uploadId("upload-1").build());
+        S3ObjectTargetProvider provider = new S3ObjectTargetProvider(client, Runnable::run, 5 * 1024 * 1024);
+        ObjectWriteSession session = provider.open(openRequest()).toCompletableFuture().join();
+
+        session.abort(new RuntimeException("failed")).toCompletableFuture().join();
+
+        verify(client).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    }
+
+    private ObjectWriteOpenRequest openRequest() {
         PipelineObjectPublishConfig target = new PipelineObjectPublishConfig(
             "results",
             "object",
             "s3",
-            Map.of("bucket", "payments"),
+            Map.of("bucket", "payments", "prefix", "out"),
             null,
             null);
-        ObjectWriteRequest request = new ObjectWriteRequest(
+        return new ObjectWriteOpenRequest(
             target.name(),
             target,
-            "out/payments.csv",
-            "id,amount\n1,10\n".getBytes(StandardCharsets.UTF_8),
+            "payments.csv",
             "text/csv",
             Map.of("groupKey", "payments.csv"),
-            "checksum",
             "idempotency");
-
-        ObjectWriteResult result = new S3ObjectTargetProvider(client).write(request).await().indefinitely();
-
-        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
-        verify(client).putObject(captor.capture(), any(RequestBody.class));
-        PutObjectRequest put = captor.getValue();
-        assertEquals("payments", put.bucket());
-        assertEquals("out/payments.csv", put.key());
-        assertEquals("text/csv", put.contentType());
-        assertEquals("payments.csv", put.metadata().get("groupKey"));
-        assertEquals("results", put.metadata().get("target"));
-        assertEquals("s3", result.reference().provider());
-        assertEquals("payments", result.reference().container());
-        assertEquals("out/payments.csv", result.reference().key());
-        assertEquals("v1", result.reference().version());
     }
 }

--- a/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProviderTest.java
+++ b/connectors/object-ingest/src/test/java/org/pipelineframework/connector/objectingest/S3ObjectTargetProviderTest.java
@@ -1,0 +1,62 @@
+package org.pipelineframework.connector.objectingest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.objectpublish.ObjectWriteRequest;
+import org.pipelineframework.objectpublish.ObjectWriteResult;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+class S3ObjectTargetProviderTest {
+
+    @Test
+    void writesObjectToConfiguredBucket() {
+        S3Client client = mock(S3Client.class);
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenReturn(PutObjectResponse.builder().versionId("v1").build());
+        PipelineObjectPublishConfig target = new PipelineObjectPublishConfig(
+            "results",
+            "object",
+            "s3",
+            Map.of("bucket", "payments"),
+            null,
+            null);
+        ObjectWriteRequest request = new ObjectWriteRequest(
+            target.name(),
+            target,
+            "out/payments.csv",
+            "id,amount\n1,10\n".getBytes(StandardCharsets.UTF_8),
+            "text/csv",
+            Map.of("groupKey", "payments.csv"),
+            "checksum",
+            "idempotency");
+
+        ObjectWriteResult result = new S3ObjectTargetProvider(client).write(request).await().indefinitely();
+
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(client).putObject(captor.capture(), any(RequestBody.class));
+        PutObjectRequest put = captor.getValue();
+        assertEquals("payments", put.bucket());
+        assertEquals("out/payments.csv", put.key());
+        assertEquals("text/csv", put.contentType());
+        assertEquals("payments.csv", put.metadata().get("groupKey"));
+        assertEquals("results", put.metadata().get("target"));
+        assertEquals("s3", result.reference().provider());
+        assertEquals("payments", result.reference().container());
+        assertEquals("out/payments.csv", result.reference().key());
+        assertEquals("v1", result.reference().version());
+    }
+}

--- a/docs/design/object-ingest.md
+++ b/docs/design/object-ingest.md
@@ -1,10 +1,12 @@
-# Object Ingest
+# Object Ingest And Publish
 
 Object ingest lets TPF admit files or object-store keys into a queue-async pipeline without making a business step list folders, poll S3, dedupe keys, or construct async execution ids.
 
 Use it when an object arrival or object listing is the pipeline input. Business steps should receive a domain input such as `CsvPaymentsInputFile` or `RawDocument`; the object shell owns listing, filtering, payload references, identity, and async admission.
 
-## Pipeline DSL
+Object publish is the output-side counterpart. It lets terminal pipeline values become durable objects without making the final business step group records, name files, write to S3, retry duplicate writes, or report object-write lifecycle state.
+
+## Ingest DSL
 
 Declare the source at top level, then bind it to the pipeline input.
 
@@ -61,9 +63,88 @@ public final class CsvPaymentFileObjectMapper
 }
 ```
 
+## Publish DSL
+
+Declare the target at top level, then bind terminal pipeline output to it.
+
+```yaml
+publish:
+  csv-payment-output-files:
+    kind: object
+    provider: filesystem
+    location:
+      root: ../input-csv-file-processing-svc/csv
+    naming:
+      keyTemplate: "{groupKey}.out"
+    payload:
+      contentType: text/csv
+    grouping:
+      maxOpenGroups: 1
+
+output:
+  to: csv-payment-output-files
+  consumes:
+    type: org.pipelineframework.csv.common.domain.PaymentOutput
+    typeName: PaymentOutput
+    mapper: org.pipelineframework.csv.common.mapper.CsvPaymentOutputPublishMapper
+```
+
+`output.to` attaches Object Publish to terminal pipeline output. It is not a user-authored step, so the pipeline still ends at the last business transition.
+
+```yaml
+steps:
+  - name: ProcessPaymentStatus
+    service: org.pipelineframework.csv.service.ProcessPaymentStatusService
+    cardinality: ONE_TO_ONE
+    input: org.pipelineframework.csv.common.domain.PaymentStatus
+    inputTypeName: PaymentStatus
+    output: org.pipelineframework.csv.common.domain.PaymentOutput
+    outputTypeName: PaymentOutput
+```
+
+The output binding type must match the last step output type.
+
+## Publish Mapper
+
+Application code renders terminal values into object payload chunks. TPF owns grouping, key templating, provider selection, write idempotency, backpressure, telemetry, and lifecycle reporting.
+
+```java
+public final class CsvPaymentOutputPublishMapper
+    implements StreamingObjectPublishMapper<PaymentOutput> {
+
+  @Override
+  public String groupKey(PaymentOutput item) {
+    return item.getCsvPaymentsOutputFilename();
+  }
+
+  @Override
+  public ObjectPublishGroupRenderer<PaymentOutput> openGroup(String groupKey, PaymentOutput firstItem) {
+    return new ObjectPublishGroupRenderer<>() {
+      private long count;
+
+      @Override
+      public String contentType() {
+        return "text/csv";
+      }
+
+      @Override
+      public ObjectPayloadChunk onItem(PaymentOutput item) {
+        count++;
+        return new ObjectPayloadChunk(renderCsvRow(item));
+      }
+
+      @Override
+      public Map<String, String> finalMetadata() {
+        return Map.of("recordCount", String.valueOf(count));
+      }
+    };
+  }
+}
+```
+
 ## Connectors
 
-Add the connector library where object ingest runs:
+Add the connector library where object ingest or publish runs:
 
 ```xml
 <dependency>
@@ -73,15 +154,16 @@ Add the connector library where object ingest runs:
 </dependency>
 ```
 
-V1 object source connectors:
+V1 object source and target connectors:
 
 | Connector | Purpose |
 | --- | --- |
-| `filesystem` | Local folders, tests, CSV-style batch inputs. |
-| `s3` | AWS S3-compatible object listing and text/reference payload admission. |
+| `filesystem` | Local folders, tests, CSV-style batch inputs and output files. |
+| `s3` | AWS S3-compatible object listing, text/reference payload admission, and object publication. |
 
 The YAML field remains `provider` in v1 because it selects the Java `ObjectSourceProvider`
-implementation behind the connector. The user-facing category is connectors because these
+or `ObjectTargetProvider` implementation behind the connector. `ObjectTargetProvider` uses JDK
+`CompletionStage`, not Mutiny or Quarkus types. The user-facing category is connectors because these
 libraries own I/O boundary behavior, not pipeline side-effect semantics.
 
 S3 text ingest example:
@@ -102,9 +184,28 @@ sources:
       charset: UTF-8
 ```
 
+S3 publish example:
+
+```yaml
+publish:
+  search-results:
+    kind: object
+    provider: s3
+    location:
+      bucket: tpf-search-results
+      prefix: rendered/
+      region: us-east-1
+    naming:
+      keyTemplate: "{groupKey}.json"
+    payload:
+      contentType: application/json
+```
+
 ## Runtime Requirements
 
 Object ingest v1 requires `pipeline.orchestrator.mode=QUEUE_ASYNC`. TPF submits each mapped input with a deterministic idempotency key derived from object identity, so duplicate listing results resolve to existing async executions.
+
+Object Publish also targets queue-async terminal output. Streaming terminal output must use `StreamingObjectPublishMapper<T>`; the batch `ObjectPublishMapper<T>` remains for unary/small compatibility only.
 
 FUNCTION pipelines are rejected in v1. Quarkus currently hosts the bootstrap, but the ingest runner and provider SPI are plain Java so a Spring Boot host can wire the same semantics later.
 

--- a/docs/evolve/io-shell-absorption.md
+++ b/docs/evolve/io-shell-absorption.md
@@ -39,7 +39,7 @@ Use this decision rule:
 | Moving data representation without changing domain meaning | Framework-owned representation shell |
 | Enforcing business correctness inside another system | Guardrail only; the target system must still participate |
 
-## Object Ingest V1
+## Object Ingest And Publish V1
 
 File/object/S3 ingest is the first connector follow-up because it removes common batch/background plumbing:
 
@@ -51,7 +51,17 @@ File/object/S3 ingest is the first connector follow-up because it removes common
 - payload references or text loading
 - async execution submission
 
-Filesystem and S3 support ship as object source connectors. They are I/O boundary
+Object Publish is the matching output-side shell. It removes terminal plumbing that otherwise appears as a final "write file" or "upload object" step:
+
+- grouping terminal business results
+- deterministic key naming
+- content type and metadata attachment
+- filesystem or S3 provider selection
+- duplicate/idempotent write keys
+- object write telemetry
+- lifecycle reporting outside the business transition list
+
+Filesystem and S3 support ship as object source and target connectors. They are I/O boundary
 capabilities, not pipeline side-effect plugins, even though the runtime-neutral Java SPI still
 uses provider selection internally.
 
@@ -83,13 +93,43 @@ input:
 
 This keeps object discovery out of business steps. In CSV Payments, the folder expansion step can be removed and the pipeline can start with `Process Csv Payments Input`. In Search, an S3 text source can emit `RawDocument` and start at `Parse Document`.
 
+The output-side DSL uses top-level `publish` plus an output binding:
+
+```yaml
+publish:
+  csv-payment-output-files:
+    kind: object
+    provider: filesystem
+    location:
+      root: ../output-csv-file-processing-svc/csv
+    naming:
+      keyTemplate: "{groupKey}.out"
+    payload:
+      contentType: text/csv
+    grouping:
+      maxOpenGroups: 1
+
+output:
+  to: csv-payment-output-files
+  consumes:
+    type: org.pipelineframework.csv.common.domain.PaymentOutput
+    typeName: PaymentOutput
+    mapper: org.pipelineframework.csv.common.mapper.CsvPaymentOutputPublishMapper
+```
+
+This keeps object writing out of business steps. In CSV Payments, the direct output-file step can be replaced by terminal publish: the last business step still emits `PaymentOutput`, and the publish mapper owns only domain-to-payload rendering.
+
+S3 should be a first-class publish target in the same slice as filesystem publish. Otherwise Object Publish would fail parity with Object Ingest and look like a local-file convenience rather than an I/O shell absorption.
+
 Guardrails:
 
 - V1 requires `QUEUE_ASYNC`.
 - V1 rejects FUNCTION pipelines.
 - The emitted input type must match the first step input.
 - The mapper must implement `ObjectSnapshotMapper<T>`.
-- The core runner and provider SPI are runtime-neutral; Quarkus only supplies the current lifecycle adapter.
+- The consumed output type must match the last step output.
+- Streaming terminal output must use `StreamingObjectPublishMapper<T>`; the batch `ObjectPublishMapper<T>` remains for unary/small compatibility only.
+- The core runner and provider SPI are runtime-neutral; provider contracts use JDK `CompletionStage`, and Quarkus/Mutiny adaptation stays inside the current runtime.
 
 ## Very High ROI Capabilities
 

--- a/examples/csv-payments/common/pom.xml
+++ b/examples/csv-payments/common/pom.xml
@@ -200,6 +200,7 @@
                             <mainClass>org.pipelineframework.proto.PipelineProtoGenerator</mainClass>
                             <arguments>
                                 <argument>--module-dir=${project.basedir}</argument>
+                                <argument>${pipeline.protoConfigArg}</argument>
                                 <argument>--output-dir=${generated.proto.dir}</argument>
                             </arguments>
                             <addOutputToClasspath>true</addOutputToClasspath>

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/domain/CsvPaymentsOutputFile.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/domain/CsvPaymentsOutputFile.java
@@ -32,11 +32,18 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+/**
+ * Legacy CSV output-file domain object used by the direct output-file pipeline step.
+ *
+ * @deprecated Use Object Publish with {@code CsvPaymentOutputPublishMapper}; terminal output files are now
+ *             framework-owned object writes instead of business-step domain outputs.
+ */
 @Entity
 @Getter
 @Setter
 @Accessors(chain = true)
 @NoArgsConstructor
+@Deprecated(forRemoval = false)
 public class CsvPaymentsOutputFile extends BaseCsvPaymentsFile implements AutoCloseable {
 
   @Transient private List<PaymentOutput> paymentOutputs = new ArrayList<>();

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/dto/CsvPaymentsOutputFileDto.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/dto/CsvPaymentsOutputFileDto.java
@@ -23,9 +23,16 @@ import java.util.UUID;
 import lombok.Builder;
 import lombok.Value;
 
+/**
+ * Legacy DTO for the direct CSV output-file step.
+ *
+ * @deprecated Use Object Publish with {@code CsvPaymentOutputPublishMapper}; published files are represented as
+ *             framework-owned object writes instead of this DTO.
+ */
 @Value
 @Builder
 @JsonDeserialize(builder = CsvPaymentsOutputFileDto.CsvPaymentsInputFileDtoBuilder.class)
+@Deprecated(forRemoval = false)
 public class CsvPaymentsOutputFileDto {
   UUID id;
   Path filepath;

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapper.java
@@ -1,0 +1,68 @@
+package org.pipelineframework.csv.common.mapper;
+
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import com.opencsv.CSVWriter;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import org.pipelineframework.csv.common.domain.PaymentOutput;
+import org.pipelineframework.csv.common.domain.PaymentRecord;
+import org.pipelineframework.csv.common.domain.PaymentStatus;
+import org.pipelineframework.objectpublish.ObjectPayload;
+import org.pipelineframework.objectpublish.ObjectPublishMapper;
+
+/**
+ * Renders terminal CSV payment outputs as grouped CSV object payloads.
+ */
+public final class CsvPaymentOutputPublishMapper implements ObjectPublishMapper<PaymentOutput> {
+
+    @Override
+    public String groupKey(PaymentOutput item) {
+        Path inputFile = inputFile(item);
+        Path fileName = inputFile.getFileName();
+        if (fileName == null) {
+            throw new IllegalArgumentException("Payment output input file path must have a file name");
+        }
+        return fileName.toString();
+    }
+
+    @Override
+    public ObjectPayload render(String groupKey, List<PaymentOutput> items) {
+        try {
+            StringWriter writer = new StringWriter();
+            new StatefulBeanToCsvBuilder<PaymentOutput>(writer)
+                .withQuotechar('\'')
+                .withSeparator(CSVWriter.DEFAULT_SEPARATOR)
+                .build()
+                .write(items.iterator());
+            return new ObjectPayload(
+                writer.toString().getBytes(StandardCharsets.UTF_8),
+                "text/csv",
+                Map.of("recordCount", String.valueOf(items.size())));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed rendering CSV payment output object for group: " + groupKey, e);
+        }
+    }
+
+    private Path inputFile(PaymentOutput item) {
+        if (item == null) {
+            throw new IllegalArgumentException("Payment output must not be null");
+        }
+        PaymentStatus status = item.getPaymentStatus();
+        if (status == null) {
+            throw new IllegalArgumentException("Payment output must include paymentStatus");
+        }
+        PaymentRecord record = status.getPaymentRecord();
+        if (record == null) {
+            throw new IllegalArgumentException("Payment output paymentStatus must include paymentRecord");
+        }
+        Path inputFile = record.getCsvPaymentsInputFilePath();
+        if (inputFile == null) {
+            throw new IllegalArgumentException("Payment output paymentRecord must include csvPaymentsInputFilePath");
+        }
+        return inputFile.toAbsolutePath().normalize();
+    }
+}

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapper.java
@@ -3,21 +3,22 @@ package org.pipelineframework.csv.common.mapper;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 
 import com.opencsv.CSVWriter;
+import com.opencsv.bean.StatefulBeanToCsv;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
 import org.pipelineframework.csv.common.domain.PaymentOutput;
 import org.pipelineframework.csv.common.domain.PaymentRecord;
 import org.pipelineframework.csv.common.domain.PaymentStatus;
-import org.pipelineframework.objectpublish.ObjectPayload;
-import org.pipelineframework.objectpublish.ObjectPublishMapper;
+import org.pipelineframework.objectpublish.ObjectPayloadChunk;
+import org.pipelineframework.objectpublish.ObjectPublishGroupRenderer;
+import org.pipelineframework.objectpublish.StreamingObjectPublishMapper;
 
 /**
  * Renders terminal CSV payment outputs as grouped CSV object payloads.
  */
-public final class CsvPaymentOutputPublishMapper implements ObjectPublishMapper<PaymentOutput> {
+public final class CsvPaymentOutputPublishMapper implements StreamingObjectPublishMapper<PaymentOutput> {
 
     @Override
     public String groupKey(PaymentOutput item) {
@@ -30,21 +31,8 @@ public final class CsvPaymentOutputPublishMapper implements ObjectPublishMapper<
     }
 
     @Override
-    public ObjectPayload render(String groupKey, List<PaymentOutput> items) {
-        try {
-            StringWriter writer = new StringWriter();
-            new StatefulBeanToCsvBuilder<PaymentOutput>(writer)
-                .withQuotechar('\'')
-                .withSeparator(CSVWriter.DEFAULT_SEPARATOR)
-                .build()
-                .write(items.iterator());
-            return new ObjectPayload(
-                writer.toString().getBytes(StandardCharsets.UTF_8),
-                "text/csv",
-                Map.of("recordCount", String.valueOf(items.size())));
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed rendering CSV payment output object for group: " + groupKey, e);
-        }
+    public ObjectPublishGroupRenderer<PaymentOutput> openGroup(String groupKey, PaymentOutput firstItem) {
+        return new CsvPaymentOutputGroupRenderer(groupKey);
     }
 
     private Path inputFile(PaymentOutput item) {
@@ -64,5 +52,47 @@ public final class CsvPaymentOutputPublishMapper implements ObjectPublishMapper<
             throw new IllegalArgumentException("Payment output paymentRecord must include csvPaymentsInputFilePath");
         }
         return inputFile.toAbsolutePath().normalize();
+    }
+
+    private static final class CsvPaymentOutputGroupRenderer implements ObjectPublishGroupRenderer<PaymentOutput> {
+        private final String groupKey;
+        private final StringWriter writer = new StringWriter();
+        private final StatefulBeanToCsv<PaymentOutput> csv;
+        private long recordCount;
+
+        private CsvPaymentOutputGroupRenderer(String groupKey) {
+            this.groupKey = groupKey;
+            this.csv = new StatefulBeanToCsvBuilder<PaymentOutput>(writer)
+                .withQuotechar('\'')
+                .withSeparator(CSVWriter.DEFAULT_SEPARATOR)
+                .build();
+        }
+
+        @Override
+        public String contentType() {
+            return "text/csv";
+        }
+
+        @Override
+        public ObjectPayloadChunk onItem(PaymentOutput item) {
+            try {
+                csv.write(item);
+                recordCount++;
+                return drain();
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed rendering CSV payment output object for group: " + groupKey, e);
+            }
+        }
+
+        @Override
+        public Map<String, String> finalMetadata() {
+            return Map.of("recordCount", String.valueOf(recordCount));
+        }
+
+        private ObjectPayloadChunk drain() {
+            String rendered = writer.toString();
+            writer.getBuffer().setLength(0);
+            return new ObjectPayloadChunk(rendered.getBytes(StandardCharsets.UTF_8));
+        }
     }
 }

--- a/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentsOutputFileMapper.java
+++ b/examples/csv-payments/common/src/main/java/org/pipelineframework/csv/common/mapper/CsvPaymentsOutputFileMapper.java
@@ -24,10 +24,17 @@ import org.mapstruct.factory.Mappers;
 import org.pipelineframework.csv.common.domain.CsvPaymentsOutputFile;
 import org.pipelineframework.csv.common.dto.CsvPaymentsOutputFileDto;
 
+/**
+ * Legacy mapper for the direct CSV output-file step.
+ *
+ * @deprecated Use Object Publish with {@code CsvPaymentOutputPublishMapper}; terminal object writing no longer
+ *             needs a domain-to-gRPC output-file mapper in the object-ingest path.
+ */
 @Mapper(
     componentModel = "jakarta",
     uses = {CommonConverters.class},
     unmappedTargetPolicy = ReportingPolicy.WARN)
+@Deprecated(forRemoval = false)
 public interface CsvPaymentsOutputFileMapper extends org.pipelineframework.mapper.Mapper<CsvPaymentsOutputFile, org.pipelineframework.csv.grpc.PipelineTypes.CsvPaymentsOutputFile> {
 
   CsvPaymentsOutputFileMapper INSTANCE = Mappers.getMapper( CsvPaymentsOutputFileMapper.class );

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapperTest.java
@@ -1,0 +1,73 @@
+package org.pipelineframework.csv.common.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Currency;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.csv.common.domain.PaymentOutput;
+import org.pipelineframework.csv.common.domain.PaymentRecord;
+import org.pipelineframework.csv.common.domain.PaymentStatus;
+import org.pipelineframework.objectpublish.ObjectPayload;
+
+class CsvPaymentOutputPublishMapperTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void groupsByInputFilenameAndRendersCsvPayload() {
+        CsvPaymentOutputPublishMapper mapper = new CsvPaymentOutputPublishMapper();
+        PaymentOutput output = paymentOutput(tempDir.resolve("payments.csv"), "csv-1", "Alice", "100.00");
+
+        String groupKey = mapper.groupKey(output);
+        ObjectPayload payload = mapper.render(groupKey, List.of(output));
+        String csv = new String(payload.bytes(), StandardCharsets.UTF_8);
+
+        assertEquals("payments.csv", groupKey);
+        assertEquals("text/csv", payload.contentType());
+        assertEquals("1", payload.metadata().get("recordCount"));
+        assertTrue(csv.contains("AMOUNT"));
+        assertTrue(csv.contains("CSV ID"));
+        assertTrue(csv.contains("RECIPIENT"));
+        assertTrue(csv.contains("STATUS"));
+        assertTrue(csv.contains("100.00"));
+        assertTrue(csv.contains("csv-1"));
+        assertTrue(csv.contains("Alice"));
+    }
+
+    private PaymentOutput paymentOutput(Path inputFile, String csvId, String recipient, String amount) {
+        PaymentRecord record = new PaymentRecord();
+        record.setCsvPaymentsInputFilePath(inputFile);
+        record.setCsvId(csvId);
+        record.setRecipient(recipient);
+        record.setAmount(new BigDecimal(amount));
+        record.setCurrency(Currency.getInstance("USD"));
+
+        PaymentStatus status = new PaymentStatus();
+        status.setPaymentRecord(record);
+        status.setConversationId(UUID.randomUUID());
+        status.setStatusCode(1000L);
+        status.setStatus("APPROVED");
+        status.setMessage("Success");
+
+        PaymentOutput output = new PaymentOutput();
+        output.setPaymentStatus(status);
+        output.setCsvId(csvId);
+        output.setRecipient(recipient);
+        output.setAmount(new BigDecimal(amount));
+        output.setCurrency(Currency.getInstance("USD"));
+        output.setConversationId(UUID.randomUUID());
+        output.setStatus(1000L);
+        output.setMessage("Success");
+        output.setFee(BigDecimal.ZERO);
+        return output;
+    }
+}

--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapperTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/CsvPaymentOutputPublishMapperTest.java
@@ -7,7 +7,6 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Currency;
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -15,7 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.pipelineframework.csv.common.domain.PaymentOutput;
 import org.pipelineframework.csv.common.domain.PaymentRecord;
 import org.pipelineframework.csv.common.domain.PaymentStatus;
-import org.pipelineframework.objectpublish.ObjectPayload;
+import org.pipelineframework.objectpublish.ObjectPublishGroupRenderer;
 
 class CsvPaymentOutputPublishMapperTest {
 
@@ -28,12 +27,12 @@ class CsvPaymentOutputPublishMapperTest {
         PaymentOutput output = paymentOutput(tempDir.resolve("payments.csv"), "csv-1", "Alice", "100.00");
 
         String groupKey = mapper.groupKey(output);
-        ObjectPayload payload = mapper.render(groupKey, List.of(output));
-        String csv = new String(payload.bytes(), StandardCharsets.UTF_8);
+        ObjectPublishGroupRenderer<PaymentOutput> renderer = mapper.openGroup(groupKey, output);
+        String csv = new String(renderer.onItem(output).bytes(), StandardCharsets.UTF_8);
 
         assertEquals("payments.csv", groupKey);
-        assertEquals("text/csv", payload.contentType());
-        assertEquals("1", payload.metadata().get("recordCount"));
+        assertEquals("text/csv", renderer.contentType());
+        assertEquals("1", renderer.finalMetadata().get("recordCount"));
         assertTrue(csv.contains("AMOUNT"));
         assertTrue(csv.contains("CSV ID"));
         assertTrue(csv.contains("RECIPIENT"));
@@ -41,6 +40,22 @@ class CsvPaymentOutputPublishMapperTest {
         assertTrue(csv.contains("100.00"));
         assertTrue(csv.contains("csv-1"));
         assertTrue(csv.contains("Alice"));
+    }
+
+    @Test
+    void streamsRowsWithoutRepeatingHeader() {
+        CsvPaymentOutputPublishMapper mapper = new CsvPaymentOutputPublishMapper();
+        PaymentOutput first = paymentOutput(tempDir.resolve("payments.csv"), "csv-1", "Alice", "100.00");
+        PaymentOutput second = paymentOutput(tempDir.resolve("payments.csv"), "csv-2", "Bob", "200.00");
+        ObjectPublishGroupRenderer<PaymentOutput> renderer = mapper.openGroup("payments.csv", first);
+
+        String csv = new String(renderer.onItem(first).bytes(), StandardCharsets.UTF_8)
+            + new String(renderer.onItem(second).bytes(), StandardCharsets.UTF_8);
+
+        assertEquals(1, occurrences(csv, "AMOUNT"));
+        assertEquals("2", renderer.finalMetadata().get("recordCount"));
+        assertTrue(csv.contains("csv-1"));
+        assertTrue(csv.contains("csv-2"));
     }
 
     private PaymentOutput paymentOutput(Path inputFile, String csvId, String recipient, String amount) {
@@ -69,5 +84,15 @@ class CsvPaymentOutputPublishMapperTest {
         output.setMessage("Success");
         output.setFee(BigDecimal.ZERO);
         return output;
+    }
+
+    private int occurrences(String value, String token) {
+        int count = 0;
+        int index = 0;
+        while ((index = value.indexOf(token, index)) >= 0) {
+            count++;
+            index += token.length();
+        }
+        return count;
     }
 }

--- a/examples/csv-payments/config/pipeline.object-ingest.yaml
+++ b/examples/csv-payments/config/pipeline.object-ingest.yaml
@@ -35,6 +35,8 @@ publish:
       keyTemplate: "{groupKey}.out"
     payload:
       contentType: text/csv
+    grouping:
+      maxOpenGroups: 1
 output:
   to: csv-payment-output-files
   consumes:

--- a/examples/csv-payments/config/pipeline.object-ingest.yaml
+++ b/examples/csv-payments/config/pipeline.object-ingest.yaml
@@ -25,6 +25,22 @@ input:
     type: org.pipelineframework.csv.common.domain.CsvPaymentsInputFile
     typeName: CsvPaymentsInputFile
     mapper: org.pipelineframework.csv.common.mapper.CsvPaymentFileObjectMapper
+publish:
+  csv-payment-output-files:
+    kind: object
+    provider: filesystem
+    location:
+      root: ../input-csv-file-processing-svc/csv
+    naming:
+      keyTemplate: "{groupKey}.out"
+    payload:
+      contentType: text/csv
+output:
+  to: csv-payment-output-files
+  consumes:
+    type: org.pipelineframework.csv.common.domain.PaymentOutput
+    typeName: PaymentOutput
+    mapper: org.pipelineframework.csv.common.mapper.CsvPaymentOutputPublishMapper
 aspects:
   persistence:
     enabled: true
@@ -34,12 +50,16 @@ aspects:
       targetSteps:
         - ProcessCsvPaymentsInputService
         - ProcessPaymentStatusService
-        - ProcessCsvPaymentsOutputFileService
       pluginImplementationClass: org.pipelineframework.plugin.persistence.PersistenceService
       enabledTargets:
         - GRPC_SERVICE
         - CLIENT_STEP
 messages:
+  CsvFolder:
+    fields:
+      - number: 1
+        name: path
+        type: path
   CsvPaymentsInputFile:
     fields:
       - number: 1
@@ -186,12 +206,3 @@ steps:
     output: org.pipelineframework.csv.common.domain.PaymentOutput
     outputTypeName: PaymentOutput
     outboundMapper: org.pipelineframework.csv.common.mapper.PaymentOutputMapper
-  - name: Process Csv Payments Output File
-    service: org.pipelineframework.csv.service.ProcessCsvPaymentsOutputFileService
-    cardinality: MANY_TO_MANY
-    input: org.pipelineframework.csv.common.domain.PaymentOutput
-    inputTypeName: PaymentOutput
-    inboundMapper: org.pipelineframework.csv.common.mapper.PaymentOutputMapper
-    output: org.pipelineframework.csv.common.domain.CsvPaymentsOutputFile
-    outputTypeName: CsvPaymentsOutputFile
-    outboundMapper: org.pipelineframework.csv.common.mapper.CsvPaymentsOutputFileMapper

--- a/examples/csv-payments/output-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsOutputFileService.java
+++ b/examples/csv-payments/output-csv-file-processing-svc/src/main/java/org/pipelineframework/csv/service/ProcessCsvPaymentsOutputFileService.java
@@ -49,9 +49,12 @@ import org.pipelineframework.service.ReactiveBidirectionalStreamingService;
  * <p>
  * The service uses the iterator-based write method from OpenCSV which provides better
  * streaming characteristics than list-based writing.
+ *
+ * @deprecated Prefer Object Publish with {@code CsvPaymentOutputPublishMapper} for framework-owned terminal output I/O.
  */
 @PipelineStep
 @ApplicationScoped
+@Deprecated(forRemoval = false)
 public class ProcessCsvPaymentsOutputFileService
     implements ReactiveBidirectionalStreamingService<PaymentOutput, CsvPaymentsOutputFile> {
 

--- a/examples/csv-payments/pom.xml
+++ b/examples/csv-payments/pom.xml
@@ -57,6 +57,8 @@
         <argLine />
         <surefireArgLine />
         <pipeline.generatedSourcesArg />
+        <pipeline.configArg />
+        <pipeline.protoConfigArg />
         <pipeline.moduleArg>-Apipeline.module=${project.artifactId}</pipeline.moduleArg>
         <protobuf.descriptor.fileArg />
         <pipeline.parallelism>PARALLEL</pipeline.parallelism>
@@ -314,6 +316,7 @@
                             <configuration>
                                 <compilerArgs>
                                     <arg>${pipeline.generatedSourcesArg}</arg>
+                                    <arg>${pipeline.configArg}</arg>
                                     <arg>${pipeline.moduleArg}</arg>
                                     <arg>${protobuf.descriptor.fileArg}</arg>
                                     <arg>-Apipeline.transport=${tpf.build.transport}</arg>

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/CheckpointBoundaryValidator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/CheckpointBoundaryValidator.java
@@ -23,6 +23,7 @@ import javax.tools.StandardLocation;
 import org.pipelineframework.config.template.PipelineTemplateConfig;
 import org.pipelineframework.config.template.PipelineTemplateStep;
 import org.pipelineframework.config.boundary.PipelineObjectInputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
 
 /**
  * Validates checkpoint publication/subscription declarations loaded from pipeline YAML.
@@ -32,6 +33,7 @@ final class CheckpointBoundaryValidator {
     private static final String QUEUE_ASYNC = "QUEUE_ASYNC";
     private static final String MAPPER_INTERFACE = "org.pipelineframework.mapper.Mapper";
     private static final String OBJECT_SNAPSHOT_MAPPER_INTERFACE = "org.pipelineframework.objectingest.ObjectSnapshotMapper";
+    private static final String OBJECT_PUBLISH_MAPPER_INTERFACE = "org.pipelineframework.objectpublish.ObjectPublishMapper";
 
     void validate(
         PipelineTemplateConfig templateConfig,
@@ -46,7 +48,8 @@ final class CheckpointBoundaryValidator {
         boolean hasInputSubscription = templateConfig.input() != null && templateConfig.input().subscription() != null;
         boolean hasObjectInput = templateConfig.input() != null && templateConfig.input().object() != null;
         boolean hasOutputCheckpoint = templateConfig.output() != null && templateConfig.output().checkpoint() != null;
-        if (!hasInputSubscription && !hasObjectInput && !hasOutputCheckpoint) {
+        boolean hasObjectOutput = templateConfig.output() != null && templateConfig.output().object() != null;
+        if (!hasInputSubscription && !hasObjectInput && !hasOutputCheckpoint && !hasObjectOutput) {
             return;
         }
         if (templateConfig.platform() != null && templateConfig.platform().name().equals("FUNCTION")) {
@@ -66,6 +69,9 @@ final class CheckpointBoundaryValidator {
         if (hasObjectInput) {
             validateObjectInput(templateConfig, processingEnv);
         }
+        if (hasObjectOutput) {
+            validateObjectOutput(templateConfig, processingEnv);
+        }
         String publication = hasOutputCheckpoint ? templateConfig.output().checkpoint().publication() : null;
         if (hasOutputCheckpoint && (publication == null || publication.isBlank())) {
             throw new IllegalStateException("output.checkpoint.publication must not be blank");
@@ -73,6 +79,71 @@ final class CheckpointBoundaryValidator {
         if (messager != null && hasOutputCheckpoint) {
             messager.printMessage(Diagnostic.Kind.NOTE,
                 "Checkpoint publication enabled for publication '" + publication + "'");
+        }
+    }
+
+    private void validateObjectOutput(PipelineTemplateConfig templateConfig, ProcessingEnvironment processingEnv) {
+        PipelineObjectOutputConfig objectOutput = templateConfig.output().object();
+        Map<String, ?> publish = templateConfig.publish() == null ? Map.of() : templateConfig.publish();
+        if (!publish.containsKey(objectOutput.target())) {
+            throw new IllegalStateException("output object publish target not found: " + objectOutput.target());
+        }
+        String lastStepOutput = templateConfig.steps().getLast().outputTypeName();
+        String expected = objectOutput.typeName() == null ? objectOutput.type() : objectOutput.typeName();
+        if (expected == null || expected.isBlank()) {
+            throw new IllegalStateException("Object output must declare a non-blank type or typeName");
+        }
+        if (lastStepOutput != null && !lastStepOutput.isBlank() && !typeMatches(lastStepOutput, expected)) {
+            throw new IllegalStateException(
+                "Object output consumes type '" + expected + "' must match last step output '" + lastStepOutput + "'");
+        }
+        validateObjectOutputMapper(objectOutput, expected, processingEnv);
+    }
+
+    private void validateObjectOutputMapper(
+        PipelineObjectOutputConfig objectOutput,
+        String expected,
+        ProcessingEnvironment processingEnv
+    ) {
+        if (processingEnv == null) {
+            return;
+        }
+        String mapperClass = objectOutput.mapper();
+        if (mapperClass == null || mapperClass.isBlank()) {
+            return;
+        }
+        TypeElement mapperElement = processingEnv.getElementUtils().getTypeElement(mapperClass);
+        if (mapperElement == null) {
+            throw new IllegalStateException("Object output mapper type not found: " + mapperClass);
+        }
+        TypeElement mapperInterface = processingEnv.getElementUtils().getTypeElement(OBJECT_PUBLISH_MAPPER_INTERFACE);
+        if (mapperInterface == null) {
+            throw new IllegalStateException("ObjectPublishMapper interface not found: " + OBJECT_PUBLISH_MAPPER_INTERFACE);
+        }
+        TypeMirror rawMapperInterfaceType = mapperInterface.asType();
+        if (!(rawMapperInterfaceType instanceof DeclaredType mapperInterfaceType)) {
+            throw new IllegalStateException(
+                "ObjectPublishMapper interface not resolvable as declared type: " + OBJECT_PUBLISH_MAPPER_INTERFACE);
+        }
+        Types types = processingEnv.getTypeUtils();
+        Optional<DeclaredType> mapperType = findImplementedInterface(
+            mapperElement.asType(), mapperInterfaceType, types, new HashSet<>());
+        if (mapperType.isEmpty()) {
+            throw new IllegalStateException(
+                "Object output mapper '" + mapperClass + "' must implement "
+                    + OBJECT_PUBLISH_MAPPER_INTERFACE);
+        }
+        DeclaredType declared = mapperType.get();
+        if (declared.getTypeArguments().size() != 1) {
+            throw new IllegalStateException(
+                "Object output mapper '" + mapperClass
+                    + "' must declare exactly one type argument for ObjectPublishMapper<PipelineOutput>");
+        }
+        String mappedType = declared.getTypeArguments().getFirst().toString();
+        if (!typeMatches(expected, mappedType)) {
+            throw new IllegalStateException(
+                "Object output mapper '" + mapperClass + "' must declare ObjectPublishMapper<"
+                    + expected + ">");
         }
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
@@ -982,6 +982,17 @@ public final class PipelineTemplateSchemaExporter {
       },
       "additionalProperties": false
     },
+    "objectPublishGrouping": {
+      "type": "object",
+      "properties": {
+        "maxOpenGroups": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 32
+        }
+      },
+      "additionalProperties": false
+    },
     "objectPublishTarget": {
       "type": "object",
       "properties": {
@@ -1001,6 +1012,9 @@ public final class PipelineTemplateSchemaExporter {
         },
         "payload": {
           "$ref": "#/$defs/objectPublishPayload"
+        },
+        "grouping": {
+          "$ref": "#/$defs/objectPublishGrouping"
         }
       },
       "required": [

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
@@ -545,8 +545,88 @@ public final class PipelineTemplateSchemaExporter {
       "properties": {
         "checkpoint": {
           "$ref": "#/$defs/checkpointPublication"
+        },
+        "object": {
+          "$ref": "#/$defs/objectOutputBoundary"
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "consumes": {
+          "$ref": "#/$defs/objectOutputConsume"
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "checkpoint"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "object"
+                ]
+              },
+              {
+                "required": [
+                  "to"
+                ]
+              },
+              {
+                "required": [
+                  "consumes"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "object"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "checkpoint"
+                ]
+              },
+              {
+                "required": [
+                  "to"
+                ]
+              },
+              {
+                "required": [
+                  "consumes"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "to",
+            "consumes"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "checkpoint"
+                ]
+              },
+              {
+                "required": [
+                  "object"
+                ]
+              }
+            ]
+          }
+        }
+      ],
       "additionalProperties": false
     },
     "checkpointSubscription": {
@@ -615,6 +695,60 @@ public final class PipelineTemplateSchemaExporter {
         {
           "required": [
             "from"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "objectOutputConsume": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "typeName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mapper": {
+          "type": "string",
+          "pattern": "^[a-zA-Z_$][a-zA-Z\\\\d_$]*(\\\\.[a-zA-Z_$][a-zA-Z\\\\d_$]*)*\\\\.[A-Z][a-zA-Z\\\\d_$]*$"
+        }
+      },
+      "required": [
+        "type",
+        "mapper"
+      ],
+      "additionalProperties": false
+    },
+    "objectOutputBoundary": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "consumes": {
+          "$ref": "#/$defs/objectOutputConsume"
+        }
+      },
+      "required": [
+        "consumes"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "target"
+          ]
+        },
+        {
+          "required": [
+            "to"
           ]
         }
       ],
@@ -822,6 +956,63 @@ public final class PipelineTemplateSchemaExporter {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/objectSource"
+      }
+    },
+    "objectPublishNaming": {
+      "type": "object",
+      "properties": {
+        "keyTemplate": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "objectPublishPayload": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "minLength": 1
+        },
+        "charset": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "objectPublishTarget": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "object"
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "location": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "naming": {
+          "$ref": "#/$defs/objectPublishNaming"
+        },
+        "payload": {
+          "$ref": "#/$defs/objectPublishPayload"
+        }
+      },
+      "required": [
+        "kind",
+        "provider"
+      ],
+      "additionalProperties": false
+    },
+    "pipelinePublishTargets": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/objectPublishTarget"
       }
     },
     "v2Execution": {
@@ -1806,6 +1997,9 @@ public final class PipelineTemplateSchemaExporter {
     },
     "sources": {
       "$ref": "#/$defs/pipelineSources"
+    },
+    "publish": {
+      "$ref": "#/$defs/pipelinePublishTargets"
     },
     "input": {
       "$ref": "#/$defs/pipelineInputBoundary"

--- a/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
+++ b/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
@@ -948,6 +948,17 @@
       },
       "additionalProperties": false
     },
+    "objectPublishGrouping": {
+      "type": "object",
+      "properties": {
+        "maxOpenGroups": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 32
+        }
+      },
+      "additionalProperties": false
+    },
     "objectPublishTarget": {
       "type": "object",
       "properties": {
@@ -967,6 +978,9 @@
         },
         "payload": {
           "$ref": "#/$defs/objectPublishPayload"
+        },
+        "grouping": {
+          "$ref": "#/$defs/objectPublishGrouping"
         }
       },
       "required": [

--- a/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
+++ b/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
@@ -511,8 +511,88 @@
       "properties": {
         "checkpoint": {
           "$ref": "#/$defs/checkpointPublication"
+        },
+        "object": {
+          "$ref": "#/$defs/objectOutputBoundary"
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "consumes": {
+          "$ref": "#/$defs/objectOutputConsume"
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "checkpoint"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "object"
+                ]
+              },
+              {
+                "required": [
+                  "to"
+                ]
+              },
+              {
+                "required": [
+                  "consumes"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "object"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "checkpoint"
+                ]
+              },
+              {
+                "required": [
+                  "to"
+                ]
+              },
+              {
+                "required": [
+                  "consumes"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "to",
+            "consumes"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "checkpoint"
+                ]
+              },
+              {
+                "required": [
+                  "object"
+                ]
+              }
+            ]
+          }
+        }
+      ],
       "additionalProperties": false
     },
     "checkpointSubscription": {
@@ -581,6 +661,60 @@
         {
           "required": [
             "from"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "objectOutputConsume": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "typeName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mapper": {
+          "type": "string",
+          "pattern": "^[a-zA-Z_$][a-zA-Z\\d_$]*(\\.[a-zA-Z_$][a-zA-Z\\d_$]*)*\\.[A-Z][a-zA-Z\\d_$]*$"
+        }
+      },
+      "required": [
+        "type",
+        "mapper"
+      ],
+      "additionalProperties": false
+    },
+    "objectOutputBoundary": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "consumes": {
+          "$ref": "#/$defs/objectOutputConsume"
+        }
+      },
+      "required": [
+        "consumes"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "target"
+          ]
+        },
+        {
+          "required": [
+            "to"
           ]
         }
       ],
@@ -788,6 +922,63 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/objectSource"
+      }
+    },
+    "objectPublishNaming": {
+      "type": "object",
+      "properties": {
+        "keyTemplate": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "objectPublishPayload": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "minLength": 1
+        },
+        "charset": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "objectPublishTarget": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "object"
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "location": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "naming": {
+          "$ref": "#/$defs/objectPublishNaming"
+        },
+        "payload": {
+          "$ref": "#/$defs/objectPublishPayload"
+        }
+      },
+      "required": [
+        "kind",
+        "provider"
+      ],
+      "additionalProperties": false
+    },
+    "pipelinePublishTargets": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/objectPublishTarget"
       }
     },
     "v2Execution": {
@@ -1772,6 +1963,9 @@
     },
     "sources": {
       "$ref": "#/$defs/pipelineSources"
+    },
+    "publish": {
+      "$ref": "#/$defs/pipelinePublishTargets"
     },
     "input": {
       "$ref": "#/$defs/pipelineInputBoundary"

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporterTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporterTest.java
@@ -56,11 +56,13 @@ class PipelineTemplateSchemaExporterTest {
         assertTrue(definitions.has("pipelineInputBoundary"));
         assertTrue(definitions.has("pipelineOutputBoundary"));
         assertTrue(definitions.has("pipelineSources"));
+        assertTrue(definitions.has("pipelinePublishTargets"));
         assertTrue(definitions.has("objectSource"));
         assertTrue(definitions.has("queryDefinition"));
         assertTrue(definitions.has("jpaQueryDefinition"));
         assertTrue(definitions.has("queryCapture"));
         assertTrue(definitions.has("queryTemplateStep"));
+        assertTrue(definitions.has("objectPublishTarget"));
         assertTrue(definitions.has("delegatedOrInternalStep"));
         assertTrue(definitions.has("v2Execution"));
         assertTrue(definitions.has("awaitTemplateStep"));
@@ -74,6 +76,7 @@ class PipelineTemplateSchemaExporterTest {
         assertTrue(properties.has("output"));
         assertTrue(properties.has("sources"));
         assertTrue(properties.has("queries"));
+        assertTrue(properties.has("publish"));
         assertTrue(properties.has("materialization"));
     }
 
@@ -107,6 +110,18 @@ class PipelineTemplateSchemaExporterTest {
         assertEquals(2, oneOf.size());
         assertContains(oneOf.get(0).getAsJsonObject().getAsJsonArray("required"), "source");
         assertContains(oneOf.get(1).getAsJsonObject().getAsJsonArray("required"), "from");
+    }
+
+    @Test
+    void objectOutputBoundaryRequiresTargetReference() {
+        JsonObject definitions = parse(PipelineTemplateSchemaExporter.schemaJson()).getAsJsonObject("$defs");
+        JsonObject objectOutput = definitions.getAsJsonObject("objectOutputBoundary");
+
+        assertContains(objectOutput.getAsJsonArray("required"), "consumes");
+        JsonArray oneOf = objectOutput.getAsJsonArray("oneOf");
+        assertEquals(2, oneOf.size());
+        assertContains(oneOf.get(0).getAsJsonObject().getAsJsonArray("required"), "target");
+        assertContains(oneOf.get(1).getAsJsonObject().getAsJsonArray("required"), "to");
     }
 
     @Test

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunner.java
@@ -34,6 +34,7 @@ import org.pipelineframework.context.PipelineContext;
 import org.pipelineframework.context.PipelineContextHolder;
 import org.pipelineframework.awaitable.AwaitExecutionContext;
 import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
+import org.pipelineframework.objectpublish.ObjectPublishRunner;
 import org.pipelineframework.runtime.core.PipelineRunnerCore;
 import org.pipelineframework.step.Configurable;
 import org.pipelineframework.step.ConfigFactory;
@@ -75,6 +76,7 @@ public class PipelineRunner implements AutoCloseable {
     PipelineStepExecutor stepExecutor;
 
     private final PipelineRunnerCore runnerCore = new PipelineRunnerCore();
+    private volatile ObjectPublishRunner objectPublishRunner;
 
     /**
      * Default constructor for PipelineRunner.
@@ -180,7 +182,11 @@ public class PipelineRunner implements AutoCloseable {
             },
             index -> logger.warnf("Warning: Found null step at index %d in configuration, skipping...", index));
 
-        return new ExecutionResult(telemetry.instrumentRunCompletion(current, telemetryContext), telemetryContext);
+        // Terminal object publish only runs after a full pipeline execution, not for partial/early-stop runs.
+        Object terminal = stopBeforeStepIndex == orderedSteps.size()
+            ? objectPublishRunner().publish(current)
+            : current;
+        return new ExecutionResult(telemetry.instrumentRunCompletion(terminal, telemetryContext), telemetryContext);
     }
 
     public record ExecutionResult(Object result, PipelineTelemetry.RunContext telemetryContext) {
@@ -259,5 +265,20 @@ public class PipelineRunner implements AutoCloseable {
      */
     @Override
     public void close() {
+    }
+
+    private ObjectPublishRunner objectPublishRunner() {
+        ObjectPublishRunner runner = objectPublishRunner;
+        if (runner != null) {
+            return runner;
+        }
+        synchronized (this) {
+            runner = objectPublishRunner;
+            if (runner == null) {
+                runner = ObjectPublishRunner.loadFromDefaultConfig();
+                objectPublishRunner = runner;
+            }
+            return runner;
+        }
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectNamingConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectNamingConfig.java
@@ -1,0 +1,23 @@
+package org.pipelineframework.config.boundary;
+
+/**
+ * Object publish key naming settings.
+ *
+ * @param keyTemplate object key template; supports {@code {groupKey}} and mapper labels
+ */
+public record PipelineObjectNamingConfig(String keyTemplate) {
+    public PipelineObjectNamingConfig {
+        keyTemplate = normalize(keyTemplate);
+        if (keyTemplate == null) {
+            keyTemplate = "{groupKey}";
+        }
+    }
+
+    public static PipelineObjectNamingConfig defaults() {
+        return new PipelineObjectNamingConfig("{groupKey}");
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectOutputConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectOutputConfig.java
@@ -1,0 +1,36 @@
+package org.pipelineframework.config.boundary;
+
+/**
+ * Object publish binding for a pipeline output boundary.
+ *
+ * @param target named publish target declared under top-level publish
+ * @param type fully qualified terminal output type consumed by the publish mapper
+ * @param typeName optional simple type name used by generator-facing templates
+ * @param mapper mapper from terminal output items to grouped object payloads
+ */
+public record PipelineObjectOutputConfig(
+    String target,
+    String type,
+    String typeName,
+    String mapper
+) {
+    public PipelineObjectOutputConfig {
+        target = normalize(target);
+        type = normalize(type);
+        typeName = normalize(typeName);
+        mapper = normalize(mapper);
+        if (target == null) {
+            throw new IllegalArgumentException("output.object.target must not be blank");
+        }
+        if (type == null) {
+            throw new IllegalArgumentException("output.object.consumes.type must not be blank");
+        }
+        if (mapper == null) {
+            throw new IllegalArgumentException("output.object.consumes.mapper must not be blank");
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishConfig.java
@@ -1,0 +1,51 @@
+package org.pipelineframework.config.boundary;
+
+import java.util.Map;
+
+/**
+ * Named object publish target declared under top-level {@code publish}.
+ *
+ * @param name target name
+ * @param kind target kind, v1 supports object
+ * @param provider object target provider, for example filesystem or s3
+ * @param location provider-specific location map
+ * @param naming object key naming settings
+ * @param payload object payload settings
+ */
+public record PipelineObjectPublishConfig(
+    String name,
+    String kind,
+    String provider,
+    Map<String, Object> location,
+    PipelineObjectNamingConfig naming,
+    PipelineObjectPublishPayloadConfig payload
+) {
+    public PipelineObjectPublishConfig {
+        name = normalize(name);
+        kind = normalize(kind);
+        provider = normalize(provider);
+        if (location != null) {
+            for (Map.Entry<String, Object> entry : location.entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) {
+                    throw new IllegalArgumentException("publish target location map must not contain null keys or values");
+                }
+            }
+        }
+        location = location == null ? Map.of() : Map.copyOf(location);
+        naming = naming == null ? PipelineObjectNamingConfig.defaults() : naming;
+        payload = payload == null ? PipelineObjectPublishPayloadConfig.defaults() : payload;
+        if (name == null) {
+            throw new IllegalArgumentException("publish target name must not be blank");
+        }
+        if (!"object".equalsIgnoreCase(kind)) {
+            throw new IllegalArgumentException("publish target '" + name + "' kind must be object");
+        }
+        if (provider == null) {
+            throw new IllegalArgumentException("publish target '" + name + "' provider must not be blank");
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishConfig.java
@@ -11,6 +11,7 @@ import java.util.Map;
  * @param location provider-specific location map
  * @param naming object key naming settings
  * @param payload object payload settings
+ * @param grouping object publish grouping settings
  */
 public record PipelineObjectPublishConfig(
     String name,
@@ -18,8 +19,20 @@ public record PipelineObjectPublishConfig(
     String provider,
     Map<String, Object> location,
     PipelineObjectNamingConfig naming,
-    PipelineObjectPublishPayloadConfig payload
+    PipelineObjectPublishPayloadConfig payload,
+    PipelineObjectPublishGroupingConfig grouping
 ) {
+    public PipelineObjectPublishConfig(
+        String name,
+        String kind,
+        String provider,
+        Map<String, Object> location,
+        PipelineObjectNamingConfig naming,
+        PipelineObjectPublishPayloadConfig payload
+    ) {
+        this(name, kind, provider, location, naming, payload, PipelineObjectPublishGroupingConfig.defaults());
+    }
+
     public PipelineObjectPublishConfig {
         name = normalize(name);
         kind = normalize(kind);
@@ -34,6 +47,7 @@ public record PipelineObjectPublishConfig(
         location = location == null ? Map.of() : Map.copyOf(location);
         naming = naming == null ? PipelineObjectNamingConfig.defaults() : naming;
         payload = payload == null ? PipelineObjectPublishPayloadConfig.defaults() : payload;
+        grouping = grouping == null ? PipelineObjectPublishGroupingConfig.defaults() : grouping;
         if (name == null) {
             throw new IllegalArgumentException("publish target name must not be blank");
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishGroupingConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishGroupingConfig.java
@@ -1,0 +1,20 @@
+package org.pipelineframework.config.boundary;
+
+/**
+ * Grouping limits for terminal Object Publish streams.
+ *
+ * @param maxOpenGroups maximum number of object groups that may be open at once
+ */
+public record PipelineObjectPublishGroupingConfig(int maxOpenGroups) {
+    private static final int DEFAULT_MAX_OPEN_GROUPS = 32;
+
+    public PipelineObjectPublishGroupingConfig {
+        if (maxOpenGroups <= 0) {
+            throw new IllegalArgumentException("publish.grouping.maxOpenGroups must be > 0");
+        }
+    }
+
+    public static PipelineObjectPublishGroupingConfig defaults() {
+        return new PipelineObjectPublishGroupingConfig(DEFAULT_MAX_OPEN_GROUPS);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishPayloadConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineObjectPublishPayloadConfig.java
@@ -1,0 +1,29 @@
+package org.pipelineframework.config.boundary;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Object publish payload settings.
+ *
+ * @param contentType content type applied to written objects
+ * @param charset text charset hint for payload renderers
+ */
+public record PipelineObjectPublishPayloadConfig(
+    String contentType,
+    Charset charset
+) {
+    public PipelineObjectPublishPayloadConfig {
+        contentType = normalize(contentType);
+        contentType = contentType == null ? "application/octet-stream" : contentType;
+        charset = charset == null ? StandardCharsets.UTF_8 : charset;
+    }
+
+    public static PipelineObjectPublishPayloadConfig defaults() {
+        return new PipelineObjectPublishPayloadConfig("application/octet-stream", StandardCharsets.UTF_8);
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineOutputBoundaryConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/boundary/PipelineOutputBoundaryConfig.java
@@ -4,8 +4,22 @@ package org.pipelineframework.config.boundary;
  * Output boundary configuration for a pipeline.
  *
  * @param checkpoint stable checkpoint publication settings
+ * @param object object publish settings
  */
 public record PipelineOutputBoundaryConfig(
-    PipelineCheckpointConfig checkpoint
+    PipelineCheckpointConfig checkpoint,
+    PipelineObjectOutputConfig object
 ) {
+    public PipelineOutputBoundaryConfig(PipelineCheckpointConfig checkpoint) {
+        this(checkpoint, null);
+    }
+
+    public PipelineOutputBoundaryConfig {
+        if (checkpoint != null && object != null) {
+            throw new IllegalArgumentException("pipeline output boundary cannot declare both checkpoint and object");
+        }
+        if (checkpoint == null && object == null) {
+            throw new IllegalArgumentException("pipeline output boundary must declare either checkpoint or object");
+        }
+    }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.pipelineframework.config.PlatformOverrideResolver;
 import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
 import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
 
@@ -33,6 +34,7 @@ import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
  * @param steps the configured pipeline steps
  * @param sources named pipeline I/O sources
  * @param queries named captured query definitions
+ * @param publish named pipeline object publish targets
  * @param aspects the configured pipeline aspects
  * @param input the configured reliable pipeline input boundary
  * @param output the configured reliable pipeline output boundary
@@ -44,6 +46,7 @@ public record PipelineYamlConfig(
     List<PipelineYamlStep> steps,
     Map<String, PipelineObjectSourceConfig> sources,
     Map<String, PipelineYamlQuery> queries,
+    Map<String, PipelineObjectPublishConfig> publish,
     List<PipelineYamlAspect> aspects,
     PipelineInputBoundaryConfig input,
     PipelineOutputBoundaryConfig output
@@ -67,8 +70,10 @@ public record PipelineYamlConfig(
         platform = normalizedPlatform;
         validateMap(sources, "sources");
         validateMap(queries, "queries");
+        validateMap(publish, "publish");
         sources = sources == null ? Map.of() : Map.copyOf(sources);
         queries = queries == null ? Map.of() : Map.copyOf(queries);
+        publish = publish == null ? Map.of() : Map.copyOf(publish);
     }
 
     private static void validateMap(Map<?, ?> values, String fieldName) {
@@ -99,7 +104,7 @@ public record PipelineYamlConfig(
         List<PipelineYamlStep> steps,
         List<PipelineYamlAspect> aspects
     ) {
-        this(basePackage, transport, "COMPUTE", steps, Map.of(), Map.of(), aspects, null, null);
+        this(basePackage, transport, "COMPUTE", steps, Map.of(), Map.of(), Map.of(), aspects, null, null);
     }
 
     /**
@@ -119,7 +124,7 @@ public record PipelineYamlConfig(
         List<PipelineYamlStep> steps,
         List<PipelineYamlAspect> aspects
     ) {
-        this(basePackage, transport, platform, steps, Map.of(), Map.of(), aspects, null, null);
+        this(basePackage, transport, platform, steps, Map.of(), Map.of(), Map.of(), aspects, null, null);
     }
 
     public PipelineYamlConfig(
@@ -127,11 +132,13 @@ public record PipelineYamlConfig(
         String transport,
         String platform,
         List<PipelineYamlStep> steps,
+        Map<String, PipelineObjectSourceConfig> sources,
+        Map<String, PipelineYamlQuery> queries,
         List<PipelineYamlAspect> aspects,
         PipelineInputBoundaryConfig input,
         PipelineOutputBoundaryConfig output
     ) {
-        this(basePackage, transport, platform, steps, Map.of(), Map.of(), aspects, input, output);
+        this(basePackage, transport, platform, steps, sources, queries, Map.of(), aspects, input, output);
     }
 
     public PipelineYamlConfig(
@@ -144,7 +151,19 @@ public record PipelineYamlConfig(
         PipelineInputBoundaryConfig input,
         PipelineOutputBoundaryConfig output
     ) {
-        this(basePackage, transport, platform, steps, sources, Map.of(), aspects, input, output);
+        this(basePackage, transport, platform, steps, sources, Map.of(), Map.of(), aspects, input, output);
+    }
+
+    public PipelineYamlConfig(
+        String basePackage,
+        String transport,
+        String platform,
+        List<PipelineYamlStep> steps,
+        List<PipelineYamlAspect> aspects,
+        PipelineInputBoundaryConfig input,
+        PipelineOutputBoundaryConfig output
+    ) {
+        this(basePackage, transport, platform, steps, Map.of(), Map.of(), Map.of(), aspects, input, output);
     }
 
     /**
@@ -154,7 +173,7 @@ public record PipelineYamlConfig(
      * @return a new PipelineYamlConfig with the updated transport
      */
     public PipelineYamlConfig withTransport(String transport) {
-        return new PipelineYamlConfig(basePackage, transport, platform, steps, sources, queries, aspects, input, output);
+        return new PipelineYamlConfig(basePackage, transport, platform, steps, sources, queries, publish, aspects, input, output);
     }
 
     /**
@@ -164,6 +183,6 @@ public record PipelineYamlConfig(
      * @return a new PipelineYamlConfig with the updated platform
      */
     public PipelineYamlConfig withPlatform(String platform) {
-        return new PipelineYamlConfig(basePackage, transport, platform, steps, sources, queries, aspects, input, output);
+        return new PipelineYamlConfig(basePackage, transport, platform, steps, sources, queries, publish, aspects, input, output);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
@@ -42,8 +43,12 @@ import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
 import org.pipelineframework.config.boundary.PipelineObjectFilterConfig;
 import org.pipelineframework.config.boundary.PipelineObjectIdentityConfig;
 import org.pipelineframework.config.boundary.PipelineObjectInputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectNamingConfig;
+import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPollConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
 import org.pipelineframework.config.boundary.PipelineSubscriptionConfig;
@@ -169,12 +174,14 @@ public class PipelineYamlConfigLoader {
         List<PipelineYamlStep> steps = readSteps(rootMap);
         Map<String, PipelineObjectSourceConfig> sources = readSources(rootMap);
         Map<String, PipelineYamlQuery> queries = readQueries(rootMap);
+        Map<String, PipelineObjectPublishConfig> publish = readPublishTargets(rootMap);
         List<PipelineYamlAspect> aspects = readAspects(rootMap);
         PipelineInputBoundaryConfig input = readInputBoundary(rootMap);
         validateObjectInputSource(input, sources);
-        PipelineOutputBoundaryConfig output = readOutputBoundary(rootMap);
+        PipelineOutputBoundaryConfig output = readOutputBoundary(rootMap).orElse(null);
+        validateObjectOutputTarget(output, publish);
 
-        return new PipelineYamlConfig(basePackage, transport, platform, steps, sources, queries, aspects, input, output);
+        return new PipelineYamlConfig(basePackage, transport, platform, steps, sources, queries, publish, aspects, input, output);
     }
 
     /**
@@ -533,6 +540,58 @@ public class PipelineYamlConfigLoader {
         return Map.copyOf(sources);
     }
 
+    private Map<String, PipelineObjectPublishConfig> readPublishTargets(Map<?, ?> rootMap) {
+        Object publishObj = rootMap.get("publish");
+        if (publishObj == null) {
+            return Map.of();
+        }
+        if (!(publishObj instanceof Map<?, ?> publishMap)) {
+            throw new IllegalArgumentException("pipeline publish targets must be defined as a map");
+        }
+        Map<String, PipelineObjectPublishConfig> targets = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : publishMap.entrySet()) {
+            String name = entry.getKey() == null ? null : entry.getKey().toString().trim();
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("pipeline publish target name must not be blank");
+            }
+            if (!(entry.getValue() instanceof Map<?, ?> targetMap)) {
+                throw new IllegalArgumentException("publish target '" + name + "' must be defined as a map");
+            }
+            targets.put(name, new PipelineObjectPublishConfig(
+                name,
+                readRequiredString(targetMap, "kind", "publish target '" + name + "'"),
+                readRequiredString(targetMap, "provider", "publish target '" + name + "'"),
+                readObjectMap(targetMap, "location"),
+                readObjectNaming(targetMap),
+                readObjectPublishPayload(targetMap)));
+        }
+        return Map.copyOf(targets);
+    }
+
+    private PipelineObjectNamingConfig readObjectNaming(Map<?, ?> targetMap) {
+        Object namingObj = targetMap.get("naming");
+        if (namingObj == null) {
+            return PipelineObjectNamingConfig.defaults();
+        }
+        if (!(namingObj instanceof Map<?, ?> namingMap)) {
+            throw new IllegalArgumentException("publish.naming must be defined as a map");
+        }
+        return new PipelineObjectNamingConfig(readString(namingMap, "keyTemplate"));
+    }
+
+    private PipelineObjectPublishPayloadConfig readObjectPublishPayload(Map<?, ?> targetMap) {
+        Object payloadObj = targetMap.get("payload");
+        if (payloadObj == null) {
+            return PipelineObjectPublishPayloadConfig.defaults();
+        }
+        if (!(payloadObj instanceof Map<?, ?> payloadMap)) {
+            throw new IllegalArgumentException("publish.payload must be defined as a map");
+        }
+        return new PipelineObjectPublishPayloadConfig(
+            readString(payloadMap, "contentType"),
+            readCharset(payloadMap, "charset", StandardCharsets.UTF_8));
+    }
+
     private PipelineObjectFilterConfig readObjectFilter(Map<?, ?> sourceMap) {
         Object filterObj = sourceMap.get("filter");
         if (filterObj == null) {
@@ -665,30 +724,79 @@ public class PipelineYamlConfigLoader {
      * Parses the optional root-level output boundary.
      *
      * @param rootMap the deserialized YAML root map
-     * @return the output boundary config, or {@code null} when no output boundary is declared
+     * @return the output boundary config, or empty when no output boundary is declared
      */
-    private PipelineOutputBoundaryConfig readOutputBoundary(Map<?, ?> rootMap) {
+    private Optional<PipelineOutputBoundaryConfig> readOutputBoundary(Map<?, ?> rootMap) {
         Object outputObj = rootMap.get("output");
         if (outputObj == null) {
-            return null;
+            return Optional.empty();
         }
         if (!(outputObj instanceof Map<?, ?> outputMap)) {
             throw new IllegalArgumentException("pipeline output boundary must be defined as a map");
         }
         Object checkpointObj = outputMap.get("checkpoint");
-        if (checkpointObj == null) {
-            return null;
+        Object objectObj = outputMap.get("object");
+        boolean hasInlineObject = outputMap.get("to") != null || outputMap.get("consumes") != null;
+        if (checkpointObj != null && (objectObj != null || hasInlineObject)) {
+            throw new IllegalArgumentException("pipeline output boundary cannot declare both checkpoint and object");
         }
-        if (!(checkpointObj instanceof Map<?, ?> checkpointMap)) {
-            throw new IllegalArgumentException("output.checkpoint must be defined as a map");
+        if (objectObj != null && hasInlineObject) {
+            throw new IllegalArgumentException("pipeline output boundary cannot mix output.object with inline to/consumes");
         }
-        Object idempotencyKeyFields = checkpointMap.get("idempotencyKeyFields");
-        if (idempotencyKeyFields != null && !(idempotencyKeyFields instanceof Iterable<?>)) {
-            throw new IllegalArgumentException("output.checkpoint.idempotencyKeyFields must be defined as a list");
+        if (checkpointObj != null) {
+            if (!(checkpointObj instanceof Map<?, ?> checkpointMap)) {
+                throw new IllegalArgumentException("output.checkpoint must be defined as a map");
+            }
+            Object idempotencyKeyFields = checkpointMap.get("idempotencyKeyFields");
+            if (idempotencyKeyFields != null && !(idempotencyKeyFields instanceof Iterable<?>)) {
+                throw new IllegalArgumentException("output.checkpoint.idempotencyKeyFields must be defined as a list");
+            }
+            return Optional.of(new PipelineOutputBoundaryConfig(new PipelineCheckpointConfig(
+                readRequiredString(checkpointMap, "publication", "output.checkpoint"),
+                readStringList(checkpointMap, "idempotencyKeyFields"))));
         }
-        return new PipelineOutputBoundaryConfig(new PipelineCheckpointConfig(
-            readRequiredString(checkpointMap, "publication", "output.checkpoint"),
-            readStringList(checkpointMap, "idempotencyKeyFields")));
+        if (objectObj != null || hasInlineObject) {
+            Map<?, ?> objectMap;
+            if (objectObj == null) {
+                objectMap = outputMap;
+            } else if (objectObj instanceof Map<?, ?> map) {
+                objectMap = map;
+            } else {
+                throw new IllegalArgumentException("output.object must be defined as a map");
+            }
+            return Optional.of(new PipelineOutputBoundaryConfig(null, readObjectOutput(objectMap)));
+        }
+        return Optional.empty();
+    }
+
+    private PipelineObjectOutputConfig readObjectOutput(Map<?, ?> outputMap) {
+        Object consumesObj = outputMap.get("consumes");
+        if (!(consumesObj instanceof Map<?, ?> consumesMap)) {
+            throw new IllegalArgumentException("output.object.consumes must be defined as a map");
+        }
+        String target = readString(outputMap, "target");
+        String to = readString(outputMap, "to");
+        if (target != null && to != null) {
+            throw new IllegalArgumentException("output.object must declare only one of target or to");
+        }
+        String resolvedTarget = firstNonBlank(target, to);
+        if (resolvedTarget == null || resolvedTarget.isBlank()) {
+            throw new IllegalArgumentException("output.object must declare target or to");
+        }
+        return new PipelineObjectOutputConfig(
+            resolvedTarget,
+            readRequiredString(consumesMap, "type", "output.object.consumes"),
+            readString(consumesMap, "typeName"),
+            readRequiredString(consumesMap, "mapper", "output.object.consumes"));
+    }
+
+    private void validateObjectOutputTarget(
+        PipelineOutputBoundaryConfig output,
+        Map<String, PipelineObjectPublishConfig> publish
+    ) {
+        if (output != null && output.object() != null && !publish.containsKey(output.object().target())) {
+            throw new IllegalArgumentException("output.object publish target not found: " + output.object().target());
+        }
     }
 
     private void rejectLegacyConnectors(Map<?, ?> rootMap) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -48,6 +48,7 @@ import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPollConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishGroupingConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPublishPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
@@ -563,7 +564,8 @@ public class PipelineYamlConfigLoader {
                 readRequiredString(targetMap, "provider", "publish target '" + name + "'"),
                 readObjectMap(targetMap, "location"),
                 readObjectNaming(targetMap),
-                readObjectPublishPayload(targetMap)));
+                readObjectPublishPayload(targetMap),
+                readObjectPublishGrouping(targetMap)));
         }
         return Map.copyOf(targets);
     }
@@ -590,6 +592,17 @@ public class PipelineYamlConfigLoader {
         return new PipelineObjectPublishPayloadConfig(
             readString(payloadMap, "contentType"),
             readCharset(payloadMap, "charset", StandardCharsets.UTF_8));
+    }
+
+    private PipelineObjectPublishGroupingConfig readObjectPublishGrouping(Map<?, ?> targetMap) {
+        Object groupingObj = targetMap.get("grouping");
+        if (groupingObj == null) {
+            return PipelineObjectPublishGroupingConfig.defaults();
+        }
+        if (!(groupingObj instanceof Map<?, ?> groupingMap)) {
+            throw new IllegalArgumentException("publish.grouping must be defined as a map");
+        }
+        return new PipelineObjectPublishGroupingConfig(readInt(groupingMap, "maxOpenGroups", 32));
     }
 
     private PipelineObjectFilterConfig readObjectFilter(Map<?, ?> sourceMap) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfig.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfig.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
 import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
 
@@ -35,6 +36,7 @@ import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
  * @param messages top-level named messages
  * @param unions top-level named closed unions
  * @param sources top-level named I/O sources
+ * @param publish top-level named object publish targets
  * @param steps pipeline steps
  * @param aspects aspect configurations keyed by aspect name
  * @param input reliable pipeline input boundary
@@ -50,6 +52,7 @@ public record PipelineTemplateConfig(
     Map<String, PipelineTemplateMessage> messages,
     Map<String, PipelineTemplateUnion> unions,
     Map<String, PipelineObjectSourceConfig> sources,
+    Map<String, PipelineObjectPublishConfig> publish,
     List<PipelineTemplateStep> steps,
     Map<String, PipelineTemplateAspect> aspects,
     PipelineInputBoundaryConfig input,
@@ -69,10 +72,12 @@ public record PipelineTemplateConfig(
         validateMap(messages, "messages");
         validateMap(unions, "unions");
         validateMap(sources, "sources");
+        validateMap(publish, "publish");
         validateMap(aspects, "aspects");
         messages = messages == null ? Map.of() : Map.copyOf(messages);
         unions = unions == null ? Map.of() : Map.copyOf(unions);
         sources = sources == null ? Map.of() : Map.copyOf(sources);
+        publish = publish == null ? Map.of() : Map.copyOf(publish);
         // Preserve null step placeholders so downstream phases/tests can explicitly skip them.
         steps = steps == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(steps));
         aspects = aspects == null ? Map.of() : Map.copyOf(aspects);
@@ -132,7 +137,7 @@ public record PipelineTemplateConfig(
         List<PipelineTemplateStep> steps,
         Map<String, PipelineTemplateAspect> aspects
     ) {
-        this(1, appName, basePackage, transport, PipelinePlatform.COMPUTE, Map.of(), Map.of(), Map.of(), steps, aspects, null, null, null);
+        this(1, appName, basePackage, transport, PipelinePlatform.COMPUTE, Map.of(), Map.of(), Map.of(), Map.of(), steps, aspects, null, null, null);
     }
 
     /**
@@ -153,7 +158,7 @@ public record PipelineTemplateConfig(
         List<PipelineTemplateStep> steps,
         Map<String, PipelineTemplateAspect> aspects
     ) {
-        this(1, appName, basePackage, transport, platform, Map.of(), Map.of(), Map.of(), steps, aspects, null, null, null);
+        this(1, appName, basePackage, transport, platform, Map.of(), Map.of(), Map.of(), Map.of(), steps, aspects, null, null, null);
     }
 
     public PipelineTemplateConfig(
@@ -168,7 +173,7 @@ public record PipelineTemplateConfig(
         PipelineInputBoundaryConfig input,
         PipelineOutputBoundaryConfig output
     ) {
-        this(version, appName, basePackage, transport, platform, messages, Map.of(), Map.of(), steps, aspects, input, output, null);
+        this(version, appName, basePackage, transport, platform, messages, Map.of(), Map.of(), Map.of(), steps, aspects, input, output, null);
     }
 
     public PipelineTemplateConfig(
@@ -185,6 +190,6 @@ public record PipelineTemplateConfig(
         PipelineOutputBoundaryConfig output,
         PipelineTemplateMaterialization materialization
     ) {
-        this(version, appName, basePackage, transport, platform, messages, unions, Map.of(), steps, aspects, input, output, materialization);
+        this(version, appName, basePackage, transport, platform, messages, unions, Map.of(), Map.of(), steps, aspects, input, output, materialization);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Logger;
@@ -41,8 +42,12 @@ import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
 import org.pipelineframework.config.boundary.PipelineObjectFilterConfig;
 import org.pipelineframework.config.boundary.PipelineObjectIdentityConfig;
 import org.pipelineframework.config.boundary.PipelineObjectInputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectNamingConfig;
+import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPollConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
 import org.pipelineframework.config.boundary.PipelineSubscriptionConfig;
@@ -114,13 +119,15 @@ public class PipelineTemplateConfigLoader {
             ? readUnions(rootMap)
             : new LinkedHashMap<>();
         Map<String, PipelineObjectSourceConfig> sources = readSources(rootMap);
+        Map<String, PipelineObjectPublishConfig> publish = readPublishTargets(rootMap);
         List<PipelineTemplateStep> steps = readSteps(rootMap, version);
         Map<String, PipelineTemplateAspect> aspects = readAspects(rootMap);
         PipelineTemplateMaterialization materialization = readMaterialization(rootMap);
         rejectLegacyConnectors(rootMap);
         PipelineInputBoundaryConfig input = readInputBoundary(rootMap);
         validateObjectInputSource(input, sources);
-        PipelineOutputBoundaryConfig output = readOutputBoundary(rootMap);
+        PipelineOutputBoundaryConfig output = readOutputBoundary(rootMap).orElse(null);
+        validateObjectOutputTarget(output, publish);
 
         if (version >= 2) {
             collectInlineMessages(rawMessages, steps);
@@ -137,6 +144,7 @@ public class PipelineTemplateConfigLoader {
                 normalizedMessages,
                 normalizedUnions,
                 sources,
+                publish,
                 steps,
                 aspects,
                 input,
@@ -153,6 +161,7 @@ public class PipelineTemplateConfigLoader {
             Map.of(),
             Map.of(),
             sources,
+            publish,
             steps,
             aspects,
             input,
@@ -1009,6 +1018,58 @@ public class PipelineTemplateConfigLoader {
         return Map.copyOf(sources);
     }
 
+    private Map<String, PipelineObjectPublishConfig> readPublishTargets(Map<?, ?> rootMap) {
+        Object publishObj = rootMap.get("publish");
+        if (publishObj == null) {
+            return Map.of();
+        }
+        if (!(publishObj instanceof Map<?, ?> publishMap)) {
+            throw new IllegalArgumentException("pipeline publish targets must be defined as a YAML map");
+        }
+        Map<String, PipelineObjectPublishConfig> targets = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : publishMap.entrySet()) {
+            String name = stringify(entry.getKey());
+            if (name == null) {
+                throw new IllegalArgumentException("pipeline publish target name must not be blank");
+            }
+            if (!(entry.getValue() instanceof Map<?, ?> targetMap)) {
+                throw new IllegalArgumentException("publish target '" + name + "' must be declared as a YAML map");
+            }
+            targets.put(name, new PipelineObjectPublishConfig(
+                name,
+                readRequiredString(targetMap, "kind", "publish target '" + name + "'"),
+                readRequiredString(targetMap, "provider", "publish target '" + name + "'"),
+                readObjectMap(targetMap, "location"),
+                readObjectNaming(targetMap),
+                readObjectPublishPayload(targetMap)));
+        }
+        return Map.copyOf(targets);
+    }
+
+    private PipelineObjectNamingConfig readObjectNaming(Map<?, ?> targetMap) {
+        Object namingObj = targetMap.get("naming");
+        if (namingObj == null) {
+            return PipelineObjectNamingConfig.defaults();
+        }
+        if (!(namingObj instanceof Map<?, ?> namingMap)) {
+            throw new IllegalArgumentException("publish.naming must be declared as a YAML map");
+        }
+        return new PipelineObjectNamingConfig(readString(namingMap, "keyTemplate"));
+    }
+
+    private PipelineObjectPublishPayloadConfig readObjectPublishPayload(Map<?, ?> targetMap) {
+        Object payloadObj = targetMap.get("payload");
+        if (payloadObj == null) {
+            return PipelineObjectPublishPayloadConfig.defaults();
+        }
+        if (!(payloadObj instanceof Map<?, ?> payloadMap)) {
+            throw new IllegalArgumentException("publish.payload must be declared as a YAML map");
+        }
+        return new PipelineObjectPublishPayloadConfig(
+            readString(payloadMap, "contentType"),
+            readCharset(payloadMap, "charset", StandardCharsets.UTF_8));
+    }
+
     private PipelineObjectFilterConfig readObjectFilter(Map<?, ?> sourceMap) {
         Object filterObj = sourceMap.get("filter");
         if (filterObj == null) {
@@ -1287,28 +1348,77 @@ public class PipelineTemplateConfigLoader {
         }
     }
 
-    private PipelineOutputBoundaryConfig readOutputBoundary(Map<?, ?> rootMap) {
+    private Optional<PipelineOutputBoundaryConfig> readOutputBoundary(Map<?, ?> rootMap) {
         Object outputObj = rootMap.get("output");
         if (outputObj == null) {
-            return null;
+            return Optional.empty();
         }
         if (!(outputObj instanceof Map<?, ?> outputMap)) {
             throw new IllegalArgumentException("pipeline output boundary must be defined as a YAML map");
         }
         Object checkpointObj = outputMap.get("checkpoint");
-        if (checkpointObj == null) {
-            return null;
+        Object objectObj = outputMap.get("object");
+        boolean hasInlineObject = outputMap.get("to") != null || outputMap.get("consumes") != null;
+        if (checkpointObj != null && (objectObj != null || hasInlineObject)) {
+            throw new IllegalArgumentException("pipeline output boundary cannot declare both checkpoint and object");
         }
-        if (!(checkpointObj instanceof Map<?, ?> checkpointMap)) {
-            throw new IllegalArgumentException("output.checkpoint must be declared as a YAML map");
+        if (objectObj != null && hasInlineObject) {
+            throw new IllegalArgumentException("pipeline output boundary cannot mix output.object with inline to/consumes");
         }
-        Object idempotencyKeyFields = checkpointMap.get("idempotencyKeyFields");
-        if (idempotencyKeyFields != null && !(idempotencyKeyFields instanceof Iterable<?>)) {
-            throw new IllegalArgumentException("output.checkpoint.idempotencyKeyFields must be declared as a YAML list");
+        if (checkpointObj != null) {
+            if (!(checkpointObj instanceof Map<?, ?> checkpointMap)) {
+                throw new IllegalArgumentException("output.checkpoint must be declared as a YAML map");
+            }
+            Object idempotencyKeyFields = checkpointMap.get("idempotencyKeyFields");
+            if (idempotencyKeyFields != null && !(idempotencyKeyFields instanceof Iterable<?>)) {
+                throw new IllegalArgumentException("output.checkpoint.idempotencyKeyFields must be declared as a YAML list");
+            }
+            return Optional.of(new PipelineOutputBoundaryConfig(new PipelineCheckpointConfig(
+                readRequiredString(checkpointMap, "publication", "output.checkpoint"),
+                readStringList(checkpointMap, "idempotencyKeyFields"))));
         }
-        return new PipelineOutputBoundaryConfig(new PipelineCheckpointConfig(
-            readRequiredString(checkpointMap, "publication", "output.checkpoint"),
-            readStringList(checkpointMap, "idempotencyKeyFields")));
+        if (objectObj != null || hasInlineObject) {
+            Map<?, ?> objectMap;
+            if (objectObj == null) {
+                objectMap = outputMap;
+            } else if (objectObj instanceof Map<?, ?> map) {
+                objectMap = map;
+            } else {
+                throw new IllegalArgumentException("output.object must be declared as a YAML map");
+            }
+            return Optional.of(new PipelineOutputBoundaryConfig(null, readObjectOutput(objectMap)));
+        }
+        return Optional.empty();
+    }
+
+    private PipelineObjectOutputConfig readObjectOutput(Map<?, ?> outputMap) {
+        Object consumesObj = outputMap.get("consumes");
+        if (!(consumesObj instanceof Map<?, ?> consumesMap)) {
+            throw new IllegalArgumentException("output.object.consumes must be declared as a YAML map");
+        }
+        String target = readString(outputMap, "target");
+        String to = readString(outputMap, "to");
+        if (target != null && to != null) {
+            throw new IllegalArgumentException("output.object must declare only one of target or to");
+        }
+        String resolvedTarget = firstNonBlank(target, to);
+        if (resolvedTarget == null || resolvedTarget.isBlank()) {
+            throw new IllegalArgumentException("output.object must declare target or to");
+        }
+        return new PipelineObjectOutputConfig(
+            resolvedTarget,
+            readRequiredString(consumesMap, "type", "output.object.consumes"),
+            readString(consumesMap, "typeName"),
+            readRequiredString(consumesMap, "mapper", "output.object.consumes"));
+    }
+
+    private void validateObjectOutputTarget(
+        PipelineOutputBoundaryConfig output,
+        Map<String, PipelineObjectPublishConfig> publish
+    ) {
+        if (output != null && output.object() != null && !publish.containsKey(output.object().target())) {
+            throw new IllegalArgumentException("output.object publish target not found: " + output.object().target());
+        }
     }
 
     private void rejectLegacyConnectors(Map<?, ?> rootMap) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
@@ -47,6 +47,7 @@ import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPollConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishGroupingConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPublishPayloadConfig;
 import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
@@ -1041,7 +1042,8 @@ public class PipelineTemplateConfigLoader {
                 readRequiredString(targetMap, "provider", "publish target '" + name + "'"),
                 readObjectMap(targetMap, "location"),
                 readObjectNaming(targetMap),
-                readObjectPublishPayload(targetMap)));
+                readObjectPublishPayload(targetMap),
+                readObjectPublishGrouping(targetMap)));
         }
         return Map.copyOf(targets);
     }
@@ -1068,6 +1070,17 @@ public class PipelineTemplateConfigLoader {
         return new PipelineObjectPublishPayloadConfig(
             readString(payloadMap, "contentType"),
             readCharset(payloadMap, "charset", StandardCharsets.UTF_8));
+    }
+
+    private PipelineObjectPublishGroupingConfig readObjectPublishGrouping(Map<?, ?> targetMap) {
+        Object groupingObj = targetMap.get("grouping");
+        if (groupingObj == null) {
+            return PipelineObjectPublishGroupingConfig.defaults();
+        }
+        if (!(groupingObj instanceof Map<?, ?> groupingMap)) {
+            throw new IllegalArgumentException("publish.grouping must be declared as a YAML map");
+        }
+        return new PipelineObjectPublishGroupingConfig(readInt(groupingMap, "maxOpenGroups", 32));
     }
 
     private PipelineObjectFilterConfig readObjectFilter(Map<?, ?> sourceMap) {

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPayload.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPayload.java
@@ -1,0 +1,36 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.Map;
+
+/**
+ * Rendered object payload produced by an application publish mapper.
+ *
+ * @param bytes encoded payload bytes
+ * @param contentType payload content type override
+ * @param metadata application metadata to attach to the written object
+ */
+public record ObjectPayload(
+    byte[] bytes,
+    String contentType,
+    Map<String, String> metadata
+) {
+    public ObjectPayload {
+        bytes = bytes == null ? new byte[0] : bytes.clone();
+        contentType = normalize(contentType);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IllegalArgumentException("object payload metadata must not contain null keys or values");
+            }
+        }
+    }
+
+    @Override
+    public byte[] bytes() {
+        return bytes.clone();
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPayloadChunk.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPayloadChunk.java
@@ -1,0 +1,19 @@
+package org.pipelineframework.objectpublish;
+
+/**
+ * Incremental object payload bytes produced by a streaming publish renderer.
+ *
+ * @param bytes encoded payload bytes for this chunk
+ */
+public record ObjectPayloadChunk(byte[] bytes) {
+    public static final ObjectPayloadChunk EMPTY = new ObjectPayloadChunk(new byte[0]);
+
+    public ObjectPayloadChunk {
+        bytes = bytes == null ? new byte[0] : bytes.clone();
+    }
+
+    @Override
+    public byte[] bytes() {
+        return bytes.clone();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishGroupRenderer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishGroupRenderer.java
@@ -1,0 +1,30 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.Map;
+
+/**
+ * Streaming renderer for one Object Publish group.
+ *
+ * @param <T> terminal pipeline output item type
+ */
+public interface ObjectPublishGroupRenderer<T> {
+    String contentType();
+
+    default Map<String, String> initialLabels() {
+        return Map.of();
+    }
+
+    default ObjectPayloadChunk onOpen() {
+        return ObjectPayloadChunk.EMPTY;
+    }
+
+    ObjectPayloadChunk onItem(T item);
+
+    default ObjectPayloadChunk onClose() {
+        return ObjectPayloadChunk.EMPTY;
+    }
+
+    default Map<String, String> finalMetadata() {
+        return Map.of();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishMapper.java
@@ -1,0 +1,39 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps terminal pipeline outputs into grouped object payloads for Object Publish.
+ *
+ * @param <T> terminal pipeline output item type
+ */
+public interface ObjectPublishMapper<T> {
+    /**
+     * Returns the non-blank grouping key used to select the output object for the item.
+     *
+     * @param item terminal pipeline output item
+     * @return non-null, non-blank group key
+     */
+    String groupKey(T item);
+
+    /**
+     * Renders all items in a group into a non-null object payload.
+     *
+     * @param groupKey non-blank group key returned by {@link #groupKey(Object)}
+     * @param items non-empty immutable view of the grouped items
+     * @return non-null payload to write to the configured object target
+     */
+    ObjectPayload render(String groupKey, List<T> items);
+
+    /**
+     * Returns optional labels available to key templating and target metadata.
+     *
+     * @param groupKey non-blank group key returned by {@link #groupKey(Object)}
+     * @param items non-empty immutable view of the grouped items
+     * @return label map, or an empty map when no labels are needed
+     */
+    default Map<String, String> labels(String groupKey, List<T> items) {
+        return Map.of();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishRunner.java
@@ -1,0 +1,278 @@
+package org.pipelineframework.objectpublish;
+
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfigLoader;
+import org.pipelineframework.config.pipeline.PipelineYamlConfigLocator;
+
+/**
+ * Runtime-neutral terminal object publish engine.
+ */
+public final class ObjectPublishRunner {
+
+    private static final Logger LOG = Logger.getLogger(ObjectPublishRunner.class);
+    private static final Pattern JAVA_CLASS_NAME = Pattern.compile("[a-zA-Z0-9._$]+");
+    private static final ObjectPublishRunner DISABLED =
+        new ObjectPublishRunner(null, new ObjectTargetRegistry(List.of()), ObjectPublishTelemetry.NOOP, true);
+
+    private final PipelineYamlConfig config;
+    private final ObjectTargetRegistry registry;
+    private final ObjectPublishTelemetry telemetry;
+    private final boolean disabled;
+    private volatile ObjectPublishMapper<Object> resolvedMapper;
+
+    public ObjectPublishRunner(
+        PipelineYamlConfig config,
+        ObjectTargetRegistry registry,
+        ObjectPublishTelemetry telemetry
+    ) {
+        this(config, registry, telemetry, false);
+    }
+
+    private ObjectPublishRunner(
+        PipelineYamlConfig config,
+        ObjectTargetRegistry registry,
+        ObjectPublishTelemetry telemetry,
+        boolean disabled
+    ) {
+        this.config = config;
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.telemetry = telemetry == null ? ObjectPublishTelemetry.NOOP : telemetry;
+        this.disabled = disabled;
+    }
+
+    public static ObjectPublishRunner disabled() {
+        return DISABLED;
+    }
+
+    public static ObjectPublishRunner loadFromDefaultConfig() {
+        Optional<Path> configPath = locateConfig();
+        if (configPath.isEmpty()) {
+            return disabled();
+        }
+        PipelineYamlConfig config = new PipelineYamlConfigLoader().load(configPath.get());
+        return new ObjectPublishRunner(config, ObjectTargetRegistry.load(), ObjectPublishTelemetry.NOOP);
+    }
+
+    public boolean enabled() {
+        return !disabled && objectOutput().isPresent();
+    }
+
+    public Object publish(Object terminalOutput) {
+        if (!enabled()) {
+            return terminalOutput;
+        }
+        if (terminalOutput instanceof Multi<?> multi) {
+            return publishMulti(multi);
+        }
+        if (terminalOutput instanceof Uni<?> uni) {
+            return publishUni(uni);
+        }
+        return terminalOutput;
+    }
+
+    private Multi<?> publishMulti(Multi<?> multi) {
+        return multi.collect().asList()
+            .onItem().transformToUni(items -> publishItems(items).replaceWith(items))
+            .onItem().transformToMulti(items -> Multi.createFrom().iterable(items));
+    }
+
+    private Uni<?> publishUni(Uni<?> uni) {
+        return uni.onItem().transformToUni(item -> {
+            if (item == null) {
+                return Uni.createFrom().nullItem();
+            }
+            return publishItems(List.of(item)).replaceWith(item);
+        });
+    }
+
+    public Uni<Void> publishItems(List<?> items) {
+        PipelineObjectOutputConfig output = objectOutput()
+            .orElseThrow(() -> new IllegalStateException("pipeline output object binding is not configured"));
+        PipelineObjectPublishConfig target = target(output);
+        if (items == null || items.isEmpty()) {
+            telemetry.skipped(target.name());
+            return Uni.createFrom().voidItem();
+        }
+        Map<String, List<Object>> groups = group(items);
+        telemetry.grouped(target.name(), items.size(), groups.size());
+        Uni<Void> chain = Uni.createFrom().voidItem();
+        for (Map.Entry<String, List<Object>> entry : groups.entrySet()) {
+            chain = chain.chain(() -> writeGroup(target, entry.getKey(), entry.getValue()));
+        }
+        return chain;
+    }
+
+    private Map<String, List<Object>> group(List<?> items) {
+        Map<String, List<Object>> groups = new LinkedHashMap<>();
+        ObjectPublishMapper<Object> mapper = mapper();
+        for (Object item : items) {
+            String groupKey = normalize(mapper.groupKey(item))
+                .orElseThrow(() -> new IllegalStateException("Object publish mapper returned a blank group key"));
+            groups.computeIfAbsent(groupKey, ignored -> new java.util.ArrayList<>()).add(item);
+        }
+        return groups;
+    }
+
+    private Uni<Void> writeGroup(PipelineObjectPublishConfig target, String groupKey, List<Object> items) {
+        ObjectPublishMapper<Object> mapper = mapper();
+        Map<String, String> labels = mapper.labels(groupKey, List.copyOf(items));
+        if (labels == null) {
+            labels = Map.of();
+        }
+        ObjectPayload payload = mapper.render(groupKey, List.copyOf(items));
+        if (payload == null) {
+            throw new IllegalStateException("Object publish mapper returned null payload for group: " + groupKey);
+        }
+        byte[] bytes = payload.bytes();
+        String contentType = normalize(payload.contentType()).orElse(target.payload().contentType());
+        String objectKey = renderKey(target.naming().keyTemplate(), groupKey, labels);
+        String checksum = sha256(bytes);
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("target", target.name());
+        metadata.put("groupKey", groupKey);
+        metadata.putAll(labels);
+        metadata.putAll(payload.metadata());
+        ObjectWriteRequest request = new ObjectWriteRequest(
+            target.name(),
+            target,
+            objectKey,
+            bytes,
+            contentType,
+            metadata,
+            checksum,
+            "object-publish:" + target.name() + ":" + objectKey + ":" + checksum);
+        ObjectTargetProvider provider = registry.require(target.provider());
+        return provider.write(request)
+            .invoke(result -> telemetry.published(target.name(), target.provider(), objectKey, result.bytes()))
+            .onFailure().invoke(failure -> {
+                telemetry.failed(target.name(), target.provider(), objectKey, failure);
+                LOG.warnf(failure, "Object publish failed for target=%s key=%s", target.name(), objectKey);
+            })
+            .replaceWithVoid();
+    }
+
+    private String renderKey(String template, String groupKey, Map<String, String> labels) {
+        String rendered = template == null ? "{groupKey}" : template;
+        rendered = rendered.replace("{groupKey}", groupKey);
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            rendered = rendered.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+        return normalize(rendered)
+            .orElseThrow(() -> new IllegalStateException("Object publish rendered a blank object key"));
+    }
+
+    private ObjectPublishMapper<Object> mapper() {
+        PipelineObjectOutputConfig output = objectOutput()
+            .orElseThrow(() -> new IllegalStateException("pipeline output object binding is not configured"));
+        ObjectPublishMapper<Object> mapper = resolvedMapper;
+        if (mapper != null) {
+            return mapper;
+        }
+        synchronized (this) {
+            mapper = resolvedMapper;
+            if (mapper != null) {
+                return mapper;
+            }
+            resolvedMapper = createMapper(output);
+            return resolvedMapper;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private ObjectPublishMapper<Object> createMapper(PipelineObjectOutputConfig output) {
+        String mapperClassName = normalize(output.mapper())
+            .orElseThrow(() -> new IllegalStateException("Object output mapper must not be blank"));
+        validateMapperClassName(mapperClassName);
+        try {
+            Class<?> mapperClass = Class.forName(mapperClassName, true, Thread.currentThread().getContextClassLoader());
+            Object mapper = mapperClass.getDeclaredConstructor().newInstance();
+            if (!(mapper instanceof ObjectPublishMapper<?> publishMapper)) {
+                throw new IllegalStateException(
+                    "Object output mapper '" + mapperClassName + "' must implement " + ObjectPublishMapper.class.getName());
+            }
+            return (ObjectPublishMapper<Object>) publishMapper;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to create object output mapper: " + mapperClassName, e);
+        }
+    }
+
+    private void validateMapperClassName(String mapperClassName) {
+        String basePackage = normalize(config.basePackage())
+            .orElseThrow(() -> new IllegalStateException(
+                "Object output mapper requires pipeline basePackage for runtime class loading"));
+        if (!JAVA_CLASS_NAME.matcher(mapperClassName).matches()
+            || mapperClassName.contains("..")
+            || mapperClassName.contains("/")
+            || mapperClassName.contains("\\")) {
+            throw new IllegalStateException("Object output mapper class name is invalid: " + mapperClassName);
+        }
+        if (!mapperClassName.startsWith(basePackage + ".")) {
+            throw new IllegalStateException(
+                "Object output mapper '" + mapperClassName + "' must be under basePackage '" + basePackage + "'");
+        }
+    }
+
+    private Optional<PipelineObjectOutputConfig> objectOutput() {
+        return config == null || config.output() == null
+            ? Optional.empty()
+            : Optional.ofNullable(config.output().object());
+    }
+
+    private PipelineObjectPublishConfig target(PipelineObjectOutputConfig output) {
+        PipelineObjectPublishConfig target = config.publish().get(output.target());
+        if (target == null) {
+            throw new IllegalStateException("output object publish target not found: " + output.target());
+        }
+        return target;
+    }
+
+    private static Optional<Path> locateConfig() {
+        Optional<String> explicit = firstNonBlank(System.getProperty("pipeline.config"), System.getenv("PIPELINE_CONFIG"));
+        if (explicit.isPresent()) {
+            return Optional.of(Path.of(explicit.get()).toAbsolutePath().normalize());
+        }
+        try {
+            return new PipelineYamlConfigLocator().locate(Path.of(System.getProperty("user.dir")));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> firstNonBlank(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return Optional.of(primary.trim());
+        }
+        if (fallback != null && !fallback.isBlank()) {
+            return Optional.of(fallback.trim());
+        }
+        return Optional.empty();
+    }
+
+    private static String sha256(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(bytes));
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest is not available", e);
+        }
+    }
+
+    private static Optional<String> normalize(String value) {
+        return value == null || value.isBlank() ? Optional.empty() : Optional.of(value.trim());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishRunner.java
@@ -2,12 +2,16 @@ package org.pipelineframework.objectpublish;
 
 import java.nio.file.Path;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionStage;
 import java.util.regex.Pattern;
 
 import io.smallrye.mutiny.Multi;
@@ -33,7 +37,7 @@ public final class ObjectPublishRunner {
     private final ObjectTargetRegistry registry;
     private final ObjectPublishTelemetry telemetry;
     private final boolean disabled;
-    private volatile ObjectPublishMapper<Object> resolvedMapper;
+    private volatile Object resolvedMapper;
 
     public ObjectPublishRunner(
         PipelineYamlConfig config,
@@ -86,15 +90,26 @@ public final class ObjectPublishRunner {
     }
 
     private Multi<?> publishMulti(Multi<?> multi) {
-        return multi.collect().asList()
-            .onItem().transformToUni(items -> publishItems(items).replaceWith(items))
-            .onItem().transformToMulti(items -> Multi.createFrom().iterable(items));
+        PipelineObjectOutputConfig output = objectOutput()
+            .orElseThrow(() -> new IllegalStateException("pipeline output object binding is not configured"));
+        PipelineObjectPublishConfig target = target(output);
+        StreamingObjectPublishMapper<Object> mapper = streamingMapper();
+        StreamingPublishState state = new StreamingPublishState(target, registry.require(target.provider()), mapper);
+        return multi.onItem()
+            .transformToUniAndConcatenate(item -> state.publishItem(item))
+            .onCompletion().call(state::closeAll)
+            .onFailure().call(state::abortAll)
+            .onCancellation().call(() -> state.abortAll(new CancellationException("Object publish stream cancelled")));
     }
 
     private Uni<?> publishUni(Uni<?> uni) {
         return uni.onItem().transformToUni(item -> {
             if (item == null) {
                 return Uni.createFrom().nullItem();
+            }
+            Object mapper = mapper();
+            if (mapper instanceof StreamingObjectPublishMapper<?>) {
+                return publishStreamingItems(List.of(item)).replaceWith(item);
             }
             return publishItems(List.of(item)).replaceWith(item);
         });
@@ -108,18 +123,35 @@ public final class ObjectPublishRunner {
             telemetry.skipped(target.name());
             return Uni.createFrom().voidItem();
         }
-        Map<String, List<Object>> groups = group(items);
+        ObjectPublishMapper<Object> mapper = batchMapper();
+        Map<String, List<Object>> groups = group(items, mapper);
         telemetry.grouped(target.name(), items.size(), groups.size());
         Uni<Void> chain = Uni.createFrom().voidItem();
         for (Map.Entry<String, List<Object>> entry : groups.entrySet()) {
-            chain = chain.chain(() -> writeGroup(target, entry.getKey(), entry.getValue()));
+            chain = chain.chain(() -> writeBatchGroup(target, mapper, entry.getKey(), entry.getValue()));
         }
         return chain;
     }
 
-    private Map<String, List<Object>> group(List<?> items) {
+    private Uni<Void> publishStreamingItems(List<?> items) {
+        PipelineObjectOutputConfig output = objectOutput()
+            .orElseThrow(() -> new IllegalStateException("pipeline output object binding is not configured"));
+        PipelineObjectPublishConfig target = target(output);
+        if (items == null || items.isEmpty()) {
+            telemetry.skipped(target.name());
+            return Uni.createFrom().voidItem();
+        }
+        StreamingObjectPublishMapper<Object> mapper = streamingMapper();
+        StreamingPublishState state = new StreamingPublishState(target, registry.require(target.provider()), mapper);
+        Uni<Void> chain = Uni.createFrom().voidItem();
+        for (Object item : items) {
+            chain = chain.chain(() -> state.publishItem(item).replaceWithVoid());
+        }
+        return chain.chain(state::closeAll).onFailure().call(state::abortAll);
+    }
+
+    private Map<String, List<Object>> group(List<?> items, ObjectPublishMapper<Object> mapper) {
         Map<String, List<Object>> groups = new LinkedHashMap<>();
-        ObjectPublishMapper<Object> mapper = mapper();
         for (Object item : items) {
             String groupKey = normalize(mapper.groupKey(item))
                 .orElseThrow(() -> new IllegalStateException("Object publish mapper returned a blank group key"));
@@ -128,8 +160,12 @@ public final class ObjectPublishRunner {
         return groups;
     }
 
-    private Uni<Void> writeGroup(PipelineObjectPublishConfig target, String groupKey, List<Object> items) {
-        ObjectPublishMapper<Object> mapper = mapper();
+    private Uni<Void> writeBatchGroup(
+        PipelineObjectPublishConfig target,
+        ObjectPublishMapper<Object> mapper,
+        String groupKey,
+        List<Object> items
+    ) {
         Map<String, String> labels = mapper.labels(groupKey, List.copyOf(items));
         if (labels == null) {
             labels = Map.of();
@@ -157,7 +193,7 @@ public final class ObjectPublishRunner {
             checksum,
             "object-publish:" + target.name() + ":" + objectKey + ":" + checksum);
         ObjectTargetProvider provider = registry.require(target.provider());
-        return provider.write(request)
+        return toUni(provider.write(request))
             .invoke(result -> telemetry.published(target.name(), target.provider(), objectKey, result.bytes()))
             .onFailure().invoke(failure -> {
                 telemetry.failed(target.name(), target.provider(), objectKey, failure);
@@ -176,10 +212,10 @@ public final class ObjectPublishRunner {
             .orElseThrow(() -> new IllegalStateException("Object publish rendered a blank object key"));
     }
 
-    private ObjectPublishMapper<Object> mapper() {
+    private Object mapper() {
         PipelineObjectOutputConfig output = objectOutput()
             .orElseThrow(() -> new IllegalStateException("pipeline output object binding is not configured"));
-        ObjectPublishMapper<Object> mapper = resolvedMapper;
+        Object mapper = resolvedMapper;
         if (mapper != null) {
             return mapper;
         }
@@ -194,18 +230,40 @@ public final class ObjectPublishRunner {
     }
 
     @SuppressWarnings("unchecked")
-    private ObjectPublishMapper<Object> createMapper(PipelineObjectOutputConfig output) {
+    private ObjectPublishMapper<Object> batchMapper() {
+        Object mapper = mapper();
+        if (!(mapper instanceof ObjectPublishMapper<?> publishMapper)) {
+            throw new IllegalStateException(
+                "Object output mapper '" + mapper.getClass().getName() + "' must implement "
+                    + ObjectPublishMapper.class.getName() + " for batch publish");
+        }
+        return (ObjectPublishMapper<Object>) publishMapper;
+    }
+
+    @SuppressWarnings("unchecked")
+    private StreamingObjectPublishMapper<Object> streamingMapper() {
+        Object mapper = mapper();
+        if (!(mapper instanceof StreamingObjectPublishMapper<?> publishMapper)) {
+            throw new IllegalStateException(
+                "Object output mapper '" + mapper.getClass().getName() + "' must implement "
+                    + StreamingObjectPublishMapper.class.getName() + " for streaming Object Publish");
+        }
+        return (StreamingObjectPublishMapper<Object>) publishMapper;
+    }
+
+    private Object createMapper(PipelineObjectOutputConfig output) {
         String mapperClassName = normalize(output.mapper())
             .orElseThrow(() -> new IllegalStateException("Object output mapper must not be blank"));
         validateMapperClassName(mapperClassName);
         try {
             Class<?> mapperClass = Class.forName(mapperClassName, true, Thread.currentThread().getContextClassLoader());
             Object mapper = mapperClass.getDeclaredConstructor().newInstance();
-            if (!(mapper instanceof ObjectPublishMapper<?> publishMapper)) {
+            if (!(mapper instanceof ObjectPublishMapper<?>) && !(mapper instanceof StreamingObjectPublishMapper<?>)) {
                 throw new IllegalStateException(
-                    "Object output mapper '" + mapperClassName + "' must implement " + ObjectPublishMapper.class.getName());
+                    "Object output mapper '" + mapperClassName + "' must implement "
+                        + ObjectPublishMapper.class.getName() + " or " + StreamingObjectPublishMapper.class.getName());
             }
-            return (ObjectPublishMapper<Object>) publishMapper;
+            return mapper;
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to create object output mapper: " + mapperClassName, e);
         }
@@ -267,12 +325,214 @@ public final class ObjectPublishRunner {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             return HexFormat.of().formatHex(digest.digest(bytes));
-        } catch (java.security.NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 digest is not available", e);
         }
     }
 
+    private static <T> Uni<T> toUni(CompletionStage<T> stage) {
+        return Uni.createFrom().completionStage(stage);
+    }
+
     private static Optional<String> normalize(String value) {
         return value == null || value.isBlank() ? Optional.empty() : Optional.of(value.trim());
+    }
+
+    private final class StreamingPublishState {
+        private final PipelineObjectPublishConfig target;
+        private final ObjectTargetProvider provider;
+        private final StreamingObjectPublishMapper<Object> mapper;
+        private final Map<String, StreamingGroupState> groups = new LinkedHashMap<>();
+
+        private StreamingPublishState(
+            PipelineObjectPublishConfig target,
+            ObjectTargetProvider provider,
+            StreamingObjectPublishMapper<Object> mapper
+        ) {
+            this.target = target;
+            this.provider = provider;
+            this.mapper = mapper;
+        }
+
+        private Uni<Object> publishItem(Object item) {
+            String groupKey = normalize(mapper.groupKey(item))
+                .orElseThrow(() -> new IllegalStateException("Object publish mapper returned a blank group key"));
+            StreamingGroupState group = groups.get(groupKey);
+            if (group == null) {
+                if (groups.size() >= target.grouping().maxOpenGroups()) {
+                    throw new IllegalStateException(
+                        "Object publish target '" + target.name() + "' exceeded grouping.maxOpenGroups="
+                            + target.grouping().maxOpenGroups());
+                }
+                group = openGroup(groupKey, item);
+                groups.put(groupKey, group);
+            }
+            return group.writeItem(item).replaceWith(item);
+        }
+
+        private StreamingGroupState openGroup(String groupKey, Object firstItem) {
+            ObjectPublishGroupRenderer<Object> renderer = mapper.openGroup(groupKey, firstItem);
+            if (renderer == null) {
+                throw new IllegalStateException("Object publish mapper returned null renderer for group: " + groupKey);
+            }
+            Map<String, String> initialLabels = safeMap(renderer.initialLabels(), "initial labels");
+            String contentType = normalize(renderer.contentType()).orElse(target.payload().contentType());
+            String objectKey = renderKey(target.naming().keyTemplate(), groupKey, initialLabels);
+            Map<String, String> metadata = new LinkedHashMap<>();
+            metadata.put("target", target.name());
+            metadata.put("groupKey", groupKey);
+            metadata.putAll(initialLabels);
+            ObjectWriteOpenRequest request = new ObjectWriteOpenRequest(
+                target.name(),
+                target,
+                objectKey,
+                contentType,
+                metadata,
+                "object-publish:" + target.name() + ":" + objectKey);
+            return new StreamingGroupState(target, provider, renderer, request, metadata);
+        }
+
+        private Uni<Void> closeAll() {
+            if (groups.isEmpty()) {
+                telemetry.skipped(target.name());
+                return Uni.createFrom().voidItem();
+            }
+            long itemCount = groups.values().stream().mapToLong(StreamingGroupState::itemCount).sum();
+            telemetry.grouped(target.name(), Math.toIntExact(itemCount), groups.size());
+            Uni<Void> chain = Uni.createFrom().voidItem();
+            for (StreamingGroupState group : groups.values()) {
+                chain = chain.chain(group::close);
+            }
+            return chain;
+        }
+
+        private Uni<Void> abortAll(Throwable failure) {
+            Uni<Void> chain = Uni.createFrom().voidItem();
+            for (StreamingGroupState group : groups.values()) {
+                chain = chain.chain(() -> group.abort(failure));
+            }
+            return chain;
+        }
+    }
+
+    private final class StreamingGroupState {
+        private final PipelineObjectPublishConfig target;
+        private final ObjectTargetProvider provider;
+        private final ObjectPublishGroupRenderer<Object> renderer;
+        private final ObjectWriteOpenRequest openRequest;
+        private final Map<String, String> initialMetadata;
+        private final MessageDigest digest;
+        private ObjectWriteSession session;
+        private Uni<ObjectWriteSession> openSession;
+        private long bytes;
+        private long itemCount;
+        private boolean closed;
+        private boolean aborted;
+
+        private StreamingGroupState(
+            PipelineObjectPublishConfig target,
+            ObjectTargetProvider provider,
+            ObjectPublishGroupRenderer<Object> renderer,
+            ObjectWriteOpenRequest openRequest,
+            Map<String, String> initialMetadata
+        ) {
+            this.target = target;
+            this.provider = provider;
+            this.renderer = renderer;
+            this.openRequest = openRequest;
+            this.initialMetadata = Map.copyOf(initialMetadata);
+            try {
+                this.digest = MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("SHA-256 digest is not available", e);
+            }
+        }
+
+        private long itemCount() {
+            return itemCount;
+        }
+
+        private Uni<Void> writeItem(Object item) {
+            boolean firstItem = itemCount == 0;
+            itemCount++;
+            Uni<Void> chain = firstItem ? writeChunk(renderer.onOpen()) : Uni.createFrom().voidItem();
+            return chain.chain(() -> writeChunk(renderer.onItem(item)));
+        }
+
+        private Uni<Void> close() {
+            if (closed || aborted) {
+                return Uni.createFrom().voidItem();
+            }
+            closed = true;
+            return writeChunk(renderer.onClose())
+                .chain(() -> open())
+                .chain(session -> toUni(session.close(new ObjectWriteCloseRequest(bytes, checksum(), finalMetadata()))))
+                .invoke(result -> telemetry.published(target.name(), target.provider(), openRequest.objectKey(), result.bytes()))
+                .onFailure().invoke(failure -> {
+                    telemetry.failed(target.name(), target.provider(), openRequest.objectKey(), failure);
+                    LOG.warnf(failure, "Object publish failed for target=%s key=%s", target.name(), openRequest.objectKey());
+                })
+                .replaceWithVoid();
+        }
+
+        private Uni<Void> abort(Throwable failure) {
+            if (aborted || session == null) {
+                aborted = true;
+                return Uni.createFrom().voidItem();
+            }
+            aborted = true;
+            return toUni(session.abort(failure)).replaceWithVoid();
+        }
+
+        private Uni<Void> writeChunk(ObjectPayloadChunk chunk) {
+            byte[] data = chunk == null ? new byte[0] : chunk.bytes();
+            if (data.length == 0) {
+                return Uni.createFrom().voidItem();
+            }
+            digest.update(data);
+            bytes += data.length;
+            return open().chain(session -> toUni(session.write(java.nio.ByteBuffer.wrap(data))).replaceWithVoid());
+        }
+
+        private Uni<ObjectWriteSession> open() {
+            if (session != null) {
+                return Uni.createFrom().item(session);
+            }
+            if (openSession == null) {
+                openSession = toUni(provider.open(openRequest))
+                    .invoke(opened -> {
+                        if (opened == null) {
+                            throw new IllegalStateException("Object target provider returned null write session");
+                        }
+                        session = opened;
+                    })
+                    .memoize().indefinitely();
+            }
+            return openSession;
+        }
+
+        private Map<String, String> finalMetadata() {
+            Map<String, String> metadata = new LinkedHashMap<>(initialMetadata);
+            metadata.putAll(safeMap(renderer.finalMetadata(), "final metadata"));
+            return metadata;
+        }
+
+        private String checksum() {
+            return HexFormat.of().formatHex(digest.digest());
+        }
+    }
+
+    private static Map<String, String> safeMap(Map<String, String> values, String label) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> copy = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IllegalStateException("Object publish " + label + " must not contain null keys or values");
+            }
+            copy.put(entry.getKey(), entry.getValue());
+        }
+        return Collections.unmodifiableMap(copy);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishTelemetry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishTelemetry.java
@@ -1,0 +1,21 @@
+package org.pipelineframework.objectpublish;
+
+/**
+ * Telemetry hook for Object Publish lifecycle events.
+ */
+public interface ObjectPublishTelemetry {
+    ObjectPublishTelemetry NOOP = new ObjectPublishTelemetry() {
+    };
+
+    default void grouped(String targetName, int itemCount, int groupCount) {
+    }
+
+    default void published(String targetName, String provider, String objectKey, long bytes) {
+    }
+
+    default void skipped(String targetName) {
+    }
+
+    default void failed(String targetName, String provider, String objectKey, Throwable failure) {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectTargetProvider.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectTargetProvider.java
@@ -1,0 +1,12 @@
+package org.pipelineframework.objectpublish;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Provider SPI for Object Publish targets.
+ */
+public interface ObjectTargetProvider {
+    String providerName();
+
+    Uni<ObjectWriteResult> write(ObjectWriteRequest request);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectTargetProvider.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectTargetProvider.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.objectpublish;
 
-import io.smallrye.mutiny.Uni;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Provider SPI for Object Publish targets.
@@ -8,5 +9,21 @@ import io.smallrye.mutiny.Uni;
 public interface ObjectTargetProvider {
     String providerName();
 
-    Uni<ObjectWriteResult> write(ObjectWriteRequest request);
+    default CompletionStage<ObjectWriteResult> write(ObjectWriteRequest request) {
+        ObjectWriteOpenRequest openRequest = new ObjectWriteOpenRequest(
+            request.targetName(),
+            request.target(),
+            request.objectKey(),
+            request.contentType(),
+            request.metadata(),
+            request.idempotencyKey());
+        return open(openRequest)
+            .thenCompose(session -> session.write(ByteBuffer.wrap(request.bytes()))
+                .thenCompose(ignored -> session.close(new ObjectWriteCloseRequest(
+                    request.bytes().length,
+                    request.checksum(),
+                    request.metadata()))));
+    }
+
+    CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request);
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectTargetRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectTargetRegistry.java
@@ -1,0 +1,56 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Registry of object publish target providers.
+ */
+public final class ObjectTargetRegistry {
+
+    private final Map<String, ObjectTargetProvider> providers;
+
+    public ObjectTargetRegistry(Collection<ObjectTargetProvider> providers) {
+        Map<String, ObjectTargetProvider> byName = new LinkedHashMap<>();
+        if (providers != null) {
+            for (ObjectTargetProvider provider : providers) {
+                String name = normalize(provider.providerName());
+                if (byName.putIfAbsent(name, provider) != null) {
+                    throw new IllegalArgumentException("Duplicate object target provider: " + name);
+                }
+            }
+        }
+        this.providers = Map.copyOf(byName);
+    }
+
+    public static ObjectTargetRegistry load() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        return new ObjectTargetRegistry(ServiceLoader.load(ObjectTargetProvider.class, loader)
+            .stream()
+            .map(ServiceLoader.Provider::get)
+            .toList());
+    }
+
+    public ObjectTargetProvider require(String providerName) {
+        String normalized = normalize(providerName);
+        ObjectTargetProvider provider = providers.get(normalized);
+        if (provider == null) {
+            throw new IllegalStateException("No object target provider registered for: " + providerName);
+        }
+        return provider;
+    }
+
+    public Map<String, ObjectTargetProvider> providers() {
+        return providers;
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("object target provider name must not be blank");
+        }
+        return value.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteCloseRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteCloseRequest.java
@@ -1,0 +1,29 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.Map;
+
+/**
+ * Provider-neutral request to close a streaming object write session.
+ */
+public record ObjectWriteCloseRequest(
+    long bytes,
+    String checksum,
+    Map<String, String> metadata
+) {
+    public ObjectWriteCloseRequest {
+        checksum = normalize(checksum);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        if (bytes < 0) {
+            throw new IllegalArgumentException("object write close bytes must be >= 0");
+        }
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IllegalArgumentException("object write metadata must not contain null keys or values");
+            }
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteOpenRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteOpenRequest.java
@@ -1,0 +1,43 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.Map;
+
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+
+/**
+ * Provider-neutral request to open a streaming object write session.
+ */
+public record ObjectWriteOpenRequest(
+    String targetName,
+    PipelineObjectPublishConfig target,
+    String objectKey,
+    String contentType,
+    Map<String, String> metadata,
+    String idempotencyKey
+) {
+    public ObjectWriteOpenRequest {
+        targetName = normalize(targetName);
+        objectKey = normalize(objectKey);
+        contentType = normalize(contentType);
+        idempotencyKey = normalize(idempotencyKey);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        if (targetName == null) {
+            throw new IllegalArgumentException("object write targetName must not be blank");
+        }
+        if (target == null) {
+            throw new IllegalArgumentException("object write target must not be null");
+        }
+        if (objectKey == null) {
+            throw new IllegalArgumentException("object write key must not be blank");
+        }
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IllegalArgumentException("object write metadata must not contain null keys or values");
+            }
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteRequest.java
@@ -1,0 +1,52 @@
+package org.pipelineframework.objectpublish;
+
+import java.util.Map;
+
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+
+/**
+ * Provider-neutral object write request.
+ */
+public record ObjectWriteRequest(
+    String targetName,
+    PipelineObjectPublishConfig target,
+    String objectKey,
+    byte[] bytes,
+    String contentType,
+    Map<String, String> metadata,
+    String checksum,
+    String idempotencyKey
+) {
+    public ObjectWriteRequest {
+        targetName = normalize(targetName);
+        objectKey = normalize(objectKey);
+        contentType = normalize(contentType);
+        checksum = normalize(checksum);
+        idempotencyKey = normalize(idempotencyKey);
+        bytes = bytes == null ? new byte[0] : bytes.clone();
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        if (targetName == null) {
+            throw new IllegalArgumentException("object write targetName must not be blank");
+        }
+        if (target == null) {
+            throw new IllegalArgumentException("object write target must not be null");
+        }
+        if (objectKey == null) {
+            throw new IllegalArgumentException("object write key must not be blank");
+        }
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IllegalArgumentException("object write metadata must not contain null keys or values");
+            }
+        }
+    }
+
+    @Override
+    public byte[] bytes() {
+        return bytes.clone();
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteResult.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteResult.java
@@ -1,0 +1,22 @@
+package org.pipelineframework.objectpublish;
+
+import java.time.Instant;
+
+import org.pipelineframework.repository.PayloadReference;
+
+/**
+ * Result returned by an object target provider after writing a payload.
+ */
+public record ObjectWriteResult(
+    PayloadReference reference,
+    long bytes,
+    String checksum,
+    Instant writtenAt
+) {
+    public ObjectWriteResult {
+        if (bytes < 0) {
+            throw new IllegalArgumentException("object write result bytes must be >= 0");
+        }
+        writtenAt = writtenAt == null ? Instant.EPOCH : writtenAt;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteSession.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectWriteSession.java
@@ -1,0 +1,15 @@
+package org.pipelineframework.objectpublish;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Provider-neutral streaming object write session.
+ */
+public interface ObjectWriteSession {
+    CompletionStage<Void> write(ByteBuffer chunk);
+
+    CompletionStage<ObjectWriteResult> close(ObjectWriteCloseRequest request);
+
+    CompletionStage<Void> abort(Throwable cause);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/StreamingObjectPublishMapper.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/StreamingObjectPublishMapper.java
@@ -1,0 +1,26 @@
+package org.pipelineframework.objectpublish;
+
+/**
+ * Maps terminal pipeline outputs into grouped object payload streams.
+ *
+ * @param <T> terminal pipeline output item type
+ */
+public interface StreamingObjectPublishMapper<T> {
+    /**
+     * Returns the non-blank grouping key used to select the output object for the item.
+     *
+     * @param item terminal pipeline output item
+     * @return non-null, non-blank group key
+     */
+    String groupKey(T item);
+
+    /**
+     * Opens a renderer for a group. The first item is supplied so renderers can derive labels
+     * without retaining a full group.
+     *
+     * @param groupKey non-blank group key returned by {@link #groupKey(Object)}
+     * @param firstItem first item observed for the group
+     * @return non-null group renderer
+     */
+    ObjectPublishGroupRenderer<T> openGroup(String groupKey, T firstItem);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -1291,6 +1291,9 @@ public class PipelineProtoGenerator {
             if (args != null) {
                 for (int i = 0; i < args.length; i++) {
                     String arg = args[i];
+                    if (arg == null || arg.isBlank()) {
+                        continue;
+                    }
                     if (arg.startsWith("--module-dir=")) {
                         moduleDir = Path.of(arg.substring("--module-dir=".length()));
                     } else if ("--module-dir".equals(arg) && i + 1 < args.length) {

--- a/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
@@ -95,6 +95,46 @@ class PipelineYamlConfigLoaderTest {
     }
 
     @Test
+    void loadsObjectPublishOutputBoundary() {
+        PipelineYamlConfig config = new PipelineYamlConfigLoader().load(new StringReader("""
+            basePackage: "com.example"
+            transport: "GRPC"
+            platform: "COMPUTE"
+            publish:
+              results:
+                kind: object
+                provider: filesystem
+                location:
+                  root: "/tmp/outgoing"
+                naming:
+                  keyTemplate: "{groupKey}.out"
+                payload:
+                  contentType: text/csv
+            output:
+              to: results
+              consumes:
+                type: com.example.DocumentOutput
+                typeName: DocumentOutput
+                mapper: com.example.DocumentOutputPublishMapper
+            steps:
+              - name: "Process Document"
+                inputTypeName: "DocumentInput"
+                outputTypeName: "DocumentOutput"
+            """));
+
+        assertEquals(1, config.publish().size());
+        assertEquals("filesystem", config.publish().get("results").provider());
+        assertEquals("/tmp/outgoing", config.publish().get("results").location().get("root"));
+        assertEquals("{groupKey}.out", config.publish().get("results").naming().keyTemplate());
+        assertEquals("text/csv", config.publish().get("results").payload().contentType());
+        assertNotNull(config.output());
+        assertEquals("results", config.output().object().target());
+        assertEquals("com.example.DocumentOutput", config.output().object().type());
+        assertEquals("DocumentOutput", config.output().object().typeName());
+        assertEquals("com.example.DocumentOutputPublishMapper", config.output().object().mapper());
+    }
+
+    @Test
     void rejectsSubscriptionAndObjectInputTogether() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new PipelineYamlConfigLoader().load(new StringReader("""
@@ -145,6 +185,39 @@ class PipelineYamlConfigLoaderTest {
                 """)));
 
         assertEquals("input.object must declare source or from", exception.getMessage());
+    }
+
+    @Test
+    void rejectsObjectOutputWithoutPublishTargetReference() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new PipelineYamlConfigLoader().load(new StringReader("""
+                basePackage: "com.example"
+                transport: "GRPC"
+                output:
+                  consumes:
+                    type: com.example.DocumentOutput
+                    mapper: com.example.DocumentOutputPublishMapper
+                steps: []
+                """)));
+
+        assertEquals("output.object must declare target or to", exception.getMessage());
+    }
+
+    @Test
+    void rejectsObjectOutputReferencingMissingPublishTarget() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new PipelineYamlConfigLoader().load(new StringReader("""
+                basePackage: "com.example"
+                transport: "GRPC"
+                output:
+                  to: missing
+                  consumes:
+                    type: com.example.DocumentOutput
+                    mapper: com.example.DocumentOutputPublishMapper
+                steps: []
+                """)));
+
+        assertEquals("output.object publish target not found: missing", exception.getMessage());
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
@@ -110,6 +110,8 @@ class PipelineYamlConfigLoaderTest {
                   keyTemplate: "{groupKey}.out"
                 payload:
                   contentType: text/csv
+                grouping:
+                  maxOpenGroups: 7
             output:
               to: results
               consumes:
@@ -127,6 +129,7 @@ class PipelineYamlConfigLoaderTest {
         assertEquals("/tmp/outgoing", config.publish().get("results").location().get("root"));
         assertEquals("{groupKey}.out", config.publish().get("results").naming().keyTemplate());
         assertEquals("text/csv", config.publish().get("results").payload().contentType());
+        assertEquals(7, config.publish().get("results").grouping().maxOpenGroups());
         assertNotNull(config.output());
         assertEquals("results", config.output().object().target());
         assertEquals("com.example.DocumentOutput", config.output().object().type());

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -341,6 +342,85 @@ class PipelineTemplateConfigLoaderTest {
     }
 
     @Test
+    void loadsObjectPublishOutputBoundary() throws Exception {
+        String yaml = """
+            appName: "Test App"
+            basePackage: "com.example.test"
+            transport: "GRPC"
+            publish:
+              results:
+                kind: object
+                provider: filesystem
+                location:
+                  root: "/tmp/outgoing"
+                naming:
+                  keyTemplate: "{groupKey}.out"
+                payload:
+                  contentType: text/csv
+            output:
+              to: results
+              consumes:
+                type: com.example.test.FooOutput
+                typeName: FooOutput
+                mapper: com.example.test.mapper.FooOutputPublishMapper
+            steps:
+              - name: "Process Foo"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "FooInput"
+                outputTypeName: "FooOutput"
+            """;
+        Path configPath = tempDir.resolve("pipeline-config-object-publish.yaml");
+        Files.writeString(configPath, yaml);
+
+        PipelineTemplateConfig config = new PipelineTemplateConfigLoader().load(configPath);
+
+        assertEquals(1, config.publish().size());
+        assertEquals("filesystem", config.publish().get("results").provider());
+        assertEquals("/tmp/outgoing", config.publish().get("results").location().get("root"));
+        assertEquals("{groupKey}.out", config.publish().get("results").naming().keyTemplate());
+        assertEquals("text/csv", config.publish().get("results").payload().contentType());
+        assertNotNull(config.output());
+        assertEquals("results", config.output().object().target());
+        assertEquals("com.example.test.FooOutput", config.output().object().type());
+        assertEquals("FooOutput", config.output().object().typeName());
+        assertEquals("com.example.test.mapper.FooOutputPublishMapper", config.output().object().mapper());
+    }
+
+    @Test
+    void loadsObjectPublishOutputBoundaryDefaults() throws Exception {
+        String yaml = """
+            appName: "Test App"
+            basePackage: "com.example.test"
+            transport: "GRPC"
+            publish:
+              results:
+                kind: object
+                provider: filesystem
+                location:
+                  root: "/tmp/outgoing"
+            output:
+              to: results
+              consumes:
+                type: com.example.test.FooOutput
+                typeName: FooOutput
+                mapper: com.example.test.mapper.FooOutputPublishMapper
+            steps:
+              - name: "Process Foo"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "FooInput"
+                outputTypeName: "FooOutput"
+            """;
+        Path configPath = tempDir.resolve("pipeline-config-object-publish-defaults.yaml");
+        Files.writeString(configPath, yaml);
+
+        PipelineTemplateConfig config = new PipelineTemplateConfigLoader().load(configPath);
+
+        assertEquals("{groupKey}", config.publish().get("results").naming().keyTemplate());
+        assertEquals("application/octet-stream", config.publish().get("results").payload().contentType());
+        assertEquals(StandardCharsets.UTF_8, config.publish().get("results").payload().charset());
+    }
+
+    @Test
     void rejectsLegacyConnectorSection() throws Exception {
         String yaml = """
             appName: "Test App"
@@ -413,6 +493,29 @@ class PipelineTemplateConfigLoaderTest {
             () -> new PipelineTemplateConfigLoader().load(configPath));
 
         assertEquals("output.checkpoint.idempotencyKeyFields must be declared as a YAML list", exception.getMessage());
+    }
+
+    @Test
+    void rejectsObjectOutputReferencingMissingPublishTarget() throws Exception {
+        String yaml = """
+            appName: "Test App"
+            basePackage: "com.example.test"
+            transport: "GRPC"
+            output:
+              to: missing
+              consumes:
+                type: com.example.test.FooOutput
+                mapper: com.example.test.mapper.FooOutputPublishMapper
+            steps: []
+            """;
+        Path configPath = tempDir.resolve("pipeline-config-missing-publish.yaml");
+        Files.writeString(configPath, yaml);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PipelineTemplateConfigLoader().load(configPath));
+
+        assertEquals("output.object publish target not found: missing", exception.getMessage());
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
@@ -357,6 +357,8 @@ class PipelineTemplateConfigLoaderTest {
                   keyTemplate: "{groupKey}.out"
                 payload:
                   contentType: text/csv
+                grouping:
+                  maxOpenGroups: 7
             output:
               to: results
               consumes:
@@ -379,6 +381,7 @@ class PipelineTemplateConfigLoaderTest {
         assertEquals("/tmp/outgoing", config.publish().get("results").location().get("root"));
         assertEquals("{groupKey}.out", config.publish().get("results").naming().keyTemplate());
         assertEquals("text/csv", config.publish().get("results").payload().contentType());
+        assertEquals(7, config.publish().get("results").grouping().maxOpenGroups());
         assertNotNull(config.output());
         assertEquals("results", config.output().object().target());
         assertEquals("com.example.test.FooOutput", config.output().object().type());

--- a/framework/runtime/src/test/java/org/pipelineframework/objectpublish/ObjectPublishRunnerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/objectpublish/ObjectPublishRunnerTest.java
@@ -1,0 +1,184 @@
+package org.pipelineframework.objectpublish;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.boundary.PipelineObjectNamingConfig;
+import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfig;
+
+class ObjectPublishRunnerTest {
+
+    @Test
+    void publishItemsGroupsRendersAndWritesObjects() {
+        PipelineObjectPublishConfig target = target(false);
+        List<ObjectWriteRequest> writes = new ArrayList<>();
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target, TestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(new RecordingProvider(writes))),
+            ObjectPublishTelemetry.NOOP);
+
+        runner.publishItems(List.of(new TestOutput("a", "one"), new TestOutput("a", "two"), new TestOutput("b", "three")))
+            .await().indefinitely();
+
+        assertEquals(2, writes.size());
+        assertEquals("a.out", writes.get(0).objectKey());
+        assertEquals("one\ntwo", new String(writes.get(0).bytes(), StandardCharsets.UTF_8));
+        assertEquals("2", writes.get(0).metadata().get("count"));
+        assertEquals("b.out", writes.get(1).objectKey());
+        assertEquals("object-publish:results:a.out:" + writes.get(0).checksum(), writes.get(0).idempotencyKey());
+    }
+
+    @Test
+    void publishItemsSkipsEmptyOutput() {
+        List<ObjectWriteRequest> writes = new ArrayList<>();
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false), TestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(new RecordingProvider(writes))),
+            ObjectPublishTelemetry.NOOP);
+
+        runner.publishItems(List.of()).await().indefinitely();
+
+        assertEquals(List.of(), writes);
+    }
+
+    @Test
+    void publishItemsRejectsMapperOutsideBasePackage() {
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false), "com.example.NotAllowedMapper"),
+            new ObjectTargetRegistry(List.of(new RecordingProvider(new ArrayList<>()))),
+            ObjectPublishTelemetry.NOOP);
+
+        assertThrows(IllegalStateException.class, () ->
+            runner.publishItems(List.of(new TestOutput("a", "one"))).await().indefinitely());
+    }
+
+    @Test
+    void publishItemsRejectsMalformedMapperClassName() {
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false), "org.pipelineframework.objectpublish..BadMapper"),
+            new ObjectTargetRegistry(List.of(new RecordingProvider(new ArrayList<>()))),
+            ObjectPublishTelemetry.NOOP);
+
+        assertThrows(IllegalStateException.class, () ->
+            runner.publishItems(List.of(new TestOutput("a", "one"))).await().indefinitely());
+    }
+
+    @Test
+    void publishItemsPropagatesProviderFailure() {
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(true), TestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(new FailingProvider())),
+            ObjectPublishTelemetry.NOOP);
+
+        assertThrows(RuntimeException.class, () ->
+            runner.publishItems(List.of(new TestOutput("a", "one"))).await().indefinitely());
+    }
+
+    @Test
+    void targetRegistryRejectsDuplicateProviderNames() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new ObjectTargetRegistry(List.of(new RecordingProvider(new ArrayList<>()), new DuplicateProvider())));
+
+        assertEquals("Duplicate object target provider: test", exception.getMessage());
+    }
+
+    private PipelineYamlConfig config(PipelineObjectPublishConfig target, String mapper) {
+        return new PipelineYamlConfig(
+            "org.pipelineframework.objectpublish",
+            "GRPC",
+            "COMPUTE",
+            List.of(),
+            Map.of(),
+            Map.of(),
+            Map.of("results", target),
+            List.of(),
+            null,
+            new PipelineOutputBoundaryConfig(null, new PipelineObjectOutputConfig(
+                "results",
+                TestOutput.class.getName(),
+                "TestOutput",
+                mapper)));
+    }
+
+    private PipelineObjectPublishConfig target(boolean failing) {
+        return new PipelineObjectPublishConfig(
+            "results",
+            "object",
+            failing ? "failing" : "test",
+            Map.of(),
+            new PipelineObjectNamingConfig("{groupKey}.out"),
+            null);
+    }
+
+    public static final class TestMapper implements ObjectPublishMapper<TestOutput> {
+        @Override
+        public String groupKey(TestOutput item) {
+            return item.group();
+        }
+
+        @Override
+        public ObjectPayload render(String groupKey, List<TestOutput> items) {
+            String body = String.join("\n", items.stream().map(TestOutput::value).toList());
+            return new ObjectPayload(
+                body.getBytes(StandardCharsets.UTF_8),
+                "text/plain",
+                Map.of("count", String.valueOf(items.size())));
+        }
+    }
+
+    record TestOutput(String group, String value) {
+    }
+
+    private static final class RecordingProvider implements ObjectTargetProvider {
+        private final List<ObjectWriteRequest> writes;
+
+        private RecordingProvider(List<ObjectWriteRequest> writes) {
+            this.writes = writes;
+        }
+
+        @Override
+        public String providerName() {
+            return "test";
+        }
+
+        @Override
+        public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
+            writes.add(request);
+            return Uni.createFrom().item(new ObjectWriteResult(null, request.bytes().length, request.checksum(), null));
+        }
+    }
+
+    private static final class FailingProvider implements ObjectTargetProvider {
+        @Override
+        public String providerName() {
+            return "failing";
+        }
+
+        @Override
+        public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
+            return Uni.createFrom().failure(new IllegalStateException("publish failed"));
+        }
+    }
+
+    private static final class DuplicateProvider implements ObjectTargetProvider {
+        @Override
+        public String providerName() {
+            return " TEST ";
+        }
+
+        @Override
+        public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
+            return Uni.createFrom().item(new ObjectWriteResult(null, 0, null, null));
+        }
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/objectpublish/ObjectPublishRunnerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/objectpublish/ObjectPublishRunnerTest.java
@@ -1,18 +1,29 @@
 package org.pipelineframework.objectpublish;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
 
-import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.subscription.MultiEmitter;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.config.boundary.PipelineObjectNamingConfig;
 import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
 import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishGroupingConfig;
 import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
 import org.pipelineframework.config.pipeline.PipelineYamlConfig;
 
@@ -85,6 +96,102 @@ class ObjectPublishRunnerTest {
     }
 
     @Test
+    void publishMultiRequiresStreamingMapper() {
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false), TestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(new RecordingProvider(new ArrayList<>()))),
+            ObjectPublishTelemetry.NOOP);
+
+        assertThrows(IllegalStateException.class, () ->
+            runner.publish(Multi.createFrom().items(new TestOutput("a", "one"))));
+    }
+
+    @Test
+    void publishMultiStreamsGroupedWrites() {
+        StreamingRecordingProvider provider = new StreamingRecordingProvider();
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false), StreamingTestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(provider)),
+            ObjectPublishTelemetry.NOOP);
+
+        @SuppressWarnings("unchecked")
+        Multi<TestOutput> result = (Multi<TestOutput>) runner.publish(Multi.createFrom().items(
+            new TestOutput("a", "one"),
+            new TestOutput("a", "two")));
+
+        List<TestOutput> emitted = result.collect().asList().await().indefinitely();
+
+        assertEquals(List.of(new TestOutput("a", "one"), new TestOutput("a", "two")), emitted);
+        assertEquals(List.of("a.out"), provider.sessions.keySet().stream().toList());
+        assertEquals("one\ntwo\n", provider.sessions.get("a.out").body());
+        assertEquals("2", provider.sessions.get("a.out").closeMetadata.get("recordCount"));
+    }
+
+    @Test
+    void publishMultiEmitsItemBeforeUpstreamCompletionAfterChunkWrite() {
+        StreamingRecordingProvider provider = new StreamingRecordingProvider();
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false), StreamingTestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(provider)),
+            ObjectPublishTelemetry.NOOP);
+        AtomicReference<MultiEmitter<? super TestOutput>> emitterRef = new AtomicReference<>();
+
+        @SuppressWarnings("unchecked")
+        Multi<TestOutput> result = (Multi<TestOutput>) runner.publish(
+            Multi.createFrom().<TestOutput>emitter(emitter -> emitterRef.set(emitter)));
+        AssertSubscriber<TestOutput> subscriber = result.subscribe().withSubscriber(AssertSubscriber.create(1));
+
+        emitterRef.get().emit(new TestOutput("a", "one"));
+
+        subscriber.awaitItems(1, Duration.ofSeconds(5));
+        subscriber.assertItems(new TestOutput("a", "one"));
+        assertEquals("one\n", provider.sessions.get("a.out").body());
+
+        emitterRef.get().complete();
+        subscriber.request(1);
+        subscriber.awaitCompletion(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void publishMultiEnforcesMaxOpenGroups() {
+        StreamingRecordingProvider provider = new StreamingRecordingProvider();
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(target(false, 1), StreamingTestMapper.class.getName()),
+            new ObjectTargetRegistry(List.of(provider)),
+            ObjectPublishTelemetry.NOOP);
+
+        @SuppressWarnings("unchecked")
+        Multi<TestOutput> result = (Multi<TestOutput>) runner.publish(Multi.createFrom().items(
+            new TestOutput("a", "one"),
+            new TestOutput("b", "two")));
+
+        assertThrows(IllegalStateException.class, () -> result.collect().asList().await().indefinitely());
+    }
+
+    @Test
+    void objectPublishProviderSpiDoesNotExposeMutinyOrQuarkusTypes() throws Exception {
+        List<Class<?>> spiTypes = List.of(
+            ObjectTargetProvider.class,
+            ObjectWriteSession.class,
+            StreamingObjectPublishMapper.class,
+            ObjectPublishGroupRenderer.class);
+
+        for (Class<?> spiType : spiTypes) {
+            assertFalse(Arrays.stream(spiType.getMethods())
+                .flatMap(method -> java.util.stream.Stream.concat(
+                    java.util.stream.Stream.of(method.getReturnType()),
+                    Arrays.stream(method.getParameterTypes())))
+                .map(Class::getName)
+                .anyMatch(name -> name.startsWith("io.smallrye.mutiny") || name.startsWith("io.quarkus")),
+                spiType.getName() + " must not expose Mutiny or Quarkus types");
+        }
+        assertEquals(CompletionStage.class,
+            ObjectTargetProvider.class.getMethod("write", ObjectWriteRequest.class).getReturnType());
+        assertEquals(CompletionStage.class,
+            ObjectTargetProvider.class.getMethod("open", ObjectWriteOpenRequest.class).getReturnType());
+    }
+
+    @Test
     void targetRegistryRejectsDuplicateProviderNames() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new ObjectTargetRegistry(List.of(new RecordingProvider(new ArrayList<>()), new DuplicateProvider())));
@@ -111,13 +218,18 @@ class ObjectPublishRunnerTest {
     }
 
     private PipelineObjectPublishConfig target(boolean failing) {
+        return target(failing, 32);
+    }
+
+    private PipelineObjectPublishConfig target(boolean failing, int maxOpenGroups) {
         return new PipelineObjectPublishConfig(
             "results",
             "object",
             failing ? "failing" : "test",
             Map.of(),
             new PipelineObjectNamingConfig("{groupKey}.out"),
-            null);
+            null,
+            new PipelineObjectPublishGroupingConfig(maxOpenGroups));
     }
 
     public static final class TestMapper implements ObjectPublishMapper<TestOutput> {
@@ -133,6 +245,36 @@ class ObjectPublishRunnerTest {
                 body.getBytes(StandardCharsets.UTF_8),
                 "text/plain",
                 Map.of("count", String.valueOf(items.size())));
+        }
+    }
+
+    public static final class StreamingTestMapper implements StreamingObjectPublishMapper<TestOutput> {
+        @Override
+        public String groupKey(TestOutput item) {
+            return item.group();
+        }
+
+        @Override
+        public ObjectPublishGroupRenderer<TestOutput> openGroup(String groupKey, TestOutput firstItem) {
+            return new ObjectPublishGroupRenderer<>() {
+                private int count;
+
+                @Override
+                public String contentType() {
+                    return "text/plain";
+                }
+
+                @Override
+                public ObjectPayloadChunk onItem(TestOutput item) {
+                    count++;
+                    return new ObjectPayloadChunk((item.value() + "\n").getBytes(StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public Map<String, String> finalMetadata() {
+                    return Map.of("recordCount", String.valueOf(count));
+                }
+            };
         }
     }
 
@@ -152,9 +294,15 @@ class ObjectPublishRunnerTest {
         }
 
         @Override
-        public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
+        public CompletionStage<ObjectWriteResult> write(ObjectWriteRequest request) {
             writes.add(request);
-            return Uni.createFrom().item(new ObjectWriteResult(null, request.bytes().length, request.checksum(), null));
+            return CompletableFuture.completedFuture(
+                new ObjectWriteResult(null, request.bytes().length, request.checksum(), null));
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+            return CompletableFuture.completedFuture(new NoopSession());
         }
     }
 
@@ -165,8 +313,13 @@ class ObjectPublishRunnerTest {
         }
 
         @Override
-        public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
-            return Uni.createFrom().failure(new IllegalStateException("publish failed"));
+        public CompletionStage<ObjectWriteResult> write(ObjectWriteRequest request) {
+            return CompletableFuture.failedFuture(new IllegalStateException("publish failed"));
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+            return CompletableFuture.failedFuture(new IllegalStateException("publish failed"));
         }
     }
 
@@ -177,8 +330,81 @@ class ObjectPublishRunnerTest {
         }
 
         @Override
-        public Uni<ObjectWriteResult> write(ObjectWriteRequest request) {
-            return Uni.createFrom().item(new ObjectWriteResult(null, 0, null, null));
+        public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+            return CompletableFuture.completedFuture(new NoopSession());
+        }
+    }
+
+    private static final class StreamingRecordingProvider implements ObjectTargetProvider {
+        private final Map<String, StreamingRecordingSession> sessions = new LinkedHashMap<>();
+
+        @Override
+        public String providerName() {
+            return "test";
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+            StreamingRecordingSession session = new StreamingRecordingSession(request);
+            sessions.put(request.objectKey(), session);
+            return CompletableFuture.completedFuture(session);
+        }
+    }
+
+    private static final class StreamingRecordingSession implements ObjectWriteSession {
+        private final ObjectWriteOpenRequest openRequest;
+        private final List<byte[]> chunks = new ArrayList<>();
+        private Map<String, String> closeMetadata = Map.of();
+
+        private StreamingRecordingSession(ObjectWriteOpenRequest openRequest) {
+            this.openRequest = openRequest;
+        }
+
+        @Override
+        public CompletionStage<Void> write(ByteBuffer chunk) {
+            ByteBuffer duplicate = chunk.slice();
+            byte[] bytes = new byte[duplicate.remaining()];
+            duplicate.get(bytes);
+            chunks.add(bytes);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteResult> close(ObjectWriteCloseRequest request) {
+            closeMetadata = request.metadata();
+            return CompletableFuture.completedFuture(new ObjectWriteResult(
+                null,
+                request.bytes(),
+                request.checksum(),
+                null));
+        }
+
+        @Override
+        public CompletionStage<Void> abort(Throwable cause) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        private String body() {
+            return chunks.stream()
+                .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .reduce("", String::concat);
+        }
+    }
+
+    private static final class NoopSession implements ObjectWriteSession {
+        @Override
+        public CompletionStage<Void> write(ByteBuffer chunk) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteResult> close(ObjectWriteCloseRequest request) {
+            return CompletableFuture.completedFuture(new ObjectWriteResult(null, request.bytes(), request.checksum(), null));
+        }
+
+        @Override
+        public CompletionStage<Void> abort(Throwable cause) {
+            return CompletableFuture.completedFuture(null);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds Object Publish as the terminal-output counterpart to Object Ingest.

- Adds runtime-neutral Object Publish SPI/runner for grouping terminal outputs, rendering payloads, applying key templates, selecting target providers, and writing with idempotency metadata.
- Adds filesystem and S3 object target providers to the object-ingest connector artifact.
- Extends YAML/template config, schema export, and boundary validation with `publish` and `output.to`.
- Updates CSV Payments object-ingest path to replace the output-file step with terminal publish while keeping legacy output-file components deprecated.
- Documents Object Ingest + Publish and the I/O shell absorption rationale.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime -am -Dtest=PipelineYamlConfigLoaderTest,PipelineTemplateConfigLoaderTest,PipelineProtoGeneratorTest,ObjectPublishRunnerTest,ObjectIngestRunnerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl deployment -am -Dtest=PipelineTemplateSchemaExporterTest,CheckpointBoundaryValidatorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl connectors/object-ingest -am -Dtest=FilesystemObjectSourceProviderTest,S3ObjectSourceProviderTest,FilesystemObjectTargetProviderTest,S3ObjectTargetProviderTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipTests install && rm -rf examples/csv-payments/common/target examples/csv-payments/orchestrator-svc/target && ./mvnw -f examples/csv-payments/pom.xml -pl orchestrator-svc -am -Dpipeline.protoConfigArg=--config=/Users/mari/tpf4-object-publish-merged/examples/csv-payments/config/pipeline.object-ingest.yaml -Dpipeline.configArg=-Apipeline.config=/Users/mari/tpf4-object-publish-merged/examples/csv-payments/config/pipeline.object-ingest.yaml -DskipTests compile`
- Verified generated CSV object-ingest orchestrator proto/service return `PaymentOutput` and no output-file service is generated in that path.
- `npm --prefix docs run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added object publishing capability to pipelines with filesystem and S3 target support.
  * Configured pipeline output boundaries to publish grouped objects with customizable key templates, content types, and metadata.
  * Updated example pipeline configuration to demonstrate CSV output publishing.

* **Documentation**
  * Enhanced guides to cover object publish workflows alongside existing ingest functionality.

* **Tests**
  * Added comprehensive test coverage for object publishing, mappers, and target providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->