### PR TITLE
[codex] Add protobuf external step-host contract pack

### DIFF
--- a/docs/guide/build/operators.md
+++ b/docs/guide/build/operators.md
@@ -146,6 +146,16 @@ For remote v2 operators, build-time validation is contract-only:
 - the remote target must be configured correctly,
 - no local Java operator resolution or remote endpoint introspection is attempted.
 
+## External Step-Host Contract Pack
+
+When a v2 pipeline declares remote execution, proto generation also emits an external step-host contract pack next to the generated `.proto` files:
+
+- `external-step-hosts.json`: machine-readable step-host manifest.
+- `EXTERNAL-STEP-HOSTS.md`: human-readable implementer notes.
+- `pipeline-types.proto` plus the per-step service `.proto` files: protobuf IDL compiled by the non-Java service.
+
+The manifest records the remote step name, operator id, service, RPC, input/output message names, protobuf file names, target configuration, and `PROTOBUF_HTTP_V1` HTTP contract. This gives Python and other non-Java implementers a stable contract without making loose payload envelopes the default TPF model.
+
 ## Current Invocation Scope
 
 Generated invokers currently support unary execution:

--- a/docs/guide/development/operators.md
+++ b/docs/guide/development/operators.md
@@ -62,6 +62,12 @@ At runtime, the generated adapter:
 - propagates canonical `x-tpf-*` metadata headers,
 - decodes either the output protobuf message or a `google.rpc.Status` failure envelope.
 
+Proto generation emits an external step-host contract pack beside the generated `.proto` files:
+
+- `external-step-hosts.json` for tooling and conformance fixtures.
+- `EXTERNAL-STEP-HOSTS.md` for implementers.
+- `pipeline-types.proto` and each remote step service proto for language-specific codegen.
+
 Remote operators are still immediate request/response steps. The remote implementation may use async I/O internally, but the pipeline execution remains on the same invocation lease and expects the reply inline. If the external system returns `accepted` and the final answer arrives later through a broker, webhook, or human task, model that boundary as `kind: await` instead.
 
 ## Operator vs Await

--- a/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
+++ b/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
@@ -40,7 +40,7 @@ Prefer these implementation slices if this work becomes active:
 3. Kafka-backed checkpoint publication/subscription. Implemented as the first broker-backed checkpoint handoff provider.
 4. SQS-backed checkpoint publication/subscription for AWS queue-shaped handoff.
 5. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
-6. Protobuf-backed external step-host contract generation for non-Java implementations.
+6. Protobuf-backed external step-host contract generation for non-Java implementations. Implemented as generated proto files plus an external step-host manifest for remote v2 operators.
 7. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
 8. Brokered step-host dispatch only after the earlier boundary types are proven.
 

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -39,8 +39,10 @@ import org.pipelineframework.config.template.PipelineTemplateConfig;
 import org.pipelineframework.config.template.PipelineTemplateConfigLoader;
 import org.pipelineframework.config.template.PipelineTemplateField;
 import org.pipelineframework.config.template.PipelineTemplateMessage;
+import org.pipelineframework.config.template.PipelineTemplateRemoteTarget;
 import org.pipelineframework.config.template.PipelineTemplateReserved;
 import org.pipelineframework.config.template.PipelineTemplateStep;
+import org.pipelineframework.config.template.PipelineTemplateStepExecution;
 import org.pipelineframework.config.template.PipelineTemplateUnion;
 import org.pipelineframework.config.template.PipelineTemplateUnionVariant;
 
@@ -51,6 +53,8 @@ public class PipelineProtoGenerator {
 
     private static final String ORCHESTRATOR_PROTO = "orchestrator.proto";
     private static final String TYPES_PROTO = "pipeline-types.proto";
+    private static final String EXTERNAL_STEP_HOSTS_MANIFEST = "external-step-hosts.json";
+    private static final String EXTERNAL_STEP_HOSTS_README = "EXTERNAL-STEP-HOSTS.md";
     private static final String IDL_SNAPSHOT_PROPERTY = "tpf.idl.compat.baseline";
     private static final String IDL_SNAPSHOT_ENV = "TPF_IDL_COMPAT_BASELINE";
     private static final ObjectMapper IDL_MAPPER = PipelineJson.mapper().copy().findAndRegisterModules();
@@ -150,6 +154,7 @@ public class PipelineProtoGenerator {
             Path protoPath = resolvedOutput.resolve(step.serviceName() + ".proto");
             writeProto(protoPath, content);
         }
+        writeExternalStepHostContracts(config.basePackage(), resolvedOutput, resolvedSteps, resolvedTypesProtoName);
 
         String transport = config.transport();
         if (transport == null || transport.isBlank() || "GRPC".equalsIgnoreCase(transport)) {
@@ -250,6 +255,14 @@ public class PipelineProtoGenerator {
         }
     }
 
+    private void writeJson(Path outputPath, Object value) {
+        try {
+            IDL_MAPPER.writerWithDefaultPrettyPrinter().writeValue(outputPath.toFile(), value);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write JSON file: " + outputPath, e);
+        }
+    }
+
     private List<ResolvedStep> normalizeSteps(List<PipelineTemplateStep> steps) {
         List<ResolvedStep> resolved = new ArrayList<>();
         ResolvedStep previous = null;
@@ -271,7 +284,8 @@ public class PipelineProtoGenerator {
                 inputTypeName,
                 inputFields,
                 step.outputTypeName(),
-                step.outputFields());
+                step.outputFields(),
+                step.execution());
             resolved.add(resolvedStep);
             previous = resolvedStep;
         }
@@ -341,6 +355,143 @@ public class PipelineProtoGenerator {
             first = false;
         }
         return builder.toString();
+    }
+
+    private void writeExternalStepHostContracts(
+        String basePackage,
+        Path outputDir,
+        List<ResolvedStep> steps,
+        String typesProtoName
+    ) {
+        List<ExternalStepHostContract> contracts = externalStepHostContracts(basePackage, steps, typesProtoName);
+        if (contracts.isEmpty()) {
+            return;
+        }
+        ExternalStepHostManifest manifest = new ExternalStepHostManifest(
+            "tpf.external-step-hosts.v1",
+            basePackage,
+            typesProtoName,
+            contracts);
+        writeJson(outputDir.resolve(EXTERNAL_STEP_HOSTS_MANIFEST), manifest);
+        writeProto(outputDir.resolve(EXTERNAL_STEP_HOSTS_README), renderExternalStepHostReadme(manifest));
+    }
+
+    private List<ExternalStepHostContract> externalStepHostContracts(
+        String basePackage,
+        List<ResolvedStep> steps,
+        String typesProtoName
+    ) {
+        if (steps == null || steps.isEmpty()) {
+            return List.of();
+        }
+        List<ExternalStepHostContract> contracts = new ArrayList<>();
+        for (ResolvedStep step : steps) {
+            PipelineTemplateStepExecution execution = step.execution();
+            if (execution == null || !execution.isRemote()) {
+                continue;
+            }
+            contracts.add(new ExternalStepHostContract(
+                step.name(),
+                "Process" + step.serviceNameFormatted() + "Service",
+                "remoteProcess",
+                step.serviceName() + ".proto",
+                typesProtoName,
+                step.cardinality(),
+                step.inputTypeName(),
+                step.outputTypeName(),
+                execution.operatorId(),
+                execution.protocol(),
+                execution.timeoutMs(),
+                targetMap(execution.target()),
+                protobufHttpContract()));
+        }
+        return List.copyOf(contracts);
+    }
+
+    private Map<String, String> targetMap(PipelineTemplateRemoteTarget target) {
+        if (target == null) {
+            return Map.of();
+        }
+        Map<String, String> values = new LinkedHashMap<>();
+        if (target.url() != null) {
+            values.put("url", target.url());
+        }
+        if (target.urlConfigKey() != null) {
+            values.put("urlConfigKey", target.urlConfigKey());
+        }
+        return values;
+    }
+
+    private Map<String, Object> protobufHttpContract() {
+        Map<String, Object> contract = new LinkedHashMap<>();
+        contract.put("method", "POST");
+        contract.put("contentType", "application/x-protobuf");
+        contract.put("accept", "application/x-protobuf");
+        contract.put("successStatus", "2xx");
+        contract.put("failureEnvelope", "google.rpc.Status");
+        contract.put("headers", List.of(
+            "x-tpf-correlation-id",
+            "x-tpf-execution-id",
+            "x-tpf-idempotency-key",
+            "x-tpf-retry-attempt",
+            "x-tpf-deadline-epoch-ms",
+            "x-tpf-dispatch-ts-epoch-ms",
+            "x-tpf-parent-item-id"));
+        return contract;
+    }
+
+    private String renderExternalStepHostReadme(ExternalStepHostManifest manifest) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("# External Step Host Contracts\n\n");
+        builder.append("This directory contains protobuf contracts for remote TPF step hosts.\n");
+        builder.append("Remote step hosts implement immediate request/response boundaries. ");
+        builder.append("If the result arrives later, model that boundary as an await step.\n\n");
+        builder.append("- Protocol version: ").append(markdownCode(manifest.protocolVersion())).append('\n');
+        builder.append("- Protobuf package: ").append(markdownCode(manifest.basePackage())).append('\n');
+        builder.append("- Shared types proto: ").append(markdownCode(manifest.typesProto())).append("\n\n");
+        builder.append("| Step | Operator id | Service | RPC | Request | Response | Proto |\n");
+        builder.append("| --- | --- | --- | --- | --- | --- | --- |\n");
+        for (ExternalStepHostContract contract : manifest.steps()) {
+            builder.append("| ")
+                .append(markdownText(contract.step()))
+                .append(" | ")
+                .append(markdownCode(contract.operatorId()))
+                .append(" | ")
+                .append(markdownCode(contract.service()))
+                .append(" | ")
+                .append(markdownCode(contract.rpc()))
+                .append(" | ")
+                .append(markdownCode(contract.inputType()))
+                .append(" | ")
+                .append(markdownCode(contract.outputType()))
+                .append(" | ")
+                .append(markdownCode(contract.proto()))
+                .append(" |\n");
+        }
+        builder.append("\n");
+        builder.append("For `PROTOBUF_HTTP_V1`, hosts receive a `POST` body encoded as `application/x-protobuf` ");
+        builder.append("using the request message and return the response message as `application/x-protobuf`.\n");
+        builder.append("Non-2xx failures should return a `google.rpc.Status` protobuf body when possible.\n");
+        return builder.toString();
+    }
+
+    private String markdownText(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return value.replace('\n', ' ').replace("|", "\\|");
+    }
+
+    private String markdownCode(String value) {
+        String text = markdownText(value);
+        if (text.isEmpty()) {
+            return "";
+        }
+        String delimiter = "`";
+        while (text.contains(delimiter)) {
+            delimiter += "`";
+        }
+        return delimiter + text + delimiter;
     }
 
     private boolean usesPayloadReference(Map<String, PipelineTemplateMessage> messages) {
@@ -1026,7 +1177,8 @@ public class PipelineProtoGenerator {
         String inputTypeName,
         List<PipelineTemplateField> inputFields,
         String outputTypeName,
-        List<PipelineTemplateField> outputFields
+        List<PipelineTemplateField> outputFields,
+        PipelineTemplateStepExecution execution
     ) {
     }
 
@@ -1034,6 +1186,31 @@ public class PipelineProtoGenerator {
     }
 
     private record AspectDefinition(String name, String position, List<String> enabledTargets) {
+    }
+
+    private record ExternalStepHostManifest(
+        String protocolVersion,
+        String basePackage,
+        String typesProto,
+        List<ExternalStepHostContract> steps
+    ) {
+    }
+
+    private record ExternalStepHostContract(
+        String step,
+        String service,
+        String rpc,
+        String proto,
+        String typesProto,
+        String cardinality,
+        String inputType,
+        String outputType,
+        String operatorId,
+        String protocol,
+        Integer timeoutMs,
+        Map<String, String> target,
+        Map<String, Object> http
+    ) {
     }
 
     private record Arguments(Path moduleDir, Path configPath, Path outputDir, String typesProtoName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -410,13 +410,18 @@ public class PipelineProtoGenerator {
 
     private Map<String, String> targetMap(PipelineTemplateRemoteTarget target) {
         if (target == null) {
-            return Map.of();
+            throw new IllegalArgumentException("Remote step host target requires exactly one of url or urlConfigKey");
+        }
+        boolean hasUrl = target.url() != null;
+        boolean hasUrlConfigKey = target.urlConfigKey() != null;
+        if (hasUrl == hasUrlConfigKey) {
+            throw new IllegalArgumentException("Remote step host target requires exactly one of url or urlConfigKey");
         }
         Map<String, String> values = new LinkedHashMap<>();
-        if (target.url() != null) {
+        if (hasUrl) {
             values.put("url", target.url());
         }
-        if (target.urlConfigKey() != null) {
+        if (hasUrlConfigKey) {
             values.put("urlConfigKey", target.urlConfigKey());
         }
         return values;

--- a/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
@@ -19,9 +19,11 @@ package org.pipelineframework.proto;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.pipelineframework.config.pipeline.PipelineJson;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -270,6 +272,84 @@ class PipelineProtoGeneratorTest {
 
         assertTrue(Files.exists(dataProtoPath));
         assertFalse(Files.exists(orchestratorProtoPath));
+        assertFalse(Files.exists(outputDir.resolve("external-step-hosts.json")));
+        assertFalse(Files.exists(outputDir.resolve("EXTERNAL-STEP-HOSTS.md")));
+    }
+
+    @Test
+    void generatesExternalStepHostContractPackForRemoteSteps() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Remote Step Test"
+            basePackage: "com.example.remote"
+            transport: "REST"
+            messages:
+              ChargeRequest:
+                fields:
+                  - number: 1
+                    name: "orderId"
+                    type: "uuid"
+              ChargeResult:
+                fields:
+                  - number: 1
+                    name: "paymentId"
+                    type: "uuid"
+            steps:
+              - name: "Charge Card"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "ChargeRequest"
+                outputTypeName: "ChargeResult"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "charge-card"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 3000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.charge-card.url"
+            """;
+        Path configPath = tempDir.resolve("remote-step-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-remote-step-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        Path manifestPath = outputDir.resolve("external-step-hosts.json");
+        Path readmePath = outputDir.resolve("EXTERNAL-STEP-HOSTS.md");
+
+        assertTrue(Files.exists(outputDir.resolve("charge-card-svc.proto")));
+        assertTrue(Files.exists(outputDir.resolve("pipeline-types.proto")));
+        assertTrue(Files.exists(manifestPath));
+        assertTrue(Files.exists(readmePath));
+
+        JsonNode manifest = PipelineJson.mapper().readTree(manifestPath.toFile());
+        assertEquals("tpf.external-step-hosts.v1", manifest.path("protocolVersion").asText());
+        assertEquals("com.example.remote", manifest.path("basePackage").asText());
+        assertEquals("pipeline-types.proto", manifest.path("typesProto").asText());
+
+        JsonNode steps = manifest.path("steps");
+        assertEquals(1, steps.size());
+        JsonNode step = steps.get(0);
+        assertEquals("Charge Card", step.path("step").asText());
+        assertEquals("charge-card", step.path("operatorId").asText());
+        assertEquals("PROTOBUF_HTTP_V1", step.path("protocol").asText());
+        assertEquals("ProcessChargeCardService", step.path("service").asText());
+        assertEquals("remoteProcess", step.path("rpc").asText());
+        assertEquals("charge-card-svc.proto", step.path("proto").asText());
+        assertEquals("ChargeRequest", step.path("inputType").asText());
+        assertEquals("ChargeResult", step.path("outputType").asText());
+        assertEquals("tpf.remote-operators.charge-card.url", step.path("target").path("urlConfigKey").asText());
+        assertEquals("application/x-protobuf", step.path("http").path("contentType").asText());
+        assertEquals("google.rpc.Status", step.path("http").path("failureEnvelope").asText());
+        JsonNode headers = step.path("http").path("headers");
+        assertTrue(headers.isArray(), "headers must be an array");
+        assertTrue(headers.size() >= 2, "headers must include at least correlation and execution ids");
+        assertEquals("x-tpf-correlation-id", headers.get(0).asText());
+        assertEquals("x-tpf-execution-id", headers.get(1).asText());
+
+        String readme = Files.readString(readmePath);
+        assertTrue(readme.contains("# External Step Host Contracts"));
+        assertTrue(readme.contains("| Charge Card | `charge-card` | `ProcessChargeCardService`"));
+        assertTrue(readme.contains("If the result arrives later, model that boundary as an await step"));
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
@@ -884,9 +884,445 @@ class PipelineProtoGeneratorTest {
     }
 
     @Test
-    void generatesPayloadReferenceTypeForPayloadRefFields() throws Exception {
+    void generatesExternalStepHostContractPackForMultipleRemoteSteps() throws Exception {
         String yaml = """
             version: 2
+            appName: "Multi Remote Step Test"
+            basePackage: "com.example.multi"
+            transport: "REST"
+            messages:
+              OrderRequest:
+                fields:
+                  - number: 1
+                    name: "orderId"
+                    type: "uuid"
+              FraudResult:
+                fields:
+                  - number: 1
+                    name: "riskScore"
+                    type: "string"
+              ChargeResult:
+                fields:
+                  - number: 1
+                    name: "paymentId"
+                    type: "uuid"
+            steps:
+              - name: "Check Fraud"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "OrderRequest"
+                outputTypeName: "FraudResult"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "fraud-check"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 2000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.fraud-check.url"
+              - name: "Charge Card"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "FraudResult"
+                outputTypeName: "ChargeResult"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "charge-card"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 3000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.charge-card.url"
+            """;
+        Path configPath = tempDir.resolve("multi-remote-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-multi-remote-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        Path manifestPath = outputDir.resolve("external-step-hosts.json");
+        assertTrue(Files.exists(manifestPath));
+        assertTrue(Files.exists(outputDir.resolve("EXTERNAL-STEP-HOSTS.md")));
+        assertTrue(Files.exists(outputDir.resolve("check-fraud-svc.proto")));
+        assertTrue(Files.exists(outputDir.resolve("charge-card-svc.proto")));
+
+        JsonNode manifest = PipelineJson.mapper().readTree(manifestPath.toFile());
+        JsonNode steps = manifest.path("steps");
+        assertEquals(2, steps.size());
+
+        JsonNode first = steps.get(0);
+        assertEquals("Check Fraud", first.path("step").asText());
+        assertEquals("fraud-check", first.path("operatorId").asText());
+        assertEquals("check-fraud-svc.proto", first.path("proto").asText());
+        assertEquals("ProcessCheckFraudService", first.path("service").asText());
+        assertEquals("OrderRequest", first.path("inputType").asText());
+        assertEquals("FraudResult", first.path("outputType").asText());
+
+        JsonNode second = steps.get(1);
+        assertEquals("Charge Card", second.path("step").asText());
+        assertEquals("charge-card", second.path("operatorId").asText());
+        assertEquals("charge-card-svc.proto", second.path("proto").asText());
+        assertEquals("ProcessChargeCardService", second.path("service").asText());
+        assertEquals("ChargeResult", second.path("outputType").asText());
+
+        String readme = Files.readString(outputDir.resolve("EXTERNAL-STEP-HOSTS.md"));
+        assertTrue(readme.contains("Check Fraud"));
+        assertTrue(readme.contains("Charge Card"));
+    }
+
+    @Test
+    void omitsLocalStepsFromExternalStepHostManifest() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Mixed Steps Test"
+            basePackage: "com.example.mixed"
+            transport: "REST"
+            messages:
+              InputMsg:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              LocalResult:
+                fields:
+                  - number: 1
+                    name: "value"
+                    type: "string"
+              RemoteResult:
+                fields:
+                  - number: 1
+                    name: "output"
+                    type: "string"
+            steps:
+              - name: "Local Step"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "InputMsg"
+                outputTypeName: "LocalResult"
+              - name: "Remote Step"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "LocalResult"
+                outputTypeName: "RemoteResult"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "remote-op"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 1000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.remote-op.url"
+            """;
+        Path configPath = tempDir.resolve("mixed-steps-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-mixed-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        Path manifestPath = outputDir.resolve("external-step-hosts.json");
+        assertTrue(Files.exists(manifestPath));
+
+        JsonNode manifest = PipelineJson.mapper().readTree(manifestPath.toFile());
+        JsonNode steps = manifest.path("steps");
+        assertEquals(1, steps.size(), "Only remote step should appear in manifest");
+        assertEquals("Remote Step", steps.get(0).path("step").asText());
+        assertEquals("remote-op", steps.get(0).path("operatorId").asText());
+    }
+
+    @Test
+    void usesDirectUrlInTargetMapWhenUrlProvided() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Direct URL Test"
+            basePackage: "com.example.directurl"
+            transport: "REST"
+            messages:
+              Input:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              Output:
+                fields:
+                  - number: 1
+                    name: "result"
+                    type: "string"
+            steps:
+              - name: "Call Service"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "Input"
+                outputTypeName: "Output"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "call-service"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 500
+                  target:
+                    url: "https://service.example.com/grpc"
+            """;
+        Path configPath = tempDir.resolve("direct-url-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-direct-url-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        Path manifestPath = outputDir.resolve("external-step-hosts.json");
+        assertTrue(Files.exists(manifestPath));
+
+        JsonNode manifest = PipelineJson.mapper().readTree(manifestPath.toFile());
+        JsonNode step = manifest.path("steps").get(0);
+        assertEquals("https://service.example.com/grpc", step.path("target").path("url").asText());
+        assertTrue(step.path("target").path("urlConfigKey").isMissingNode(),
+            "urlConfigKey must not appear when direct url is used");
+    }
+
+    @Test
+    void generatesExternalStepHostContractPackWithGrpcTransport() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "GRPC Remote Test"
+            basePackage: "com.example.grpcremote"
+            transport: "GRPC"
+            messages:
+              GrpcInput:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              GrpcOutput:
+                fields:
+                  - number: 1
+                    name: "result"
+                    type: "string"
+            steps:
+              - name: "Grpc Remote"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "GrpcInput"
+                outputTypeName: "GrpcOutput"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "grpc-remote"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 1000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.grpc-remote.url"
+            """;
+        Path configPath = tempDir.resolve("grpc-remote-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-grpc-remote-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        assertTrue(Files.exists(outputDir.resolve("external-step-hosts.json")),
+            "Contract pack must be emitted even when transport is GRPC");
+        assertTrue(Files.exists(outputDir.resolve("EXTERNAL-STEP-HOSTS.md")));
+        assertTrue(Files.exists(outputDir.resolve("orchestrator.proto")),
+            "GRPC transport still generates orchestrator proto");
+
+        JsonNode manifest = PipelineJson.mapper().readTree(outputDir.resolve("external-step-hosts.json").toFile());
+        assertEquals(1, manifest.path("steps").size());
+        assertEquals("grpc-remote", manifest.path("steps").get(0).path("operatorId").asText());
+    }
+
+    @Test
+    void externalStepHostManifestContainsAllRequiredHttpHeaders() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Header Test"
+            basePackage: "com.example.headers"
+            transport: "REST"
+            messages:
+              Req:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              Res:
+                fields:
+                  - number: 1
+                    name: "value"
+                    type: "string"
+            steps:
+              - name: "Step One"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "Req"
+                outputTypeName: "Res"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "step-one"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 1000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.step-one.url"
+            """;
+        Path configPath = tempDir.resolve("headers-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-headers-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        JsonNode manifest = PipelineJson.mapper().readTree(outputDir.resolve("external-step-hosts.json").toFile());
+        JsonNode headers = manifest.path("steps").get(0).path("http").path("headers");
+        assertTrue(headers.isArray());
+        List<String> headerList = new java.util.ArrayList<>();
+        headers.forEach(h -> headerList.add(h.asText()));
+
+        assertTrue(headerList.contains("x-tpf-correlation-id"), "must include x-tpf-correlation-id");
+        assertTrue(headerList.contains("x-tpf-execution-id"), "must include x-tpf-execution-id");
+        assertTrue(headerList.contains("x-tpf-idempotency-key"), "must include x-tpf-idempotency-key");
+        assertTrue(headerList.contains("x-tpf-retry-attempt"), "must include x-tpf-retry-attempt");
+        assertTrue(headerList.contains("x-tpf-deadline-epoch-ms"), "must include x-tpf-deadline-epoch-ms");
+        assertTrue(headerList.contains("x-tpf-dispatch-ts-epoch-ms"), "must include x-tpf-dispatch-ts-epoch-ms");
+        assertTrue(headerList.contains("x-tpf-parent-item-id"), "must include x-tpf-parent-item-id");
+        assertEquals(7, headerList.size(), "exactly 7 TPF metadata headers must be declared");
+
+        JsonNode http = manifest.path("steps").get(0).path("http");
+        assertEquals("POST", http.path("method").asText());
+        assertEquals("application/x-protobuf", http.path("accept").asText());
+        assertEquals("2xx", http.path("successStatus").asText());
+    }
+
+    @Test
+    void readmeTableEscapesPipeCharacterInStepName() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Pipe Escape Test"
+            basePackage: "com.example.pipe"
+            transport: "REST"
+            messages:
+              PipeInput:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              PipeOutput:
+                fields:
+                  - number: 1
+                    name: "result"
+                    type: "string"
+            steps:
+              - name: "Step A | Step B"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "PipeInput"
+                outputTypeName: "PipeOutput"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "pipe-step"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 500
+                  target:
+                    urlConfigKey: "tpf.remote-operators.pipe-step.url"
+            """;
+        Path configPath = tempDir.resolve("pipe-escape-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-pipe-escape-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        String readme = Files.readString(outputDir.resolve("EXTERNAL-STEP-HOSTS.md"));
+        assertTrue(readme.contains("Step A \\| Step B"),
+            "Pipe characters in step names must be escaped as \\| in readme table");
+        assertFalse(readme.contains("| Step A | Step B |"),
+            "Unescaped pipe in step name would break markdown table");
+    }
+
+    @Test
+    void omitsTimeoutFromContractWhenNotSpecified() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "No Timeout Test"
+            basePackage: "com.example.notimeout"
+            transport: "REST"
+            messages:
+              NtInput:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              NtOutput:
+                fields:
+                  - number: 1
+                    name: "result"
+                    type: "string"
+            steps:
+              - name: "No Timeout Step"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "NtInput"
+                outputTypeName: "NtOutput"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "no-timeout-op"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  target:
+                    urlConfigKey: "tpf.remote-operators.no-timeout-op.url"
+            """;
+        Path configPath = tempDir.resolve("no-timeout-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-no-timeout-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        Path manifestPath = outputDir.resolve("external-step-hosts.json");
+        assertTrue(Files.exists(manifestPath));
+
+        JsonNode manifest = PipelineJson.mapper().readTree(manifestPath.toFile());
+        JsonNode step = manifest.path("steps").get(0);
+        assertEquals("No Timeout Step", step.path("step").asText());
+        assertTrue(step.path("timeoutMs").isNull() || step.path("timeoutMs").isMissingNode(),
+            "timeoutMs must be absent or null when not configured");
+    }
+
+    @Test
+    void externalStepHostManifestUsesCustomTypesProtoName() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Custom Types Proto Test"
+            basePackage: "com.example.custom"
+            transport: "REST"
+            messages:
+              CtInput:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              CtOutput:
+                fields:
+                  - number: 1
+                    name: "result"
+                    type: "string"
+            steps:
+              - name: "Custom Types Step"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "CtInput"
+                outputTypeName: "CtOutput"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "custom-types-op"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 1000
+                  target:
+                    urlConfigKey: "tpf.remote-operators.custom-types-op.url"
+            """;
+        Path configPath = tempDir.resolve("custom-types-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-custom-types-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir, "my-shared-types.proto");
+
+        Path manifestPath = outputDir.resolve("external-step-hosts.json");
+        assertTrue(Files.exists(manifestPath));
+        assertTrue(Files.exists(outputDir.resolve("my-shared-types.proto")));
+
+        JsonNode manifest = PipelineJson.mapper().readTree(manifestPath.toFile());
+        assertEquals("my-shared-types.proto", manifest.path("typesProto").asText(),
+            "manifest typesProto must reflect the custom types proto name");
+
+        JsonNode step = manifest.path("steps").get(0);
+        assertEquals("my-shared-types.proto", step.path("typesProto").asText(),
+            "per-step typesProto must match the custom types proto name");
+
+        String readme = Files.readString(outputDir.resolve("EXTERNAL-STEP-HOSTS.md"));
+        assertTrue(readme.contains("`my-shared-types.proto`"),
+            "Readme shared types proto line must use the custom name");
+    }
+
+    @Test
+    void generatesPayloadReferenceTypeForPayloadRefFields() throws Exception {
+        String yaml = """
+
             appName: "Materialized Search"
             basePackage: "com.example.search"
             transport: "GRPC"

--- a/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
@@ -18,6 +18,7 @@ package org.pipelineframework.proto;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
@@ -1070,6 +1071,47 @@ class PipelineProtoGeneratorTest {
     }
 
     @Test
+    void rejectsRemoteTargetWithBothUrlAndUrlConfigKey() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Ambiguous Target Test"
+            basePackage: "com.example.ambiguous"
+            transport: "REST"
+            messages:
+              Input:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              Output:
+                fields:
+                  - number: 1
+                    name: "result"
+                    type: "string"
+            steps:
+              - name: "Call Service"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "Input"
+                outputTypeName: "Output"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "call-service"
+                  protocol: "PROTOBUF_HTTP_V1"
+                  timeoutMs: 500
+                  target:
+                    url: "https://service.example.com/grpc"
+                    urlConfigKey: "tpf.remote-operators.call-service.url"
+            """;
+        Path configPath = tempDir.resolve("ambiguous-target-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-ambiguous-target-out");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> new PipelineProtoGenerator().generate(tempDir, configPath, outputDir));
+        assertTrue(error.getMessage().contains("Specify either url or urlConfigKey"));
+    }
+
+    @Test
     void generatesExternalStepHostContractPackWithGrpcTransport() throws Exception {
         String yaml = """
             version: 2
@@ -1322,7 +1364,7 @@ class PipelineProtoGeneratorTest {
     @Test
     void generatesPayloadReferenceTypeForPayloadRefFields() throws Exception {
         String yaml = """
-
+            version: 2
             appName: "Materialized Search"
             basePackage: "com.example.search"
             transport: "GRPC"


### PR DESCRIPTION
## Summary

- generate an external step-host contract pack for remote v2 `PROTOBUF_HTTP_V1` steps
- emit `external-step-hosts.json` plus `EXTERNAL-STEP-HOSTS.md` beside generated protobuf files
- document the contract pack for non-Java implementers and mark the brokered-boundary slice as implemented

## Scope

This PR keeps remote execution as immediate unary request/response. It does not add brokered step-host dispatch, envelope compatibility mode, Kafka/SQS step-host transport, or template-generator changes.

`PipelineProtoGenerator` is now large; the decomposition is intentionally deferred to #421 so this PR stays focused on the contract-pack feature.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime -Dtest=PipelineProtoGeneratorTest test`
- `./mvnw -f framework/pom.xml -pl runtime -DskipTests compile`
- `./mvnw -f framework/pom.xml -pl runtime spotless:check`
- `./mvnw -f framework/pom.xml -pl deployment -Dtest='RemoteOperatorAdapterRendererTest,StepDefinitionParserTest' test`
- `npm --prefix docs run build`
- `git diff --check`

## Review Notes

Local CodeRabbit review was run twice. All actionable findings were fixed in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework now emits an external step-host contract pack alongside generated protocol buffer files for remote v2 pipeline steps, including `external-step-hosts.json` and `EXTERNAL-STEP-HOSTS.md` with per-step HTTP contract and RPC/service metadata for stable non-Java integration.

* **Documentation**
  * Added and updated guide sections explaining the external step-host contract pack, its artifact contents, and how it relates to remote operator execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->