### PR TITLE
Add envelope HTTP remote operator protocol

### DIFF
--- a/docs/guide/build/operators.md
+++ b/docs/guide/build/operators.md
@@ -87,7 +87,27 @@ Rules:
 - Remote execution is immediate request/response only. It does not persist durable waiting state or resume later from correlated completion.
 - Exactly one of `execution.target.url` or `execution.target.urlConfigKey` must be set.
 - `execution.target.urlConfigKey` resolves at runtime startup, not at compile time.
-- `pipeline.transport` and the remote operator protocol are orthogonal. TPF can expose the pipeline over REST, gRPC, or local transport while invoking the remote operator over Protobuf-over-HTTP.
+- `execution.protocol` can be `PROTOBUF_HTTP_V1` for generated protobuf contracts or `ENVELOPE_HTTP_V1` for explicit loose-payload envelope compatibility.
+- `pipeline.transport` and the remote operator protocol are orthogonal. TPF can expose the pipeline over REST, gRPC, or local transport while invoking the remote operator over Protobuf-over-HTTP or envelope-over-HTTP.
+
+Use `ENVELOPE_HTTP_V1` only when the external step host needs a strict TPF control envelope with a loose payload region:
+
+```yaml
+steps:
+  - name: "Chunk Document"
+    cardinality: "ONE_TO_ONE"
+    inputTypeName: "ParsedDocument"
+    outputTypeName: "ChunkResult"
+    execution:
+      mode: "REMOTE"
+      operatorId: "chunker"
+      protocol: "ENVELOPE_HTTP_V1"
+      timeoutMs: 3000
+      target:
+        urlConfigKey: "tpf.remote-operators.chunker.url"
+```
+
+Envelope mode sends and receives `application/vnd.tpf.envelope.v1+json`. TPF owns the control metadata (`step`, `operatorId`, correlation, execution, idempotency, retry, deadline, and parent item metadata); only the payload region is loose JSON, bytes, or a payload reference. Prefer `PROTOBUF_HTTP_V1` when the external host can compile generated protobuf contracts.
 
 ## Operator vs Await
 
@@ -142,7 +162,7 @@ Simple concrete parameterised returns such as `List<Foo>` and `Map<String, Foo>`
 For remote v2 operators, build-time validation is contract-only:
 - input/output messages must resolve from the v2 message table,
 - the step must be unary,
-- the protocol must be `PROTOBUF_HTTP_V1`,
+- the protocol must be `PROTOBUF_HTTP_V1` or `ENVELOPE_HTTP_V1`,
 - the remote target must be configured correctly,
 - no local Java operator resolution or remote endpoint introspection is attempted.
 
@@ -154,7 +174,7 @@ When a v2 pipeline declares remote execution, proto generation also emits an ext
 - `EXTERNAL-STEP-HOSTS.md`: human-readable implementer notes.
 - `pipeline-types.proto` plus the per-step service `.proto` files: protobuf IDL compiled by the non-Java service.
 
-The manifest records the remote step name, operator id, service, RPC, input/output message names, protobuf file names, target configuration, and `PROTOBUF_HTTP_V1` HTTP contract. This gives Python and other non-Java implementers a stable contract without making loose payload envelopes the default TPF model.
+The manifest records the remote step name, operator id, service, RPC, input/output message names, protobuf file names, target configuration, protocol-specific HTTP contract, and payload policy. This gives Python and other non-Java implementers a stable contract without making loose payload envelopes the default TPF model.
 
 ## Current Invocation Scope
 

--- a/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
+++ b/docs/guide/evolve/brokered-boundaries/adoption-and-slices.md
@@ -41,7 +41,7 @@ Prefer these implementation slices if this work becomes active:
 4. SQS-backed checkpoint publication/subscription for AWS queue-shaped handoff.
 5. Kafka-backed transition-worker dispatcher using the existing command/result envelope.
 6. Protobuf-backed external step-host contract generation for non-Java implementations. Implemented as generated proto files plus an external step-host manifest for remote v2 operators.
-7. Optional envelope compatibility lane with strict TPF control metadata and loose payload.
+7. Optional envelope compatibility lane with strict TPF control metadata and loose payload. Implemented first for remote v2 HTTP step hosts through `ENVELOPE_HTTP_V1`; brokered dispatch remains separate.
 8. Brokered step-host dispatch only after the earlier boundary types are proven.
 
 Avoid starting with broad "Kafka transport" or "SQS transport" PRs. They mix unrelated risks and blur TPF semantics.

--- a/docs/guide/evolve/brokered-boundaries/envelope-and-data-policy.md
+++ b/docs/guide/evolve/brokered-boundaries/envelope-and-data-policy.md
@@ -10,6 +10,8 @@ Keep typed DTO contracts as the normal TPF model. Add envelope compatibility onl
 
 The control envelope must remain strict even when the payload is loose.
 
+The first concrete implementation is `ENVELOPE_HTTP_V1` for remote v2 HTTP step hosts. It is a request/response operator boundary, not a brokered step-host dispatcher.
+
 ```mermaid
 flowchart TB
     Envelope["TPF envelope"]

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -763,9 +763,10 @@ public class StepDefinitionParser {
             report(Diagnostic.Kind.ERROR, message);
             throw new IllegalArgumentException(message);
         }
-        if (!"PROTOBUF_HTTP_V1".equalsIgnoreCase(execution.protocol())) {
+        if (!"PROTOBUF_HTTP_V1".equalsIgnoreCase(execution.protocol())
+            && !"ENVELOPE_HTTP_V1".equalsIgnoreCase(execution.protocol())) {
             String message = "Skipping step '" + stepName
-                + "': remote execution requires execution.protocol=PROTOBUF_HTTP_V1";
+                + "': remote execution requires execution.protocol=PROTOBUF_HTTP_V1 or ENVELOPE_HTTP_V1";
             LOG.warn(message);
             report(Diagnostic.Kind.ERROR, message);
             throw new IllegalArgumentException(message);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRenderer.java
@@ -50,7 +50,8 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
     private static final ClassName OPTIONAL = ClassName.get(Optional.class);
     private static final ClassName MAPPER = ClassName.get("org.pipelineframework.mapper", "Mapper");
     private static final ClassName REACTIVE_SERVICE = ClassName.get("org.pipelineframework.service", "ReactiveService");
-    private static final ClassName REMOTE_CLIENT = ClassName.get("org.pipelineframework.transport.http", "ProtobufHttpRemoteOperatorClient");
+    private static final ClassName PROTOBUF_REMOTE_CLIENT = ClassName.get("org.pipelineframework.transport.http", "ProtobufHttpRemoteOperatorClient");
+    private static final ClassName ENVELOPE_REMOTE_CLIENT = ClassName.get("org.pipelineframework.transport.http", "EnvelopeHttpRemoteOperatorClient");
 
     @Override
     public GenerationTarget target() {
@@ -78,18 +79,10 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
             throw new IllegalStateException("Remote operator adapter rendering requires remote execution metadata");
         }
 
-        GrpcJavaTypeResolver.GrpcJavaTypes grpcTypes = GRPC_TYPE_RESOLVER.resolve(binding, messager);
         TypeName domainInputType = Objects.requireNonNull(model.inboundDomainType(),
             "Remote operator adapter requires a non-null inbound domain type for " + model.generatedName());
         TypeName domainOutputType = Objects.requireNonNull(model.outboundDomainType(),
             "Remote operator adapter requires a non-null outbound domain type for " + model.generatedName());
-        TypeName protoInputType = grpcTypes.grpcParameterType();
-        TypeName protoOutputType = grpcTypes.grpcReturnType();
-        if (protoInputType == null || ClassName.OBJECT.equals(protoInputType)
-            || protoOutputType == null || ClassName.OBJECT.equals(protoOutputType)) {
-            throw new IllegalStateException(
-                "Remote operator adapter requires resolved gRPC protobuf input/output types for " + model.generatedName());
-        }
         if (model.remoteExecution().target() == null
             || (model.remoteExecution().target().url() == null && model.remoteExecution().target().urlConfigKey() == null)) {
             throw new IllegalStateException(
@@ -116,22 +109,40 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
                 .build())
             .addSuperinterface(ParameterizedTypeName.get(REACTIVE_SERVICE, domainInputType, domainOutputType));
 
-        builder.addField(FieldSpec.builder(REMOTE_CLIENT, "remoteOperatorClient")
-            .addAnnotation(INJECT)
-            .addModifiers(Modifier.PRIVATE)
-            .build());
-        builder.addField(FieldSpec.builder(
-                ParameterizedTypeName.get(MAPPER, domainInputType, protoInputType),
-                "requestMapper")
-            .addAnnotation(INJECT)
-            .addModifiers(Modifier.PRIVATE)
-            .build());
-        builder.addField(FieldSpec.builder(
-                ParameterizedTypeName.get(MAPPER, domainOutputType, protoOutputType),
-                "responseMapper")
-            .addAnnotation(INJECT)
-            .addModifiers(Modifier.PRIVATE)
-            .build());
+        TypeName protoInputType = null;
+        if (isEnvelopeProtocol(model)) {
+            builder.addField(FieldSpec.builder(ENVELOPE_REMOTE_CLIENT, "remoteOperatorClient")
+                .addModifiers(Modifier.PRIVATE)
+                .initializer("new $T()", ENVELOPE_REMOTE_CLIENT)
+                .build());
+        } else {
+            validateProtobufProtocol(model);
+            GrpcJavaTypeResolver.GrpcJavaTypes grpcTypes = GRPC_TYPE_RESOLVER.resolve(binding, messager);
+            protoInputType = grpcTypes.grpcParameterType();
+            TypeName protoOutputType = grpcTypes.grpcReturnType();
+            if (protoInputType == null || ClassName.OBJECT.equals(protoInputType)
+                || protoOutputType == null || ClassName.OBJECT.equals(protoOutputType)) {
+                throw new IllegalStateException(
+                    "Remote operator adapter requires resolved gRPC protobuf input/output types for " + model.generatedName());
+            }
+            builder.addField(FieldSpec.builder(PROTOBUF_REMOTE_CLIENT, "remoteOperatorClient")
+                .addAnnotation(INJECT)
+                .addModifiers(Modifier.PRIVATE)
+                .build());
+            builder.addField(FieldSpec.builder(
+                    ParameterizedTypeName.get(MAPPER, domainInputType, protoInputType),
+                    "requestMapper")
+                .addAnnotation(INJECT)
+                .addModifiers(Modifier.PRIVATE)
+                .build());
+            builder.addField(FieldSpec.builder(
+                    ParameterizedTypeName.get(MAPPER, domainOutputType, protoOutputType),
+                    "responseMapper")
+                .addAnnotation(INJECT)
+                .addModifiers(Modifier.PRIVATE)
+                .build());
+            builder.addMethod(buildDecodeResponseMethod(protoOutputType));
+        }
 
         if (model.remoteExecution().target() != null && model.remoteExecution().target().urlConfigKey() != null) {
             builder.addField(FieldSpec.builder(
@@ -150,10 +161,27 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
             .build());
         builder.addMethod(buildValidateTargetMethod(model));
         builder.addMethod(buildResolveTargetUrlMethod(model));
-        builder.addMethod(buildDecodeResponseMethod(protoOutputType));
-        builder.addMethod(buildProcessMethod(model, domainInputType, domainOutputType, protoInputType));
+        if (isEnvelopeProtocol(model)) {
+            builder.addMethod(buildEnvelopeProcessMethod(model, domainInputType, domainOutputType));
+        } else {
+            builder.addMethod(buildProtobufProcessMethod(model, domainInputType, domainOutputType, protoInputType));
+        }
 
         return builder.build();
+    }
+
+    private boolean isEnvelopeProtocol(PipelineStepModel model) {
+        return model.remoteExecution() != null
+            && "ENVELOPE_HTTP_V1".equalsIgnoreCase(model.remoteExecution().protocol());
+    }
+
+    private void validateProtobufProtocol(PipelineStepModel model) {
+        if (model.remoteExecution() == null
+            || !"PROTOBUF_HTTP_V1".equalsIgnoreCase(model.remoteExecution().protocol())) {
+            throw new IllegalStateException("Remote operator adapter does not support protocol '"
+                + (model.remoteExecution() == null ? "<missing>" : model.remoteExecution().protocol())
+                + "' for " + model.generatedName());
+        }
     }
 
     private MethodSpec buildValidateTargetMethod(PipelineStepModel model) {
@@ -198,7 +226,7 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
             .build();
     }
 
-    private MethodSpec buildProcessMethod(
+    private MethodSpec buildProtobufProcessMethod(
         PipelineStepModel model,
         TypeName domainInputType,
         TypeName domainOutputType,
@@ -224,6 +252,35 @@ public final class RemoteOperatorAdapterRenderer implements PipelineRenderer<Grp
                     + ".map(bytes -> responseMapper.fromExternal(decodeResponse(bytes)))",
                 model.remoteExecution().operatorId(),
                 timeoutMs == null ? "null" : timeoutMs.toString());
+        return builder.build();
+    }
+
+    private MethodSpec buildEnvelopeProcessMethod(
+        PipelineStepModel model,
+        TypeName domainInputType,
+        TypeName domainOutputType
+    ) {
+        if (model.remoteExecution() == null || model.remoteExecution().operatorId() == null) {
+            throw new IllegalStateException("Remote operator adapter requires a non-null remote execution operatorId");
+        }
+        Integer timeoutMs = model.remoteExecution().timeoutMs();
+
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("process")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(ClassName.get(Uni.class), domainOutputType))
+            .addParameter(domainInputType, "input");
+
+        if (model.executionMode() == org.pipelineframework.processor.ir.ExecutionMode.VIRTUAL_THREADS) {
+            builder.addAnnotation(ClassName.get("io.smallrye.common.annotation", "RunOnVirtualThread"));
+        }
+
+        builder.addStatement("return $T.createFrom().completionStage(() -> remoteOperatorClient.invoke(resolveTargetUrl(), $S, $S, input, $T.class, $L))",
+            ClassName.get(Uni.class),
+            model.serviceName(),
+            model.remoteExecution().operatorId(),
+            domainOutputType,
+            timeoutMs == null ? "null" : timeoutMs.toString());
         return builder.build();
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
@@ -723,7 +723,8 @@ public final class PipelineTemplateSchemaExporter {
         "protocol": {
           "type": "string",
           "enum": [
-            "PROTOBUF_HTTP_V1"
+            "PROTOBUF_HTTP_V1",
+            "ENVELOPE_HTTP_V1"
           ]
         },
         "timeoutMs": {

--- a/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
+++ b/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
@@ -689,7 +689,8 @@
         "protocol": {
           "type": "string",
           "enum": [
-            "PROTOBUF_HTTP_V1"
+            "PROTOBUF_HTTP_V1",
+            "ENVELOPE_HTTP_V1"
           ]
         },
         "timeoutMs": {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -1258,6 +1258,33 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void acceptsEnvelopeHttpRemoteExecutionProtocol() throws IOException {
+        Path file = tempDir.resolve("pipeline.yaml");
+        Files.writeString(file, """
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "chunk"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "com.example.contract.ParsedDocument"
+                outputTypeName: "com.example.contract.ChunkResult"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "chunker"
+                  protocol: "ENVELOPE_HTTP_V1"
+                  target:
+                    url: "https://example.com/operators/chunker"
+            """);
+
+        List<StepDefinition> steps = new StepDefinitionParser().parseStepDefinitions(file);
+
+        assertEquals(1, steps.size());
+        assertEquals("ENVELOPE_HTTP_V1", steps.getFirst().remoteExecution().protocol());
+        assertEquals("chunker", steps.getFirst().remoteExecution().operatorId());
+    }
+
+    @Test
     void rejectsRemoteExecutionWhenMixedWithLocalServiceFields() throws IOException {
         List<String> diagnostics = new ArrayList<>();
         Path file = tempDir.resolve("pipeline.yaml");

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRendererTest.java
@@ -104,6 +104,7 @@ class RemoteOperatorAdapterRendererTest {
         assertFalse(source.contains("ProtobufHttpRemoteOperatorClient"));
         assertFalse(source.contains("requestMapper"));
         assertFalse(source.contains("decodeResponse"));
+        assertFalse(source.contains("responseMapper"));
     }
 
     private PipelineStepModel remoteModel(PipelineTemplateRemoteTarget target) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/RemoteOperatorAdapterRendererTest.java
@@ -81,7 +81,36 @@ class RemoteOperatorAdapterRendererTest {
         assertFalse(source.contains("configuredTargetUrl"));
     }
 
+    @Test
+    void rendersEnvelopeRemoteAdapterWithoutProtobufMappers() throws IOException {
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getFiler()).thenReturn(new TestFiler(tempDir));
+
+        RemoteOperatorAdapterRenderer renderer = new RemoteOperatorAdapterRenderer();
+        renderer.render(
+            new GrpcBinding(
+                remoteModel(new PipelineTemplateRemoteTarget("https://operator.example/process", null), "ENVELOPE_HTTP_V1"),
+                serviceDescriptor(),
+                methodDescriptor()),
+            new GenerationContext(processingEnv, tempDir, DeploymentRole.PIPELINE_SERVER,
+                java.util.Set.of(), null, null));
+
+        Path generatedSource =
+            tempDir.resolve("org/example/checkout/service/pipeline/ChargeCardRemoteOperatorAdapter.java");
+        String source = Files.readString(generatedSource);
+
+        assertTrue(source.contains("EnvelopeHttpRemoteOperatorClient remoteOperatorClient"));
+        assertTrue(source.contains("Uni.createFrom().completionStage(() -> remoteOperatorClient.invoke(resolveTargetUrl(), \"ChargeCard\", \"charge-card\", input, ChargeResult.class, 3000))"));
+        assertFalse(source.contains("ProtobufHttpRemoteOperatorClient"));
+        assertFalse(source.contains("requestMapper"));
+        assertFalse(source.contains("decodeResponse"));
+    }
+
     private PipelineStepModel remoteModel(PipelineTemplateRemoteTarget target) {
+        return remoteModel(target, "PROTOBUF_HTTP_V1");
+    }
+
+    private PipelineStepModel remoteModel(PipelineTemplateRemoteTarget target, String protocol) {
         return new PipelineStepModel.Builder()
             .serviceName("ChargeCard")
             .generatedName("ChargeCard")
@@ -102,7 +131,7 @@ class RemoteOperatorAdapterRendererTest {
             .remoteExecution(new PipelineTemplateStepExecution(
                 "REMOTE",
                 "charge-card",
-                "PROTOBUF_HTTP_V1",
+                protocol,
                 3000,
                 target))
             .build();

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporterTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporterTest.java
@@ -143,6 +143,18 @@ class PipelineTemplateSchemaExporterTest {
     }
 
     @Test
+    void remoteExecutionProtocolEnumIncludesEnvelopeCompatibilityProtocol() {
+        JsonObject definitions = parse(PipelineTemplateSchemaExporter.schemaJson()).getAsJsonObject("$defs");
+        JsonObject execution = definitions.getAsJsonObject("v2Execution");
+        JsonArray protocols = execution.getAsJsonObject("properties")
+            .getAsJsonObject("protocol")
+            .getAsJsonArray("enum");
+
+        assertContains(protocols, "PROTOBUF_HTTP_V1");
+        assertContains(protocols, "ENVELOPE_HTTP_V1");
+    }
+
+    @Test
     void deterministicTopLevelOrderingKeepsSchemaStableForConsumers() {
         JsonObject schema = parse(PipelineTemplateSchemaExporter.schemaJson());
         List<String> keys = new ArrayList<>();

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
@@ -686,9 +686,11 @@ public class PipelineTemplateConfigLoader {
         if (execution.operatorId() == null) {
             throw new IllegalStateException("Step '" + stepName + "' remote execution requires execution.operatorId");
         }
-        if (!"PROTOBUF_HTTP_V1".equalsIgnoreCase(execution.protocol())) {
+        if (!"PROTOBUF_HTTP_V1".equalsIgnoreCase(execution.protocol())
+            && !"ENVELOPE_HTTP_V1".equalsIgnoreCase(execution.protocol())) {
             throw new IllegalStateException(
-                "Step '" + stepName + "' remote execution requires execution.protocol=PROTOBUF_HTTP_V1");
+                "Step '" + stepName
+                    + "' remote execution requires execution.protocol=PROTOBUF_HTTP_V1 or ENVELOPE_HTTP_V1");
         }
         PipelineTemplateRemoteTarget target = execution.target();
         if (target == null) {

--- a/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelope.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelope.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.envelope;
+
+import java.util.Objects;
+
+/**
+ * Strict-control, loose-payload envelope for external step-host compatibility.
+ */
+public record TpfEnvelope(
+    String protocolVersion,
+    TpfEnvelopeControl control,
+    TpfEnvelopePayload payload
+) {
+    public static final String PROTOCOL_VERSION = "tpf.envelope.v1";
+
+    public TpfEnvelope {
+        protocolVersion = protocolVersion == null || protocolVersion.isBlank() ? PROTOCOL_VERSION : protocolVersion.trim();
+        if (!PROTOCOL_VERSION.equals(protocolVersion)) {
+            throw new IllegalArgumentException("Unsupported TPF envelope protocolVersion '" + protocolVersion + "'");
+        }
+        control = Objects.requireNonNull(control, "control must not be null");
+        payload = Objects.requireNonNull(payload, "payload must not be null");
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopeCodec.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopeCodec.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.envelope;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.pipelineframework.config.pipeline.PipelineJson;
+
+/**
+ * JSON codec for the TPF compatibility envelope.
+ */
+public final class TpfEnvelopeCodec {
+    private final ObjectMapper mapper;
+
+    public TpfEnvelopeCodec() {
+        this(PipelineJson.mapper());
+    }
+
+    public TpfEnvelopeCodec(ObjectMapper mapper) {
+        this.mapper = Objects.requireNonNull(mapper, "mapper must not be null");
+    }
+
+    public TpfEnvelope envelope(TpfEnvelopeControl control, TpfEnvelopePayload payload) {
+        return new TpfEnvelope(TpfEnvelope.PROTOCOL_VERSION, control, payload);
+    }
+
+    public TpfEnvelopePayload jsonPayload(Object value, String schemaHint) {
+        Objects.requireNonNull(value, "value must not be null");
+        return new TpfEnvelopePayload(
+            "json",
+            "application/json",
+            schemaHint,
+            "utf-8",
+            mapper.valueToTree(value),
+            Map.of());
+    }
+
+    public TpfEnvelopePayload bytesPayload(byte[] value, String contentType, String schemaHint) {
+        Objects.requireNonNull(value, "value must not be null");
+        ObjectNode data = mapper.createObjectNode();
+        data.put("bytesBase64", Base64.getEncoder().encodeToString(value));
+        return new TpfEnvelopePayload(
+            "bytes",
+            contentType == null || contentType.isBlank() ? "application/octet-stream" : contentType,
+            schemaHint,
+            "base64",
+            data,
+            Map.of());
+    }
+
+    public TpfEnvelopePayload refPayload(TpfPayloadRef ref, String schemaHint) {
+        Objects.requireNonNull(ref, "ref must not be null");
+        return new TpfEnvelopePayload(
+            "ref",
+            ref.contentType(),
+            schemaHint,
+            "ref",
+            mapper.valueToTree(ref),
+            Map.of());
+    }
+
+    public byte[] write(TpfEnvelope envelope) {
+        Objects.requireNonNull(envelope, "envelope must not be null");
+        try {
+            return mapper.writeValueAsBytes(envelope);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to encode TPF envelope", e);
+        }
+    }
+
+    public String writeString(TpfEnvelope envelope) {
+        Objects.requireNonNull(envelope, "envelope must not be null");
+        try {
+            return mapper.writeValueAsString(envelope);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to encode TPF envelope", e);
+        }
+    }
+
+    public TpfEnvelope read(byte[] body) {
+        Objects.requireNonNull(body, "body must not be null");
+        try {
+            return mapper.readValue(body, TpfEnvelope.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to decode TPF envelope", e);
+        }
+    }
+
+    public TpfEnvelope read(String body) {
+        Objects.requireNonNull(body, "body must not be null");
+        try {
+            return mapper.readValue(body, TpfEnvelope.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to decode TPF envelope", e);
+        }
+    }
+
+    public <T> T readJsonPayload(TpfEnvelopePayload payload, Class<T> targetType) {
+        Objects.requireNonNull(payload, "payload must not be null");
+        Objects.requireNonNull(targetType, "targetType must not be null");
+        if (!"json".equalsIgnoreCase(payload.kind())) {
+            throw new IllegalArgumentException("Expected json envelope payload but got '" + payload.kind() + "'");
+        }
+        try {
+            return mapper.treeToValue(payload.data(), targetType);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to decode TPF envelope JSON payload as " + targetType.getName(), e);
+        }
+    }
+
+    public byte[] readBytesPayload(TpfEnvelopePayload payload) {
+        Objects.requireNonNull(payload, "payload must not be null");
+        if (!"bytes".equalsIgnoreCase(payload.kind())) {
+            throw new IllegalArgumentException("Expected bytes envelope payload but got '" + payload.kind() + "'");
+        }
+        String encoded = payload.data().path("bytesBase64").asText();
+        if (encoded.isBlank()) {
+            throw new IllegalArgumentException("bytes envelope payload requires data.bytesBase64");
+        }
+        return Base64.getDecoder().decode(encoded);
+    }
+
+    public TpfPayloadRef readRefPayload(TpfEnvelopePayload payload) {
+        Objects.requireNonNull(payload, "payload must not be null");
+        if (!"ref".equalsIgnoreCase(payload.kind())) {
+            throw new IllegalArgumentException("Expected ref envelope payload but got '" + payload.kind() + "'");
+        }
+        try {
+            return mapper.treeToValue(payload.data(), TpfPayloadRef.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to decode TPF envelope reference payload", e);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopeCodec.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopeCodec.java
@@ -59,9 +59,12 @@ public final class TpfEnvelopeCodec {
         Objects.requireNonNull(value, "value must not be null");
         ObjectNode data = mapper.createObjectNode();
         data.put("bytesBase64", Base64.getEncoder().encodeToString(value));
+        String normalizedContentType = contentType == null ? null : contentType.trim();
         return new TpfEnvelopePayload(
             "bytes",
-            contentType == null || contentType.isBlank() ? "application/octet-stream" : contentType,
+            normalizedContentType == null || normalizedContentType.isBlank()
+                ? "application/octet-stream"
+                : normalizedContentType,
             schemaHint,
             "base64",
             data,

--- a/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopeControl.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopeControl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.envelope;
+
+import java.util.Map;
+
+/**
+ * Strict framework-owned control metadata for an envelope boundary.
+ *
+ * @param pipeline pipeline/release/context label known at dispatch time
+ * @param step generated step name
+ * @param operatorId logical remote operator id
+ * @param context optional execution/correlation metadata, omitted from the map when absent
+ * @param metadata additional strict control metadata
+ */
+public record TpfEnvelopeControl(
+    String pipeline,
+    String step,
+    String operatorId,
+    Map<String, String> context,
+    Map<String, String> metadata
+) {
+    public TpfEnvelopeControl {
+        pipeline = requireText(pipeline, "pipeline");
+        step = requireText(step, "step");
+        operatorId = requireText(operatorId, "operatorId");
+        context = context == null ? Map.of() : Map.copyOf(context);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopePayload.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfEnvelopePayload.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.envelope;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Loose payload region inside a strict TPF envelope.
+ *
+ * @param kind payload variant: {@code json}, {@code bytes}, or {@code ref}
+ * @param contentType payload media type
+ * @param schemaHint schema or class-name hint for loose consumers
+ * @param encoding payload encoding such as {@code utf-8} or {@code base64}
+ * @param data variant data; JSON payload directly, bytes object, or reference object
+ * @param metadata additional payload metadata
+ */
+public record TpfEnvelopePayload(
+    String kind,
+    String contentType,
+    String schemaHint,
+    String encoding,
+    JsonNode data,
+    Map<String, String> metadata
+) {
+    public TpfEnvelopePayload {
+        kind = requireKind(kind);
+        contentType = contentType == null || contentType.isBlank() ? defaultContentType(kind) : contentType.trim();
+        schemaHint = schemaHint == null || schemaHint.isBlank() ? "unspecified" : schemaHint.trim();
+        encoding = encoding == null || encoding.isBlank() ? defaultEncoding(kind) : encoding.trim();
+        data = Objects.requireNonNull(data, "data must not be null");
+        if (data.isNull()) {
+            throw new IllegalArgumentException("data must not be JSON null");
+        }
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    private static String requireKind(String kind) {
+        if (kind == null || kind.isBlank()) {
+            throw new IllegalArgumentException("kind must not be blank");
+        }
+        String normalized = kind.trim().toLowerCase();
+        if (!"json".equals(normalized) && !"bytes".equals(normalized) && !"ref".equals(normalized)) {
+            throw new IllegalArgumentException("Unsupported envelope payload kind '" + kind + "'");
+        }
+        return normalized;
+    }
+
+    private static String defaultContentType(String kind) {
+        return "json".equals(kind) ? "application/json" : "application/octet-stream";
+    }
+
+    private static String defaultEncoding(String kind) {
+        return "bytes".equals(kind) ? "base64" : "utf-8";
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfPayloadRef.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/envelope/TpfPayloadRef.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.envelope;
+
+import java.util.Map;
+
+/**
+ * Reference to an externally materialized payload.
+ *
+ * @param ref provider-owned payload reference
+ * @param contentType media type for the referenced payload
+ * @param metadata optional reference metadata such as size and hash
+ */
+public record TpfPayloadRef(
+    String ref,
+    String contentType,
+    Map<String, String> metadata
+) {
+    public TpfPayloadRef {
+        ref = ref == null ? null : ref.trim();
+        if (ref == null || ref.isBlank()) {
+            throw new IllegalArgumentException("ref must not be blank");
+        }
+        contentType = contentType == null || contentType.isBlank() ? "application/octet-stream" : contentType.trim();
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/proto/PipelineProtoGenerator.java
@@ -55,6 +55,7 @@ public class PipelineProtoGenerator {
     private static final String TYPES_PROTO = "pipeline-types.proto";
     private static final String EXTERNAL_STEP_HOSTS_MANIFEST = "external-step-hosts.json";
     private static final String EXTERNAL_STEP_HOSTS_README = "EXTERNAL-STEP-HOSTS.md";
+    private static final String EXTERNAL_STEP_HOSTS_PROTOCOL_VERSION = "tpf.external-step-hosts.v1";
     private static final String IDL_SNAPSHOT_PROPERTY = "tpf.idl.compat.baseline";
     private static final String IDL_SNAPSHOT_ENV = "TPF_IDL_COMPAT_BASELINE";
     private static final ObjectMapper IDL_MAPPER = PipelineJson.mapper().copy().findAndRegisterModules();
@@ -368,7 +369,7 @@ public class PipelineProtoGenerator {
             return;
         }
         ExternalStepHostManifest manifest = new ExternalStepHostManifest(
-            "tpf.external-step-hosts.v1",
+            EXTERNAL_STEP_HOSTS_PROTOCOL_VERSION,
             basePackage,
             typesProtoName,
             contracts);
@@ -403,7 +404,8 @@ public class PipelineProtoGenerator {
                 execution.protocol(),
                 execution.timeoutMs(),
                 targetMap(execution.target()),
-                protobufHttpContract()));
+                httpContract(execution.protocol()),
+                payloadPolicy(execution.protocol())));
         }
         return List.copyOf(contracts);
     }
@@ -424,7 +426,17 @@ public class PipelineProtoGenerator {
         if (hasUrlConfigKey) {
             values.put("urlConfigKey", target.urlConfigKey());
         }
-        return values;
+        return Collections.unmodifiableMap(new LinkedHashMap<>(values));
+    }
+
+    private Map<String, Object> httpContract(String protocol) {
+        if ("ENVELOPE_HTTP_V1".equalsIgnoreCase(protocol)) {
+            return envelopeHttpContract();
+        }
+        if ("PROTOBUF_HTTP_V1".equalsIgnoreCase(protocol)) {
+            return protobufHttpContract();
+        }
+        throw new IllegalArgumentException("Unsupported remote step host protocol '" + protocol + "'");
     }
 
     private Map<String, Object> protobufHttpContract() {
@@ -442,7 +454,43 @@ public class PipelineProtoGenerator {
             "x-tpf-deadline-epoch-ms",
             "x-tpf-dispatch-ts-epoch-ms",
             "x-tpf-parent-item-id"));
-        return contract;
+        return Collections.unmodifiableMap(new LinkedHashMap<>(contract));
+    }
+
+    private Map<String, Object> envelopeHttpContract() {
+        Map<String, Object> contract = new LinkedHashMap<>();
+        contract.put("method", "POST");
+        contract.put("contentType", "application/vnd.tpf.envelope.v1+json");
+        contract.put("accept", "application/vnd.tpf.envelope.v1+json");
+        contract.put("successStatus", "2xx");
+        contract.put("failureEnvelope", "tpf.envelope.v1 error payload or HTTP error body");
+        contract.put("headers", List.of(
+            "x-tpf-correlation-id",
+            "x-tpf-execution-id",
+            "x-tpf-idempotency-key",
+            "x-tpf-retry-attempt",
+            "x-tpf-deadline-epoch-ms",
+            "x-tpf-dispatch-ts-epoch-ms",
+            "x-tpf-parent-item-id"));
+        return Collections.unmodifiableMap(new LinkedHashMap<>(contract));
+    }
+
+    private Map<String, Object> payloadPolicy(String protocol) {
+        Map<String, Object> policy = new LinkedHashMap<>();
+        if ("ENVELOPE_HTTP_V1".equalsIgnoreCase(protocol)) {
+            policy.put("mode", "ENVELOPE");
+            policy.put("control", "strict");
+            policy.put("payload", List.of("json", "bytes", "ref"));
+            policy.put("protocolVersion", "tpf.envelope.v1");
+            return Collections.unmodifiableMap(new LinkedHashMap<>(policy));
+        }
+        if (!"PROTOBUF_HTTP_V1".equalsIgnoreCase(protocol)) {
+            throw new IllegalArgumentException("Unsupported remote step host payload protocol '" + protocol + "'");
+        }
+        policy.put("mode", "PROTOBUF");
+        policy.put("control", "http-headers");
+        policy.put("payload", List.of("protobuf"));
+        return Collections.unmodifiableMap(new LinkedHashMap<>(policy));
     }
 
     private String renderExternalStepHostReadme(ExternalStepHostManifest manifest) {
@@ -477,6 +525,8 @@ public class PipelineProtoGenerator {
         builder.append("For `PROTOBUF_HTTP_V1`, hosts receive a `POST` body encoded as `application/x-protobuf` ");
         builder.append("using the request message and return the response message as `application/x-protobuf`.\n");
         builder.append("Non-2xx failures should return a `google.rpc.Status` protobuf body when possible.\n");
+        builder.append("For `ENVELOPE_HTTP_V1`, hosts receive and return `application/vnd.tpf.envelope.v1+json`; ");
+        builder.append("TPF owns the control metadata while the payload region may carry JSON, bytes, or a payload reference.\n");
         return builder.toString();
     }
 
@@ -1214,7 +1264,8 @@ public class PipelineProtoGenerator {
         String protocol,
         Integer timeoutMs,
         Map<String, String> target,
-        Map<String, Object> http
+        Map<String, Object> http,
+        Map<String, Object> payloadPolicy
     ) {
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClient.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClient.java
@@ -156,7 +156,9 @@ public class EnvelopeHttpRemoteOperatorClient {
     }
 
     private void putContext(Map<String, String> context, String name, Optional<String> value) {
-        value.ifPresent(actual -> context.put(name, actual));
+        value.map(String::trim)
+            .filter(actual -> !actual.isEmpty())
+            .ifPresent(actual -> context.put(name, actual));
     }
 
     private void putContext(Map<String, String> context, String name, OptionalLong value) {

--- a/framework/runtime/src/main/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClient.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClient.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.transport.http;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.grpc.StatusRuntimeException;
+import org.pipelineframework.context.DispatchDeadlineValidator;
+import org.pipelineframework.context.PipelineContext;
+import org.pipelineframework.context.PipelineContextHeaders;
+import org.pipelineframework.context.PipelineContextHolder;
+import org.pipelineframework.context.TransportDispatchMetadata;
+import org.pipelineframework.context.TransportDispatchMetadataHolder;
+import org.pipelineframework.envelope.TpfEnvelope;
+import org.pipelineframework.envelope.TpfEnvelopeCodec;
+import org.pipelineframework.envelope.TpfEnvelopeControl;
+import org.pipelineframework.step.NonRetryableException;
+
+/**
+ * Dispatches unary JSON envelope requests to remote operators.
+ */
+public class EnvelopeHttpRemoteOperatorClient {
+    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final HttpClient httpClient;
+    private final TpfEnvelopeCodec codec;
+
+    public EnvelopeHttpRemoteOperatorClient() {
+        this(HttpClient.newBuilder()
+            .connectTimeout(DEFAULT_CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build(), new TpfEnvelopeCodec());
+    }
+
+    EnvelopeHttpRemoteOperatorClient(HttpClient httpClient, TpfEnvelopeCodec codec) {
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient must not be null");
+        this.codec = Objects.requireNonNull(codec, "codec must not be null");
+    }
+
+    public <I, O> CompletionStage<O> invoke(
+        String targetUrl,
+        String step,
+        String operatorId,
+        I input,
+        Class<O> outputType,
+        Integer timeoutMs
+    ) {
+        Objects.requireNonNull(targetUrl, "targetUrl must not be null");
+        Objects.requireNonNull(step, "step must not be null");
+        Objects.requireNonNull(operatorId, "operatorId must not be null");
+        Objects.requireNonNull(input, "input must not be null");
+        Objects.requireNonNull(outputType, "outputType must not be null");
+        PipelineContext pipelineContext = PipelineContextHolder.get();
+        TransportDispatchMetadata transportMetadata = TransportDispatchMetadataHolder.get();
+        return send(targetUrl, step, operatorId, input, outputType, timeoutMs, pipelineContext, transportMetadata);
+    }
+
+    private <I, O> CompletionStage<O> send(
+        String targetUrl,
+        String step,
+        String operatorId,
+        I input,
+        Class<O> outputType,
+        Integer timeoutMs,
+        PipelineContext pipelineContext,
+        TransportDispatchMetadata transportMetadata
+    ) {
+        try {
+            EnvelopeDispatchMetadata metadata = currentTransportMetadata(input, operatorId, transportMetadata);
+            Duration effectiveTimeout = computeEffectiveTimeout(metadata, timeoutMs, operatorId);
+            TpfEnvelope requestEnvelope = codec.envelope(control(step, operatorId, pipelineContext, metadata),
+                codec.jsonPayload(input, input.getClass().getName()));
+            byte[] requestBody = codec.write(requestEnvelope);
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(URI.create(targetUrl))
+                .timeout(effectiveTimeout)
+                .header("Content-Type", ProtobufHttpContentTypes.APPLICATION_TPF_ENVELOPE_JSON)
+                .header("Accept", ProtobufHttpContentTypes.APPLICATION_TPF_ENVELOPE_JSON)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(requestBody));
+            applyContextHeaders(requestBuilder, pipelineContext, metadata);
+
+            return httpClient.sendAsync(requestBuilder.build(), HttpResponse.BodyHandlers.ofByteArray())
+                .thenApply(response -> decodeResponse(response, targetUrl, operatorId, outputType));
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private <O> O decodeResponse(
+        HttpResponse<byte[]> response,
+        String targetUrl,
+        String operatorId,
+        Class<O> outputType
+    ) {
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            TpfEnvelope responseEnvelope = codec.read(response.body() == null ? new byte[0] : response.body());
+            return codec.readJsonPayload(responseEnvelope.payload(), outputType);
+        }
+        throw toRemoteFailure(response, targetUrl, operatorId);
+    }
+
+    private TpfEnvelopeControl control(
+        String step,
+        String operatorId,
+        PipelineContext pipelineContext,
+        EnvelopeDispatchMetadata metadata
+    ) {
+        return new TpfEnvelopeControl(
+            pipelineContext == null || pipelineContext.versionTag() == null || pipelineContext.versionTag().isBlank()
+                ? "unspecified"
+                : pipelineContext.versionTag(),
+            step,
+            operatorId,
+            controlContext(metadata),
+            Map.of());
+    }
+
+    private Map<String, String> controlContext(EnvelopeDispatchMetadata metadata) {
+        Map<String, String> context = new LinkedHashMap<>();
+        putContext(context, "correlationId", metadata.correlationId());
+        putContext(context, "executionId", metadata.executionId());
+        putContext(context, "idempotencyKey", metadata.idempotencyKey());
+        putContext(context, "retryAttempt", metadata.retryAttempt());
+        putContext(context, "deadlineEpochMs", metadata.deadlineEpochMs());
+        putContext(context, "dispatchTsEpochMs", metadata.dispatchTsEpochMs());
+        putContext(context, "parentItemId", metadata.parentItemId());
+        return Map.copyOf(context);
+    }
+
+    private void putContext(Map<String, String> context, String name, Optional<String> value) {
+        value.ifPresent(actual -> context.put(name, actual));
+    }
+
+    private void putContext(Map<String, String> context, String name, OptionalLong value) {
+        value.ifPresent(actual -> context.put(name, String.valueOf(actual)));
+    }
+
+    private void putContext(Map<String, String> context, String name, Object value) {
+        context.put(name, String.valueOf(value));
+    }
+
+    private void applyContextHeaders(
+        HttpRequest.Builder requestBuilder,
+        PipelineContext pipelineContext,
+        EnvelopeDispatchMetadata metadata
+    ) {
+        if (pipelineContext != null) {
+            putHeader(requestBuilder, PipelineContextHeaders.VERSION, pipelineContext.versionTag());
+            putHeader(requestBuilder, PipelineContextHeaders.REPLAY, pipelineContext.replayMode());
+            putHeader(requestBuilder, PipelineContextHeaders.CACHE_POLICY, pipelineContext.cachePolicy());
+        }
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_CORRELATION_ID, metadata.correlationId());
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_EXECUTION_ID, metadata.executionId());
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_IDEMPOTENCY_KEY, metadata.idempotencyKey());
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_RETRY_ATTEMPT, metadata.retryAttempt());
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_DEADLINE_EPOCH_MS, metadata.deadlineEpochMs());
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_DISPATCH_TS_EPOCH_MS, metadata.dispatchTsEpochMs());
+        putHeader(requestBuilder, PipelineContextHeaders.TPF_PARENT_ITEM_ID, metadata.parentItemId());
+    }
+
+    private void putHeader(HttpRequest.Builder requestBuilder, String name, String value) {
+        if (value != null && !value.isBlank()) {
+            requestBuilder.header(name, value);
+        }
+    }
+
+    private void putHeader(HttpRequest.Builder requestBuilder, String name, Optional<String> value) {
+        value.ifPresent(actual -> putHeader(requestBuilder, name, actual));
+    }
+
+    private void putHeader(HttpRequest.Builder requestBuilder, String name, OptionalLong value) {
+        value.ifPresent(actual -> requestBuilder.header(name, String.valueOf(actual)));
+    }
+
+    private void putHeader(HttpRequest.Builder requestBuilder, String name, Object value) {
+        if (value != null) {
+            requestBuilder.header(name, String.valueOf(value));
+        }
+    }
+
+    private EnvelopeDispatchMetadata currentTransportMetadata(
+        Object input,
+        String operatorId,
+        TransportDispatchMetadata existingMetadata
+    ) {
+        if (existingMetadata != null) {
+            return new EnvelopeDispatchMetadata(
+                Optional.ofNullable(existingMetadata.correlationId()),
+                Optional.ofNullable(existingMetadata.executionId()),
+                Optional.ofNullable(existingMetadata.idempotencyKey()),
+                existingMetadata.retryAttempt() == null ? 0 : existingMetadata.retryAttempt(),
+                existingMetadata.deadlineEpochMs() == null ? OptionalLong.empty() : OptionalLong.of(existingMetadata.deadlineEpochMs()),
+                existingMetadata.dispatchTsEpochMs() == null ? Instant.now().toEpochMilli() : existingMetadata.dispatchTsEpochMs(),
+                Optional.ofNullable(existingMetadata.parentItemId()));
+        }
+        String seed = UUID.nameUUIDFromBytes(codec.write(codec.envelope(
+            new TpfEnvelopeControl("generated", operatorId, operatorId, Map.of("retryAttempt", "0"), Map.of()),
+            codec.jsonPayload(input, input.getClass().getName())))).toString();
+        long now = Instant.now().toEpochMilli();
+        return new EnvelopeDispatchMetadata(
+            Optional.of("remote-" + seed),
+            Optional.of("remote-" + seed),
+            Optional.of(operatorId + ":" + seed),
+            0,
+            OptionalLong.empty(),
+            now,
+            Optional.empty());
+    }
+
+    private Duration computeEffectiveTimeout(
+        EnvelopeDispatchMetadata metadata,
+        Integer timeoutMs,
+        String operatorId
+    ) {
+        OptionalLong deadlineEpochMs = metadata.deadlineEpochMs();
+        Long remainingDeadlineMs = deadlineEpochMs.isPresent() ? deadlineEpochMs.getAsLong() - Instant.now().toEpochMilli() : null;
+        if (remainingDeadlineMs != null && remainingDeadlineMs <= 0) {
+            try {
+                DispatchDeadlineValidator.ensureNotExpired(deadlineEpochMs.getAsLong(), "remote-operator:" + operatorId);
+            } catch (StatusRuntimeException ex) {
+                throw new NonRetryableException("Remote operator deadline exceeded before dispatch", ex);
+            }
+        }
+
+        Long effectiveMs = null;
+        if (timeoutMs != null && deadlineEpochMs.isPresent()) {
+            effectiveMs = Math.min(timeoutMs.longValue(), remainingDeadlineMs);
+        } else if (timeoutMs != null) {
+            effectiveMs = timeoutMs.longValue();
+        } else if (remainingDeadlineMs != null) {
+            effectiveMs = remainingDeadlineMs;
+        }
+
+        if (effectiveMs == null) {
+            return DEFAULT_REQUEST_TIMEOUT;
+        }
+        if (effectiveMs <= 0) {
+            throw new NonRetryableException("Remote operator deadline exceeded before dispatch");
+        }
+        return Duration.ofMillis(effectiveMs);
+    }
+
+    private RuntimeException toRemoteFailure(HttpResponse<byte[]> response, String targetUrl, String operatorId) {
+        byte[] body = response.body() == null ? new byte[0] : response.body();
+        String responseBody = new String(body, StandardCharsets.UTF_8);
+        if (responseBody.length() > 512) {
+            responseBody = responseBody.substring(0, 512) + "...";
+        }
+        String message = "Remote operator '" + operatorId + "' failed with HTTP " + response.statusCode()
+            + " at " + targetUrl + " (" + responseBody + ")";
+        int statusCode = response.statusCode();
+        if (statusCode >= 400 && statusCode < 500 && statusCode != 408 && statusCode != 429) {
+            return new NonRetryableException(message);
+        }
+        return new IllegalStateException(message);
+    }
+
+    private record EnvelopeDispatchMetadata(
+        Optional<String> correlationId,
+        Optional<String> executionId,
+        Optional<String> idempotencyKey,
+        int retryAttempt,
+        OptionalLong deadlineEpochMs,
+        long dispatchTsEpochMs,
+        Optional<String> parentItemId
+    ) {
+        private EnvelopeDispatchMetadata {
+            correlationId = Objects.requireNonNull(correlationId, "correlationId must not be null");
+            executionId = Objects.requireNonNull(executionId, "executionId must not be null");
+            idempotencyKey = Objects.requireNonNull(idempotencyKey, "idempotencyKey must not be null");
+            deadlineEpochMs = Objects.requireNonNull(deadlineEpochMs, "deadlineEpochMs must not be null");
+            parentItemId = Objects.requireNonNull(parentItemId, "parentItemId must not be null");
+            if (retryAttempt < 0) {
+                throw new IllegalArgumentException("retryAttempt must not be negative");
+            }
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/transport/http/ProtobufHttpContentTypes.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/transport/http/ProtobufHttpContentTypes.java
@@ -22,6 +22,7 @@ package org.pipelineframework.transport.http;
 public final class ProtobufHttpContentTypes {
     public static final String APPLICATION_X_PROTOBUF = "application/x-protobuf";
     public static final String APPLICATION_JSON = "application/json";
+    public static final String APPLICATION_TPF_ENVELOPE_JSON = "application/vnd.tpf.envelope.v1+json";
 
     private ProtobufHttpContentTypes() {
         throw new AssertionError("No instances");

--- a/framework/runtime/src/test/java/org/pipelineframework/envelope/TpfEnvelopeCodecTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/envelope/TpfEnvelopeCodecTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.envelope;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TpfEnvelopeCodecTest {
+
+    private final TpfEnvelopeCodec codec = new TpfEnvelopeCodec();
+
+    @Test
+    void roundTripsJsonPayloadWithStrictControlMetadata() {
+        TpfEnvelopeControl control = control(Map.of("tenant", "tenant-a"));
+        TpfEnvelope envelope = codec.envelope(control, codec.jsonPayload(new DemoPayload("doc-1", 3), DemoPayload.class.getName()));
+
+        TpfEnvelope decoded = codec.read(codec.write(envelope));
+        DemoPayload payload = codec.readJsonPayload(decoded.payload(), DemoPayload.class);
+
+        assertEquals(TpfEnvelope.PROTOCOL_VERSION, decoded.protocolVersion());
+        assertEquals("Chunk", decoded.control().step());
+        assertEquals("chunker", decoded.control().operatorId());
+        assertEquals("corr-1", decoded.control().context().get("correlationId"));
+        assertEquals("tenant-a", decoded.control().metadata().get("tenant"));
+        assertEquals(new DemoPayload("doc-1", 3), payload);
+    }
+
+    @Test
+    void normalizesNullControlAndPayloadMetadataToImmutableEmptyMaps() {
+        TpfEnvelopeControl control = control(null);
+        TpfEnvelopePayload payload = codec.jsonPayload(new DemoPayload("doc-2", 1), DemoPayload.class.getName());
+
+        assertTrue(control.metadata().isEmpty());
+        assertTrue(payload.metadata().isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> control.metadata().put("x", "y"));
+        assertThrows(UnsupportedOperationException.class, () -> payload.metadata().put("x", "y"));
+    }
+
+    @Test
+    void supportsBytesPayload() {
+        byte[] bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        TpfEnvelopePayload payload = codec.bytesPayload(bytes, "text/plain", "raw-text");
+
+        TpfEnvelope decoded = codec.read(codec.write(codec.envelope(control(Map.of()), payload)));
+
+        assertEquals("bytes", decoded.payload().kind());
+        assertEquals("text/plain", decoded.payload().contentType());
+        assertArrayEquals(bytes, codec.readBytesPayload(decoded.payload()));
+    }
+
+    @Test
+    void supportsReferencePayload() {
+        TpfPayloadRef ref = new TpfPayloadRef(" repo://documents/doc-1 ", "application/pdf",
+            Map.of("sizeBytes", "1024", "sha256", "abc123"));
+
+        TpfEnvelope decoded = codec.read(codec.write(codec.envelope(control(Map.of()), codec.refPayload(ref, "DocumentRef"))));
+        TpfPayloadRef decodedRef = codec.readRefPayload(decoded.payload());
+
+        assertEquals("ref", decoded.payload().kind());
+        assertEquals("repo://documents/doc-1", decodedRef.ref());
+        assertEquals("application/pdf", decodedRef.contentType());
+    }
+
+    @Test
+    void rejectsUnsupportedProtocolVersion() {
+        TpfEnvelope envelope = codec.envelope(control(Map.of()), codec.jsonPayload(new DemoPayload("doc-3", 1), "DemoPayload"));
+        String json = codec.writeString(envelope).replace(TpfEnvelope.PROTOCOL_VERSION, "tpf.envelope.v0");
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> codec.read(json));
+
+        assertTrue(error.getMessage().contains("Failed to decode TPF envelope"));
+    }
+
+    @Test
+    void rejectsJsonReaderForNonJsonPayload() {
+        TpfEnvelopePayload payload = codec.bytesPayload("hello".getBytes(StandardCharsets.UTF_8), "text/plain", "raw-text");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> codec.readJsonPayload(payload, DemoPayload.class));
+
+        assertTrue(error.getMessage().contains("Expected json envelope payload"));
+    }
+
+    @Test
+    void rejectsNullCodecInputs() {
+        assertThrows(NullPointerException.class, () -> codec.write(null));
+        assertThrows(NullPointerException.class, () -> codec.read((byte[]) null));
+        assertThrows(NullPointerException.class, () -> codec.read((String) null));
+        assertThrows(NullPointerException.class, () -> codec.jsonPayload(null, "DemoPayload"));
+        assertThrows(NullPointerException.class, () -> codec.bytesPayload(null, "text/plain", "raw-text"));
+        assertThrows(NullPointerException.class, () -> codec.refPayload(null, "DocumentRef"));
+        assertThrows(NullPointerException.class, () -> codec.readBytesPayload(null));
+        assertThrows(NullPointerException.class, () -> codec.readRefPayload(null));
+    }
+
+    @Test
+    void bytesPayloadDefaultsContentType() {
+        TpfEnvelopePayload payload = codec.bytesPayload("hello".getBytes(StandardCharsets.UTF_8), null, "raw-text");
+
+        assertEquals("application/octet-stream", payload.contentType());
+    }
+
+    private TpfEnvelopeControl control(Map<String, String> metadata) {
+        return new TpfEnvelopeControl(
+            "pipeline-v1",
+            "Chunk",
+            "chunker",
+            Map.of(
+                "correlationId", "corr-1",
+                "executionId", "exec-1",
+                "idempotencyKey", "idem-1",
+                "retryAttempt", "2",
+                "deadlineEpochMs", "2000000000000",
+                "dispatchTsEpochMs", "1900000000000",
+                "parentItemId", "parent-1"),
+            metadata);
+    }
+
+    private record DemoPayload(String id, int count) {
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/envelope/TpfEnvelopeCodecTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/envelope/TpfEnvelopeCodecTest.java
@@ -121,6 +121,14 @@ class TpfEnvelopeCodecTest {
         assertEquals("application/octet-stream", payload.contentType());
     }
 
+    @Test
+    void bytesPayloadTrimsContentType() {
+        TpfEnvelopePayload payload = codec.bytesPayload("hello".getBytes(StandardCharsets.UTF_8),
+            " text/plain ", "raw-text");
+
+        assertEquals("text/plain", payload.contentType());
+    }
+
     private TpfEnvelopeControl control(Map<String, String> metadata) {
         return new TpfEnvelopeControl(
             "pipeline-v1",

--- a/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/proto/PipelineProtoGeneratorTest.java
@@ -18,6 +18,7 @@ package org.pipelineframework.proto;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -1071,6 +1072,57 @@ class PipelineProtoGeneratorTest {
     }
 
     @Test
+    void generatesEnvelopeExternalStepHostContractPolicy() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Envelope Remote Test"
+            basePackage: "com.example.envelope"
+            transport: "REST"
+            messages:
+              ParsedDocument:
+                fields:
+                  - number: 1
+                    name: "id"
+                    type: "uuid"
+              ChunkResult:
+                fields:
+                  - number: 1
+                    name: "status"
+                    type: "string"
+            steps:
+              - name: "Chunk Document"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "ParsedDocument"
+                outputTypeName: "ChunkResult"
+                execution:
+                  mode: "REMOTE"
+                  operatorId: "chunker"
+                  protocol: "ENVELOPE_HTTP_V1"
+                  timeoutMs: 500
+                  target:
+                    url: "https://service.example.com/chunker"
+            """;
+        Path configPath = tempDir.resolve("envelope-remote-config.yaml");
+        Files.writeString(configPath, yaml);
+        Path outputDir = tempDir.resolve("proto-envelope-remote-out");
+
+        new PipelineProtoGenerator().generate(tempDir, configPath, outputDir);
+
+        JsonNode manifest = PipelineJson.mapper().readTree(outputDir.resolve("external-step-hosts.json").toFile());
+        JsonNode step = manifest.path("steps").get(0);
+        assertEquals("ENVELOPE_HTTP_V1", step.path("protocol").asText());
+        assertEquals("application/vnd.tpf.envelope.v1+json", step.path("http").path("contentType").asText());
+        assertEquals("ENVELOPE", step.path("payloadPolicy").path("mode").asText());
+        assertEquals("strict", step.path("payloadPolicy").path("control").asText());
+        assertEquals("tpf.envelope.v1", step.path("payloadPolicy").path("protocolVersion").asText());
+        assertEquals("json", step.path("payloadPolicy").path("payload").get(0).asText());
+
+        String readme = Files.readString(outputDir.resolve("EXTERNAL-STEP-HOSTS.md"));
+        assertTrue(readme.contains("For `ENVELOPE_HTTP_V1`"));
+        assertTrue(readme.contains("application/vnd.tpf.envelope.v1+json"));
+    }
+
+    @Test
     void rejectsRemoteTargetWithBothUrlAndUrlConfigKey() throws Exception {
         String yaml = """
             version: 2
@@ -1199,7 +1251,7 @@ class PipelineProtoGeneratorTest {
         JsonNode manifest = PipelineJson.mapper().readTree(outputDir.resolve("external-step-hosts.json").toFile());
         JsonNode headers = manifest.path("steps").get(0).path("http").path("headers");
         assertTrue(headers.isArray());
-        List<String> headerList = new java.util.ArrayList<>();
+        List<String> headerList = new ArrayList<>();
         headers.forEach(h -> headerList.add(h.asText()));
 
         assertTrue(headerList.contains("x-tpf-correlation-id"), "must include x-tpf-correlation-id");

--- a/framework/runtime/src/test/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClientTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClientTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.transport.http;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.context.PipelineContext;
+import org.pipelineframework.context.PipelineContextHolder;
+import org.pipelineframework.context.TransportDispatchMetadata;
+import org.pipelineframework.context.TransportDispatchMetadataHolder;
+import org.pipelineframework.envelope.TpfEnvelope;
+import org.pipelineframework.envelope.TpfEnvelopeCodec;
+import org.pipelineframework.step.NonRetryableException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnvelopeHttpRemoteOperatorClientTest {
+
+    private final TpfEnvelopeCodec codec = new TpfEnvelopeCodec();
+
+    @AfterEach
+    void tearDown() {
+        PipelineContextHolder.clear();
+        TransportDispatchMetadataHolder.clear();
+    }
+
+    @Test
+    void postsStrictEnvelopeAndDecodesJsonPayloadResponse() throws Exception {
+        AtomicReference<String> contentType = new AtomicReference<>();
+        AtomicReference<String> correlationHeader = new AtomicReference<>();
+        AtomicReference<TpfEnvelope> requestEnvelope = new AtomicReference<>();
+
+        try (ServerHandle server = startServer(exchange -> {
+            contentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+            correlationHeader.set(exchange.getRequestHeaders().getFirst("x-tpf-correlation-id"));
+            requestEnvelope.set(codec.read(exchange.getRequestBody().readAllBytes()));
+            TpfEnvelope response = codec.envelope(requestEnvelope.get().control(),
+                codec.jsonPayload(new DemoResponse("ok"), DemoResponse.class.getName()));
+            byte[] body = codec.write(response);
+            exchange.getResponseHeaders().add("Content-Type", ProtobufHttpContentTypes.APPLICATION_TPF_ENVELOPE_JSON);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        })) {
+            PipelineContextHolder.set(new PipelineContext("pipeline-v1", "replay", "prefer-cache"));
+            TransportDispatchMetadataHolder.set(new TransportDispatchMetadata(
+                "corr-1", "exec-1", "idem-1", 3, 2_000_000_000_000L, 1_900_000_000_000L, "parent-1"));
+
+            EnvelopeHttpRemoteOperatorClient client = new EnvelopeHttpRemoteOperatorClient();
+            DemoResponse response = client.invoke(
+                    server.url(), "Chunk", "chunker", new DemoRequest("doc-1"), DemoResponse.class, 3000)
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+
+            assertEquals("ok", response.status());
+            assertEquals(ProtobufHttpContentTypes.APPLICATION_TPF_ENVELOPE_JSON, contentType.get());
+            assertEquals("corr-1", correlationHeader.get());
+            assertEquals("Chunk", requestEnvelope.get().control().step());
+            assertEquals("chunker", requestEnvelope.get().control().operatorId());
+            assertEquals("corr-1", requestEnvelope.get().control().context().get("correlationId"));
+            assertEquals("doc-1", requestEnvelope.get().payload().data().path("id").asText());
+        }
+    }
+
+    @Test
+    void mapsClientErrorsToNonRetryableException() throws Exception {
+        try (ServerHandle server = startServer(exchange -> respond(exchange, 400, "bad request"))) {
+            ExecutionException error = invokeExpectingFailure(server.url());
+
+            assertEquals(NonRetryableException.class, error.getCause().getClass());
+        }
+    }
+
+    @Test
+    void mapsServerErrorsToRetryableException() throws Exception {
+        try (ServerHandle server = startServer(exchange -> respond(exchange, 503, "try later"))) {
+            ExecutionException error = invokeExpectingFailure(server.url());
+
+            assertEquals(IllegalStateException.class, error.getCause().getClass());
+            assertTrue(error.getCause().getMessage().contains("HTTP 503"));
+        }
+    }
+
+    @Test
+    void mapsTimeoutAndRateLimitStatusesToRetryableException() throws Exception {
+        try (ServerHandle timeout = startServer(exchange -> respond(exchange, 408, "timeout"))) {
+            ExecutionException error = invokeExpectingFailure(timeout.url());
+            assertEquals(IllegalStateException.class, error.getCause().getClass());
+        }
+        try (ServerHandle rateLimit = startServer(exchange -> respond(exchange, 429, "rate limit"))) {
+            ExecutionException error = invokeExpectingFailure(rateLimit.url());
+            assertEquals(IllegalStateException.class, error.getCause().getClass());
+        }
+    }
+
+    @Test
+    void rejectsExpiredDeadlineBeforeDispatch() {
+        TransportDispatchMetadataHolder.set(new TransportDispatchMetadata(
+            "corr-1", "exec-1", "idem-1", 0, System.currentTimeMillis() - 1000, System.currentTimeMillis(), "parent-1"));
+        EnvelopeHttpRemoteOperatorClient client = new EnvelopeHttpRemoteOperatorClient();
+
+        ExecutionException error = assertThrows(ExecutionException.class, () -> client.invoke(
+                "http://127.0.0.1:1/", "Chunk", "chunker", new DemoRequest("doc-1"), DemoResponse.class, 3000)
+            .toCompletableFuture()
+            .get(2, TimeUnit.SECONDS));
+
+        assertEquals(NonRetryableException.class, error.getCause().getClass());
+        assertTrue(error.getCause().getMessage().contains("deadline exceeded"));
+    }
+
+    private ExecutionException invokeExpectingFailure(String url) {
+        EnvelopeHttpRemoteOperatorClient client = new EnvelopeHttpRemoteOperatorClient();
+        return assertThrows(ExecutionException.class, () -> client.invoke(
+                url, "Chunk", "chunker", new DemoRequest("doc-1"), DemoResponse.class, 3000)
+            .toCompletableFuture()
+            .get(2, TimeUnit.SECONDS));
+    }
+
+    private void respond(HttpExchange exchange, int status, String message) throws IOException {
+        byte[] body = message.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, body.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+        }
+    }
+
+    private ServerHandle startServer(HttpHandler handler) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", handler);
+        server.start();
+        return new ServerHandle(server);
+    }
+
+    private record ServerHandle(HttpServer server) implements AutoCloseable {
+        String url() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    private record DemoRequest(String id) {
+    }
+
+    private record DemoResponse(String status) {
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClientTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/transport/http/EnvelopeHttpRemoteOperatorClientTest.java
@@ -37,6 +37,7 @@ import org.pipelineframework.envelope.TpfEnvelopeCodec;
 import org.pipelineframework.step.NonRetryableException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -117,6 +118,35 @@ class EnvelopeHttpRemoteOperatorClientTest {
         try (ServerHandle rateLimit = startServer(exchange -> respond(exchange, 429, "rate limit"))) {
             ExecutionException error = invokeExpectingFailure(rateLimit.url());
             assertEquals(IllegalStateException.class, error.getCause().getClass());
+        }
+    }
+
+    @Test
+    void omitsBlankOptionalContextValuesFromEnvelopeControl() throws Exception {
+        AtomicReference<TpfEnvelope> requestEnvelope = new AtomicReference<>();
+
+        try (ServerHandle server = startServer(exchange -> {
+            requestEnvelope.set(codec.read(exchange.getRequestBody().readAllBytes()));
+            TpfEnvelope response = codec.envelope(requestEnvelope.get().control(),
+                codec.jsonPayload(new DemoResponse("ok"), DemoResponse.class.getName()));
+            byte[] body = codec.write(response);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        })) {
+            TransportDispatchMetadataHolder.set(new TransportDispatchMetadata(
+                " ", "", " idem-1 ", 0, 2_000_000_000_000L, 1_900_000_000_000L, "   "));
+
+            EnvelopeHttpRemoteOperatorClient client = new EnvelopeHttpRemoteOperatorClient();
+            client.invoke(server.url(), "Chunk", "chunker", new DemoRequest("doc-1"), DemoResponse.class, 3000)
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+
+            assertFalse(requestEnvelope.get().control().context().containsKey("correlationId"));
+            assertFalse(requestEnvelope.get().control().context().containsKey("executionId"));
+            assertEquals("idem-1", requestEnvelope.get().control().context().get("idempotencyKey"));
+            assertFalse(requestEnvelope.get().control().context().containsKey("parentItemId"));
         }
     }
 


### PR DESCRIPTION
## Summary

Adds the optional envelope compatibility lane for remote v2 HTTP step hosts:

- introduces `ENVELOPE_HTTP_V1` as an explicit remote execution protocol
- adds strict TPF envelope records and JSON codec with loose payload variants (`json`, `bytes`, `ref`)
- adds a framework-neutral `EnvelopeHttpRemoteOperatorClient` using JDK `HttpClient.sendAsync` and `CompletionStage`
- updates generated remote operator adapters to bridge `CompletionStage` to the existing Quarkus `ReactiveService`/`Uni` seam
- extends external step-host contract metadata with protocol-specific HTTP contract and payload policy
- updates schema, docs, and focused runtime/deployment tests

## Scope

In scope: remote v2 HTTP step-host compatibility for explicit envelope payloads.

Out of scope: Kafka/SQS brokered step-host dispatch, broad renderer portability, changing the existing `ReactiveService` contract, or replacing protobuf as the default remote operator path.

## Review loop

Ran local CodeRabbit review twice. Fixed the relevant changed-surface findings around protocol validation, immutable contract metadata, endpoint ref trimming, null/header handling, and focused envelope HTTP/codec tests.

Skipped as out of scope/stale:

- Spring smoke dependency guard hardening belongs to the Spring smoke workstream, not this envelope protocol slice.
- The remote-target assertion finding was stale/wrong for this branch because config loading fails earlier through `PipelineTemplateRemoteTarget` with the current one-of validation message.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime,deployment -Dtest='TpfEnvelopeCodecTest,EnvelopeHttpRemoteOperatorClientTest,PipelineProtoGeneratorTest,StepDefinitionParserTest,RemoteOperatorAdapterRendererTest,PipelineTemplateSchemaExporterTest' test`
- `./mvnw -f framework/pom.xml -pl runtime,deployment -DskipTests compile`
- `npm --prefix docs run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced `ENVELOPE_HTTP_V1` remote operator protocol option for remote v2 HTTP step hosts, enabling loose-payload envelope contracts with strict control metadata as an alternative to protobuf-based contracts.
  * Updated remote operator configuration and validation to support both `PROTOBUF_HTTP_V1` and `ENVELOPE_HTTP_V1` protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->