### PR TITLE
Add command-step docs, replay telemetry, and effect metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ Prefer the split annotation-processor guide under `docs/guide/evolve/annotation-
   - `evolve`: internals, design notes, and backlog-oriented material
 - Keep risk registers, update reports, and future-work tracking out of user-facing docs unless they are actionable operator runbooks; place backlog/planning artifacts under `docs/guide/evolve/` or external issue trackers.
 - When changing operator or mapper semantics, update code + tests + docs together in the same change set.
+- When adding or changing a semantic step kind (`kind: await`, `kind: command`, query steps, object I/O, or future DSL-owned I/O shells), update compiler/runtime support, validation tests, user docs, telemetry/replay metadata, replay-viewer node rendering/legend, and any affected example replay datasets or generation paths in the same change set.
 - When changing runtime-layout, generator, or Canvas/web UI semantics, update `web-ui`, affected docs, tests, and the separate `The-Pipeline-Framework/tpf-mcp-bridge` repository when applicable.
 
 ## PR Slicing Criteria

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -145,6 +145,7 @@ const mainSidebar = [
                     {text: 'Operator Libraries', link: '/develop/extension/operator-libraries'},
                     {text: 'Client Steps', link: '/develop/extension/client-steps'},
                     {text: 'Orchestrator Runtime Extensions', link: '/develop/extension/orchestrator-runtime'},
+                    {text: 'Command Connectors', link: '/develop/extension/command-connectors'},
                     {text: 'Reactive Services', link: '/develop/extension/reactive-services'},
                     {text: 'REST Resources', link: '/develop/extension/rest-resources'}
                 ]
@@ -186,6 +187,7 @@ const mainSidebar = [
                     {text: 'Overview', link: '/deploy/orchestrator-runtime/'},
                     {text: 'Queue-Async Runtime', link: '/deploy/orchestrator-runtime/queue-async'},
                     {text: 'Checkpoint Handoff', link: '/deploy/orchestrator-runtime/checkpoint-handoff'},
+                    {text: 'Command Steps', link: '/deploy/orchestrator-runtime/command'},
                     {text: 'Await Runtime Setup', link: '/deploy/orchestrator-runtime/await'}
                 ]
             },

--- a/docs/deploy/orchestrator-runtime/command.md
+++ b/docs/deploy/orchestrator-runtime/command.md
@@ -15,7 +15,7 @@ Use `kind: command` when the step:
 
 Good fits include search indexing, ticket creation, email submission, provider provisioning, or payment-provider commands with idempotency keys.
 
-Use a normal `ReactiveService`, operator, or generated adapter when the call is just application logic and does not need an effect record. Use [Await Runtime Setup](/deploy/orchestrator-runtime/await) when the external system completes later through a callback, broker response, or human action. Use [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) when a completed pipeline hands work to another pipeline.
+For application logic that does not need an effect record, keep using a normal `ReactiveService`, operator, or generated adapter. If the external system completes later through a callback, broker response, or human action, configure [Await Runtime Setup](/deploy/orchestrator-runtime/await). When a completed pipeline hands work to another pipeline, model that boundary with [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff).
 
 ## YAML
 

--- a/docs/deploy/orchestrator-runtime/command.md
+++ b/docs/deploy/orchestrator-runtime/command.md
@@ -1,0 +1,70 @@
+# Command Steps
+
+Command steps record and dispatch external writes from a `QUEUE_ASYNC` pipeline. Use them when a retry or replay must not blindly call the external system again.
+
+Start here when you need to declare a command step in `pipeline.yaml`. For connector code, see [Writing Command Connectors](/develop/extension/command-connectors). For runtime signals, see [Replay & Live Topology](/operate/observability/replay) and [Metrics](/operate/observability/metrics).
+
+## When To Use
+
+Use `kind: command` when the step:
+
+1. writes to an external system,
+2. has a deterministic command id,
+3. needs duplicate handling on replay,
+4. should record the external write result as pipeline output.
+
+Good fits include search indexing, ticket creation, email submission, provider provisioning, or payment-provider commands with idempotency keys.
+
+Use a normal `ReactiveService`, operator, or generated adapter when the call is just application logic and does not need an effect record. Use [Await Runtime Setup](/deploy/orchestrator-runtime/await) when the external system completes later through a callback, broker response, or human action. Use [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) when a completed pipeline hands work to another pipeline.
+
+## YAML
+
+V1 command steps are `ONE_TO_ONE` and require `QUEUE_ASYNC`.
+
+```yaml
+steps:
+  - name: "Write Search Index Document"
+    kind: "command"
+    command: "opensearch-index-document"
+    cardinality: "ONE_TO_ONE"
+    input: "org.pipelineframework.search.common.domain.SearchIndexDocument"
+    output: "org.pipelineframework.search.common.domain.SearchIndexWriteResult"
+    commandIdGenerator: "org.pipelineframework.search.common.command.SearchIndexDocumentCommandIdGenerator"
+    duplicatePolicy: "RETURN_RECORDED"
+```
+
+The authored step names the command and the typed input/output contract. Provider details such as endpoint, credentials, index name, timeout, and provider retry tuning belong in runtime configuration.
+
+## Required Runtime Pieces
+
+| Piece | Purpose |
+| --- | --- |
+| `CommandIdGenerator<I>` | Builds the deterministic command id from the input. |
+| `CommandConnector<I, O>` | Calls the external system and returns the command output. |
+| `CommandEffectStore` | Records pending, dispatching, success, retryable failure, and DLQ state. |
+
+The generated command step calls these pieces. Application code does not call the effect store directly.
+
+## Duplicate Policy
+
+`RETURN_RECORDED` returns the stored output when the same command id has already succeeded. This is the usual replay-safe setting.
+
+`FAIL` rejects a duplicate successful command. Use it only when a duplicate is a business error and the caller should not receive the earlier result.
+
+## Failure Behavior
+
+| Result | Runtime behavior |
+| --- | --- |
+| Connector succeeds | Output is recorded and returned. |
+| Same command id already succeeded with `RETURN_RECORDED` | Stored output is returned; the connector is not called again. |
+| Connector throws a retryable failure | Effect is marked retryable and queue-async retry policy applies. |
+| Connector throws a non-retryable failure | Effect is marked terminal/DLQ. |
+
+The external system still needs an idempotency key or deterministic external id. TPF can avoid repeat dispatch after success is recorded, but it cannot make a third-party system exactly-once.
+
+## Related Docs
+
+- [Writing Command Connectors](/develop/extension/command-connectors)
+- [Queue-Async Runtime](/deploy/orchestrator-runtime/queue-async)
+- [Replay & Live Topology](/operate/observability/replay)
+- [Functional Core, Imperative Shell](/design/fcis)

--- a/docs/deploy/orchestrator-runtime/index.md
+++ b/docs/deploy/orchestrator-runtime/index.md
@@ -10,6 +10,7 @@ Current applications host their own generated orchestrator. For implementation n
 2. [Queue-Async Runtime](/deploy/orchestrator-runtime/queue-async) covers durable execution, crash behaviour, idempotency, providers, and HA baseline configuration.
 3. [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) covers reliable cross-pipeline publication and admission.
 4. [Await Runtime Setup](/deploy/orchestrator-runtime/await) covers durable external suspend/resume adapters and runtime configuration.
+5. [Command Steps](/deploy/orchestrator-runtime/command) covers replay-safe external effects with command ids, effect logging, duplicate policy, and connector execution.
 
 ## Runtime Modes
 
@@ -27,6 +28,8 @@ pipeline.orchestrator.mode=QUEUE_ASYNC
 ```
 
 Use [Queue-Async Runtime](/deploy/orchestrator-runtime/queue-async) before relying on background execution in production-style environments.
+
+`kind: await` and `kind: command` are framework-owned I/O shells on top of `QUEUE_ASYNC`. Await owns suspend/resume around a deferred external result. Command owns idempotent external effects that should be recorded, retried, replayed, or dead-lettered as part of the pipeline lifecycle.
 
 ## Generated Transport Entry Points
 

--- a/docs/deploy/orchestrator-runtime/queue-async.md
+++ b/docs/deploy/orchestrator-runtime/queue-async.md
@@ -36,6 +36,8 @@ Think about `QUEUE_ASYNC` in terms of safe re-execution:
 
 The important boundary is this: TPF makes the orchestrator state crash-surviving, but your business-side effects must still be safe when the same work is attempted again.
 
+Use [Command Steps](/deploy/orchestrator-runtime/command) when the external side effect itself should be a managed pipeline boundary with a deterministic command id, effect log, duplicate policy, and recorded output replay.
+
 ## Re-execution, Re-entrancy, And Idempotency
 
 These three ideas are related but not identical:

--- a/docs/design/fcis.md
+++ b/docs/design/fcis.md
@@ -18,6 +18,7 @@ The shell is where distributed-system concerns live.
 | Expose or call a step over REST, gRPC, local, or function entry points | generated transport adapters |
 | Admit files, object-store entries, or external payloads | connectors such as [Object Ingest](/design/object-ingest) |
 | Wait for human approval, webhook callbacks, provider responses, or long-running jobs | [Await Boundaries](/design/await-boundaries) |
+| Record and replay-safe external effects such as indexing, tickets, emails, or provisioning | [Command Steps](/deploy/orchestrator-runtime/command) |
 | Call a synchronous existing method or remote request/response endpoint | [Operators](/design/operators) |
 | Store business outputs for later query or audit | [Persistence](/design/persistence) |
 | Reuse expensive derived outputs | [Caching](/design/caching/) |
@@ -35,6 +36,8 @@ Object ingest keeps directory scans, S3 listings, ETags, duplicate admission, an
 
 Await keeps pending interaction state, resume tokens, timeout handling, duplicate completion, and callback admission out of a business approval step. The step sees an explicit typed outcome.
 
+Command keeps effect ids, recorded outputs, duplicate policy, retry classification, and DLQ state out of a business projection step. The connector executes the external write, but the pipeline owns the effect boundary.
+
 Checkpoint handoff keeps downstream admission, handoff idempotency, and publication envelopes out of application bridge code. The source pipeline publishes a stable typed checkpoint; the target pipeline receives a typed input.
 
 ## What TPF Does Not Hide
@@ -48,4 +51,3 @@ TPF does not remove architectural decisions. It makes them explicit:
 - operational state is observable.
 
 That is the point of "Keep the core pure. Connect to reality."
-

--- a/docs/develop/configuration/await-and-checkpoint.md
+++ b/docs/develop/configuration/await-and-checkpoint.md
@@ -1,10 +1,10 @@
 ---
-title: Await and Checkpoint Settings
+title: Await, Command, and Checkpoint Settings
 ---
 
-# Await and Checkpoint Settings
+# Await, Command, and Checkpoint Settings
 
-Await and checkpoint configuration belongs to the runtime shell. It keeps human approvals, webhook callbacks, long-running provider responses, and cross-pipeline handoff out of business functions.
+Await, command, and checkpoint configuration belongs to the runtime shell. It keeps human approvals, webhook callbacks, long-running provider responses, replay-safe external effects, and cross-pipeline handoff out of business functions.
 
 ## Main Surfaces
 
@@ -12,6 +12,7 @@ Await and checkpoint configuration belongs to the runtime shell. It keeps human 
 | --- | --- | --- |
 | Queue-async execution | durable background execution and retry ownership | [Orchestrator Background Execution](/develop/configuration/all-settings#orchestrator-background-execution) |
 | Await transports | pending interaction and completion admission wiring | [Await Transports](/develop/configuration/all-settings#await-transports) |
+| Command connectors | connector endpoint, credentials, timeout, provider retry tuning, and effect-store implementation | [Command Steps](/deploy/orchestrator-runtime/command) |
 | Checkpoint handoff bindings | publication targets and subscriber admission | [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) |
 | Function handler context | context attributes captured at function boundaries | [Function Transport Context Attributes](/develop/configuration/all-settings#function-transport-context-attributes-function-handlersadapters) |
 
@@ -19,6 +20,6 @@ Await and checkpoint configuration belongs to the runtime shell. It keeps human 
 
 - [Await Boundaries](/design/await-boundaries)
 - [Await Runtime Setup](/deploy/orchestrator-runtime/await)
+- [Command Steps](/deploy/orchestrator-runtime/command)
 - [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff)
 - [State Model](/design/state-model)
-

--- a/docs/develop/configuration/index.md
+++ b/docs/develop/configuration/index.md
@@ -14,7 +14,7 @@ Use this guide to choose the right configuration surface first. Use [All Setting
 | --- | --- |
 | Generated artifacts, annotation processor options, REST path overrides | [Build-Time Settings](/develop/configuration/build-time) |
 | Runtime execution, clients, telemetry, health, in-flight probe | [Runtime Settings](/develop/configuration/runtime) |
-| Await, queue-async, checkpoint handoff, background execution | [Await and Checkpoint Settings](/develop/configuration/await-and-checkpoint) |
+| Await, command steps, queue-async, checkpoint handoff, background execution | [Await, Command, and Checkpoint Settings](/develop/configuration/await-and-checkpoint) |
 | REST, gRPC, LOCAL transport modes; `FUNCTION` platform and generated entry points | [Transport and Platform Settings](/develop/configuration/transport-and-platform) |
 | Persistence, caching, materialization, reject sinks | [Providers and Plugins](/develop/configuration/providers-and-plugins) |
 | Replay Viewer URL/query parameter behavior | [Replay Viewer Parameters](/develop/configuration/replay-viewer-parameters) |

--- a/docs/develop/configuration/replay-viewer-parameters.md
+++ b/docs/develop/configuration/replay-viewer-parameters.md
@@ -11,4 +11,4 @@ The replay viewer surfaces that subset in its `Run parameters` pane. The initial
 - retry-amplification guardrail settings
 - item-reject sink provider
 
-The full key catalog still lives in the build configuration reference. Replay export does not mirror arbitrary application configuration or secrets into the artifact.
+The full key reference still lives in the build configuration reference. Replay export does not mirror arbitrary application configuration or secrets into the artifact.

--- a/docs/develop/extension/command-connectors.md
+++ b/docs/develop/extension/command-connectors.md
@@ -1,0 +1,134 @@
+# Writing Command Connectors
+
+Command connectors adapt a typed pipeline command to an external system. Use one when the effect benefits from command semantics: command id, effect logging, duplicate policy, recorded-output replay, retry/DLQ handling, and telemetry.
+
+For YAML setup, see [Command Steps](/deploy/orchestrator-runtime/command). This page covers the Java code.
+
+## What You Implement
+
+A command step needs two application classes:
+
+1. `CommandIdGenerator<I>` for the command input type
+2. `CommandConnector<I, O>` for the command input and output types
+
+Keep both classes typed. Do not implement command connectors as `CommandConnector<Object, Object>`.
+
+## Command Id Generator
+
+The command id must be stable for the same business command. Do not include the current time, a random UUID, or a process-local counter.
+
+```java
+@ApplicationScoped
+public class SearchIndexDocumentCommandIdGenerator
+    implements CommandIdGenerator<SearchIndexDocument> {
+
+  @Override
+  public String commandId(CommandDescriptor descriptor, SearchIndexDocument input) {
+    if (input.docId == null) {
+      throw new IllegalArgumentException("docId is required");
+    }
+    if (input.batchIndex == null || input.batchIndex < 0) {
+      throw new IllegalArgumentException("batchIndex must be >= 0");
+    }
+    if (input.vectorVersion == null || input.vectorVersion.isBlank()) {
+      throw new IllegalArgumentException("vectorVersion is required");
+    }
+    if (input.vectorHash == null || input.vectorHash.isBlank()) {
+      throw new IllegalArgumentException("vectorHash is required");
+    }
+
+    return descriptor.command() + ":" + sha256Base64Url(String.join("|",
+        input.docId.toString(),
+        input.batchIndex.toString(),
+        input.vectorVersion.trim(),
+        input.vectorHash.trim()));
+  }
+}
+```
+
+Include the command name, or another command namespace, so two different commands cannot collide on the same business fields.
+
+## Connector
+
+The connector performs one external write and returns the recorded result.
+
+```java
+@ApplicationScoped
+public class OpenSearchIndexDocumentCommandConnector
+    implements CommandConnector<SearchIndexDocument, SearchIndexWriteResult> {
+
+  @Override
+  public String command() {
+    return "opensearch-index-document";
+  }
+
+  @Override
+  public Uni<SearchIndexWriteResult> execute(CommandRequest<SearchIndexDocument> request) {
+    SearchIndexDocument input = request.input();
+
+    return upsertIntoOpenSearch(input.externalId, input)
+        .map(ignored -> {
+          SearchIndexWriteResult result = new SearchIndexWriteResult();
+          result.commandId = request.commandId();
+          result.externalId = input.externalId;
+          result.indexName = input.indexName;
+          result.resultStatus = "UPSERTED";
+          result.createdOrUpdated = true;
+          return result;
+        });
+  }
+}
+```
+
+Use `request.commandId()` as the provider idempotency key when the provider supports it. If the provider has its own document id or external id, derive it from the same stable business fields.
+
+## What TPF Handles
+
+The generated command step calls the generator and connector. TPF also handles:
+
+- creating the effect record,
+- marking dispatch start,
+- recording success output,
+- returning stored output for `RETURN_RECORDED`,
+- marking retryable failures,
+- marking terminal DLQ failures.
+
+The connector should not read or write the `CommandEffectStore` directly.
+
+## Error Classification
+
+Throw a retryable exception for provider failures that may succeed later, such as transient network errors or `5xx` responses.
+
+Throw `NonRetryableException`, or an exception wrapped in `NonRetryableException`, when the same command input cannot succeed without a code, data, or configuration change. Examples include malformed payloads, missing required fields, and provider `4xx` validation errors.
+
+## Configuration
+
+Read provider details from runtime configuration:
+
+```properties
+search.index.opensearch.endpoint=http://localhost:9200
+search.index.opensearch.index=search-documents
+search.index.opensearch.timeout-seconds=5
+```
+
+Do not put endpoint URLs, credentials, or provider timeout tuning in the authored step unless the value is part of the pipeline contract.
+
+## Testing
+
+At minimum, test:
+
+1. command id stability for the same input,
+2. validation failures before dispatch,
+3. provider success mapping to the output type,
+4. retryable provider failure classification,
+5. non-retryable provider failure classification.
+
+Also test replay behavior through `CommandStepSupport`: with `RETURN_RECORDED`, a second execution for the same command id should return the stored output and should not call the connector again.
+
+## Example
+
+The Search example implements an OpenSearch command connector:
+
+- `examples/search/common/src/main/java/org/pipelineframework/search/common/command/SearchIndexDocumentCommandIdGenerator.java`
+- `examples/search/common/src/main/java/org/pipelineframework/search/common/command/OpenSearchIndexDocumentCommandConnector.java`
+- `examples/search/common/src/test/java/org/pipelineframework/search/common/command/OpenSearchIndexDocumentCommandConnectorTest.java`

--- a/docs/evolve/io-shell-absorption.md
+++ b/docs/evolve/io-shell-absorption.md
@@ -301,7 +301,7 @@ Estimated effort:
 
 - Current first-class MVP: medium-large, covering DSL parsing, generated query client step, first-party JPA connector runtime, in-memory capture store, and captured replay semantics.
 - Durable production stores beyond memory: medium per store.
-- Provider-specific query catalogs/connectors: medium per provider family.
+- Provider-specific query connectors: medium per provider family.
 - Query observability and replay tooling polish: medium.
 
 MCP-friendliness:
@@ -373,7 +373,7 @@ Estimated effort:
 MCP-friendliness:
 
 - High. Agents can generate provider-specific job specs from intent, then bind request/result DTOs.
-- The capability benefits from a provider catalog, because users should not hand-author every provider's status and terminal states.
+- The capability benefits from provider templates, because users should not hand-author every provider's status and terminal states.
 
 Third-party integration priorities:
 
@@ -437,6 +437,8 @@ This proof separates three concerns that are easy to collapse accidentally:
 The deterministic external id and command id derive from `docId + batchIndex + vectorVersion + vectorHash`, with the command name included to avoid cross-command collisions. The write result records `commandId`, `externalId`, `indexName`, `resultStatus`, `createdOrUpdated`, and `recordedDuplicate`.
 
 This proof indexes text/hash metadata only. It should not be described as vector-search support until Search carries actual vector arrays.
+
+Future command connector catalog: promote OpenSearch first because it already demonstrates typed command input/output, deterministic external identity, result recording, duplicate replay, and provider failure mapping. Email delivery is a strong second candidate after the command result model settles; SMTP or AWS SES are better first baselines than Gmail because they represent service-oriented delivery without starting from user-mailbox OAuth. A connector belongs here only when TPF semantics remove effect logging, duplicate suppression, retry/DLQ, replay, or observability code that application teams would otherwise write.
 
 Examples and inspiration:
 
@@ -541,4 +543,4 @@ The adoption wedge should stay narrow:
 4. Treat idempotent commands/outbox as a separate reliability primitive with strong safety language.
 5. Use object ingest as a practical example path that connects source handling, materialization, reject sinks, replay, and background execution.
 
-Do not build a broad connector catalog before these semantics are clear. A connector without replay, identity, idempotency, or continuation semantics is usually just ordinary Java/Quarkus integration code.
+Do not broaden provider packaging before these semantics are clear. A connector without replay, identity, idempotency, or continuation semantics is usually just ordinary Java/Quarkus integration code.

--- a/docs/guide/development/orchestrator-runtime/command.md
+++ b/docs/guide/development/orchestrator-runtime/command.md
@@ -1,0 +1,26 @@
+---
+title: Redirecting...
+search: false
+head:
+  - - meta
+    - name: robots
+      content: noindex
+  - - meta
+    - http-equiv: refresh
+      content: 0;url=/deploy/orchestrator-runtime/command
+---
+
+<script setup>
+import {onMounted} from 'vue'
+import {withBase} from 'vitepress'
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.location.replace(withBase('/deploy/orchestrator-runtime/command'))
+  }
+})
+</script>
+
+# Redirecting...
+
+This page moved to [/deploy/orchestrator-runtime/command](/deploy/orchestrator-runtime/command).

--- a/docs/operate/observability/index.md
+++ b/docs/operate/observability/index.md
@@ -13,3 +13,5 @@ Observability in The Pipeline Framework is designed for distributed pipelines: y
 - [Security Notes](/operate/observability/security): Prevent accidental leakage of sensitive information
 - [Working with NewRelic OTel](/operate/observability/newrelic): Enabling OTel export to use NewRelic
 - [Test locally using LGTM](/operate/observability/lgtm): Enabling Prometheus metrics for Grafana dashboards on Quarkus LGTM stack
+
+Managed external boundaries appear as first-class nodes. Await steps expose suspend/resume lifecycle events. Command steps appear as command nodes in replay topology and participate in normal step spans and metrics while their effect lifecycle is recorded by the command effect store.

--- a/docs/operate/observability/metrics.md
+++ b/docs/operate/observability/metrics.md
@@ -158,9 +158,9 @@ Command effect metrics:
 
 | OpenTelemetry metric | Prometheus name | Type | Key attributes |
 | --- | --- | --- | --- |
-| `tpf.command.effect.transition.total` | `tpf_command_effect_transition_total` | counter | `tpf_command`, `tpf_command_step`, `tpf_command_status` |
-| `tpf.command.effect.duplicate.total` | `tpf_command_effect_duplicate_total` | counter | `tpf_command`, `tpf_command_step`, `tpf_command_duplicate_policy`, `tpf_command_duplicate_result` |
-| `tpf.command.effect.duration` | `tpf_command_effect_duration_*` | histogram | `tpf_command`, `tpf_command_step`, `tpf_command_status` |
+| `tpf.command.effect.transition.total` | `tpf_command_effect_transition_total` | counter | `tpf.command`, `tpf.command.step`, `tpf.command.status` |
+| `tpf.command.effect.duplicate.total` | `tpf_command_effect_duplicate_total` | counter | `tpf.command`, `tpf.command.step`, `tpf.command.duplicate_policy`, `tpf.command.duplicate_result` |
+| `tpf.command.effect.duration` | `tpf_command_effect_duration_*` | histogram | `tpf.command`, `tpf.command.step`, `tpf.command.status` |
 
 Command status values are `pending`, `dispatching`, `succeeded`, `failed_retryable`, and `dlq`.
 Duplicate result values are `returned_recorded`, `rejected`, and `in_progress`.

--- a/docs/operate/observability/metrics.md
+++ b/docs/operate/observability/metrics.md
@@ -145,6 +145,29 @@ Await signal:
 
 Await execution logs include the parked await unit when a `QUEUE_ASYNC` execution waits or resumes. Replay and trace events expose await unit lifecycle transitions, including dispatch, waiting, item completion, unit completion, resume release, and terminal timeout/failure states. The metrics surface intentionally remains limited to dropped-completion counting plus provider-native backlog/latency signals.
 
+Command signal:
+
+- command steps participate in normal `tpf.step.*` metrics and `tpf.step` spans,
+- effect lifecycle state is recorded in the configured `CommandEffectStore`,
+- provider backlog, throttling, and external latency should come from the provider connector or platform telemetry.
+
+Replay topology marks command steps with `renderRole: "command"` and `actorKind` equal to the command name. That topology signal is for inspection and playback; it is not a replacement for provider-native command metrics.
+
+Command step SLO examples:
+
+| SLO | Primary signal | Example objective |
+| --- | --- | --- |
+| Command effect completion | command effect store status | 99.9% of command effects reach `SUCCEEDED` within 5 minutes. |
+| Terminal command failure budget | command effect store `DLQ` status | Fewer than 0.1% of command effects enter terminal DLQ over 30 days. |
+| Command step latency | `tpf.step` latency for the command step | p95 under the service target for the provider, such as 2 seconds for search indexing. |
+| Replay duplicate safety | effect store plus connector/provider telemetry | `RETURN_RECORDED` duplicates return stored output with zero extra provider writes. |
+| Provider health | connector or provider metrics | Provider throttling and backlog stay below the connector's retry budget. |
+
+For a Search/OpenSearch indexing command, use the command effect store to count `SUCCEEDED`,
+`FAILED_RETRYABLE`, and `DLQ` effects by command name. Use the `Write Search Index Document`
+step span for pipeline latency, and use OpenSearch client or cluster metrics for provider latency,
+throttling, and indexing failures.
+
 Backlog signal note:
 
 1. TPF emits `tpf.step.reject.total` for reject throughput.

--- a/docs/operate/observability/metrics.md
+++ b/docs/operate/observability/metrics.md
@@ -148,25 +148,64 @@ Await execution logs include the parked await unit when a `QUEUE_ASYNC` executio
 Command signal:
 
 - command steps participate in normal `tpf.step.*` metrics and `tpf.step` spans,
-- effect lifecycle state is recorded in the configured `CommandEffectStore`,
+- command effect lifecycle is exposed through `tpf.command.effect.*` metrics,
+- effect lifecycle state is also recorded in the configured `CommandEffectStore`,
 - provider backlog, throttling, and external latency should come from the provider connector or platform telemetry.
 
 Replay topology marks command steps with `renderRole: "command"` and `actorKind` equal to the command name. That topology signal is for inspection and playback; it is not a replacement for provider-native command metrics.
+
+Command effect metrics:
+
+| OpenTelemetry metric | Prometheus name | Type | Key attributes |
+| --- | --- | --- | --- |
+| `tpf.command.effect.transition.total` | `tpf_command_effect_transition_total` | counter | `tpf_command`, `tpf_command_step`, `tpf_command_status` |
+| `tpf.command.effect.duplicate.total` | `tpf_command_effect_duplicate_total` | counter | `tpf_command`, `tpf_command_step`, `tpf_command_duplicate_policy`, `tpf_command_duplicate_result` |
+| `tpf.command.effect.duration` | `tpf_command_effect_duration_*` | histogram | `tpf_command`, `tpf_command_step`, `tpf_command_status` |
+
+Command status values are `pending`, `dispatching`, `succeeded`, `failed_retryable`, and `dlq`.
+Duplicate result values are `returned_recorded`, `rejected`, and `in_progress`.
 
 Command step SLO examples:
 
 | SLO | Primary signal | Example objective |
 | --- | --- | --- |
-| Command effect completion | command effect store status | 99.9% of command effects reach `SUCCEEDED` within 5 minutes. |
-| Terminal command failure budget | command effect store `DLQ` status | Fewer than 0.1% of command effects enter terminal DLQ over 30 days. |
+| Command effect completion | `tpf.command.effect.transition.total{tpf_command_status="succeeded"}` | 99.9% of command effects reach `SUCCEEDED` within 5 minutes. |
+| Terminal command failure budget | `tpf.command.effect.transition.total{tpf_command_status="dlq"}` | Fewer than 0.1% of command effects enter terminal DLQ over 30 days. |
 | Command step latency | `tpf.step` latency for the command step | p95 under the service target for the provider, such as 2 seconds for search indexing. |
-| Replay duplicate safety | effect store plus connector/provider telemetry | `RETURN_RECORDED` duplicates return stored output with zero extra provider writes. |
+| Replay duplicate safety | `tpf.command.effect.duplicate.total{tpf_command_duplicate_result="returned_recorded"}` plus provider write count | `RETURN_RECORDED` duplicates return stored output with zero extra provider writes. |
 | Provider health | connector or provider metrics | Provider throttling and backlog stay below the connector's retry budget. |
 
-For a Search/OpenSearch indexing command, use the command effect store to count `SUCCEEDED`,
-`FAILED_RETRYABLE`, and `DLQ` effects by command name. Use the `Write Search Index Document`
-step span for pipeline latency, and use OpenSearch client or cluster metrics for provider latency,
-throttling, and indexing failures.
+PromQL examples:
+
+```text
+# Success ratio by command over 5 minutes.
+sum by (tpf_command) (rate(tpf_command_effect_transition_total{tpf_command_status="succeeded"}[5m]))
+/
+sum by (tpf_command) (rate(tpf_command_effect_transition_total{tpf_command_status=~"succeeded|failed_retryable|dlq"}[5m]))
+```
+
+```text
+# Terminal DLQ rate by command.
+sum by (tpf_command) (rate(tpf_command_effect_transition_total{tpf_command_status="dlq"}[5m]))
+```
+
+```text
+# Recorded duplicate replays by command.
+sum by (tpf_command) (increase(tpf_command_effect_duplicate_total{tpf_command_duplicate_result="returned_recorded"}[1h]))
+```
+
+```text
+# p95 command effect duration by command.
+histogram_quantile(
+  0.95,
+  sum by (le, tpf_command) (rate(tpf_command_effect_duration_bucket{tpf_command_status="succeeded"}[5m]))
+)
+```
+
+For a Search/OpenSearch indexing command, use `tpf.command.effect.transition.total` to count
+`succeeded`, `failed_retryable`, and `dlq` effects by `tpf_command="opensearch-index-document"`.
+Use `tpf.step.duration` for the `Write Search Index Document` step's pipeline latency, and use
+OpenSearch client or cluster metrics for provider latency, throttling, and indexing failures.
 
 Backlog signal note:
 

--- a/docs/operate/observability/replay.md
+++ b/docs/operate/observability/replay.md
@@ -37,6 +37,8 @@ It is emitted by the framework replay exporter and contains:
 
 Replay JSON is the supported offline input for the TPF replay viewer.
 
+Command steps are included in the topology as authored pipeline nodes with `renderRole: "command"` and `actorKind` set to the command name. This keeps managed external effects visible in playback even when the connector hides provider details such as endpoint, credentials, index name, or SDK configuration.
+
 ## Live versus offline
 
 ### Live
@@ -88,6 +90,19 @@ TPF emits:
 Replay JSON is written from the same runtime semantics by the framework replay exporter.
 
 Await boundaries park the owning `QUEUE_ASYNC` execution on a durable await unit and resume from that unit after completion admission. Replay events include await unit ids, execution ids, interaction ids, step ids, unit status, and expected/completed item counts where the runtime knows them. For operations, see [Await Boundary Operations](/operate/await-boundaries); for the implementation model, see [Await Unit Runtime](/evolve/await-unit-runtime/).
+
+Command telemetry has two layers:
+
+1. the pipeline layer, where the command appears in `tpf.step` spans, step metrics, and replay topology like other authored steps;
+2. the effect layer, where the command effect store records pending, dispatching, succeeded, retryable failure, or terminal DLQ state for the command id.
+
+That split is intentional. The step span shows where the pipeline spent time. The effect record shows whether the external effect was recorded, replayed, retried, or dead-lettered. Use provider telemetry for external backlog and provider-side latency.
+
+Example command replay checks:
+
+- The topology contains `renderRole: "command"` for the command step.
+- `actorKind` is the authored command name, such as `opensearch-index-document`.
+- For `RETURN_RECORDED`, a replayed duplicate should return the recorded output and should not require another provider write.
 
 ## Replay exporter configuration
 

--- a/docs/operate/observability/replay.md
+++ b/docs/operate/observability/replay.md
@@ -94,9 +94,9 @@ Await boundaries park the owning `QUEUE_ASYNC` execution on a durable await unit
 Command telemetry has two layers:
 
 1. the pipeline layer, where the command appears in `tpf.step` spans, step metrics, and replay topology like other authored steps;
-2. the effect layer, where the command effect store records pending, dispatching, succeeded, retryable failure, or terminal DLQ state for the command id.
+2. the effect layer, where `tpf.command.effect.*` metrics and the command effect store record pending, dispatching, succeeded, retryable failure, duplicate handling, or terminal DLQ state.
 
-That split is intentional. The step span shows where the pipeline spent time. The effect record shows whether the external effect was recorded, replayed, retried, or dead-lettered. Use provider telemetry for external backlog and provider-side latency.
+That split is intentional. The step span shows where the pipeline spent time. Command effect metrics support dashboards and SLOs. The effect record preserves command-id detail for investigation and replay. Use provider telemetry for external backlog and provider-side latency.
 
 Example command replay checks:
 

--- a/docs/public/replay-viewer-app/app.js
+++ b/docs/public/replay-viewer-app/app.js
@@ -2326,6 +2326,9 @@ function nodeColorForStep(step) {
     if (role === "await") {
       return 0x78c8ff;
     }
+    if (role === "command") {
+      return 0xffd166;
+    }
     return 0x5cc8ff;
   }
   switch (resolveDisplayIconKind(step)) {

--- a/docs/public/replay-viewer-app/index.html
+++ b/docs/public/replay-viewer-app/index.html
@@ -229,6 +229,12 @@
                 <div class="legend-item"><span class="legend-swatch legend-swatch--error"></span><span>error burst</span></div>
                 <div class="legend-item"><span class="legend-swatch legend-swatch--branch"></span><span>DB/store transit</span></div>
               </div>
+              <h4>Step nodes</h4>
+              <div class="legend-list">
+                <div class="legend-item"><span class="legend-node legend-node--primary"></span><span>business transition</span></div>
+                <div class="legend-item"><span class="legend-node legend-node--await"></span><span>await boundary</span></div>
+                <div class="legend-item"><span class="legend-node legend-node--command"></span><span>command / effect boundary</span></div>
+              </div>
               <h4>Support actors</h4>
               <div class="legend-list legend-list--support">
                 <div class="legend-item">

--- a/docs/public/replay-viewer-app/style.css
+++ b/docs/public/replay-viewer-app/style.css
@@ -767,6 +767,11 @@ button:disabled {
   box-shadow: 0 0 14px rgb(92 200 255 / 42%);
 }
 
+.legend-node--primary {
+  background: #5cc8ff;
+  box-shadow: 0 0 14px rgb(92 200 255 / 42%);
+}
+
 .legend-node--await {
   background: #78c8ff;
   box-shadow: 0 0 14px rgb(120 200 255 / 42%);

--- a/docs/public/replay-viewer-app/style.css
+++ b/docs/public/replay-viewer-app/style.css
@@ -759,6 +759,24 @@ button:disabled {
   box-shadow: 0 0 12px rgb(139 255 165 / 40%);
 }
 
+.legend-node {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #5cc8ff;
+  box-shadow: 0 0 14px rgb(92 200 255 / 42%);
+}
+
+.legend-node--await {
+  background: #78c8ff;
+  box-shadow: 0 0 14px rgb(120 200 255 / 42%);
+}
+
+.legend-node--command {
+  background: #ffd166;
+  box-shadow: 0 0 14px rgb(255 209 102 / 40%);
+}
+
 .legend-list--support {
   gap: 9px;
 }

--- a/docs/public/replay-viewer-app/style.css
+++ b/docs/public/replay-viewer-app/style.css
@@ -767,7 +767,10 @@ button:disabled {
   box-shadow: 0 0 14px rgb(92 200 255 / 42%);
 }
 
-.legend-node--primary {
+.legend-node-primary {
+  background: `#5cc8ff`;
+  box-shadow: 0 0 14px rgb(92 200 255 / 42%);
+}
   background: #5cc8ff;
   box-shadow: 0 0 14px rgb(92 200 255 / 42%);
 }

--- a/docs/versions/v26.4.4/guide/application/configuration.md
+++ b/docs/versions/v26.4.4/guide/application/configuration.md
@@ -8,7 +8,7 @@ This page maps the most-used configuration entry points and where to manage them
 
 ## Primary References
 
-- [Configuration Reference](/versions/v26.4.4/guide/build/configuration/) for full build-time and runtime key catalog
+- [Configuration Reference](/versions/v26.4.4/guide/build/configuration/) for full build-time and runtime key reference
 - [Performance](/versions/v26.4.4/guide/development/performance) for throughput/latency tuning
 
 ## Lambda-Focused Configuration

--- a/docs/versions/v26.5.1/guide/application/configuration.md
+++ b/docs/versions/v26.5.1/guide/application/configuration.md
@@ -8,7 +8,7 @@ This page maps the most-used configuration entry points and where to manage them
 
 ## Primary References
 
-- [Configuration Reference](/versions/v26.5.1/guide/build/configuration/) for full build-time and runtime key catalog
+- [Configuration Reference](/versions/v26.5.1/guide/build/configuration/) for full build-time and runtime key reference
 - [Performance](/versions/v26.5.1/guide/development/performance) for throughput/latency tuning
 
 ## Lambda-Focused Configuration

--- a/docs/versions/v26.5.2/guide/application/configuration.md
+++ b/docs/versions/v26.5.2/guide/application/configuration.md
@@ -8,7 +8,7 @@ This page maps the most-used configuration entry points and where to manage them
 
 ## Primary References
 
-- [Configuration Reference](/versions/v26.5.2/guide/build/configuration/) for full build-time and runtime key catalog
+- [Configuration Reference](/versions/v26.5.2/guide/build/configuration/) for full build-time and runtime key reference
 - [Performance](/versions/v26.5.2/guide/development/performance) for throughput/latency tuning
 
 ## Replay Viewer Parameter Snapshot
@@ -24,7 +24,7 @@ The replay viewer surfaces that subset in its `Run parameters` pane. The initial
 - retry-amplification guardrail settings
 - item-reject sink provider
 
-The full key catalog still lives in the build configuration reference. Replay export does not mirror arbitrary application configuration or secrets into the artifact.
+The full key reference still lives in the build configuration reference. Replay export does not mirror arbitrary application configuration or secrets into the artifact.
 
 ## Lambda-Focused Configuration
 

--- a/docs/versions/v26.6.1/guide/application/configuration.md
+++ b/docs/versions/v26.6.1/guide/application/configuration.md
@@ -8,7 +8,7 @@ This page maps the most-used configuration entry points and where to manage them
 
 ## Primary References
 
-- [Configuration Reference](/versions/v26.6.1/guide/build/configuration/) for full build-time and runtime key catalog
+- [Configuration Reference](/versions/v26.6.1/guide/build/configuration/) for full build-time and runtime key reference
 - [Performance](/versions/v26.6.1/guide/development/performance) for throughput/latency tuning
 
 ## Replay Viewer Parameter Snapshot
@@ -24,7 +24,7 @@ The replay viewer surfaces that subset in its `Run parameters` pane. The initial
 - retry-amplification guardrail settings
 - item-reject sink provider
 
-The full key catalog still lives in the build configuration reference. Replay export does not mirror arbitrary application configuration or secrets into the artifact.
+The full key reference still lives in the build configuration reference. Replay export does not mirror arbitrary application configuration or secrets into the artifact.
 
 ## Lambda-Focused Configuration
 

--- a/framework/runtime/src/main/java/org/pipelineframework/command/CommandEffectMetrics.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/command/CommandEffectMetrics.java
@@ -1,0 +1,132 @@
+package org.pipelineframework.command;
+
+import java.util.Locale;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+
+/**
+ * Command effect observability helpers.
+ */
+public final class CommandEffectMetrics {
+
+    static final String TRANSITION_TOTAL = "tpf.command.effect.transition.total";
+    static final String DUPLICATE_TOTAL = "tpf.command.effect.duplicate.total";
+    static final String DURATION = "tpf.command.effect.duration";
+
+    private static final AttributeKey<String> COMMAND = AttributeKey.stringKey("tpf.command");
+    private static final AttributeKey<String> COMMAND_STEP = AttributeKey.stringKey("tpf.command.step");
+    private static final AttributeKey<String> COMMAND_STATUS = AttributeKey.stringKey("tpf.command.status");
+    private static final AttributeKey<String> DUPLICATE_POLICY = AttributeKey.stringKey("tpf.command.duplicate_policy");
+    private static final AttributeKey<String> DUPLICATE_RESULT = AttributeKey.stringKey("tpf.command.duplicate_result");
+
+    private static volatile LongCounter transitionCounter;
+    private static volatile LongCounter duplicateCounter;
+    private static volatile DoubleHistogram durationHistogram;
+
+    private CommandEffectMetrics() {
+    }
+
+    public static long startNanos() {
+        return System.nanoTime();
+    }
+
+    public static void recordTransition(CommandDescriptor descriptor, CommandEffectStatus status) {
+        if (descriptor == null || status == null) {
+            return;
+        }
+        ensureInitialized();
+        transitionCounter.add(1, transitionAttributes(descriptor, status));
+    }
+
+    public static void recordTerminalTransition(
+        CommandDescriptor descriptor,
+        CommandEffectStatus status,
+        long startNanos
+    ) {
+        if (descriptor == null || status == null) {
+            return;
+        }
+        ensureInitialized();
+        Attributes attributes = transitionAttributes(descriptor, status);
+        transitionCounter.add(1, attributes);
+        durationHistogram.record(elapsedMillis(startNanos), attributes);
+    }
+
+    public static void recordDuplicate(CommandDescriptor descriptor, String duplicateResult) {
+        if (descriptor == null) {
+            return;
+        }
+        ensureInitialized();
+        duplicateCounter.add(1, Attributes.builder()
+            .put(COMMAND, normalize(descriptor.command()))
+            .put(COMMAND_STEP, normalize(descriptor.stepId()))
+            .put(DUPLICATE_POLICY, descriptor.duplicatePolicy().name())
+            .put(DUPLICATE_RESULT, normalize(duplicateResult))
+            .build());
+    }
+
+    static synchronized void resetForTest() {
+        transitionCounter = null;
+        duplicateCounter = null;
+        durationHistogram = null;
+    }
+
+    private static Attributes transitionAttributes(CommandDescriptor descriptor, CommandEffectStatus status) {
+        return Attributes.builder()
+            .put(COMMAND, normalize(descriptor.command()))
+            .put(COMMAND_STEP, normalize(descriptor.stepId()))
+            .put(COMMAND_STATUS, statusValue(status))
+            .build();
+    }
+
+    private static void ensureInitialized() {
+        if (transitionCounter != null && duplicateCounter != null && durationHistogram != null) {
+            return;
+        }
+        synchronized (CommandEffectMetrics.class) {
+            if (transitionCounter == null) {
+                transitionCounter = GlobalOpenTelemetry.getMeter("org.pipelineframework")
+                    .counterBuilder(TRANSITION_TOTAL)
+                    .setDescription("Total command effect lifecycle transitions recorded by TPF")
+                    .setUnit("events")
+                    .build();
+            }
+            if (duplicateCounter == null) {
+                duplicateCounter = GlobalOpenTelemetry.getMeter("org.pipelineframework")
+                    .counterBuilder(DUPLICATE_TOTAL)
+                    .setDescription("Total duplicate command ids resolved by TPF duplicate policy")
+                    .setUnit("events")
+                    .build();
+            }
+            if (durationHistogram == null) {
+                durationHistogram = GlobalOpenTelemetry.getMeter("org.pipelineframework")
+                    .histogramBuilder(DURATION)
+                    .setDescription("Command effect duration from pending record creation to terminal effect state")
+                    .setUnit("ms")
+                    .build();
+            }
+        }
+    }
+
+    private static String statusValue(CommandEffectStatus status) {
+        return status.name().toLowerCase(Locale.ROOT);
+    }
+
+    private static double elapsedMillis(long startNanos) {
+        if (startNanos <= 0) {
+            return 0.0d;
+        }
+        return Math.max(0.0d, (System.nanoTime() - startNanos) / 1_000_000.0d);
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return "unknown";
+        }
+        return value;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/command/CommandStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/command/CommandStepSupport.java
@@ -109,37 +109,52 @@ public class CommandStepSupport {
             CommandEffectRecord record = existing.get();
             if (record.status() == CommandEffectStatus.SUCCEEDED) {
                 if (request.descriptor().duplicatePolicy() == CommandDuplicatePolicy.FAIL) {
+                    CommandEffectMetrics.recordDuplicate(request.descriptor(), "rejected");
                     return Uni.createFrom().failure(new NonRetryableException(
                         "Duplicate command completion for commandId " + request.commandId()));
                 }
                 @SuppressWarnings("unchecked")
                 O recorded = (O) record.output();
                 CommandRecordedDuplicateMarker.mark(recorded);
+                CommandEffectMetrics.recordDuplicate(request.descriptor(), "returned_recorded");
                 return Uni.createFrom().item(recorded);
             }
             if (record.status() == CommandEffectStatus.PENDING || record.status() == CommandEffectStatus.DISPATCHING) {
+                CommandEffectMetrics.recordDuplicate(request.descriptor(), "in_progress");
                 return Uni.createFrom().failure(new CommandInProgressException(
                     "Command already in progress for commandId " + request.commandId()));
             }
         }
         // Each effect transition records its own wall-clock time so the store can show dispatch/write duration.
+        long effectStartNanos = CommandEffectMetrics.startNanos();
         return store.createPending(request, System.currentTimeMillis())
+            .invoke(ignored -> CommandEffectMetrics.recordTransition(
+                request.descriptor(),
+                CommandEffectStatus.PENDING))
             .onItem().transformToUni(ignored -> store.markDispatching(
                 request.executionContext().tenantId(),
                 request.commandId(),
                 System.currentTimeMillis()))
+            .invoke(ignored -> CommandEffectMetrics.recordTransition(
+                request.descriptor(),
+                CommandEffectStatus.DISPATCHING))
             .onItem().transformToUni(ignored -> connector.execute(request))
             .onItem().transformToUni(output -> store.markSucceeded(
                     request.executionContext().tenantId(),
                     request.commandId(),
                     output,
                     System.currentTimeMillis())
+                .invoke(ignored -> CommandEffectMetrics.recordTerminalTransition(
+                    request.descriptor(),
+                    CommandEffectStatus.SUCCEEDED,
+                    effectStartNanos))
                 .replaceWith(output))
             .onFailure().call(failure -> recordFailure(
                     store,
                     request,
                     failure,
-                    System.currentTimeMillis())
+                    System.currentTimeMillis(),
+                    effectStartNanos)
                 .replaceWithVoid());
     }
 
@@ -147,20 +162,29 @@ public class CommandStepSupport {
         CommandEffectStore store,
         CommandRequest<?> request,
         Throwable failure,
-        long nowEpochMs
+        long nowEpochMs,
+        long effectStartNanos
     ) {
         if (isNonRetryable(failure)) {
             return store.markDlq(
                 request.executionContext().tenantId(),
                 request.commandId(),
                 failure,
-                nowEpochMs);
+                nowEpochMs)
+                .invoke(ignored -> CommandEffectMetrics.recordTerminalTransition(
+                    request.descriptor(),
+                    CommandEffectStatus.DLQ,
+                    effectStartNanos));
         }
         return store.markFailed(
             request.executionContext().tenantId(),
             request.commandId(),
             failure,
-            nowEpochMs);
+            nowEpochMs)
+            .invoke(ignored -> CommandEffectMetrics.recordTerminalTransition(
+                request.descriptor(),
+                CommandEffectStatus.FAILED_RETRYABLE,
+                effectStartNanos));
     }
 
     private boolean isNonRetryable(Throwable failure) {

--- a/framework/runtime/src/test/java/org/pipelineframework/command/CommandStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/command/CommandStepSupportTest.java
@@ -7,12 +7,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.smallrye.mutiny.Uni;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.awaitable.AwaitExecutionContext;
 import org.pipelineframework.awaitable.AwaitExecutionContextHolder;
@@ -23,6 +31,8 @@ import org.pipelineframework.step.NonRetryableException;
 class CommandStepSupportTest {
   private final InMemoryCommandEffectStore store = new InMemoryCommandEffectStore();
   private final RecordingConnector connector = new RecordingConnector();
+  private InMemoryMetricReader metricReader;
+  private SdkMeterProvider meterProvider;
   private final CommandStepSupport support = new CommandStepSupport(
       List.of(connector),
       List.of(store),
@@ -36,9 +46,28 @@ class CommandStepSupportTest {
       CommandDuplicatePolicy.RETURN_RECORDED,
       Map.of());
 
+  @BeforeEach
+  void setUpMetrics() {
+    metricReader = InMemoryMetricReader.create();
+    meterProvider = SdkMeterProvider.builder()
+        .registerMetricReader(metricReader)
+        .build();
+    OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+        .setMeterProvider(meterProvider)
+        .build();
+    GlobalOpenTelemetry.resetForTest();
+    GlobalOpenTelemetry.set(sdk);
+    CommandEffectMetrics.resetForTest();
+  }
+
   @AfterEach
   void clearContext() {
     AwaitExecutionContextHolder.clear();
+    if (meterProvider != null) {
+      meterProvider.shutdown();
+    }
+    GlobalOpenTelemetry.resetForTest();
+    CommandEffectMetrics.resetForTest();
   }
 
   @Test
@@ -54,6 +83,10 @@ class CommandStepSupportTest {
     CommandEffectRecord record = store.find("tenant", "cmd-doc-1").await().atMost(Duration.ofSeconds(5)).orElseThrow();
     assertEquals(CommandEffectStatus.SUCCEEDED, record.status());
     assertSame(output, record.output());
+    assertTransitionCount("pending", 1);
+    assertTransitionCount("dispatching", 1);
+    assertTransitionCount("succeeded", 1);
+    assertDurationCount("succeeded", 1);
   }
 
   @Test
@@ -68,6 +101,7 @@ class CommandStepSupportTest {
 
     assertEquals(1, connector.calls.get());
     assertEquals(Boolean.TRUE, duplicate.recordedDuplicate);
+    assertDuplicateCount("RETURN_RECORDED", "returned_recorded", 1);
   }
 
   @Test
@@ -91,6 +125,27 @@ class CommandStepSupportTest {
 
     assertEquals("Duplicate command completion for commandId cmd-doc-1", error.getMessage());
     assertEquals(1, connector.calls.get());
+    assertDuplicateCount("FAIL", "rejected", 1);
+  }
+
+  @Test
+  void inProgressDuplicateEmitsDuplicateMetric() {
+    AwaitExecutionContextHolder.set(new AwaitExecutionContext("tenant", "exec-1", 4));
+    CommandRequest<CommandInput> request = new CommandRequest<>(
+        descriptor,
+        "cmd-doc-1",
+        new CommandInput("doc-1"),
+        new AwaitExecutionContext("tenant", "exec-1", 4),
+        Map.of());
+    store.createPending(request, System.currentTimeMillis()).await().atMost(Duration.ofSeconds(5));
+
+    CommandInProgressException error = assertThrows(CommandInProgressException.class,
+        () -> support.<CommandInput, CommandOutput>execute(descriptor, new StaticCommandIdGenerator(), new CommandInput("doc-1"))
+            .await().atMost(Duration.ofSeconds(5)));
+
+    assertEquals("Command already in progress for commandId cmd-doc-1", error.getMessage());
+    assertEquals(0, connector.calls.get());
+    assertDuplicateCount("RETURN_RECORDED", "in_progress", 1);
   }
 
   @Test
@@ -168,6 +223,8 @@ class CommandStepSupportTest {
     assertEquals(CommandEffectStatus.FAILED_RETRYABLE, record.status());
     assertEquals(IllegalStateException.class.getName(), record.errorClass());
     assertEquals("opensearch unavailable", record.errorMessage());
+    assertTransitionCount("failed_retryable", 1);
+    assertDurationCount("failed_retryable", 1);
   }
 
   @Test
@@ -184,6 +241,67 @@ class CommandStepSupportTest {
     assertEquals(CommandEffectStatus.DLQ, record.status());
     assertEquals(NonRetryableException.class.getName(), record.errorClass());
     assertEquals("invalid index document", record.errorMessage());
+    assertTransitionCount("dlq", 1);
+    assertDurationCount("dlq", 1);
+  }
+
+  private void assertTransitionCount(String status, long expected) {
+    long actual = longSumPointValue(
+        CommandEffectMetrics.TRANSITION_TOTAL,
+        Map.of(
+            "tpf.command", "opensearch-index-document",
+            "tpf.command.step", "ProcessWriteSearchIndexDocumentService",
+            "tpf.command.status", status));
+    assertEquals(expected, actual);
+  }
+
+  private void assertDuplicateCount(String duplicatePolicy, String duplicateResult, long expected) {
+    long actual = longSumPointValue(
+        CommandEffectMetrics.DUPLICATE_TOTAL,
+        Map.of(
+            "tpf.command", "opensearch-index-document",
+            "tpf.command.step", "ProcessWriteSearchIndexDocumentService",
+            "tpf.command.duplicate_policy", duplicatePolicy,
+            "tpf.command.duplicate_result", duplicateResult));
+    assertEquals(expected, actual);
+  }
+
+  private void assertDurationCount(String status, long expected) {
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    MetricData metric = metrics.stream()
+        .filter(candidate -> CommandEffectMetrics.DURATION.equals(candidate.getName()))
+        .findFirst()
+        .orElseThrow();
+    long actual = metric.getHistogramData().getPoints().stream()
+        .filter(point -> attributesMatch(point.getAttributes().asMap(), Map.of(
+            "tpf.command", "opensearch-index-document",
+            "tpf.command.step", "ProcessWriteSearchIndexDocumentService",
+            "tpf.command.status", status)))
+        .findFirst()
+        .orElseThrow()
+        .getCount();
+    assertEquals(expected, actual);
+  }
+
+  private long longSumPointValue(String metricName, Map<String, String> expectedAttributes) {
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    MetricData metric = metrics.stream()
+        .filter(candidate -> metricName.equals(candidate.getName()))
+        .findFirst()
+        .orElseThrow();
+    return metric.getLongSumData().getPoints().stream()
+        .filter(point -> attributesMatch(point.getAttributes().asMap(), expectedAttributes))
+        .findFirst()
+        .orElseThrow()
+        .getValue();
+  }
+
+  private boolean attributesMatch(
+      Map<AttributeKey<?>, Object> actualAttributes,
+      Map<String, String> expectedAttributes
+  ) {
+    return expectedAttributes.entrySet().stream()
+        .allMatch(entry -> entry.getValue().equals(actualAttributes.get(AttributeKey.stringKey(entry.getKey()))));
   }
 
   private PipelineOrchestratorConfig config(OrchestratorMode mode) {

--- a/tools/replay-viewer/app.js
+++ b/tools/replay-viewer/app.js
@@ -2326,6 +2326,9 @@ function nodeColorForStep(step) {
     if (role === "await") {
       return 0x78c8ff;
     }
+    if (role === "command") {
+      return 0xffd166;
+    }
     return 0x5cc8ff;
   }
   switch (resolveDisplayIconKind(step)) {

--- a/tools/replay-viewer/index.html
+++ b/tools/replay-viewer/index.html
@@ -229,6 +229,12 @@
                 <div class="legend-item"><span class="legend-swatch legend-swatch--error"></span><span>error burst</span></div>
                 <div class="legend-item"><span class="legend-swatch legend-swatch--branch"></span><span>DB/store transit</span></div>
               </div>
+              <h4>Step nodes</h4>
+              <div class="legend-list">
+                <div class="legend-item"><span class="legend-node legend-node--primary"></span><span>business transition</span></div>
+                <div class="legend-item"><span class="legend-node legend-node--await"></span><span>await boundary</span></div>
+                <div class="legend-item"><span class="legend-node legend-node--command"></span><span>command / effect boundary</span></div>
+              </div>
               <h4>Support actors</h4>
               <div class="legend-list legend-list--support">
                 <div class="legend-item">

--- a/tools/replay-viewer/style.css
+++ b/tools/replay-viewer/style.css
@@ -767,6 +767,11 @@ button:disabled {
   box-shadow: 0 0 14px rgb(92 200 255 / 42%);
 }
 
+.legend-node--primary {
+  background: #5cc8ff;
+  box-shadow: 0 0 14px rgb(92 200 255 / 42%);
+}
+
 .legend-node--await {
   background: #78c8ff;
   box-shadow: 0 0 14px rgb(120 200 255 / 42%);

--- a/tools/replay-viewer/style.css
+++ b/tools/replay-viewer/style.css
@@ -759,6 +759,24 @@ button:disabled {
   box-shadow: 0 0 12px rgb(139 255 165 / 40%);
 }
 
+.legend-node {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #5cc8ff;
+  box-shadow: 0 0 14px rgb(92 200 255 / 42%);
+}
+
+.legend-node--await {
+  background: #78c8ff;
+  box-shadow: 0 0 14px rgb(120 200 255 / 42%);
+}
+
+.legend-node--command {
+  background: #ffd166;
+  box-shadow: 0 0 14px rgb(255 209 102 / 40%);
+}
+
 .legend-list--support {
   gap: 9px;
 }

--- a/tools/replay-viewer/style.css
+++ b/tools/replay-viewer/style.css
@@ -767,7 +767,10 @@ button:disabled {
   box-shadow: 0 0 14px rgb(92 200 255 / 42%);
 }
 
-.legend-node--primary {
+.legend-node-primary {
+  background: `#5cc8ff`;
+  box-shadow: 0 0 14px rgb(92 200 255 / 42%);
+}
   background: #5cc8ff;
   box-shadow: 0 0 14px rgb(92 200 255 / 42%);
 }


### PR DESCRIPTION
## Summary
- Add user-facing docs for `kind: command` steps, including authoring shape, runtime contracts, duplicate policy, failure semantics, OpenSearch proof lane, telemetry, and replay behavior.
- Add runtime command-effect metrics for Grafana/SLOs: `tpf.command.effect.transition.total`, `tpf.command.effect.duplicate.total`, and `tpf.command.effect.duration`.
- Document concrete Prometheus/Grafana metric names, attributes, and PromQL examples for command success rate, DLQ rate, duplicate replay count, and p95 effect duration.
- Add replay-viewer command node coloring plus legend entry, including synced docs public viewer copy.
- Add an `AGENTS.md` definition-of-done rule for future semantic step kinds to include docs, telemetry/replay metadata, and replay-viewer legend/rendering updates.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -Dtest=CommandStepSupportTest test -Dmaven.repo.local="$PWD/.m2/repository"`
- `npm --prefix docs run build`

## Stacking
- Base PR/branch: `codex/command-outbox-opensearch-proof-fresh` / PR #433
- This PR is intentionally stacked so CodeRabbit reviews docs, replay-viewer/DoD, and command-effect telemetry additions separately from the core command runtime/OpenSearch proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Command Steps with deterministic command ids, duplicate policies, retry/DLQ semantics, and replay-safe external effect handling.
  * Introduced Command Connectors for typed command integrations.
  * Added command effect telemetry/metrics and replay-aware observability.
  * Updated Replay Viewer visuals/legend to distinguish command step nodes.
* **Bug Fixes**
  * Improved command effect terminal-transition timing consistency and duplicate metrics ordering.
* **Documentation**
  * Added Command Steps and Command Connectors guides; updated FCIS, configuration, and replay/observability documentation.
* **Tests**
  * Expanded metrics assertions for command step scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->