### PR TITLE
Add connector object I/O observability

### DIFF
--- a/docs/design/object-ingest.md
+++ b/docs/design/object-ingest.md
@@ -233,6 +233,25 @@ Object Publish also targets queue-async terminal output. Streaming terminal outp
 
 FUNCTION pipelines are rejected in v1. Quarkus currently hosts the bootstrap, but the ingest runner and provider SPI are plain Java so a Spring Boot host can wire the same semantics later.
 
+## Observability Proof
+
+Object I/O emits metrics for aggregate health and replay/span events for high-cardinality investigation.
+
+Use metrics to answer SLO questions:
+
+1. Are source objects being listed and admitted? Check `tpf.object_ingest.listed.objects.total`, `tpf.object_ingest.submitted.total`, `tpf.object_ingest.duplicate.total`, and `tpf.object_ingest.failed.total`.
+2. Are terminal values being published? Check `tpf.object_publish.grouped.items.total`, `tpf.object_publish.published.total`, `tpf.object_publish.published.bytes.total`, `tpf.object_publish.failed.total`, and `tpf.object_publish.write.duration`.
+3. Is the await boundary draining? Check `tpf.await.completion.admitted.total`, `tpf.await.completion.early_held.total`, `tpf.await.resume.released.total`, and `tpf.await.completion.dropped.total`.
+
+Use replay to answer per-run questions:
+
+1. Which source object was admitted?
+2. Which await unit parked the execution?
+3. Which completions were admitted, held, dropped, or released?
+4. Which output object key was published?
+
+See [Metrics](/operate/observability/metrics), [Await Boundary Operations](/operate/await-boundaries), and [Replay And Live Topology](/operate/observability/replay).
+
 ## Example Configs
 
 - CSV Payments connector-owned input/output path: `examples/csv-payments/config/pipeline.yaml`

--- a/docs/operate/await-boundaries.md
+++ b/docs/operate/await-boundaries.md
@@ -51,6 +51,39 @@ Late or duplicate completions can be dropped when the target interaction is alre
 
 - `tpf.await.completion.dropped.total`
 
+## Gate Signals
+
+In `QUEUE_ASYNC`, itemized await is not one continuous in-memory stream across the external provider gap. The runtime turns that gap into durable coordination gates:
+
+1. **Interaction dispatched**: TPF created await interactions and handed requests to the configured await transport.
+2. **Unit dispatch complete**: the await unit has finished dispatching the known item set for that live segment.
+3. **Parent wait durable**: the parent execution is stored as `WAITING_EXTERNAL` for that await unit.
+4. **Completion admitted**: a provider completion matched an interaction and was recorded idempotently.
+5. **Early completion held**: a completion arrived before both release gates were true, so it was recorded but not used to start continuation yet.
+6. **Resume released**: dispatch is complete, the parent wait is durable, and enough completions exist to resume the next segment.
+7. **Unit terminal**: the await unit completed, timed out, or failed.
+
+The matching metrics are:
+
+| Gate | Metric |
+| --- | --- |
+| Interaction dispatched | `tpf.await.interaction.dispatched.total` |
+| Unit dispatch complete | `tpf.await.unit.dispatch_complete.total` |
+| Completion admitted | `tpf.await.completion.admitted.total` |
+| Item completed | `tpf.await.item.completed.total` |
+| Early completion held | `tpf.await.completion.early_held.total` |
+| Resume released | `tpf.await.resume.released.total` |
+| Unit terminal | `tpf.await.unit.terminal.total` |
+| Completion latency | `tpf.await.completion.latency` |
+| Unit duration | `tpf.await.unit.duration` |
+
+Operational interpretation:
+
+1. Admitted completions rising without resume releases points to parent-wait persistence, dispatch-complete, or worker-lag pressure.
+2. Early-held completions are normal during races where providers answer quickly, but they should drain after the parent execution is durably waiting.
+3. Dropped completions indicate stale, duplicate, or non-admissible completions; correlate them with transport retries and replay events.
+4. Queue depth and provider lag remain provider-native signals. TPF does not scan the await store to synthesize backlog gauges.
+
 ## Replay And Tracing
 
 Replay and trace events expose the lifecycle of the await unit:

--- a/docs/operate/observability/alerting.md
+++ b/docs/operate/observability/alerting.md
@@ -39,6 +39,10 @@ Queue-async additions:
 2. Lease conflict/stale-commit rate spikes above baseline (warning)
 3. Retry-saturation exceeds threshold (warning/critical by tenant tier)
 4. Queue age/lag exceeds execution SLO budget (critical)
+5. Await dropped completions are non-zero outside known duplicate/retry windows (warning/critical by workflow)
+6. Early-held await completions rise without matching resume releases (warning)
+7. Object Publish failures are non-zero for terminal-output pipelines (critical)
+8. Object Ingest failures or duplicate-admission spikes exceed baseline (warning)
 
 When using New Relic, derive these from `tpf.pipeline.run` spans, `tpf.step.*` metrics (for example `tpf.step.reject.total`), and provider-native queue-depth metrics for DLQ/reject backlog.
 
@@ -48,6 +52,10 @@ Suggested starter thresholds:
 2. Retry-saturation ratio > 0.2 for 15 minutes (warning), > 0.4 (critical).
 3. Sweeper recoveries = 0 while due backlog grows for 5 minutes (critical).
 4. Lease/stale conflict rate > 3x 7-day baseline for 10 minutes (warning).
+5. `rate(tpf_await_completion_dropped_total[5m]) > 0` for 10 minutes (warning; critical when paired with provider completion backlog).
+6. `increase(tpf_await_completion_early_held_total[10m]) > increase(tpf_await_resume_released_total[10m])` for 10 minutes (warning; check parent wait persistence and dispatch completion).
+7. `rate(tpf_object_publish_failed_total[5m]) > 0` for 5 minutes (critical for pipelines where terminal output is contractual).
+8. `rate(tpf_object_ingest_failed_total[5m]) > 0` for 10 minutes (warning), or duplicate admissions > 3x baseline (warning).
 
 ## What Alerts Mean Operationally
 
@@ -106,3 +114,56 @@ Immediate operator actions:
 1. Check dependency latency/error spikes and retry amplification signals.
 2. Scale workers or reduce ingest pressure temporarily.
 3. Verify sweeper activity and lease conflict levels during catch-up.
+
+### Await Gate Drain Failure (Warning/Critical)
+
+Operational meaning:
+
+1. External completions are arriving, but item continuations are not being released at the expected rate.
+2. The parent execution may not have reached durable `WAITING_EXTERNAL`, dispatch completion may be delayed, or the worker queue may be saturated.
+
+Business meaning:
+
+1. Provider work may have completed, but the pipeline is not yet turning those completions into downstream business transitions.
+2. User-visible completion time can breach even when the provider itself is healthy.
+
+Immediate operator actions:
+
+1. Compare `tpf.await.completion.admitted.total`, `tpf.await.completion.early_held.total`, `tpf.await.resume.released.total`, and provider-native completion queue age.
+2. Inspect replay for `await_unit_dispatch_complete`, `await_execution_waiting`, `await_unit_item_completed`, and `await_resume_released`.
+3. Check queue-async worker lag and state-store write latency before increasing provider throughput.
+
+### Object Publish Failure (Critical)
+
+Operational meaning:
+
+1. Terminal output reached the connector boundary, but the object target did not accept the write.
+2. The execution should not be marked successful until configured Object Publish completes.
+
+Business meaning:
+
+1. The business transition completed in memory, but the expected durable output file/object is missing or delayed.
+2. Downstream consumers that rely on object output can see incomplete results.
+
+Immediate operator actions:
+
+1. Check `tpf.object_publish.failed.total`, `tpf.object_publish.published.total`, and write-duration p95/p99 by target/provider.
+2. Inspect replay for `object_publish_grouped`, `object_publish_published`, and `object_publish_failed` events; object keys are in replay, not metric labels.
+3. Validate target credentials, permissions, disk/S3 availability, and idempotency before replaying failed executions.
+
+### Object Ingest Admission Spike (Warning)
+
+Operational meaning:
+
+1. Source listing is returning failed or duplicate admissions above the normal baseline.
+2. This can be a source-store issue, a mapping error, or expected duplicate listing after a restart.
+
+Business meaning:
+
+1. New inputs may not be admitted into queue-async executions, or duplicate source notifications may be creating avoidable load.
+
+Immediate operator actions:
+
+1. Compare listed, submitted, duplicate, and failed Object Ingest counters by source/provider.
+2. Inspect replay/span events for object keys and idempotency identity.
+3. Check provider-native source backlog or object-store notification health before scaling consumers.

--- a/docs/operate/observability/metrics.md
+++ b/docs/operate/observability/metrics.md
@@ -114,6 +114,62 @@ Counter success = registry.counter("payment.processing.success");
 return timer.recordCallable(() -> processPayment(record));
 ```
 
+## Connector And Await Boundary Metrics
+
+Connector-owned I/O and await gates use low-cardinality metrics. Keep object keys, execution ids, await unit ids, interaction ids, and correlation ids in spans/replay events, not metric attributes.
+
+Object Ingest metrics:
+
+| Metric | Type | Attributes | Meaning |
+| --- | --- | --- | --- |
+| `tpf.object_ingest.list.total` | counter | `tpf.object_ingest.source`, `tpf.object_ingest.provider` | Source listing attempts. |
+| `tpf.object_ingest.listed.objects.total` | counter | `tpf.object_ingest.source`, `tpf.object_ingest.provider` | Objects returned by listing. |
+| `tpf.object_ingest.submitted.total` | counter | `tpf.object_ingest.source`, `tpf.object_ingest.provider` | Objects accepted as queue-async execution inputs. |
+| `tpf.object_ingest.duplicate.total` | counter | `tpf.object_ingest.source`, `tpf.object_ingest.provider` | Duplicate object admissions resolved by idempotency. |
+| `tpf.object_ingest.failed.total` | counter | `tpf.object_ingest.source`, `tpf.object_ingest.provider` | Listing, mapping, or submission failures. |
+
+Object Publish metrics:
+
+| Metric | Type | Attributes | Meaning |
+| --- | --- | --- | --- |
+| `tpf.object_publish.grouped.total` | counter | `tpf.object_publish.target` | Terminal output grouping operations. |
+| `tpf.object_publish.grouped.items.total` | counter | `tpf.object_publish.target` | Terminal items seen by Object Publish. |
+| `tpf.object_publish.grouped.groups.total` | counter | `tpf.object_publish.target` | Object groups created for publication. |
+| `tpf.object_publish.published.total` | counter | `tpf.object_publish.target`, `tpf.object_publish.provider` | Objects successfully written. |
+| `tpf.object_publish.published.bytes.total` | counter | `tpf.object_publish.target`, `tpf.object_publish.provider` | Bytes written by successful publishes. |
+| `tpf.object_publish.skipped.total` | counter | `tpf.object_publish.target` | Empty terminal outputs skipped. |
+| `tpf.object_publish.failed.total` | counter | `tpf.object_publish.target`, `tpf.object_publish.provider` | Publish failures. |
+| `tpf.object_publish.write.duration` | histogram | `tpf.object_publish.target`, `tpf.object_publish.provider` | Provider write duration in milliseconds. |
+
+Await gate metrics:
+
+| Metric | Type | Attributes | Meaning |
+| --- | --- | --- | --- |
+| `tpf.await.interaction.dispatched.total` | counter | step, status, transport | Await interactions dispatched to an external actor. |
+| `tpf.await.unit.dispatch_complete.total` | counter | step, cardinality, status | Await units whose dispatch phase completed. |
+| `tpf.await.completion.admitted.total` | counter | step, status, transport | Completion envelopes admitted into await state. |
+| `tpf.await.item.completed.total` | counter | step, cardinality, status, transport | Itemized await completions recorded. |
+| `tpf.await.completion.early_held.total` | counter | step, cardinality, status, transport | Item completions held until the parent execution is durably waiting. |
+| `tpf.await.resume.released.total` | counter | step, cardinality/status/transport when known | Await resumes released after durable gates are satisfied. |
+| `tpf.await.unit.terminal.total` | counter | step, cardinality, status, transport | Await units reaching terminal state. |
+| `tpf.await.completion.latency` | histogram | step, status, transport | Time from interaction creation to completion admission. |
+| `tpf.await.unit.duration` | histogram | step, cardinality, status, transport | Time from await unit creation to terminal state. |
+| `tpf.await.completion.dropped.total` | counter | transport, reason | Completions that cannot be admitted because the target interaction is already terminal, stale, or otherwise not admissible. |
+
+Prometheus exports OpenTelemetry units in the metric name. For example, the duration histograms are exported with `_milliseconds_*` suffixes in the Quarkus Prometheus endpoint.
+
+SLO-friendly derived indicators:
+
+1. Await admission reliability: admitted completions divided by admitted plus dropped completions.
+2. Await release health: resume releases compared with terminal await units, with early-held completions draining over the same window.
+3. Object publish reliability: published objects divided by published plus failed objects.
+4. Object publish latency: p95/p99 of `tpf.object_publish.write.duration` by provider and target.
+5. CSV output completeness: Object Publish grouped item count matches the terminal `PaymentOutput` count for the run.
+
+Keep demo expectations separate from production SLOs. The CSV Payments demo may report provider permits/sec, wall time, throughput, output count, and checksum, but production thresholds should come from service-specific latency/error budgets and provider-native backlog/lag signals.
+
+Use replay JSON for high-cardinality drill-down. It includes object keys, await unit ids, interaction ids, execution ids, and correlation fields that must not become metric dimensions.
+
 ## Orchestrator Queue-Async Signals
 
 For `QUEUE_ASYNC`, include control-plane metrics in addition to step metrics.
@@ -139,11 +195,7 @@ Step-level reject signal:
 
 - `tpf.step.reject.total` (counter): rejected step items published to item reject sinks.
 
-Await signal:
-
-- `tpf.await.completion.dropped.total` (counter): completions that cannot be admitted because the target interaction is already terminal, stale, or otherwise not admissible.
-
-Await execution logs include the parked await unit when a `QUEUE_ASYNC` execution waits or resumes. Replay and trace events expose await unit lifecycle transitions, including dispatch, waiting, item completion, unit completion, resume release, and terminal timeout/failure states. The metrics surface intentionally remains limited to dropped-completion counting plus provider-native backlog/latency signals.
+Await execution logs include the parked await unit when a `QUEUE_ASYNC` execution waits or resumes. Replay and trace events expose await unit lifecycle transitions, including dispatch, waiting, item completion, unit completion, resume release, and terminal timeout/failure states. Metrics expose aggregate await-gate health without high-cardinality ids.
 
 Backlog signal note:
 

--- a/docs/operate/observability/replay.md
+++ b/docs/operate/observability/replay.md
@@ -8,6 +8,8 @@ TPF exposes three different observability surfaces:
 
 They answer different questions. Do not treat them as interchangeable.
 
+Metrics are the aggregate SLO layer. Replay is the high-cardinality diagnostic layer. Object keys, execution ids, await unit ids, interaction ids, correlation ids, and connector lifecycle details belong in spans/replay events; metric labels should stay limited to low-cardinality dimensions such as source, target, provider, step, status, and transport.
+
 ## Replay artifact
 
 The offline artifact is **replay JSON**.
@@ -90,6 +92,19 @@ Replay JSON is written from the same runtime semantics by the framework replay e
 Await boundaries park the owning `QUEUE_ASYNC` execution on a durable await unit and resume from that unit after completion admission. Replay events include await unit ids, execution ids, interaction ids, step ids, unit status, and expected/completed item counts where the runtime knows them. For operations, see [Await Boundary Operations](/operate/await-boundaries); for the implementation model, see [Await Unit Runtime](/evolve/await-unit-runtime/).
 
 Connector-first pipelines add framework-owned nodes that are not user-authored business steps. In CSV Payments, replay should show Object Ingest as source admission, `Await Payment Provider` as the durable external boundary, item continuations through `Process Payment Status`, and Object Publish as terminal object output. The old folder and output-file services should only appear when the legacy file-step config is being replayed.
+
+Connector replay events include:
+
+- `object_ingest_listed`
+- `object_ingest_submitted`
+- `object_ingest_duplicate`
+- `object_ingest_failed`
+- `object_publish_grouped`
+- `object_publish_published`
+- `object_publish_failed`
+- `object_publish_skipped`
+
+Use these events to debug a single object key or output object. Use `tpf.object_ingest.*`, `tpf.object_publish.*`, and `tpf.await.*` metrics to alert on aggregate health.
 
 ## Replay exporter configuration
 

--- a/examples/checkout/README.md
+++ b/examples/checkout/README.md
@@ -146,4 +146,4 @@ Run the full TPFGo checkpoint-flow integration suite directly:
 
 ## Docs
 
-The user-facing walkthrough is in [docs/guide/development/tpfgo-example.md](../../docs/guide/development/tpfgo-example.md).
+The user-facing walkthrough is in [docs/develop/tpfgo-example.md](../../docs/develop/tpfgo-example.md).

--- a/examples/csv-payments/README.md
+++ b/examples/csv-payments/README.md
@@ -206,6 +206,12 @@ The deprecated file-step path can still use `BlockingIteratorPacer` as a legacy 
 
 Use provider concurrency and retry settings to shape the payment-provider portion of the demo. Use the object I/O connector settings to shape file admission and terminal object writes.
 
+Operational proof for the connector-first path comes from three surfaces:
+
+1. Grafana metrics show Object Ingest admission, await gate health, provider/request pressure, Object Publish writes, and output completeness.
+2. Tempo traces show the live service topology and step spans.
+3. Replay JSON shows the high-cardinality details: object keys, await unit ids, interaction ids, item completions, resume release, and published output keys.
+
 ### Performance Expectations
 
 Do not read the 1k demo duration as only `record-count / permits-per-second`. The mock payment provider also has per-item processing delay, and the first few items pay cold-path costs for the packaged Quarkus app, gRPC clients, Kafka channels, persistence, telemetry export, and provider warmup.
@@ -684,19 +690,44 @@ The telemetry harness launches the packaged orchestrator application. If the pac
 
 The application ships separate observability surfaces:
 
-1. **Grafana metrics dashboard**: Prometheus-backed throughput, latency, queue depth, inflight, and retry panels
+1. **Grafana metrics dashboard**: Prometheus-backed throughput, latency, queue depth, inflight, retry, Object Ingest, await-gate, and Object Publish panels
 2. **Tempo tracing surface**: live topology and trace drill-down
 3. **Replay viewer**: deterministic playback from `csv-payments-replay.json`
 
 Dashboards are discovered from `META-INF/grafana/grafana-dashboard-*.json` resources when LGTM Dev Services are active.
 
-### Custom Metrics
+### Connector-First Metrics
 
-The application exposes custom metrics to demonstrate reactive programming concepts:
+The connector-first path is healthy when:
 
-- **Backpressure Events**: Count of backpressure events triggered by rate limiting
-- **Retry Attempts**: Number of retry attempts with exponential back-off
-- **Lazy Evaluation**: Metrics showing the benefits of lazy stream processing
+1. Object Ingest listed and submitted the expected source object count.
+2. Await completions are admitted, early-held completions drain, and resume releases follow completed await units.
+3. Object Publish grouped the same terminal item count the run produced and published the expected `.out` object.
+4. Object Publish failures and await dropped completions remain zero outside intentional duplicate/retry tests.
+
+The relevant TPF metrics are:
+
+- `tpf.object_ingest.listed.objects.total`
+- `tpf.object_ingest.submitted.total`
+- `tpf.object_ingest.duplicate.total`
+- `tpf.object_ingest.failed.total`
+- `tpf.await.interaction.dispatched.total`
+- `tpf.await.unit.dispatch_complete.total`
+- `tpf.await.completion.admitted.total`
+- `tpf.await.item.completed.total`
+- `tpf.await.completion.early_held.total`
+- `tpf.await.resume.released.total`
+- `tpf.await.unit.terminal.total`
+- `tpf.await.completion.dropped.total`
+- `tpf.object_publish.grouped.items.total`
+- `tpf.object_publish.grouped.groups.total`
+- `tpf.object_publish.published.total`
+- `tpf.object_publish.published.bytes.total`
+- `tpf.object_publish.skipped.total`
+- `tpf.object_publish.failed.total`
+- `tpf.object_publish.write.duration`
+
+Object keys, await unit ids, interaction ids, and execution ids are intentionally visible in replay and traces, not metric labels.
 
 ### Distributed Tracing
 

--- a/examples/csv-payments/orchestrator-svc/README.md
+++ b/examples/csv-payments/orchestrator-svc/README.md
@@ -102,6 +102,19 @@ sequenceDiagram
 3. **Awaited Provider Completion**: The await adapter dispatches provider requests and resumes the execution from correlated completions.
 4. **Output Publication**: Object Publish streams terminal `PaymentOutput` records into grouped output files.
 
+### Connector-First Observability
+
+The orchestrator owns the framework-side metrics for Object Ingest, await gates, and Object Publish.
+
+Use the Grafana CSV Payments dashboard to confirm:
+
+1. Object Ingest listed and submitted the expected source object.
+2. Await completions are admitted, early-held completions drain, and resume releases follow dispatch completion.
+3. Object Publish grouped the terminal `PaymentOutput` count and wrote the expected output bytes before execution success.
+4. Legacy `ProcessFolderService` and `ProcessCsvPaymentsOutputFileService` are absent from the default replay/order path.
+
+Use replay JSON for the high-cardinality details: source object key, await unit id, interaction ids, correlation ids, and published output key.
+
 ### gRPC Communication
 The service communicates with other services via gRPC, using clients injected with `@GrpcClient`:
 - Processing input CSV files

--- a/examples/csv-payments/orchestrator-svc/src/main/resources/META-INF/grafana/grafana-dashboard-csv-payments.json
+++ b/examples/csv-payments/orchestrator-svc/src/main/resources/META-INF/grafana/grafana-dashboard-csv-payments.json
@@ -2306,12 +2306,781 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 110
       },
       "id": 24,
       "panels": [],
       "title": "Topology & Replay Metrics",
       "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Connector-First Object I/O And Await Gates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_ingest_source, tpf_object_ingest_provider) (rate(tpf_object_ingest_listed_objects_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "listed {{tpf_object_ingest_source}}/{{tpf_object_ingest_provider}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_ingest_source, tpf_object_ingest_provider) (rate(tpf_object_ingest_submitted_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "submitted {{tpf_object_ingest_source}}/{{tpf_object_ingest_provider}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_ingest_source, tpf_object_ingest_provider) (rate(tpf_object_ingest_duplicate_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "duplicate {{tpf_object_ingest_source}}/{{tpf_object_ingest_provider}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_ingest_source, tpf_object_ingest_provider) (rate(tpf_object_ingest_failed_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "failed {{tpf_object_ingest_source}}/{{tpf_object_ingest_provider}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Object Ingest Admission",
+      "type": "timeseries",
+      "description": "Object source listing, accepted submissions, duplicates, and failures. Object keys live in replay/span events, not metric labels.",
+      "minInterval": "10s"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id, tpf_await_transport) (rate(tpf_await_interaction_dispatched_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "dispatched {{tpf_await_step_id}}/{{tpf_await_transport}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id) (rate(tpf_await_unit_dispatch_complete_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "dispatch complete {{tpf_await_step_id}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id, tpf_await_transport) (rate(tpf_await_completion_admitted_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "admitted {{tpf_await_step_id}}/{{tpf_await_transport}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id, tpf_await_transport) (rate(tpf_await_item_completed_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "item completed {{tpf_await_step_id}}/{{tpf_await_transport}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id) (rate(tpf_await_resume_released_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "resume released {{tpf_await_step_id}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id) (rate(tpf_await_unit_terminal_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "unit terminal {{tpf_await_step_id}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Await Gate Health",
+      "type": "timeseries",
+      "description": "QUEUE_ASYNC itemized await gates: dispatch completion, admitted completions, item completions, resume release, and terminal units.",
+      "minInterval": "10s"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id, tpf_await_transport) (rate(tpf_await_completion_early_held_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "early held {{tpf_await_step_id}}/{{tpf_await_transport}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_transport, tpf_await_completion_reason) (rate(tpf_await_completion_dropped_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "dropped {{tpf_await_transport}}/{{tpf_await_completion_reason}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_await_step_id) (rate(tpf_await_resume_released_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "resume released {{tpf_await_step_id}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Await Held And Dropped Completions",
+      "type": "timeseries",
+      "description": "Early-held completions should drain after parent WAITING_EXTERNAL and dispatch-complete gates are true. Dropped completions indicate stale, duplicate, or non-admissible completions.",
+      "minInterval": "10s"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target) (rate(tpf_object_publish_grouped_items_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "grouped items {{tpf_object_publish_target}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target, tpf_object_publish_provider) (rate(tpf_object_publish_published_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "published {{tpf_object_publish_target}}/{{tpf_object_publish_provider}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target, tpf_object_publish_provider) (rate(tpf_object_publish_published_bytes_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "bytes {{tpf_object_publish_target}}/{{tpf_object_publish_provider}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target) (rate(tpf_object_publish_skipped_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "skipped {{tpf_object_publish_target}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target, tpf_object_publish_provider) (rate(tpf_object_publish_failed_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "failed {{tpf_object_publish_target}}/{{tpf_object_publish_provider}}",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Object Publish Success And Bytes",
+      "type": "timeseries",
+      "description": "Terminal Object Publish grouping, successful writes, bytes, skips, and failures. Publication must complete before execution success.",
+      "minInterval": "10s"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 102
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, tpf_object_publish_target, tpf_object_publish_provider) (rate(tpf_object_publish_write_duration_milliseconds_bucket[$__rate_interval])) or sum by (le, tpf_object_publish_target, tpf_object_publish_provider) (rate(tpf_object_publish_write_duration_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p95 {{tpf_object_publish_target}}/{{tpf_object_publish_provider}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Object Publish Write Duration p95",
+      "type": "timeseries",
+      "description": "Provider write duration by target/provider. For filesystem this includes temp-file write and final move; for S3 it includes multipart session close as exposed by the provider.",
+      "minInterval": "10s"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 102
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target) (increase(tpf_object_publish_grouped_items_total[$__range]))",
+          "instant": false,
+          "legendFormat": "grouped items {{tpf_object_publish_target}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target, tpf_object_publish_provider) (increase(tpf_object_publish_published_total[$__range]))",
+          "instant": false,
+          "legendFormat": "published objects {{tpf_object_publish_target}}/{{tpf_object_publish_provider}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tpf_object_publish_target, tpf_object_publish_provider) (increase(tpf_object_publish_failed_total[$__range]))",
+          "instant": false,
+          "legendFormat": "publish failures {{tpf_object_publish_target}}/{{tpf_object_publish_provider}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "CSV Output Completeness",
+      "type": "timeseries",
+      "description": "Run-window comparison between terminal items grouped for publish and successfully published output objects. Use replay for exact object keys and checksums.",
+      "minInterval": "10s"
     },
     {
       "datasource": {
@@ -2344,7 +3113,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 86
+        "y": 111
       },
       "id": 25,
       "options": {
@@ -2408,7 +3177,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 86
+        "y": 111
       },
       "id": 26,
       "options": {
@@ -2472,7 +3241,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 119
       },
       "id": 27,
       "options": {

--- a/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
+++ b/examples/csv-payments/orchestrator-svc/src/test/java/org/pipelineframework/csv/orchestrator/service/AbstractCsvPaymentsEndToEnd.java
@@ -879,6 +879,8 @@ abstract class AbstractCsvPaymentsEndToEnd {
             command.add("bash");
             command.add("build-monolith.sh");
             command.add("-DskipTests");
+            command.add("-Dquarkus.container-image.build=false");
+            command.add("-Dquarkus.container-image.push=false");
             if (!mavenRepoLocal.isBlank()) {
                 command.add("-Dmaven.repo.local=" + mavenRepoLocal);
             }
@@ -890,6 +892,8 @@ abstract class AbstractCsvPaymentsEndToEnd {
             command.add("orchestrator-svc");
             command.add("-am");
             command.add("-DskipTests");
+            command.add("-Dquarkus.container-image.build=false");
+            command.add("-Dquarkus.container-image.push=false");
             if (!mavenRepoLocal.isBlank()) {
                 command.add("-Dmaven.repo.local=" + mavenRepoLocal);
             }

--- a/examples/restaurant-approval/self-host/README.md
+++ b/examples/restaurant-approval/self-host/README.md
@@ -8,7 +8,7 @@ The separate REST worker script remains available for protocol experiments, but 
 
 For a compute-first HA-shaped reference with containers, DynamoDB/SQS-compatible backing services, S3-compatible release artifact storage, and a separate REST worker, use [container/](./container/README.md).
 
-For the terminology behind coordinator, transition worker, and the historical `orchestrator` naming, see [Coordinator And Worker Topology](/guide/evolve/durable-coordinator/coordinator-worker-topology).
+For the terminology behind coordinator, transition worker, and the historical `orchestrator` naming, see [Coordinator And Worker Topology](/evolve/durable-coordinator/coordinator-worker-topology).
 
 ## Quick Start
 
@@ -57,7 +57,7 @@ The incident script sets `TPF_ORCHESTRATOR_MAX_RETRIES=0` by default so the fail
 
 These defaults are local/dev only. Real self-host deployments should use secret references, durable stores, and explicit operational runbooks.
 
-For the production-ish topology, durable provider choices, secret refs, and manual upgrade/drain procedure, see [Self-Hosted Deployment](/guide/evolve/durable-coordinator/self-hosted-deployment).
+For the production-ish topology, durable provider choices, secret refs, and manual upgrade/drain procedure, see [Self-Hosted Deployment](/evolve/durable-coordinator/self-hosted-deployment).
 
 For the local containerized HA reference:
 

--- a/examples/restaurant-approval/self-host/container/README.md
+++ b/examples/restaurant-approval/self-host/container/README.md
@@ -8,7 +8,7 @@ This directory runs the restaurant approval self-host path as the base compute-f
 
 It uses the same `monolith-svc` image in two modes. The coordinator is configured with `pipeline.orchestrator.control-plane.require-remote-worker=true`, so it fails instead of silently falling back to local in-process execution.
 
-`monolith-svc` is the packaged artifact shape. The runtime role is selected by configuration: one container enables coordinator/admin APIs and points at a remote worker, while the other enables the REST transition worker endpoint. For the general model, see [Coordinator And Worker Topology](/guide/evolve/durable-coordinator/coordinator-worker-topology).
+`monolith-svc` is the packaged artifact shape. The runtime role is selected by configuration: one container enables coordinator/admin APIs and points at a remote worker, while the other enables the REST transition worker endpoint. For the general model, see [Coordinator And Worker Topology](/evolve/durable-coordinator/coordinator-worker-topology).
 
 ## Run The Happy Path
 
@@ -75,4 +75,4 @@ These defaults are for local verification only. Real deployments should use secr
 5. Worker lifecycle must report a healthy worker for the active release before hosted submissions are accepted.
 6. Coordinator and worker process restarts do not lose parked await state or pinned release identity.
 
-This is still a local reference stack, not a production deployment package. For milestone status and deferred hardening, see [Self-Hosted HA Roadmap](/guide/evolve/durable-coordinator/self-hosted-ha-roadmap).
+This is still a local reference stack, not a production deployment package. For milestone status and deferred hardening, see [Self-Hosted HA Roadmap](/evolve/durable-coordinator/self-hosted-ha-roadmap).

--- a/examples/search/DEMO-RUNBOOK.md
+++ b/examples/search/DEMO-RUNBOOK.md
@@ -55,4 +55,4 @@ Use higher `search.replay.embed.delay-ms` values when recording close-ups. Avoid
 
 ## Adjacent Capabilities
 
-Keep this video focused on typed stream fan-out/fan-in and replay. For deferred external completion, use [Await Boundaries](../../docs/guide/development/orchestrator-runtime/await.md) and the CSV Payments replay. For runtime failure triage, use [Error Handling](../../docs/guide/operations/error-handling.md) and the item reject sink docs.
+Keep this video focused on typed stream fan-out/fan-in and replay. For deferred external completion, use [Await Boundaries](../../docs/deploy/orchestrator-runtime/await.md) and the CSV Payments replay. For runtime failure triage, use [Error Handling](../../docs/operate/error-handling.md) and the item reject sink docs.

--- a/examples/search/README.md
+++ b/examples/search/README.md
@@ -147,7 +147,7 @@ The function will be available at:
 - HTTP Trigger URL: `http://localhost:7071/api/{route}`
 - Health endpoint: `http://localhost:7071/q/health` (if configured)
 
-**Prerequisites**: Azure Functions Core Tools v4.x must be installed. See [Search Azure Functions Verification Lane](../../docs/guide/build/runtime-layouts/search-azure-functions.md) for installation instructions.
+**Prerequisites**: Azure Functions Core Tools v4.x must be installed. See [Search Azure Functions Verification Lane](../../docs/deploy/search-azure-functions.md) for installation instructions.
 
 ### Function Streaming Lane Status
 

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -25,6 +25,7 @@ import org.pipelineframework.checkpoint.CheckpointPublicationService;
 import org.pipelineframework.config.pipeline.PipelineJson;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
 import org.pipelineframework.awaitable.AwaitCompletionAdmissionFailures;
+import org.pipelineframework.awaitable.AwaitCompletionMetrics;
 import org.pipelineframework.awaitable.AwaitCompletionTenantMismatchException;
 import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitCoordinator;
@@ -645,6 +646,8 @@ class QueueAsyncCoordinator {
                                   unit,
                                   itemContinuationHandler,
                                   normalized.nowEpochMs());
+                            } else {
+                              AwaitCompletionMetrics.recordEarlyCompletionHeld(validated.record(), unit);
                             }
                           })
                           .replaceWith(validated);
@@ -1396,6 +1399,7 @@ class QueueAsyncCoordinator {
                     unit.expectedItemCount(),
                     unit.completedItemCount(),
                     unit.dispatchComplete()));
+                AwaitCompletionMetrics.recordResumeReleased(unit);
                 return workDispatcher.enqueueNow(new ExecutionWorkItem(
                         updated.get().tenantId(),
                         updated.get().executionId()))
@@ -1467,6 +1471,20 @@ class QueueAsyncCoordinator {
                 awaitUnitId,
                 updated.get().currentStepIndex());
             recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
+                AwaitReplayLifecycleEvent.RESUME_RELEASED,
+                executionId,
+                awaitUnitId,
+                stepId,
+                stepIndex,
+                updated.get().status().name(),
+                interactionId,
+                correlationId,
+                transportType,
+                itemIndex,
+                null,
+                null,
+                null));
+            AwaitCompletionMetrics.recordResumeReleased(new AwaitReplayLifecycleEvent(
                 AwaitReplayLifecycleEvent.RESUME_RELEASED,
                 executionId,
                 awaitUnitId,

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionMetrics.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCompletionMetrics.java
@@ -3,7 +3,9 @@ package org.pipelineframework.awaitable;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.DoubleHistogram;
 
 /**
  * Await completion observability helpers.
@@ -12,8 +14,20 @@ public final class AwaitCompletionMetrics {
 
     private static final AttributeKey<String> TRANSPORT = AttributeKey.stringKey("tpf.await.transport");
     private static final AttributeKey<String> REASON = AttributeKey.stringKey("tpf.await.completion.reason");
+    private static final AttributeKey<String> STEP_ID = AttributeKey.stringKey("tpf.await.step_id");
+    private static final AttributeKey<String> CARDINALITY = AttributeKey.stringKey("tpf.await.cardinality");
+    private static final AttributeKey<String> STATUS = AttributeKey.stringKey("tpf.await.status");
 
     private static volatile LongCounter droppedCompletionCounter;
+    private static volatile LongCounter interactionDispatchedCounter;
+    private static volatile LongCounter unitDispatchCompleteCounter;
+    private static volatile LongCounter completionAdmittedCounter;
+    private static volatile LongCounter itemCompletedCounter;
+    private static volatile LongCounter earlyCompletionHeldCounter;
+    private static volatile LongCounter resumeReleasedCounter;
+    private static volatile LongCounter unitTerminalCounter;
+    private static volatile DoubleHistogram completionLatencyHistogram;
+    private static volatile DoubleHistogram unitDurationHistogram;
 
     private AwaitCompletionMetrics() {
     }
@@ -24,6 +38,54 @@ public final class AwaitCompletionMetrics {
             .put(TRANSPORT, normalize(transport))
             .put(REASON, normalize(reason))
             .build());
+    }
+
+    public static void recordInteractionDispatched(AwaitInteractionRecord record) {
+        ensureInitialized();
+        interactionDispatchedCounter.add(1, interactionAttributes(record));
+    }
+
+    public static void recordUnitDispatchComplete(AwaitUnitRecord unit) {
+        ensureInitialized();
+        unitDispatchCompleteCounter.add(1, unitAttributes(unit));
+    }
+
+    public static void recordCompletionAdmitted(AwaitInteractionRecord record) {
+        ensureInitialized();
+        Attributes attributes = interactionAttributes(record);
+        completionAdmittedCounter.add(1, attributes);
+        if (record != null && record.createdAtEpochMs() > 0 && record.updatedAtEpochMs() >= record.createdAtEpochMs()) {
+            completionLatencyHistogram.record(record.updatedAtEpochMs() - record.createdAtEpochMs(), attributes);
+        }
+    }
+
+    public static void recordItemCompleted(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        ensureInitialized();
+        itemCompletedCounter.add(1, unitAttributes(unit, record == null ? null : record.transportType()));
+    }
+
+    public static void recordEarlyCompletionHeld(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        ensureInitialized();
+        earlyCompletionHeldCounter.add(1, unitAttributes(unit, record == null ? null : record.transportType()));
+    }
+
+    public static void recordResumeReleased(AwaitUnitRecord unit) {
+        ensureInitialized();
+        resumeReleasedCounter.add(1, unitAttributes(unit));
+    }
+
+    public static void recordResumeReleased(AwaitReplayView lifecycleEvent) {
+        ensureInitialized();
+        resumeReleasedCounter.add(1, lifecycleAttributes(lifecycleEvent));
+    }
+
+    public static void recordUnitTerminal(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        ensureInitialized();
+        Attributes attributes = unitAttributes(unit, record == null ? null : record.transportType());
+        unitTerminalCounter.add(1, attributes);
+        if (unit != null && unit.createdAtEpochMs() > 0 && unit.updatedAtEpochMs() >= unit.createdAtEpochMs()) {
+            unitDurationHistogram.record(unit.updatedAtEpochMs() - unit.createdAtEpochMs(), attributes);
+        }
     }
 
     private static void ensureInitialized() {
@@ -39,7 +101,90 @@ public final class AwaitCompletionMetrics {
                 .setDescription("Total deterministic await completions dropped by transport consumers")
                 .setUnit("events")
                 .build();
+            var meter = GlobalOpenTelemetry.getMeter("org.pipelineframework");
+            interactionDispatchedCounter = meter.counterBuilder("tpf.await.interaction.dispatched.total")
+                .setDescription("Total await interactions dispatched")
+                .setUnit("interactions")
+                .build();
+            unitDispatchCompleteCounter = meter.counterBuilder("tpf.await.unit.dispatch_complete.total")
+                .setDescription("Total await units whose dispatch completed")
+                .setUnit("units")
+                .build();
+            completionAdmittedCounter = meter.counterBuilder("tpf.await.completion.admitted.total")
+                .setDescription("Total await completions admitted")
+                .setUnit("completions")
+                .build();
+            itemCompletedCounter = meter.counterBuilder("tpf.await.item.completed.total")
+                .setDescription("Total itemized await completions recorded")
+                .setUnit("items")
+                .build();
+            earlyCompletionHeldCounter = meter.counterBuilder("tpf.await.completion.early_held.total")
+                .setDescription("Total itemized await completions held until parent wait was durable")
+                .setUnit("completions")
+                .build();
+            resumeReleasedCounter = meter.counterBuilder("tpf.await.resume.released.total")
+                .setDescription("Total await resumes released")
+                .setUnit("resumes")
+                .build();
+            unitTerminalCounter = meter.counterBuilder("tpf.await.unit.terminal.total")
+                .setDescription("Total await units moved to a terminal state")
+                .setUnit("units")
+                .build();
+            completionLatencyHistogram = meter.histogramBuilder("tpf.await.completion.latency")
+                .setDescription("Time from await interaction creation to completion admission")
+                .setUnit("ms")
+                .build();
+            unitDurationHistogram = meter.histogramBuilder("tpf.await.unit.duration")
+                .setDescription("Time from await unit creation to terminal state")
+                .setUnit("ms")
+                .build();
         }
+    }
+
+    private static Attributes interactionAttributes(AwaitInteractionRecord record) {
+        AttributesBuilder builder = Attributes.builder();
+        put(builder, STEP_ID, record == null ? null : record.stepId());
+        put(builder, TRANSPORT, record == null ? null : record.transportType());
+        put(builder, STATUS, record == null || record.status() == null ? null : record.status().name());
+        return builder.build();
+    }
+
+    private static Attributes unitAttributes(AwaitUnitRecord unit) {
+        return unitAttributes(unit, null);
+    }
+
+    private static Attributes unitAttributes(AwaitUnitRecord unit, String transport) {
+        AttributesBuilder builder = Attributes.builder();
+        put(builder, STEP_ID, unit == null ? null : unit.stepId());
+        put(builder, CARDINALITY, unit == null ? null : unit.cardinality());
+        put(builder, STATUS, unit == null || unit.status() == null ? null : unit.status().name());
+        put(builder, TRANSPORT, transport);
+        return builder.build();
+    }
+
+    private static Attributes lifecycleAttributes(AwaitReplayView event) {
+        AttributesBuilder builder = Attributes.builder();
+        put(builder, STEP_ID, event == null ? null : event.stepId());
+        put(builder, STATUS, event == null ? null : event.status());
+        put(builder, TRANSPORT, event == null ? null : event.transport());
+        return builder.build();
+    }
+
+    private static void put(AttributesBuilder builder, AttributeKey<String> key, String value) {
+        builder.put(key, normalize(value));
+    }
+
+    public static synchronized void resetForTest() {
+        droppedCompletionCounter = null;
+        interactionDispatchedCounter = null;
+        unitDispatchCompleteCounter = null;
+        completionAdmittedCounter = null;
+        itemCompletedCounter = null;
+        earlyCompletionHeldCounter = null;
+        resumeReleasedCounter = null;
+        unitTerminalCounter = null;
+        completionLatencyHistogram = null;
+        unitDurationHistogram = null;
     }
 
     private static String normalize(String value) {
@@ -47,5 +192,13 @@ public final class AwaitCompletionMetrics {
             return "unknown";
         }
         return value;
+    }
+
+    public interface AwaitReplayView {
+        String stepId();
+
+        String status();
+
+        String transport();
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitCoordinator.java
@@ -340,6 +340,7 @@ public class AwaitCoordinator {
     }
 
     private void recordInteractionDispatched(AwaitInteractionRecord record) {
+        AwaitCompletionMetrics.recordInteractionDispatched(record);
         recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
             AwaitReplayLifecycleEvent.INTERACTION_DISPATCHED,
             record.executionId(),
@@ -357,6 +358,7 @@ public class AwaitCoordinator {
     }
 
     private void recordUnitDispatchComplete(AwaitUnitRecord unit) {
+        AwaitCompletionMetrics.recordUnitDispatchComplete(unit);
         recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
             AwaitReplayLifecycleEvent.UNIT_DISPATCH_COMPLETE,
             unit.executionId(),
@@ -374,7 +376,9 @@ public class AwaitCoordinator {
     }
 
     private void recordCompletionLifecycle(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        AwaitCompletionMetrics.recordCompletionAdmitted(record);
         if (record.itemInteraction()) {
+            AwaitCompletionMetrics.recordItemCompleted(record, unit);
             recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
                 AwaitReplayLifecycleEvent.UNIT_ITEM_COMPLETED,
                 record.executionId(),
@@ -409,6 +413,7 @@ public class AwaitCoordinator {
     }
 
     private void recordUnitTerminal(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        AwaitCompletionMetrics.recordUnitTerminal(record, unit);
         recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
             AwaitReplayLifecycleEvent.UNIT_TERMINAL,
             unit.executionId(),

--- a/framework/runtime/src/main/java/org/pipelineframework/objectingest/ObjectIngestRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectingest/ObjectIngestRunner.java
@@ -129,10 +129,17 @@ public final class ObjectIngestRunner implements AutoCloseable {
                 String idempotencyKey = ObjectIdentity.executionKey(source.name(), snapshot, source.identity());
                 org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto accepted =
                     admission.submit(pipelineInput, DEFAULT_TENANT_ID, idempotencyKey).await().atMost(Duration.ofSeconds(30));
-                if (accepted != null && accepted.executionId() != null && !accepted.executionId().isBlank()) {
+                if (accepted == null) {
+                    throw new IllegalStateException("Object execution admission returned null accepted response");
+                }
+                if (accepted.executionId() != null && !accepted.executionId().isBlank()) {
                     executionIds.add(accepted.executionId());
                 }
-                telemetry.submitted(source.name(), source.provider(), item.key());
+                if (accepted.duplicate()) {
+                    telemetry.duplicate(source.name(), source.provider(), item.key());
+                } else {
+                    telemetry.submitted(source.name(), source.provider(), item.key());
+                }
                 submitted++;
             } catch (RuntimeException e) {
                 telemetry.failed(source.name(), source.provider(), item.key(), e);

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishRunner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishRunner.java
@@ -3,6 +3,8 @@ package org.pipelineframework.objectpublish;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HexFormat;
@@ -236,9 +238,14 @@ public final class ObjectPublishRunner {
             checksum,
             "object-publish:" + target.name() + ":" + objectKey + ":" + checksum);
         ObjectTargetProvider provider = registry.require(target.provider());
+        Instant writeStarted = Instant.now();
         return toUni(provider.write(request))
-            .invoke(result -> telemetry.published(target.name(), target.provider(), objectKey, result.bytes()))
+            .invoke(result -> {
+                telemetry.writeDuration(target.name(), target.provider(), Duration.between(writeStarted, Instant.now()));
+                telemetry.published(target.name(), target.provider(), objectKey, result.bytes());
+            })
             .onFailure().invoke(failure -> {
+                telemetry.writeDuration(target.name(), target.provider(), Duration.between(writeStarted, Instant.now()));
                 telemetry.failed(target.name(), target.provider(), objectKey, failure);
                 LOG.warnf(failure, "Object publish failed for target=%s key=%s", target.name(), objectKey);
             })
@@ -560,11 +567,16 @@ public final class ObjectPublishRunner {
                 return Uni.createFrom().voidItem();
             }
             closed = true;
+            Instant writeStarted = Instant.now();
             return writeChunk(renderer.onClose())
                 .chain(() -> open())
                 .chain(session -> toUni(session.close(new ObjectWriteCloseRequest(bytes, checksum(), finalMetadata()))))
-                .invoke(result -> telemetry.published(target.name(), target.provider(), openRequest.objectKey(), result.bytes()))
+                .invoke(result -> {
+                    telemetry.writeDuration(target.name(), target.provider(), Duration.between(writeStarted, Instant.now()));
+                    telemetry.published(target.name(), target.provider(), openRequest.objectKey(), result.bytes());
+                })
                 .onFailure().invoke(failure -> {
+                    telemetry.writeDuration(target.name(), target.provider(), Duration.between(writeStarted, Instant.now()));
                     telemetry.failed(target.name(), target.provider(), openRequest.objectKey(), failure);
                     LOG.warnf(failure, "Object publish failed for target=%s key=%s", target.name(), openRequest.objectKey());
                 })

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishTelemetry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishTelemetry.java
@@ -1,5 +1,7 @@
 package org.pipelineframework.objectpublish;
 
+import java.time.Duration;
+
 /**
  * Telemetry hook for Object Publish lifecycle events.
  */
@@ -17,5 +19,8 @@ public interface ObjectPublishTelemetry {
     }
 
     default void failed(String targetName, String provider, String objectKey, Throwable failure) {
+    }
+
+    default void writeDuration(String targetName, String provider, Duration duration) {
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/telemetry/AwaitReplayLifecycleEvent.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/telemetry/AwaitReplayLifecycleEvent.java
@@ -16,6 +16,8 @@
 
 package org.pipelineframework.telemetry;
 
+import org.pipelineframework.awaitable.AwaitCompletionMetrics;
+
 /**
  * Replay-friendly control-plane event for durable await unit lifecycle changes.
  */
@@ -33,7 +35,7 @@ public record AwaitReplayLifecycleEvent(
     Integer expectedItemCount,
     Integer completedItemCount,
     Boolean dispatchComplete
-) {
+) implements AwaitCompletionMetrics.AwaitReplayView {
     public static final String INTERACTION_DISPATCHED = "await_interaction_dispatched";
     public static final String UNIT_DISPATCH_COMPLETE = "await_unit_dispatch_complete";
     public static final String EXECUTION_WAITING = "await_execution_waiting";

--- a/framework/runtime/src/main/java/org/pipelineframework/telemetry/ObjectIngestReplayTelemetry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/telemetry/ObjectIngestReplayTelemetry.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
 import org.pipelineframework.objectingest.ObjectIngestTelemetry;
 
 /**
@@ -15,27 +19,65 @@ public class ObjectIngestReplayTelemetry implements ObjectIngestTelemetry {
 
     private static final String STEP = "ObjectIngest";
     private static final String SERVICE = "ObjectIngestConnector";
+    private static final AttributeKey<String> SOURCE = AttributeKey.stringKey("tpf.object_ingest.source");
+    private static final AttributeKey<String> PROVIDER = AttributeKey.stringKey("tpf.object_ingest.provider");
+
+    private final LongCounter listedCounter;
+    private final LongCounter listedObjectCounter;
+    private final LongCounter submittedCounter;
+    private final LongCounter duplicateCounter;
+    private final LongCounter failedCounter;
 
     @Inject
     PipelineTelemetry telemetry;
 
+    public ObjectIngestReplayTelemetry() {
+        var meter = GlobalOpenTelemetry.getMeter("org.pipelineframework");
+        listedCounter = meter.counterBuilder("tpf.object_ingest.list.total")
+            .setDescription("Total Object Ingest listing attempts")
+            .setUnit("events")
+            .build();
+        listedObjectCounter = meter.counterBuilder("tpf.object_ingest.listed.objects.total")
+            .setDescription("Total objects returned by Object Ingest listing")
+            .setUnit("objects")
+            .build();
+        submittedCounter = meter.counterBuilder("tpf.object_ingest.submitted.total")
+            .setDescription("Total object inputs submitted as queue-async executions")
+            .setUnit("objects")
+            .build();
+        duplicateCounter = meter.counterBuilder("tpf.object_ingest.duplicate.total")
+            .setDescription("Total duplicate object admissions detected")
+            .setUnit("objects")
+            .build();
+        failedCounter = meter.counterBuilder("tpf.object_ingest.failed.total")
+            .setDescription("Total Object Ingest failures")
+            .setUnit("objects")
+            .build();
+    }
+
     @Override
     public void listed(String sourceName, String provider, int count) {
+        Attributes attributes = metricAttributes(sourceName, provider);
+        listedCounter.add(1, attributes);
+        listedObjectCounter.add(Math.max(0, count), attributes);
         emit("object_ingest_listed", sourceName, provider, null, Map.of("count", Integer.toString(count)));
     }
 
     @Override
     public void submitted(String sourceName, String provider, String key) {
+        submittedCounter.add(1, metricAttributes(sourceName, provider));
         emit("object_ingest_submitted", sourceName, provider, key, Map.of());
     }
 
     @Override
     public void duplicate(String sourceName, String provider, String key) {
+        duplicateCounter.add(1, metricAttributes(sourceName, provider));
         emit("object_ingest_duplicate", sourceName, provider, key, Map.of());
     }
 
     @Override
     public void failed(String sourceName, String provider, String key, Throwable failure) {
+        failedCounter.add(1, metricAttributes(sourceName, provider));
         Map<String, String> attributes = new LinkedHashMap<>();
         if (failure != null) {
             attributes.put("errorType", failure.getClass().getName());
@@ -61,12 +103,25 @@ public class ObjectIngestReplayTelemetry implements ObjectIngestTelemetry {
         if (extraAttributes != null) {
             attributes.putAll(extraAttributes);
         }
-        telemetry.recordConnectorReplayEvent(STEP, SERVICE, event, STEP, null, attributes);
+        if (telemetry != null) {
+            telemetry.recordConnectorReplayEvent(STEP, SERVICE, event, STEP, null, attributes);
+        }
+    }
+
+    private static Attributes metricAttributes(String sourceName, String provider) {
+        return Attributes.builder()
+            .put(SOURCE, normalize(sourceName))
+            .put(PROVIDER, normalize(provider))
+            .build();
     }
 
     private static void put(Map<String, String> attributes, String key, String value) {
         if (value != null && !value.isBlank()) {
             attributes.put(key, value);
         }
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? "unknown" : value.trim();
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/telemetry/ObjectPublishReplayTelemetry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/telemetry/ObjectPublishReplayTelemetry.java
@@ -1,10 +1,17 @@
 package org.pipelineframework.telemetry;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
 import org.pipelineframework.objectpublish.ObjectPublishTelemetry;
 
 /**
@@ -15,30 +22,86 @@ public class ObjectPublishReplayTelemetry implements ObjectPublishTelemetry {
 
     private static final String STEP = "ObjectPublish";
     private static final String SERVICE = "ObjectPublishConnector";
+    private static final AttributeKey<String> TARGET = AttributeKey.stringKey("tpf.object_publish.target");
+    private static final AttributeKey<String> PROVIDER = AttributeKey.stringKey("tpf.object_publish.provider");
+
+    private final LongCounter groupedCounter;
+    private final LongCounter groupedItemsCounter;
+    private final LongCounter groupedGroupsCounter;
+    private final LongCounter publishedCounter;
+    private final LongCounter publishedBytesCounter;
+    private final LongCounter skippedCounter;
+    private final LongCounter failedCounter;
+    private final DoubleHistogram writeDurationHistogram;
 
     @Inject
     PipelineTelemetry telemetry;
 
+    public ObjectPublishReplayTelemetry() {
+        var meter = GlobalOpenTelemetry.getMeter("org.pipelineframework");
+        groupedCounter = meter.counterBuilder("tpf.object_publish.grouped.total")
+            .setDescription("Total Object Publish grouping operations")
+            .setUnit("events")
+            .build();
+        groupedItemsCounter = meter.counterBuilder("tpf.object_publish.grouped.items.total")
+            .setDescription("Total terminal items grouped for Object Publish")
+            .setUnit("items")
+            .build();
+        groupedGroupsCounter = meter.counterBuilder("tpf.object_publish.grouped.groups.total")
+            .setDescription("Total object groups produced for Object Publish")
+            .setUnit("groups")
+            .build();
+        publishedCounter = meter.counterBuilder("tpf.object_publish.published.total")
+            .setDescription("Total objects successfully published")
+            .setUnit("objects")
+            .build();
+        publishedBytesCounter = meter.counterBuilder("tpf.object_publish.published.bytes.total")
+            .setDescription("Total bytes successfully published")
+            .setUnit("bytes")
+            .build();
+        skippedCounter = meter.counterBuilder("tpf.object_publish.skipped.total")
+            .setDescription("Total empty Object Publish outputs skipped")
+            .setUnit("events")
+            .build();
+        failedCounter = meter.counterBuilder("tpf.object_publish.failed.total")
+            .setDescription("Total Object Publish failures")
+            .setUnit("objects")
+            .build();
+        writeDurationHistogram = meter.histogramBuilder("tpf.object_publish.write.duration")
+            .setDescription("Object Publish provider write duration")
+            .setUnit("ms")
+            .build();
+    }
+
     @Override
     public void grouped(String targetName, int itemCount, int groupCount) {
-        Map<String, String> attributes = new LinkedHashMap<>();
-        attributes.put("itemCount", Integer.toString(itemCount));
-        attributes.put("groupCount", Integer.toString(groupCount));
-        emit("object_publish_grouped", targetName, null, null, null, attributes);
+        Attributes metricAttributes = metricAttributes(targetName, null);
+        groupedCounter.add(1, metricAttributes);
+        groupedItemsCounter.add(Math.max(0, itemCount), metricAttributes);
+        groupedGroupsCounter.add(Math.max(0, groupCount), metricAttributes);
+        Map<String, String> replayAttributes = new LinkedHashMap<>();
+        replayAttributes.put("itemCount", Integer.toString(itemCount));
+        replayAttributes.put("groupCount", Integer.toString(groupCount));
+        emit("object_publish_grouped", targetName, null, null, null, replayAttributes);
     }
 
     @Override
     public void published(String targetName, String provider, String objectKey, long bytes) {
+        Attributes attributes = metricAttributes(targetName, provider);
+        publishedCounter.add(1, attributes);
+        publishedBytesCounter.add(Math.max(0L, bytes), attributes);
         emit("object_publish_published", targetName, provider, objectKey, Long.toString(bytes), Map.of());
     }
 
     @Override
     public void skipped(String targetName) {
+        skippedCounter.add(1, metricAttributes(targetName, null));
         emit("object_publish_skipped", targetName, null, null, null, Map.of());
     }
 
     @Override
     public void failed(String targetName, String provider, String objectKey, Throwable failure) {
+        failedCounter.add(1, metricAttributes(targetName, provider));
         Map<String, String> attributes = new LinkedHashMap<>();
         if (failure != null) {
             attributes.put("errorType", failure.getClass().getName());
@@ -47,6 +110,16 @@ public class ObjectPublishReplayTelemetry implements ObjectPublishTelemetry {
             }
         }
         emit("object_publish_failed", targetName, provider, objectKey, null, attributes);
+    }
+
+    @Override
+    public void writeDuration(String targetName, String provider, Duration duration) {
+        if (duration == null) {
+            return;
+        }
+        writeDurationHistogram.record(
+            Math.max(0.0d, duration.toNanos() / 1_000_000.0d),
+            metricAttributes(targetName, provider));
     }
 
     private void emit(
@@ -66,12 +139,27 @@ public class ObjectPublishReplayTelemetry implements ObjectPublishTelemetry {
         if (extraAttributes != null) {
             attributes.putAll(extraAttributes);
         }
-        telemetry.recordConnectorReplayEvent(STEP, SERVICE, event, null, STEP, attributes);
+        if (telemetry != null) {
+            telemetry.recordConnectorReplayEvent(STEP, SERVICE, event, null, STEP, attributes);
+        }
+    }
+
+    private static Attributes metricAttributes(String targetName, String provider) {
+        AttributesBuilder builder = Attributes.builder()
+            .put(TARGET, normalize(targetName));
+        if (provider != null && !provider.isBlank()) {
+            builder.put(PROVIDER, provider.trim());
+        }
+        return builder.build();
     }
 
     private static void put(Map<String, String> attributes, String key, String value) {
         if (value != null && !value.isBlank()) {
             attributes.put(key, value);
         }
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? "unknown" : value.trim();
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionMetricsTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitCompletionMetricsTest.java
@@ -1,0 +1,146 @@
+package org.pipelineframework.awaitable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AwaitCompletionMetricsTest {
+
+    private InMemoryMetricReader metricReader;
+    private SdkMeterProvider meterProvider;
+
+    @BeforeEach
+    void setUp() {
+        AwaitCompletionMetrics.resetForTest();
+        metricReader = InMemoryMetricReader.create();
+        meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+        GlobalOpenTelemetry.resetForTest();
+        GlobalOpenTelemetry.set(OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterProvider.close();
+        GlobalOpenTelemetry.resetForTest();
+        AwaitCompletionMetrics.resetForTest();
+    }
+
+    @Test
+    void recordsAwaitLifecycleMetricsWithoutHighCardinalityIds() {
+        AwaitInteractionRecord interaction = new AwaitInteractionRecord(
+            "tenant-1",
+            "exec-1",
+            "Await Payment Provider",
+            1,
+            "PaymentStatus",
+            "interaction-1",
+            "correlation-1",
+            "cause-1",
+            "idem-1",
+            1L,
+            AwaitInteractionStatus.COMPLETED,
+            "request",
+            "response",
+            "unit-1",
+            0,
+            null,
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            2_000L,
+            1_000L,
+            1_500L,
+            100_000L);
+        AwaitUnitRecord unit = new AwaitUnitRecord(
+            "tenant-1",
+            "unit-1",
+            "exec-1",
+            "Await Payment Provider",
+            1,
+            "ONE_TO_ONE",
+            1L,
+            AwaitUnitStatus.COMPLETED,
+            null,
+            1,
+            1,
+            Set.of("item:0"),
+            true,
+            1_000L,
+            1_750L,
+            100_000L);
+
+        AwaitCompletionMetrics.recordInteractionDispatched(interaction);
+        AwaitCompletionMetrics.recordUnitDispatchComplete(unit);
+        AwaitCompletionMetrics.recordCompletionAdmitted(interaction);
+        AwaitCompletionMetrics.recordItemCompleted(interaction, unit);
+        AwaitCompletionMetrics.recordEarlyCompletionHeld(interaction, unit);
+        AwaitCompletionMetrics.recordResumeReleased(unit);
+        AwaitCompletionMetrics.recordUnitTerminal(interaction, unit);
+        AwaitCompletionMetrics.recordDroppedCompletion("kafka", "terminal");
+
+        var metrics = metricReader.collectAllMetrics();
+        assertTrue(hasMetric(metrics, "tpf.await.interaction.dispatched.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.unit.dispatch_complete.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.completion.admitted.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.item.completed.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.completion.early_held.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.resume.released.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.unit.terminal.total"));
+        assertTrue(hasMetric(metrics, "tpf.await.completion.latency"));
+        assertTrue(hasMetric(metrics, "tpf.await.unit.duration"));
+        assertTrue(hasMetric(metrics, "tpf.await.completion.dropped.total"));
+        assertFalse(hasAttribute(metrics, "tpf.await.unit_id"));
+        assertFalse(hasAttribute(metrics, "tpf.await.interaction_id"));
+        assertFalse(hasAttribute(metrics, "tpf.await.execution_id"));
+    }
+
+    private static boolean hasMetric(Iterable<MetricData> metrics, String name) {
+        for (MetricData metric : metrics) {
+            if (name.equals(metric.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAttribute(Iterable<MetricData> metrics, String key) {
+        for (MetricData metric : metrics) {
+            switch (metric.getType()) {
+                case LONG_SUM -> {
+                    if (metric.getLongSumData().getPoints().stream()
+                        .map(point -> point.getAttributes())
+                        .anyMatch(attrs -> hasKey(attrs, key))) {
+                        return true;
+                    }
+                }
+                case HISTOGRAM -> {
+                    if (metric.getHistogramData().getPoints().stream()
+                        .map(point -> point.getAttributes())
+                        .anyMatch(attrs -> hasKey(attrs, key))) {
+                        return true;
+                    }
+                }
+                default -> {
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasKey(Attributes attributes, String key) {
+        return attributes.asMap().keySet().stream().anyMatch(attributeKey -> key.equals(attributeKey.getKey()));
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/objectingest/ObjectIngestMetricsTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/objectingest/ObjectIngestMetricsTest.java
@@ -1,0 +1,167 @@
+package org.pipelineframework.objectingest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
+import org.pipelineframework.config.boundary.PipelineObjectInputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectSourceConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfig;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+import org.pipelineframework.telemetry.ObjectIngestReplayTelemetry;
+
+class ObjectIngestMetricsTest {
+
+    private InMemoryMetricReader metricReader;
+    private SdkMeterProvider meterProvider;
+
+    @BeforeEach
+    void setUp() {
+        metricReader = InMemoryMetricReader.create();
+        meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+        GlobalOpenTelemetry.resetForTest();
+        GlobalOpenTelemetry.set(OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterProvider.close();
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void pollOnceRecordsLowCardinalityObjectIngestMetrics() {
+        PipelineObjectSourceConfig source = new PipelineObjectSourceConfig(
+            "documents",
+            "object",
+            "test",
+            Map.of(),
+            null,
+            null,
+            null,
+            null);
+        PipelineYamlConfig config = new PipelineYamlConfig(
+            "org.pipelineframework.objectingest",
+            "GRPC",
+            "COMPUTE",
+            List.of(),
+            Map.of("documents", source),
+            List.of(),
+            new PipelineInputBoundaryConfig(null, new PipelineObjectInputConfig(
+                "documents",
+                ObjectIngestRunnerTest.TestInput.class.getName(),
+                "TestInput",
+                ObjectIngestRunnerTest.TestMapper.class.getName())),
+            null);
+        ObjectIngestRunner runner = new ObjectIngestRunner(
+            config,
+            new ObjectSourceRegistry(List.of(new TwoItemProvider())),
+            (input, tenantId, idempotencyKey) -> Uni.createFrom().item(
+                idempotencyKey.endsWith("beta.txt:v1:etag-2")
+                    ? new RunAsyncAcceptedDto("execution-2", true, "/executions/execution-2", 1L)
+                    : new RunAsyncAcceptedDto("execution-1", false, "/executions/execution-1", 1L)),
+            new ObjectIngestReplayTelemetry());
+
+        runner.pollOnce();
+
+        var metrics = metricReader.collectAllMetrics();
+        assertTrue(hasMetric(metrics, "tpf.object_ingest.list.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_ingest.listed.objects.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_ingest.submitted.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_ingest.duplicate.total"));
+        assertFalse(hasAttribute(metrics, "key"));
+        assertFalse(hasAttribute(metrics, "execution_id"));
+    }
+
+    @Test
+    void pollOnceRecordsObjectIngestFailureMetrics() {
+        ObjectIngestRunner runner = new ObjectIngestRunner(
+            config(),
+            new ObjectSourceRegistry(List.of(new TwoItemProvider())),
+            (input, tenantId, idempotencyKey) -> Uni.createFrom().failure(new IllegalStateException("admission failed")),
+            new ObjectIngestReplayTelemetry());
+
+        ObjectIngestRunner.PollResult result = runner.pollOnce();
+
+        assertEquals(2, result.failed());
+        assertTrue(hasMetric(metricReader.collectAllMetrics(), "tpf.object_ingest.failed.total"));
+    }
+
+    private static boolean hasMetric(Iterable<MetricData> metrics, String name) {
+        for (MetricData metric : metrics) {
+            if (name.equals(metric.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAttribute(Iterable<MetricData> metrics, String key) {
+        for (MetricData metric : metrics) {
+            if (metric.getType() == io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_SUM
+                && metric.getLongSumData().getPoints().stream()
+                    .map(point -> point.getAttributes())
+                    .anyMatch(attrs -> hasKey(attrs, key))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasKey(Attributes attributes, String key) {
+        return attributes.asMap().keySet().stream().anyMatch(attributeKey -> key.equals(attributeKey.getKey()));
+    }
+
+    private static PipelineYamlConfig config() {
+        PipelineObjectSourceConfig source = new PipelineObjectSourceConfig(
+            "documents",
+            "object",
+            "test",
+            Map.of(),
+            null,
+            null,
+            null,
+            null);
+        return new PipelineYamlConfig(
+            "org.pipelineframework.objectingest",
+            "GRPC",
+            "COMPUTE",
+            List.of(),
+            Map.of("documents", source),
+            List.of(),
+            new PipelineInputBoundaryConfig(null, new PipelineObjectInputConfig(
+                "documents",
+                ObjectIngestRunnerTest.TestInput.class.getName(),
+                "TestInput",
+                ObjectIngestRunnerTest.TestMapper.class.getName())),
+            null);
+    }
+
+    private static final class TwoItemProvider implements ObjectSourceProvider {
+        @Override
+        public String providerName() {
+            return "test";
+        }
+
+        @Override
+        public List<ObjectSourceItem> list(PipelineObjectSourceConfig source, int limit) {
+            return List.of(
+                new ObjectSourceItem("test", "bucket", "alpha.txt", "v1", "etag-1", 12L, 100L, "text/plain", Map.of(), null, null),
+                new ObjectSourceItem("test", "bucket", "beta.txt", "v1", "etag-2", 12L, 100L, "text/plain", Map.of(), null, null));
+        }
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/objectingest/ObjectIngestRunnerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/objectingest/ObjectIngestRunnerTest.java
@@ -107,6 +107,43 @@ class ObjectIngestRunnerTest {
     }
 
     @Test
+    void pollOnceTreatsNullAdmissionAsFailure() {
+        PipelineObjectSourceConfig source = new PipelineObjectSourceConfig(
+            "documents",
+            "object",
+            "test",
+            Map.of(),
+            null,
+            null,
+            null,
+            null);
+        PipelineYamlConfig config = new PipelineYamlConfig(
+            "org.pipelineframework.objectingest",
+            "GRPC",
+            "COMPUTE",
+            List.of(),
+            Map.of("documents", source),
+            List.of(),
+            new PipelineInputBoundaryConfig(null, new PipelineObjectInputConfig(
+                "documents",
+                TestInput.class.getName(),
+                "TestInput",
+                TestMapper.class.getName())),
+            null);
+        ObjectIngestRunner runner = new ObjectIngestRunner(
+            config,
+            new ObjectSourceRegistry(List.of(new TestProvider())),
+            (input, tenantId, idempotencyKey) -> Uni.createFrom().nullItem(),
+            ObjectIngestTelemetry.NOOP);
+
+        ObjectIngestRunner.PollResult result = runner.pollOnce();
+
+        assertEquals(1, result.listed());
+        assertEquals(0, result.submitted());
+        assertEquals(1, result.failed());
+    }
+
+    @Test
     void executionKeyEscapesSourceName() {
         ObjectSnapshot snapshot = new ObjectSnapshot(
             "documents",

--- a/framework/runtime/src/test/java/org/pipelineframework/objectpublish/ObjectPublishMetricsTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/objectpublish/ObjectPublishMetricsTest.java
@@ -1,0 +1,218 @@
+package org.pipelineframework.objectpublish;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.boundary.PipelineObjectNamingConfig;
+import org.pipelineframework.config.boundary.PipelineObjectOutputConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishConfig;
+import org.pipelineframework.config.boundary.PipelineObjectPublishGroupingConfig;
+import org.pipelineframework.config.boundary.PipelineOutputBoundaryConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfig;
+import org.pipelineframework.telemetry.ObjectPublishReplayTelemetry;
+
+class ObjectPublishMetricsTest {
+
+    private InMemoryMetricReader metricReader;
+    private SdkMeterProvider meterProvider;
+
+    @BeforeEach
+    void setUp() {
+        metricReader = InMemoryMetricReader.create();
+        meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+        GlobalOpenTelemetry.resetForTest();
+        GlobalOpenTelemetry.set(OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterProvider.close();
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void publishItemsRecordsLowCardinalityObjectPublishMetrics() {
+        RecordingProvider provider = new RecordingProvider();
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(),
+            new ObjectTargetRegistry(List.of(provider)),
+            new ObjectPublishReplayTelemetry());
+
+        runner.publishItems(List.of(new TestOutput("a", "one"))).await().indefinitely();
+        runner.publishItems(List.of()).await().indefinitely();
+
+        var metrics = metricReader.collectAllMetrics();
+        assertTrue(hasMetric(metrics, "tpf.object_publish.grouped.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_publish.published.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_publish.published.bytes.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_publish.skipped.total"));
+        assertTrue(hasMetric(metrics, "tpf.object_publish.write.duration"));
+        assertFalse(hasAttribute(metrics, "key"));
+        assertFalse(hasAttribute(metrics, "object_key"));
+    }
+
+    @Test
+    void publishItemsRecordsObjectPublishFailureMetrics() {
+        ObjectPublishRunner runner = new ObjectPublishRunner(
+            config(),
+            new ObjectTargetRegistry(List.of(new FailingProvider())),
+            new ObjectPublishReplayTelemetry());
+
+        assertThrows(RuntimeException.class, () ->
+            runner.publishItems(List.of(new TestOutput("a", "one"))).await().indefinitely());
+
+        assertTrue(hasMetric(metricReader.collectAllMetrics(), "tpf.object_publish.failed.total"));
+    }
+
+    private static boolean hasMetric(Iterable<MetricData> metrics, String name) {
+        for (MetricData metric : metrics) {
+            if (name.equals(metric.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAttribute(Iterable<MetricData> metrics, String key) {
+        for (MetricData metric : metrics) {
+            switch (metric.getType()) {
+                case LONG_SUM -> {
+                    if (metric.getLongSumData().getPoints().stream()
+                        .map(point -> point.getAttributes())
+                        .anyMatch(attrs -> hasKey(attrs, key))) {
+                        return true;
+                    }
+                }
+                case HISTOGRAM -> {
+                    if (metric.getHistogramData().getPoints().stream()
+                        .map(point -> point.getAttributes())
+                        .anyMatch(attrs -> hasKey(attrs, key))) {
+                        return true;
+                    }
+                }
+                default -> {
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasKey(Attributes attributes, String key) {
+        return attributes.asMap().keySet().stream().anyMatch(attributeKey -> key.equals(attributeKey.getKey()));
+    }
+
+    private static PipelineYamlConfig config() {
+        PipelineObjectPublishConfig target = new PipelineObjectPublishConfig(
+            "results",
+            "object",
+            "test",
+            Map.of(),
+            new PipelineObjectNamingConfig("{groupKey}.out"),
+            null,
+            new PipelineObjectPublishGroupingConfig(32));
+        return new PipelineYamlConfig(
+            "org.pipelineframework.objectpublish",
+            "GRPC",
+            "COMPUTE",
+            List.of(),
+            Map.of(),
+            Map.of(),
+            Map.of("results", target),
+            List.of(),
+            null,
+            new PipelineOutputBoundaryConfig(null, new PipelineObjectOutputConfig(
+                "results",
+                TestOutput.class.getName(),
+                "TestOutput",
+                TestMapper.class.getName())));
+    }
+
+    public static final class TestMapper implements ObjectPublishMapper<TestOutput> {
+        @Override
+        public String groupKey(TestOutput item) {
+            return item.group();
+        }
+
+        @Override
+        public ObjectPayload render(String groupKey, List<TestOutput> items) {
+            String body = String.join("\n", items.stream().map(TestOutput::value).toList());
+            return new ObjectPayload(body.getBytes(StandardCharsets.UTF_8), "text/plain", Map.of());
+        }
+    }
+
+    record TestOutput(String group, String value) {
+    }
+
+    private static final class RecordingProvider implements ObjectTargetProvider {
+        private final List<ObjectWriteRequest> writes = new ArrayList<>();
+
+        @Override
+        public String providerName() {
+            return "test";
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteResult> write(ObjectWriteRequest request) {
+            writes.add(request);
+            return CompletableFuture.completedFuture(new ObjectWriteResult(null, request.bytes().length, request.checksum(), null));
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+            return CompletableFuture.completedFuture(new ObjectWriteSession() {
+                @Override
+                public CompletionStage<Void> write(ByteBuffer chunk) {
+                    return CompletableFuture.completedFuture(null);
+                }
+
+                @Override
+                public CompletionStage<ObjectWriteResult> close(ObjectWriteCloseRequest closeRequest) {
+                    return CompletableFuture.completedFuture(
+                        new ObjectWriteResult(null, closeRequest.bytes(), closeRequest.checksum(), null));
+                }
+
+                @Override
+                public CompletionStage<Void> abort(Throwable cause) {
+                    return CompletableFuture.completedFuture(null);
+                }
+            });
+        }
+    }
+
+    private static final class FailingProvider implements ObjectTargetProvider {
+        @Override
+        public String providerName() {
+            return "test";
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteResult> write(ObjectWriteRequest request) {
+            CompletableFuture<ObjectWriteResult> failure = new CompletableFuture<>();
+            failure.completeExceptionally(new IllegalStateException("publish failed"));
+            return failure;
+        }
+
+        @Override
+        public CompletionStage<ObjectWriteSession> open(ObjectWriteOpenRequest request) {
+            return CompletableFuture.failedFuture(new IllegalStateException("open failed"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the observability completion slice on top of PR #431:

- records low-cardinality Object Ingest/Object Publish metrics through the existing telemetry interfaces
- adds await-gate metrics for dispatch, completion admission, early-held completions, item completion, resume release, and terminal units
- keeps high-cardinality object keys and await ids in replay events rather than metric labels
- adds CSV Payments Grafana panels and README/runbook/docs updates for connector-first operational proof
- adds runtime metric tests using `InMemoryMetricReader`

## Base

Stacked on #431 (`codex/csv-object-io-migration`). This PR should be retargeted to `main` only after #431 lands.

## Validation

- `./mvnw -N -Dmaven.repo.local="$PWD/.m2/repository" -DskipTests install`
- `./mvnw -f framework/pom.xml -Dmaven.repo.local="$PWD/.m2/repository" -DskipTests install`
- `./mvnw -f framework/pom.xml -Dmaven.repo.local="$PWD/.m2/repository" -pl runtime -Dtest=ObjectIngestMetricsTest,ObjectPublishMetricsTest,AwaitCompletionMetricsTest,ObjectIngestRunnerTest,ObjectPublishRunnerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -Dmaven.repo.local="$PWD/.m2/repository" -pl runtime -Dtest=QueueAsyncCoordinatorTest,AwaitCoordinatorTest,AwaitCompletionMetricsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -Dmaven.repo.local="$PWD/.m2/repository" -pl runtime test`
- `./mvnw -f framework/pom.xml -Dmaven.repo.local="$PWD/.m2/repository" -pl runtime -Dtest=ObjectIngestRunnerTest,ObjectIngestMetricsTest,ObjectPublishMetricsTest,AwaitCompletionMetricsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `npm --prefix docs test`
- `npm --prefix docs run build`
- stale `/guide` link scan excluding redirects/version snapshots
- `git diff --check`
- local `cr review --agent --base origin/pr/431 --config ./AGENTS.md`; fixed all 5 valid findings

Note: I intentionally stopped a second local CR pass because it was not required and slows down PR creation; GitHub CodeRabbit will run its normal review on the PR.
