### PR TITLE
Refactor queue async semantic flows

### DIFF
--- a/docs/evolve/await-unit-runtime/index.md
+++ b/docs/evolve/await-unit-runtime/index.md
@@ -1,4 +1,4 @@
-# Await Unit Runtime
+# Await Unit Flow Model
 
 Await units are the durable suspend/resume model for `kind: await` steps. The unit is the interaction boundary TPF owns: it records what was dispatched, what completion is required, and what payload should be replayed when the owning execution resumes.
 
@@ -63,6 +63,13 @@ classDiagram
     class PipelineExecutionService
     class PipelineRunner
     class QueueAsyncCoordinator
+    class QueueAsyncExecutionFlow
+    class AwaitCompletionFlow
+    class ItemContinuationFlow
+    class TransitionCommitFlow
+    class TerminalPublicationFlow
+    class ItemizedAwaitStream
+    class LiveAwaitSession
     class AwaitStepSupport
     class AwaitCoordinator
     class AwaitUnitStore
@@ -74,16 +81,41 @@ classDiagram
     AwaitUnitRecord "1" --> "1..n" AwaitInteractionRecord : owns
     PipelineExecutionService --> PipelineRunner : run / resume steps
     PipelineRunner --> AwaitStepSupport : execute generated await step
+    AwaitStepSupport --> ItemizedAwaitStream : stream await dispatch
     AwaitStepSupport --> AwaitCoordinator : create / dispatch unit
+    ItemizedAwaitStream --> LiveAwaitSession : open live stream
     PipelineExecutionService --> QueueAsyncCoordinator : async execution lifecycle
-    QueueAsyncCoordinator --> AwaitCoordinator : complete / resume
-    QueueAsyncCoordinator --> ExecutionStateStore : wait / resume execution
+    QueueAsyncCoordinator --> QueueAsyncExecutionFlow : process work item
+    QueueAsyncCoordinator --> AwaitCompletionFlow : route completions
+    QueueAsyncCoordinator --> ItemContinuationFlow : item continuations
+    QueueAsyncCoordinator --> TransitionCommitFlow : commit worker outcome
+    AwaitCompletionFlow --> AwaitCoordinator : complete / record
+    AwaitCompletionFlow --> LiveAwaitSession : signal accepted item
+    AwaitCompletionFlow --> ItemContinuationFlow : durable fallback
+    ItemContinuationFlow --> ExecutionStateStore : child records / parent release
+    TransitionCommitFlow --> ExecutionStateStore : wait / succeed / fail
+    TransitionCommitFlow --> ItemContinuationFlow : release already-completed items
+    TransitionCommitFlow --> TerminalPublicationFlow : publish-before-success barrier
     AwaitCoordinator --> AwaitUnitStore
     AwaitCoordinator --> AwaitInteractionStore
     AwaitCoordinator --> AwaitTransportAdapter : dispatch
 ```
 
 `AwaitUnitRecord` is the source of truth for completion of the authored await boundary. `AwaitInteractionRecord` is the transport-facing projection. That distinction prevents execution state, dispatch strategy, and step cardinality from collapsing into one ambiguous record.
+
+The current queue-async implementation keeps `QueueAsyncCoordinator` as the facade for API entrypoints, worker lifecycle, provider wiring, and sweeper startup. The semantic behavior is named as flows over immutable facts:
+
+1. `QueueAsyncExecutionFlow` claims work and composes the transition worker pipeline as a `Uni`.
+2. `ItemizedAwaitStream` owns the live `Multi` shape for stream await dispatch and completion emission.
+3. `AwaitCompletionFlow` records completions, then chooses live-session admission or durable fallback.
+4. `ItemContinuationFlow` owns durable item continuation fallback and ordered parent release.
+5. `TransitionCommitFlow` commits completed, suspended, and failed worker outcomes.
+6. `TerminalPublicationFlow` owns checkpoint and Object Publish publish-before-success effects.
+7. `LiveAwaitSession` owns demand, duplicate handling, terminal delivery, and cancellation as an immutable state machine.
+
+Small records such as `AwaitCompletionOutcome`, `TransitionCommitPlan`, and `TerminalPublicationPlan` describe decisions. Store writes, dispatch, publication, and telemetry remain interpreted effects at the boundary.
+
+Distributed correctness still comes from the central store and versioned writes. A live await session is process-local optimization: if a completion lands on the process that owns the live stream, it can be emitted by demand after the durable completion record is written. If it lands elsewhere, or if the live stream is gone, the same durable facts drive item continuation fallback.
 
 ## CSV Payments Applied Model
 

--- a/docs/evolve/await-unit-runtime/patterns.md
+++ b/docs/evolve/await-unit-runtime/patterns.md
@@ -9,10 +9,41 @@ The await unit runtime is not a new transport. It is a persistence and replay mo
 | Unit of Work | `AwaitUnitRecord` | One authored await boundary has one durable completion contract. |
 | Durable continuation | `ExecutionRecord.awaitUnitId` | The execution parks without embedding response payload state in the execution row. |
 | Adapter | `AwaitTransportAdapter` | `interaction-api`, `webhook`, and `kafka` differ at dispatch/admission edges, not in core resume semantics. |
-| State machine | unit and interaction statuses | Runtime transitions are explicit and terminal states are guarded. |
+| State machine | unit and interaction statuses | State transitions are explicit and terminal states are guarded. |
 | Optimistic concurrency | versioned stores and conditional updates | Concurrent dispatch/completion cannot silently overwrite progress. |
 | Lease-based recovery | `QUEUE_ASYNC` execution claiming | Worker failure is handled by re-claiming and replaying safe transitions. |
 | Idempotent admission | idempotency and correlation lookups | Duplicate completions resolve to the same logical interaction where possible. |
+
+## Semantic Flow Objects
+
+The queue-async refactor names the flows and immutable decisions that were previously buried inside the coordinator.
+
+| Owner | Owns | Does not own |
+| --- | --- | --- |
+| `QueueAsyncCoordinator` | API entrypoints, worker lifecycle, provider wiring, sweeper startup | completion routing, transition commit decisions |
+| `QueueAsyncExecutionFlow` | work-item `Uni` chain: admission, lease claim, transition command, worker execution, commit routing | store semantics, await completion admission, publication mechanics |
+| `ItemizedAwaitStream` | live stream-await `Multi`: demand-bounded dispatch, live completion emission, live session lifecycle | durable fallback, child continuation records, success commit |
+| `AwaitCompletionFlow` | completion normalization, durable recording, live-session signalling, durable fallback routing | step execution, provider dispatch, terminal publication |
+| `ItemContinuationFlow` | item-continuation readiness gates, durable fallback dispatch, retry/failure handling, child continuation records, ordered parent release | live stream demand, non-item await resume, terminal publication |
+| `TransitionCommitFlow` | completed/suspended/failed transition commit ordering, result-shape validation, success/wait/failure store commits | await completion admission, live stream demand, terminal publication mechanics |
+| `TerminalPublicationFlow` | checkpoint handoff, terminal Object Publish, portable output decoding, publish-before-success effects | success/wait/failure store commits, await completion admission |
+| `LiveAwaitSession` | immutable live-session state, subscriber readiness, demand, duplicate completion handling, terminal stream signals | stores, dispatchers, object writers, telemetry policy |
+
+The split is useful only because each owner has a narrow decision model. `AwaitCompletionOutcome`, `TransitionCommitPlan`, and `TerminalPublicationPlan` are immutable records, not service calls. Stores, dispatchers, publishers, and metrics are effects at the boundary; they are not hidden inside the state machine.
+
+The naming matters. A flow object composes `Uni`/`Multi` work and interprets plans. It should not become a procedural bag of helpers. A plan or outcome object is data: it says what should happen, but it does not mutate a store, call a dispatcher, publish an object, or emit telemetry.
+
+## Distributed Semantics
+
+Queue-async is allowed to run on more than one process. The central store is the distributed source of truth:
+
+1. execution records are claimed by lease and versioned writes,
+2. await completions are recorded idempotently by interaction/unit facts,
+3. stale execution versions lose optimistic-concurrency races,
+4. duplicate completions either signal the same live session once or become record-only no-ops,
+5. terminal publication still happens before success commit.
+
+`LiveAwaitSession` is not distributed in this slice. It is a process-local fast path for a stream that is still alive. When a completion lands on a different node, or when the stream has already suspended or disappeared, `AwaitCompletionFlow` falls back to durable item continuations guarded by `dispatchComplete` and parent `WAITING_EXTERNAL`.
 
 ## Why The Unit Model Fixed The Design
 

--- a/docs/evolve/await-unit-runtime/sequences.md
+++ b/docs/evolve/await-unit-runtime/sequences.md
@@ -2,6 +2,43 @@
 
 These diagrams show how the await unit model parks and resumes `QUEUE_ASYNC` executions.
 
+`QueueAsyncCoordinator` is still the entrypoint and lifecycle facade. The diagrams below name the internal semantic owners when the distinction matters: `QueueAsyncExecutionFlow` composes claimed work as a `Uni`, `ItemizedAwaitStream` owns the stream-await `Multi`, `AwaitCompletionFlow` routes completions, `LiveAwaitSession` owns live demand and stream terminal signals, `ItemContinuationFlow` owns durable item fallback, `TransitionCommitFlow` commits suspended or completed transitions, and `TerminalPublicationFlow` owns publish-before-success effects.
+
+## Queue-Async Transition Flow
+
+Processing one execution work item is a reactive flow over durable facts. The coordinator admits and delegates; the flow claims the execution, prepares the transition command, invokes the worker, and passes the result to commit. The immutable `TransitionCommitPlan` decides whether the result is success, wait, or failure before effects are interpreted.
+
+```mermaid
+sequenceDiagram
+    participant Dispatcher as WorkDispatcher
+    participant Facade as QueueAsyncCoordinator facade
+    participant Flow as QueueAsyncExecutionFlow
+    participant ExecStore as ExecutionStateStore
+    participant Worker as PipelineTransitionWorker
+    participant Commit as TransitionCommitFlow
+    participant Terminal as TerminalPublicationFlow
+
+    Dispatcher->>Facade: execution work item
+    Facade->>Flow: processExecutionWorkItem(item)
+    Flow->>Flow: admit worker + tenant quota
+    Flow->>ExecStore: claimLease(executionId, workerId)
+    ExecStore-->>Flow: claimed ExecutionRecord(version)
+    Flow->>Flow: prepare TransitionCommandEnvelope
+    Flow->>Worker: executeTransition(command)
+    Worker-->>Flow: TransitionResultEnvelope
+    Flow->>Commit: commit(record, result)
+    Commit->>Commit: TransitionCommitPlan.from(record, result)
+    alt completed
+      Commit->>Terminal: publishBeforeSuccess(record, result)
+      Terminal-->>Commit: publication complete
+      Commit->>ExecStore: markSucceeded(expectedVersion)
+    else waiting external
+      Commit->>ExecStore: mark WAITING_EXTERNAL(awaitUnitId)
+    else failed
+      Commit->>ExecStore: retry / fail / DLQ policy
+    end
+```
+
 ## Unary Await
 
 ```mermaid
@@ -32,42 +69,52 @@ Suspension is normal control flow. It should not be logged as a failed step or r
 
 `ONE_TO_ONE` over a `Multi` is a stream of unary awaits inside one owning unit. This is the model used by `csv-payments`: each `PaymentRecord` is one input unit and each provider completion is one output unit.
 
-For brokered await transports, the preferred queue-async path is live. `AwaitStepSupport` opens a live await session for the unit, source dispatch is bounded by the configured in-flight window, and each completion is recorded before it is emitted to the resumed suffix. If that live session is unavailable, the coordinator falls back to durable item continuations.
+For brokered await transports, the preferred queue-async path is live. `AwaitStepSupport` delegates stream await work to `ItemizedAwaitStream`, which opens a live await session for the unit. Source dispatch is bounded by the configured in-flight window, and each completion is recorded before it is emitted to the resumed suffix. If that live session is unavailable, the coordinator falls back to durable item continuations.
 
 ```mermaid
 sequenceDiagram
     participant Source as Upstream Multi
     participant Step as AwaitStepSupport
+    participant Stream as ItemizedAwaitStream
     participant Coord as AwaitCoordinator
     participant Adapter as AwaitTransportAdapter
     participant UnitStore as AwaitUnitStore
-    participant Queue as QueueAsyncCoordinator
+    participant Queue as QueueAsyncCoordinator facade
+    participant Completion as AwaitCompletionFlow
     participant Live as LiveAwaitSession
+    participant Items as ItemContinuationFlow
     participant Suffix as Item continuation suffix
+    participant Commit as TransitionCommitFlow
     participant ExecStore as ExecutionStateStore
 
     Source->>Step: item 0
-    Step->>Coord: createOrGetItem(unitId, itemIndex=0)
+    Step->>Stream: await item 0
+    Stream->>Coord: createOrGetItem(unitId, itemIndex=0)
     Coord->>Adapter: dispatch item 0
     Source->>Step: item 1
-    Step->>Coord: createOrGetItem(unitId, itemIndex=1)
+    Step->>Stream: await item 1
+    Stream->>Coord: createOrGetItem(unitId, itemIndex=1)
     Coord->>Adapter: dispatch item 1
     Adapter-->>Coord: complete item 1
-    Coord->>UnitStore: recordItemCompleted
-    Coord->>Queue: signal completion
-    Queue->>Live: accept item 1 after durable record
+    Coord->>Queue: complete await interaction
+    Queue->>Completion: route completion
+    Completion->>UnitStore: recordItemCompleted
+    Completion->>Live: accept item 1 after durable record
     Live->>Suffix: emit item 1 when downstream requests
     Adapter-->>Coord: complete item 0
-    Coord->>UnitStore: recordItemCompleted -> COMPLETED
-    Coord->>Queue: signal completion
-    Queue->>Live: accept item 0 after durable record
+    Coord->>Queue: complete await interaction
+    Queue->>Completion: route completion
+    Completion->>UnitStore: recordItemCompleted -> COMPLETED
+    Completion->>Live: accept item 0 after durable record
     Live->>Suffix: emit item 0 when downstream requests
-    Step->>UnitStore: markDispatchComplete(expectedItemCount=2)
+    Stream->>UnitStore: markDispatchComplete(expectedItemCount=2)
     alt live session unavailable
-      Step-->>ExecStore: park execution with awaitUnitId
-      Queue->>UnitStore: require dispatchComplete
-      Queue->>ExecStore: require parent WAITING_EXTERNAL(awaitUnitId)
-      Queue->>Suffix: dispatch durable item continuation
+      Stream-->>Commit: suspend parent execution(awaitUnitId)
+      Commit->>ExecStore: mark WAITING_EXTERNAL(awaitUnitId)
+      Completion->>Items: durable item fallback
+      Items->>UnitStore: require dispatchComplete
+      Items->>ExecStore: require parent WAITING_EXTERNAL(awaitUnitId)
+      Items->>Suffix: dispatch durable item continuation
     end
 ```
 
@@ -107,10 +154,15 @@ sequenceDiagram
     participant Kafka as Kafka broker
     participant Provider as payments-processing-svc
     participant Exec as PipelineExecutionService
-    participant Queue as QueueAsyncCoordinator
+    participant Queue as QueueAsyncCoordinator facade
+    participant Completion as AwaitCompletionFlow
     participant Live as LiveAwaitSession
+    participant Items as ItemContinuationFlow
     participant Status as Process Payment Status
     participant Publish as Object Publish
+    participant Commit as TransitionCommitFlow
+    participant Terminal as TerminalPublicationFlow
+    participant Store as ExecutionStateStore
 
     Input-->>Runner: PaymentRecord item 0
     Runner->>Await: execute item 0
@@ -120,8 +172,9 @@ sequenceDiagram
     Provider-->>Kafka: PaymentStatus item 0
     Kafka-->>Exec: complete by correlationId
     Exec->>Queue: complete await interaction
-    Queue->>AwaitCoord: record item 0 completed
-    Queue->>Live: signal item 0 after durable record
+    Queue->>Completion: route completion
+    Completion->>AwaitCoord: record item 0 completed
+    Completion->>Live: signal item 0 after durable record
     Live->>Status: emit item 0 when requested
     Status-->>Publish: PaymentOutput item 0 chunk
 
@@ -134,39 +187,53 @@ sequenceDiagram
     Provider-->>Kafka: PaymentStatus item 1
     Kafka-->>Exec: complete by correlationId
     Exec->>Queue: complete await interaction
-    Queue->>AwaitCoord: record item 1 completed
-    Queue->>Live: signal item 1 after durable record
+    Queue->>Completion: route completion
+    Completion->>AwaitCoord: record item 1 completed
+    Completion->>Live: signal item 1 after durable record
     Live->>Status: emit item 1 when requested
     Status-->>Publish: PaymentOutput item 1 chunk
 
     alt live session lost or worker restarted
       Await->>AwaitCoord: mark dispatchComplete(expectedItemCount=2)
-      Await-->>Queue: suspend parent execution(awaitUnitId)
-      Queue->>Queue: mark WAITING_EXTERNAL(awaitUnitId)
-      Queue->>Status: dispatch durable item continuations
+      Await-->>Commit: suspend parent execution(awaitUnitId)
+      Commit->>Store: mark WAITING_EXTERNAL(awaitUnitId)
+      Commit->>Items: release already-completed items
+      Completion->>Items: dispatch later completions
+      Items->>Status: dispatch durable item continuations
     end
 
-    Publish-->>Queue: target sessions closed
-    Queue->>Queue: mark execution succeeded
+    Commit->>Terminal: publishBeforeSuccess(result)
+    Terminal->>Publish: complete target sessions
+    Publish-->>Terminal: target sessions closed
+    Terminal-->>Commit: publication complete
+    Commit->>Store: mark execution succeeded
 ```
 
 The model is itemized until the next aggregate or terminal boundary. If an authored downstream step is `MANY_TO_ONE` or `MANY_TO_MANY`, durable fallback resumes the parent execution there with the collected ordered item outputs. If the suffix remains itemized through the terminal output, Object Publish owns final grouping and object writes.
 
 ```mermaid
 sequenceDiagram
-    participant Queue as QueueAsyncCoordinator
+    participant Queue as QueueAsyncCoordinator facade
+    participant Completion as AwaitCompletionFlow
+    participant Items as ItemContinuationFlow
     participant AwaitCoord as AwaitCoordinator
     participant ExecStore as ExecutionStateStore
     participant Status as Process Payment Status
+    participant Commit as TransitionCommitFlow
+    participant Terminal as TerminalPublicationFlow
     participant Publish as Object Publish
 
-    Queue->>AwaitCoord: completion already recorded, no live session
-    Queue->>ExecStore: require WAITING_EXTERNAL(awaitUnitId)
-    Queue->>AwaitCoord: require dispatchComplete
-    Queue->>Status: continue item 1
-    Status-->>Queue: PaymentOutput item 1
-    Queue->>Publish: publish terminal output before success
-    Queue->>Queue: mark execution succeeded
+    Queue->>Completion: completion already recorded, no live session
+    Completion->>Items: durable item fallback
+    Items->>ExecStore: require WAITING_EXTERNAL(awaitUnitId)
+    Items->>AwaitCoord: require dispatchComplete
+    Items->>Status: continue item 1
+    Status-->>Commit: PaymentOutput item 1
+    Commit->>Terminal: publishBeforeSuccess(result)
+    Terminal->>Publish: publish terminal output
+    Publish-->>Terminal: publication complete
+    Terminal-->>Commit: success barrier passed
+    Commit->>ExecStore: mark execution succeeded
 ```
 
 ## Aggregate Unit

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitCompletionFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitCompletionFlow.java
@@ -1,0 +1,151 @@
+package org.pipelineframework;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitCompletionAdmissionFailures;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCompletionTenantMismatchException;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitLiveCompletionRegistry;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+
+final class AwaitCompletionFlow {
+
+    private final AwaitCoordinator awaitCoordinator;
+    private final AwaitLiveCompletionRegistry liveCompletionRegistry;
+    private final Effects effects;
+
+    AwaitCompletionFlow(
+        AwaitCoordinator awaitCoordinator,
+        AwaitLiveCompletionRegistry liveCompletionRegistry,
+        Effects effects) {
+        this.awaitCoordinator = awaitCoordinator;
+        this.liveCompletionRegistry = liveCompletionRegistry;
+        this.effects = effects;
+    }
+
+    Uni<AwaitCompletionResult> complete(
+        QueueAsyncCommand.CompleteAwait command,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        AwaitCompletionCommand normalized = command.command();
+        return awaitCoordinator.complete(normalized)
+            .onFailure(failure -> !AwaitCompletionAdmissionFailures.isDeterministic(failure))
+            .transform(failure -> new IllegalStateException(
+                "Failed completing await interaction tenant=" + normalized.tenantId()
+                    + ", interactionId=" + normalized.interactionId()
+                    + ", correlationId=" + normalized.correlationId(),
+                failure))
+            .onItem().transformToUni(result -> validateTenant(result, normalized)
+                .onItem().transformToUni(validated -> awaitCoordinator
+                    .recordCompletion(validated.record(), normalized.nowEpochMs())
+                    .onItem().transformToUni(unit -> interpretLiveSignal(
+                        new AwaitCompletionOutcome.SignalLiveSession(validated.record(), unit))
+                        .onFailure().recoverWithItem(false)
+                        .onItem().transformToUni(liveAccepted -> liveAccepted
+                            ? Uni.createFrom().item(validated)
+                            : handleRecordedCompletion(
+                                validated,
+                                unit,
+                                itemContinuationHandler,
+                                normalized.nowEpochMs())))));
+    }
+
+    private Uni<AwaitCompletionResult> handleRecordedCompletion(
+        AwaitCompletionResult validated,
+        AwaitUnitRecord unit,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        long nowEpochMs) {
+        AwaitInteractionRecord record = validated.record();
+        if (ItemContinuationFlow.usesItemContinuations(record, unit)) {
+            return effects.itemContinuationReady(record, unit)
+                .onItem().invoke(ready -> interpretRecordedItemOutcome(
+                    itemCompletionOutcome(record, unit, ready, nowEpochMs),
+                    itemContinuationHandler,
+                    record,
+                    unit))
+                .replaceWith(validated);
+        }
+        return interpretAggregateOutcome(aggregateCompletionOutcome(record, unit, nowEpochMs)).replaceWith(validated);
+    }
+
+    static AwaitCompletionOutcome itemCompletionOutcome(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        boolean ready,
+        long nowEpochMs) {
+        return ready
+            ? new AwaitCompletionOutcome.DispatchItemContinuation(record, unit, nowEpochMs)
+            : new AwaitCompletionOutcome.RecordOnly("itemized-await-parent-not-ready");
+    }
+
+    static AwaitCompletionOutcome aggregateCompletionOutcome(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        long nowEpochMs) {
+        return unit.status() == AwaitUnitStatus.COMPLETED
+            ? new AwaitCompletionOutcome.ReleaseParent(record, unit, nowEpochMs)
+            : new AwaitCompletionOutcome.RecordOnly("await-unit-not-complete");
+    }
+
+    private Uni<Boolean> interpretLiveSignal(AwaitCompletionOutcome.SignalLiveSession decision) {
+        if (liveCompletionRegistry == null) {
+            return Uni.createFrom().item(false);
+        }
+        return liveCompletionRegistry.signal(decision.record(), decision.unit());
+    }
+
+    private void interpretRecordedItemOutcome(
+        AwaitCompletionOutcome outcome,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit) {
+        switch (outcome) {
+            case AwaitCompletionOutcome.DispatchItemContinuation dispatch -> effects.dispatchItemContinuation(
+                dispatch.record(),
+                dispatch.unit(),
+                itemContinuationHandler,
+                dispatch.nowEpochMs());
+            case AwaitCompletionOutcome.RecordOnly ignored -> effects.recordEarlyCompletionHeld(record, unit);
+            default -> throw new IllegalStateException("Unsupported await item outcome: " + outcome);
+        }
+    }
+
+    private Uni<Void> interpretAggregateOutcome(AwaitCompletionOutcome outcome) {
+        return switch (outcome) {
+            case AwaitCompletionOutcome.ReleaseParent release -> effects.releaseAwaitResume(
+                release.record(),
+                release.unit().unitId(),
+                release.nowEpochMs());
+            case AwaitCompletionOutcome.RecordOnly ignored -> Uni.createFrom().voidItem();
+            default -> Uni.createFrom().failure(new IllegalStateException(
+                "Unsupported aggregate await outcome: " + outcome));
+        };
+    }
+
+    private Uni<AwaitCompletionResult> validateTenant(
+        AwaitCompletionResult result,
+        AwaitCompletionCommand command) {
+        if (!command.tenantId().equals(result.record().tenantId())) {
+            return Uni.createFrom().failure(new AwaitCompletionTenantMismatchException(
+                "Await completion tenant mismatch: command tenant=" + command.tenantId()
+                    + ", record tenant=" + result.record().tenantId()));
+        }
+        return Uni.createFrom().item(result);
+    }
+
+    interface Effects {
+        Uni<Boolean> itemContinuationReady(AwaitInteractionRecord record, AwaitUnitRecord unit);
+
+        void dispatchItemContinuation(
+            AwaitInteractionRecord record,
+            AwaitUnitRecord unit,
+            AwaitItemContinuationHandler itemContinuationHandler,
+            long nowEpochMs);
+
+        Uni<Void> releaseAwaitResume(AwaitInteractionRecord record, String awaitUnitId, long nowEpochMs);
+
+        void recordEarlyCompletionHeld(AwaitInteractionRecord record, AwaitUnitRecord unit);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitCompletionOutcome.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitCompletionOutcome.java
@@ -1,0 +1,27 @@
+package org.pipelineframework;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+
+sealed interface AwaitCompletionOutcome
+    permits AwaitCompletionOutcome.RecordOnly,
+    AwaitCompletionOutcome.SignalLiveSession,
+    AwaitCompletionOutcome.DispatchItemContinuation,
+    AwaitCompletionOutcome.ReleaseParent {
+
+    record RecordOnly(String reason) implements AwaitCompletionOutcome {
+    }
+
+    record SignalLiveSession(AwaitInteractionRecord record, AwaitUnitRecord unit) implements AwaitCompletionOutcome {
+    }
+
+    record DispatchItemContinuation(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        long nowEpochMs) implements AwaitCompletionOutcome {
+    }
+
+    record ReleaseParent(AwaitInteractionRecord record, AwaitUnitRecord unit, long nowEpochMs)
+        implements AwaitCompletionOutcome {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ItemContinuationFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ItemContinuationFlow.java
@@ -1,0 +1,472 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCompletionMetrics;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
+
+final class ItemContinuationFlow {
+
+    private static final Logger LOG = Logger.getLogger(ItemContinuationFlow.class);
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long RETRY_BASE_MS = 100L;
+    private static final String ONE_TO_ONE_CARDINALITY = "ONE_TO_ONE";
+
+    private final AwaitCoordinator awaitCoordinator;
+    private final ExecutionStateStore executionStateStore;
+    private final WorkDispatcher workDispatcher;
+    private final TransitionWorkerExecutor transitionWorkerExecutor;
+    private final Scheduler scheduler;
+    private final Executor continuationExecutor;
+    private final Supplier<Duration> saturatedDelay;
+    private final AwaitItemContinuationHandler noopHandler;
+    private final NonItemAwaitReleaser nonItemAwaitReleaser;
+    private final Effects effects;
+
+    ItemContinuationFlow(
+        AwaitCoordinator awaitCoordinator,
+        ExecutionStateStore executionStateStore,
+        WorkDispatcher workDispatcher,
+        TransitionWorkerExecutor transitionWorkerExecutor,
+        Scheduler scheduler,
+        Executor continuationExecutor,
+        Supplier<Duration> saturatedDelay,
+        AwaitItemContinuationHandler noopHandler,
+        NonItemAwaitReleaser nonItemAwaitReleaser,
+        Effects effects) {
+        this.awaitCoordinator = awaitCoordinator;
+        this.executionStateStore = executionStateStore;
+        this.workDispatcher = workDispatcher;
+        this.transitionWorkerExecutor = transitionWorkerExecutor;
+        this.scheduler = scheduler;
+        this.continuationExecutor = continuationExecutor;
+        this.saturatedDelay = saturatedDelay;
+        this.noopHandler = noopHandler;
+        this.nonItemAwaitReleaser = nonItemAwaitReleaser;
+        this.effects = effects;
+    }
+
+    Uni<Boolean> itemContinuationReady(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        if (record == null || unit == null || !unit.dispatchComplete()) {
+            return Uni.createFrom().item(false);
+        }
+        Uni<Optional<ExecutionRecord<Object, Object>>> parentLookup =
+            executionStateStore.getExecution(record.tenantId(), record.executionId());
+        if (parentLookup == null) {
+            return Uni.createFrom().item(false);
+        }
+        return parentLookup.onItem().transform(parent -> itemContinuationReady(parent, unit));
+    }
+
+    void dispatchItemContinuation(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        long nowEpochMs) {
+        if (itemContinuationHandler == null || itemContinuationHandler == noopHandler) {
+            return;
+        }
+        dispatchItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, 1);
+    }
+
+    Uni<Void> releaseAlreadyCompletedAwaitUnit(
+        ExecutionRecord<Object, Object> record,
+        TransitionAwaitSuspension suspended,
+        long nowEpochMs,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        return awaitCoordinator.getUnit(record.tenantId(), suspended.unitId())
+            .onItem().transformToUni(unit -> {
+                if (unit == null || unit.status() != AwaitUnitStatus.COMPLETED) {
+                    return unit != null && usesItemContinuations(unit)
+                        ? dispatchCompletedAwaitItemContinuations(record, unit, itemContinuationHandler, nowEpochMs)
+                        : Uni.createFrom().voidItem();
+                }
+                if (usesItemContinuations(unit)) {
+                    return dispatchCompletedAwaitItemContinuations(record, unit, itemContinuationHandler, nowEpochMs)
+                        .onItem().transformToUni(ignored -> itemContinuationHandler.releaseAwaitParentIfReady(
+                            record,
+                            unit,
+                            suspended.stepIndex() + 1,
+                            nowEpochMs));
+                }
+                return nonItemAwaitReleaser.release(record, unit, suspended, nowEpochMs);
+            });
+    }
+
+    Uni<Void> recordAwaitItemContinuation(
+        AwaitInteractionRecord interaction,
+        AwaitUnitRecord unit,
+        int aggregateStepIndex,
+        ExecutionInputSnapshot continuationInput,
+        List<?> segmentOutputs,
+        long nowEpochMs) {
+        if (!usesItemContinuations(interaction, unit)) {
+            return Uni.createFrom().voidItem();
+        }
+        if (interaction.itemIndex() == null) {
+            return Uni.createFrom().failure(new IllegalArgumentException("Itemized await continuation requires itemIndex"));
+        }
+        if (continuationInput == null) {
+            return Uni.createFrom().failure(new IllegalArgumentException(
+                "Itemized await continuation requires normalized continuation input"));
+        }
+        ExecutionInputSnapshot normalizedInput = copyInputSnapshot(continuationInput);
+        return executionStateStore.getExecution(interaction.tenantId(), interaction.executionId())
+            .onItem().transformToUni(parent -> {
+                if (parent.isEmpty()) {
+                    return Uni.createFrom().voidItem();
+                }
+                ExecutionRecord<Object, Object> parentRecord = parent.get();
+                String childKey = awaitItemContinuationKey(parentRecord, unit, interaction.itemIndex());
+                return executionStateStore.getExecutionByKey(interaction.tenantId(), childKey)
+                    .onItem().transformToUni(existing -> {
+                        if (existing.isPresent() && existing.get().status() == ExecutionStatus.SUCCEEDED) {
+                            return releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs);
+                        }
+                        long ttl = parentRecord.ttlEpochS();
+                        ExecutionCreateCommand create = new ExecutionCreateCommand(
+                            interaction.tenantId(),
+                            childKey,
+                            parentRecord.pipelineId(),
+                            parentRecord.contractVersion(),
+                            parentRecord.releaseVersion(),
+                            normalizedInput,
+                            ExecutionResultShape.MATERIALIZED_MULTI,
+                            nowEpochMs,
+                            ttl);
+                        return executionStateStore.createOrGetExecution(create)
+                            .onItem().transformToUni(created -> {
+                                ExecutionRecord<Object, Object> child = created.record();
+                                if (created.duplicate() && child.status() == ExecutionStatus.SUCCEEDED) {
+                                    return releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs);
+                                }
+                                String transitionKey = "await-item-continuation:" + unit.unitId() + ":" + interaction.itemIndex();
+                                return executionStateStore.markSucceeded(
+                                        child.tenantId(),
+                                        child.executionId(),
+                                        child.version(),
+                                        transitionKey,
+                                        List.copyOf(segmentOutputs == null ? List.of() : segmentOutputs),
+                                        nowEpochMs)
+                                    .onItem().transformToUni(ignored ->
+                                        releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
+                            });
+                    });
+            });
+    }
+
+    Uni<Void> releaseItemizedAwaitParentIfReady(
+        ExecutionRecord<Object, Object> parent,
+        AwaitUnitRecord unit,
+        int aggregateStepIndex,
+        long nowEpochMs) {
+        return releaseItemizedAwaitParentIfReady(
+            new QueueAsyncCommand.ReleaseItemizedParent(parent, unit, aggregateStepIndex, nowEpochMs));
+    }
+
+    private Uni<Void> releaseItemizedAwaitParentIfReady(QueueAsyncCommand.ReleaseItemizedParent command) {
+        ExecutionRecord<Object, Object> parent = command.parent();
+        AwaitUnitRecord unit = command.unit();
+        if (parent == null || unit == null || !usesItemContinuations(unit)
+            || !unit.dispatchComplete() || unit.expectedItemCount() == null) {
+            return Uni.createFrom().voidItem();
+        }
+        List<Uni<Optional<ExecutionRecord<Object, Object>>>> lookups = new ArrayList<>();
+        for (int index = 0; index < unit.expectedItemCount(); index++) {
+            lookups.add(executionStateStore.getExecutionByKey(
+                parent.tenantId(),
+                awaitItemContinuationKey(parent, unit, index)));
+        }
+        return Uni.join().all(lookups).andCollectFailures()
+            .onItem().transformToUni(children -> {
+                List<Object> orderedOutputs = new ArrayList<>();
+                for (Object childObject : children) {
+                    @SuppressWarnings("unchecked")
+                    Optional<ExecutionRecord<Object, Object>> child =
+                        (Optional<ExecutionRecord<Object, Object>>) childObject;
+                    if (child.isEmpty() || child.get().status() != ExecutionStatus.SUCCEEDED) {
+                        return Uni.createFrom().voidItem();
+                    }
+                    Object payload = child.get().resultPayload();
+                    if (payload instanceof Iterable<?> iterable) {
+                        iterable.forEach(orderedOutputs::add);
+                    } else if (payload != null) {
+                        orderedOutputs.add(payload);
+                    }
+                }
+                Object resumePayload = new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(orderedOutputs));
+                return executionStateStore.markAwaitItemContinuationsCompleted(
+                        parent.tenantId(),
+                        parent.executionId(),
+                        unit.unitId(),
+                        command.aggregateStepIndex(),
+                        resumePayload,
+                        command.nowEpochMs())
+                    .onItem().transformToUni(updated -> {
+                        if (updated.isEmpty()) {
+                            return Uni.createFrom().voidItem();
+                        }
+                        AwaitReplayLifecycleEvent lifecycleEvent = new AwaitReplayLifecycleEvent(
+                            AwaitReplayLifecycleEvent.RESUME_RELEASED,
+                            parent.executionId(),
+                            unit.unitId(),
+                            unit.stepId(),
+                            unit.stepIndex(),
+                            updated.get().status().name(),
+                            null,
+                            null,
+                            null,
+                            null,
+                            unit.expectedItemCount(),
+                            unit.completedItemCount(),
+                            unit.dispatchComplete());
+                        effects.recordAwaitLifecycle(lifecycleEvent);
+                        AwaitCompletionMetrics.recordResumeReleased(unit);
+                        return workDispatcher.enqueueNow(new ExecutionWorkItem(
+                                updated.get().tenantId(),
+                                updated.get().executionId()))
+                            .replaceWithVoid();
+                    });
+            });
+    }
+
+    private Uni<Void> dispatchCompletedAwaitItemContinuations(
+        ExecutionRecord<Object, Object> parent,
+        AwaitUnitRecord unit,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        long nowEpochMs) {
+        if (parent == null || unit == null || !usesItemContinuations(unit) || !unit.dispatchComplete()
+            || itemContinuationHandler == null || itemContinuationHandler == noopHandler) {
+            return Uni.createFrom().voidItem();
+        }
+        return awaitCoordinator.findByUnit(parent.tenantId(), unit.unitId())
+            .onItem().invoke(records -> records.stream()
+                .filter(record -> record.itemInteraction()
+                    && record.itemIndex() != null
+                    && record.status() == AwaitInteractionStatus.COMPLETED)
+                .forEach(record -> dispatchItemContinuation(
+                    record,
+                    unit,
+                    itemContinuationHandler,
+                    nowEpochMs)))
+            .replaceWithVoid();
+    }
+
+    private void dispatchItemContinuationAttempt(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        long nowEpochMs,
+        int attempt) {
+        Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
+        if (admission.isEmpty()) {
+            if (attempt >= MAX_ATTEMPTS) {
+                markAwaitItemContinuationFailed(
+                    record,
+                    new IllegalStateException("Transition worker admission remained saturated"),
+                    attempt);
+                return;
+            }
+            scheduler.schedule(
+                () -> dispatchItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, attempt + 1),
+                saturatedDelay.get().toMillis());
+            return;
+        }
+        TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
+        try {
+            continuationExecutor.execute(() -> runAdmittedContinuation(
+                permit,
+                record,
+                unit,
+                itemContinuationHandler,
+                nowEpochMs,
+                attempt));
+        } catch (Throwable failure) {
+            permit.close();
+            handleContinuationFailure(record, unit, itemContinuationHandler, nowEpochMs, attempt, failure);
+        }
+    }
+
+    private void runAdmittedContinuation(
+        TransitionWorkerExecutor.TransitionAdmission permit,
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        long nowEpochMs,
+        int attempt) {
+        try {
+            Uni<Void> continuation = executionStateStore
+                .getExecution(record.tenantId(), record.executionId())
+                .onItem().transformToUni(parent -> {
+                    if (!itemContinuationReady(parent, unit)) {
+                        return Uni.createFrom().voidItem();
+                    }
+                    return itemContinuationHandler.continueAwaitItem(
+                        record,
+                        unit,
+                        record.stepIndex() + 1,
+                        parent,
+                        nowEpochMs);
+                });
+            continuation.subscribe().with(
+                ignored -> permit.close(),
+                failure -> {
+                    permit.close();
+                    handleContinuationFailure(record, unit, itemContinuationHandler, nowEpochMs, attempt, failure);
+                });
+        } catch (Throwable failure) {
+            permit.close();
+            handleContinuationFailure(record, unit, itemContinuationHandler, nowEpochMs, attempt, failure);
+        }
+    }
+
+    private void handleContinuationFailure(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        AwaitItemContinuationHandler itemContinuationHandler,
+        long nowEpochMs,
+        int attempt,
+        Throwable failure) {
+        if (attempt < MAX_ATTEMPTS) {
+            long retryDelayMs = retryDelayMs(attempt);
+            LOG.warnf(
+                failure,
+                "Retrying await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s attempt=%d delayMs=%d",
+                record.tenantId(),
+                record.executionId(),
+                record.unitId(),
+                record.interactionId(),
+                record.itemIndex(),
+                attempt + 1,
+                retryDelayMs);
+            scheduler.schedule(
+                () -> dispatchItemContinuationAttempt(
+                    record,
+                    unit,
+                    itemContinuationHandler,
+                    nowEpochMs,
+                    attempt + 1),
+                retryDelayMs);
+            return;
+        }
+        markAwaitItemContinuationFailed(record, failure, attempt);
+    }
+
+    private void markAwaitItemContinuationFailed(
+        AwaitInteractionRecord record,
+        Throwable failure,
+        int attempt) {
+        long nowEpochMs = System.currentTimeMillis();
+        executionStateStore.getExecution(record.tenantId(), record.executionId())
+            .onItem().transformToUni(parent -> {
+                if (parent.isEmpty() || parent.get().status().terminal()) {
+                    return Uni.createFrom().item(Optional.<ExecutionRecord<Object, Object>>empty());
+                }
+                ExecutionRecord<Object, Object> parentRecord = parent.get();
+                return executionStateStore.markTerminalFailure(
+                    parentRecord.tenantId(),
+                    parentRecord.executionId(),
+                    parentRecord.version(),
+                    ExecutionStatus.FAILED,
+                    "await-item-continuation-failed:" + record.unitId() + ":" + record.itemIndex(),
+                    "AWAIT_ITEM_CONTINUATION_FAILED",
+                    "Await item continuation failed after " + attempt + " attempts: " + failure.getMessage(),
+                    nowEpochMs);
+            })
+            .subscribe().with(
+                ignored -> LOG.errorf(
+                    failure,
+                    "Failed processing await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s after %d attempts; marked parent failed when still active",
+                    record.tenantId(),
+                    record.executionId(),
+                    record.unitId(),
+                    record.interactionId(),
+                    record.itemIndex(),
+                    attempt),
+                persistenceFailure -> LOG.errorf(
+                    persistenceFailure,
+                    "Failed marking parent execution failed after await item continuation failure tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s",
+                    record.tenantId(),
+                    record.executionId(),
+                    record.unitId(),
+                    record.interactionId(),
+                    record.itemIndex()));
+    }
+
+    static boolean usesItemContinuations(AwaitInteractionRecord record, AwaitUnitRecord unit) {
+        return record != null
+            && record.itemInteraction()
+            && usesItemContinuations(unit);
+    }
+
+    static boolean usesItemContinuations(AwaitUnitRecord unit) {
+        return unit != null
+            && unit.primaryInteractionId() == null
+            && ONE_TO_ONE_CARDINALITY.equalsIgnoreCase(unit.cardinality());
+    }
+
+    private static boolean itemContinuationReady(Optional<ExecutionRecord<Object, Object>> parent, AwaitUnitRecord unit) {
+        return parent.isPresent()
+            && parent.get().status() == ExecutionStatus.WAITING_EXTERNAL
+            && unit.unitId().equals(parent.get().awaitUnitId());
+    }
+
+    private static ExecutionInputSnapshot copyInputSnapshot(ExecutionInputSnapshot snapshot) {
+        Object payload = snapshot.payload();
+        if (payload instanceof List<?> list) {
+            payload = List.copyOf(list);
+        }
+        return new ExecutionInputSnapshot(snapshot.shape(), payload);
+    }
+
+    private static String awaitItemContinuationKey(
+        ExecutionRecord<Object, Object> parent,
+        AwaitUnitRecord unit,
+        int itemIndex) {
+        return parent.executionKey() + ":await-item:" + unit.unitId() + ":" + itemIndex;
+    }
+
+    private static long retryDelayMs(int attempt) {
+        int boundedAttempt = Math.max(1, Math.min(attempt, MAX_ATTEMPTS));
+        return RETRY_BASE_MS << (boundedAttempt - 1);
+    }
+
+    interface Scheduler {
+        void schedule(Runnable task, long delayMs);
+    }
+
+    interface NonItemAwaitReleaser {
+        Uni<Void> release(
+            ExecutionRecord<Object, Object> record,
+            AwaitUnitRecord unit,
+            TransitionAwaitSuspension suspended,
+            long nowEpochMs);
+    }
+
+    interface Effects {
+        void recordAwaitLifecycle(AwaitReplayLifecycleEvent lifecycleEvent);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ObjectPublishTerminalPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ObjectPublishTerminalPublisher.java
@@ -1,0 +1,30 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+final class ObjectPublishTerminalPublisher implements TerminalOutputPublisher {
+
+    private final ObjectPublishCompletionService objectPublishCompletionService;
+    private final TransitionPayloadCodec payloadCodec;
+
+    ObjectPublishTerminalPublisher(
+        ObjectPublishCompletionService objectPublishCompletionService,
+        TransitionPayloadCodec payloadCodec) {
+        this.objectPublishCompletionService = objectPublishCompletionService;
+        this.payloadCodec = payloadCodec;
+    }
+
+    @Override
+    public Uni<Void> publishIfConfigured(TransitionResultEnvelope result) {
+        Objects.requireNonNull(result, "result must not be null");
+        if (result.terminalOutputPublished() || objectPublishCompletionService == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return objectPublishCompletionService.publishIfConfigured(() -> result.decodeOutputItems(payloadCodec));
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCommand.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCommand.java
@@ -1,0 +1,28 @@
+package org.pipelineframework;
+
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+
+sealed interface QueueAsyncCommand
+    permits QueueAsyncCommand.CompleteAwait,
+    QueueAsyncCommand.TransitionSuspended,
+    QueueAsyncCommand.ReleaseItemizedParent {
+
+    record CompleteAwait(AwaitCompletionCommand command) implements QueueAsyncCommand {
+    }
+
+    record TransitionSuspended(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionAwaitSuspension suspension) implements QueueAsyncCommand {
+    }
+
+    record ReleaseItemizedParent(
+        ExecutionRecord<Object, Object> parent,
+        AwaitUnitRecord unit,
+        int aggregateStepIndex,
+        long nowEpochMs) implements QueueAsyncCommand {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -18,22 +18,20 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 
+import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.jboss.logging.Logger;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
 import org.pipelineframework.config.pipeline.PipelineJson;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
-import org.pipelineframework.awaitable.AwaitCompletionAdmissionFailures;
 import org.pipelineframework.awaitable.AwaitCompletionMetrics;
-import org.pipelineframework.awaitable.AwaitCompletionTenantMismatchException;
 import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitCoordinator;
-import org.pipelineframework.awaitable.AwaitInteractionStatus;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.awaitable.AwaitLiveCompletionRegistry;
 import org.pipelineframework.awaitable.AwaitThrowableSupport;
-import org.pipelineframework.awaitable.AwaitUnitStatus;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
@@ -45,7 +43,6 @@ import org.pipelineframework.telemetry.PipelineTelemetry;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
 import org.pipelineframework.orchestrator.DeadLetterPublisher;
 import org.pipelineframework.orchestrator.ExecutionCreateCommand;
-import org.pipelineframework.orchestrator.ExecutionInputShape;
 import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRedriveResult;
 import org.pipelineframework.orchestrator.ExecutionRecord;
@@ -80,9 +77,6 @@ import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
 class QueueAsyncCoordinator {
 
   private static final Logger LOG = Logger.getLogger(QueueAsyncCoordinator.class);
-  private static final int AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS = 3;
-  private static final long AWAIT_ITEM_CONTINUATION_RETRY_BASE_MS = 100L;
-  private static final String ONE_TO_ONE_CARDINALITY = "ONE_TO_ONE";
   private static final AwaitItemContinuationHandler NOOP_ITEM_CONTINUATION_HANDLER =
       new AwaitItemContinuationHandler() {
         @Override
@@ -502,76 +496,7 @@ class QueueAsyncCoordinator {
       ExecutionWorkItem workItem,
       PipelineTransitionWorker worker,
       AwaitItemContinuationHandler itemContinuationHandler) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
-      return Uni.createFrom().voidItem();
-    }
-    if (worker == null) {
-      return Uni.createFrom().failure(new IllegalArgumentException("PipelineTransitionWorker must not be null"));
-    }
-    Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
-    if (admission.isEmpty()) {
-      return workDispatcher.enqueueDelayed(workItem, saturatedDelay());
-    }
-    TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
-    ControlPlaneTransitionAdmission tenantAdmission = admissionPolicy().admitTransition(admissionRequest(
-        workItem.tenantId(),
-        ControlPlaneAdmissionOperation.PROCESS_WORK_ITEM,
-        workItem.executionId(),
-        "worker-dispatch",
-        true));
-    if (!tenantAdmission.decision().allowed()) {
-      permit.close();
-      if (ControlPlaneAdmissionDecision.TENANT_TRANSITION_QUOTA_SATURATED.equals(tenantAdmission.decision().errorCode())) {
-        return workDispatcher.enqueueDelayed(workItem, saturatedDelay());
-      }
-      LOG.warnf(
-          "Skipping async execution work item tenant=%s executionId=%s: %s",
-          workItem.tenantId(),
-          workItem.executionId(),
-          tenantAdmission.decision().reason());
-      return Uni.createFrom().voidItem();
-    }
-    long now = System.currentTimeMillis();
-    return executionStateStore.claimLease(
-            workItem.tenantId(),
-            workItem.executionId(),
-            queueWorkerId,
-            now,
-            orchestratorConfig.leaseMs())
-        .onItem().transformToUni(claimed -> {
-          if (claimed.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          ExecutionRecord<Object, Object> record = claimed.get();
-          LOG.infof(
-              "Claimed async execution %s tenant=%s stepIndex=%d attempt=%d resultShape=%s awaitUnitId=%s",
-              record.executionId(),
-              record.tenantId(),
-              record.currentStepIndex(),
-              record.attempt(),
-              record.resultShape(),
-              record.awaitUnitId() == null ? "<none>" : record.awaitUnitId());
-          String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-          return prepareTransitionCommand(record, transitionKey)
-              .onItem().transformToUni(command -> transitionWorkerExecutor.execute(worker, command))
-              .onItem().transformToUni(result -> handleTransitionResult(record, transitionKey, result, itemContinuationHandler))
-              .onFailure(AwaitThrowableSupport::containsAwaitSuspension).recoverWithUni(failure ->
-                  awaitCoordinator.suspensionSnapshot(AwaitThrowableSupport.extractAwaitSuspension(failure))
-                      .onItem().transformToUni(suspension ->
-                          markWaitingExternal(record, suspension, transitionKey, itemContinuationHandler)))
-              .onFailure().recoverWithUni(
-                  failure -> executionFailureHandler.handleExecutionFailure(
-                      record,
-                      transitionKey,
-                      failure,
-                      executionStateStore,
-                      workDispatcher,
-                      deadLetterPublisher));
-        })
-        .onTermination().invoke(() -> {
-          permit.close();
-          tenantAdmission.permit().close();
-        });
+    return queueAsyncExecutionFlow().processExecutionWorkItem(workItem, worker, itemContinuationHandler);
   }
 
   void sweepDueExecutions() {
@@ -581,19 +506,14 @@ class QueueAsyncCoordinator {
     long now = System.currentTimeMillis();
     sweepTimedOutAwaitInteractions(now)
         .onItem().transformToUni(ignored -> executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit()))
-        .onItem().transformToUni(due -> {
-          if (due.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          List<Uni<Void>> enqueueOperations = new ArrayList<>(due.size());
-          for (ExecutionRecord<Object, Object> record : due) {
-            enqueueOperations.add(workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
+        .onItem().transformToMulti(Multi.createFrom()::iterable)
+        .onItem().transformToUniAndMerge(record -> captureFailure(
+            workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
                 .onFailure().transform(failure -> new IllegalStateException(
                     "Failed to re-dispatch due execution " + record.executionId(),
-                    failure)));
-          }
-          return Uni.join().all(enqueueOperations).andCollectFailures().replaceWithVoid();
-        })
+                    failure))))
+        .collect().asList()
+        .onItem().transformToUni(this::failIfAny)
         .subscribe()
         .with(
             ignored -> {
@@ -630,224 +550,7 @@ class QueueAsyncCoordinator {
     if (admissionFailure != null) {
       return Uni.createFrom().failure(admissionFailure);
     }
-    return awaitCoordinator.complete(normalized)
-        .onFailure(failure -> !AwaitCompletionAdmissionFailures.isDeterministic(failure))
-        .transform(failure -> new IllegalStateException(
-            "Failed completing await interaction tenant=" + normalized.tenantId()
-                + ", interactionId=" + normalized.interactionId()
-                + ", correlationId=" + normalized.correlationId(),
-            failure))
-        .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
-            .onItem().transformToUni(validated -> {
-              return awaitCoordinator.recordCompletion(validated.record(), normalized.nowEpochMs())
-                  .onItem().transformToUni(unit -> signalLiveAwaitCompletion(validated.record(), unit)
-                      .onFailure().recoverWithItem(false)
-                      .onItem().transformToUni(liveAccepted -> liveAccepted
-                          ? Uni.createFrom().item(validated)
-                          : handleRecordedAwaitCompletion(
-                              validated,
-                              unit,
-                              itemContinuationHandler,
-                              normalized.nowEpochMs())));
-            }));
-  }
-
-  private Uni<AwaitCompletionResult> handleRecordedAwaitCompletion(
-      AwaitCompletionResult validated,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs) {
-    if (usesItemContinuations(validated.record(), unit)) {
-      return awaitItemContinuationReady(validated.record(), unit)
-          .onItem().invoke(ready -> {
-            if (ready) {
-              dispatchAwaitItemContinuation(
-                  validated.record(),
-                  unit,
-                  itemContinuationHandler,
-                  nowEpochMs);
-            } else {
-              AwaitCompletionMetrics.recordEarlyCompletionHeld(validated.record(), unit);
-            }
-          })
-          .replaceWith(validated);
-    }
-    return unit.status() == AwaitUnitStatus.COMPLETED
-        ? releaseAwaitResume(validated.record(), unit.unitId(), nowEpochMs).replaceWith(validated)
-        : Uni.createFrom().item(validated);
-  }
-
-  private Uni<Boolean> signalLiveAwaitCompletion(
-      AwaitInteractionRecord record,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit) {
-    if (awaitLiveCompletionRegistry == null) {
-      return Uni.createFrom().item(false);
-    }
-    return awaitLiveCompletionRegistry.signal(record, unit);
-  }
-
-  private void dispatchAwaitItemContinuation(
-      AwaitInteractionRecord record,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs) {
-    if (itemContinuationHandler == NOOP_ITEM_CONTINUATION_HANDLER) {
-      return;
-    }
-    dispatchAwaitItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, 1);
-  }
-
-  private Uni<Boolean> awaitItemContinuationReady(
-      AwaitInteractionRecord record,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit) {
-    if (record == null || unit == null || !unit.dispatchComplete()) {
-      return Uni.createFrom().item(false);
-    }
-    Uni<Optional<ExecutionRecord<Object, Object>>> parentLookup =
-        executionStateStore.getExecution(record.tenantId(), record.executionId());
-    if (parentLookup == null) {
-      return Uni.createFrom().item(false);
-    }
-    return parentLookup
-        .onItem().transform(parent -> awaitItemContinuationReady(parent, unit));
-  }
-
-  private static boolean awaitItemContinuationReady(
-      Optional<ExecutionRecord<Object, Object>> parent,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit) {
-    return parent.isPresent()
-        && parent.get().status() == ExecutionStatus.WAITING_EXTERNAL
-        && unit.unitId().equals(parent.get().awaitUnitId());
-  }
-
-  private Uni<Void> dispatchCompletedAwaitItemContinuations(
-      ExecutionRecord<Object, Object> parent,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs) {
-    if (parent == null || unit == null || !usesItemContinuations(unit) || !unit.dispatchComplete()
-        || itemContinuationHandler == NOOP_ITEM_CONTINUATION_HANDLER) {
-      return Uni.createFrom().voidItem();
-    }
-    return awaitCoordinator.findByUnit(parent.tenantId(), unit.unitId())
-        .onItem().invoke(records -> records.stream()
-            .filter(record -> record.itemInteraction()
-                && record.itemIndex() != null
-                && record.status() == AwaitInteractionStatus.COMPLETED)
-            .forEach(record -> dispatchAwaitItemContinuation(
-                record,
-                unit,
-                itemContinuationHandler,
-                nowEpochMs)))
-        .replaceWithVoid();
-  }
-
-  private void dispatchAwaitItemContinuationAttempt(
-      AwaitInteractionRecord record,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs,
-      int attempt) {
-    Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
-    if (admission.isEmpty()) {
-      queueSweepExecutor.schedule(
-          () -> dispatchAwaitItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, attempt),
-          saturatedDelay().toMillis(),
-          TimeUnit.MILLISECONDS);
-      return;
-    }
-    TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
-    Infrastructure.getDefaultExecutor().execute(() ->
-        executionStateStore
-            .getExecution(record.tenantId(), record.executionId())
-            .onItem().transformToUni(parent -> {
-              if (!awaitItemContinuationReady(parent, unit)) {
-                return Uni.createFrom().voidItem();
-              }
-              return itemContinuationHandler.continueAwaitItem(
-                  record,
-                  unit,
-                  record.stepIndex() + 1,
-                  parent,
-                  nowEpochMs);
-            })
-            .subscribe().with(
-                ignored -> {
-                  permit.close();
-                },
-                failure -> {
-                  permit.close();
-                  if (attempt < AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS) {
-                    long retryDelayMs = awaitItemContinuationRetryDelayMs(attempt);
-                    LOG.warnf(
-                        failure,
-                        "Retrying await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s attempt=%d delayMs=%d",
-                        record.tenantId(),
-                        record.executionId(),
-                        record.unitId(),
-                        record.interactionId(),
-                        record.itemIndex(),
-                        attempt + 1,
-                        retryDelayMs);
-                    queueSweepExecutor.schedule(
-                        () -> dispatchAwaitItemContinuationAttempt(
-                            record,
-                            unit,
-                            itemContinuationHandler,
-                            nowEpochMs,
-                            attempt + 1),
-                        retryDelayMs,
-                        TimeUnit.MILLISECONDS);
-                    return;
-                  }
-                  markAwaitItemContinuationFailed(record, failure, attempt);
-                }));
-  }
-
-  private static long awaitItemContinuationRetryDelayMs(int attempt) {
-    int boundedAttempt = Math.max(1, Math.min(attempt, AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS));
-    return AWAIT_ITEM_CONTINUATION_RETRY_BASE_MS << (boundedAttempt - 1);
-  }
-
-  private void markAwaitItemContinuationFailed(
-      AwaitInteractionRecord record,
-      Throwable failure,
-      int attempt) {
-    long nowEpochMs = System.currentTimeMillis();
-    executionStateStore.getExecution(record.tenantId(), record.executionId())
-        .onItem().transformToUni(parent -> {
-          if (parent.isEmpty() || parent.get().status().terminal()) {
-            return Uni.createFrom().item(Optional.<ExecutionRecord<Object, Object>>empty());
-          }
-          ExecutionRecord<Object, Object> parentRecord = parent.get();
-          return executionStateStore.markTerminalFailure(
-              parentRecord.tenantId(),
-              parentRecord.executionId(),
-              parentRecord.version(),
-              ExecutionStatus.FAILED,
-              "await-item-continuation-failed:" + record.unitId() + ":" + record.itemIndex(),
-              "AWAIT_ITEM_CONTINUATION_FAILED",
-              "Await item continuation failed after " + attempt + " attempts: " + failure.getMessage(),
-              nowEpochMs);
-        })
-        .subscribe().with(
-            ignored -> LOG.errorf(
-                failure,
-                "Failed processing await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s after %d attempts; marked parent failed when still active",
-                record.tenantId(),
-                record.executionId(),
-                record.unitId(),
-                record.interactionId(),
-                record.itemIndex(),
-                attempt),
-            persistenceFailure -> LOG.errorf(
-                persistenceFailure,
-                "Failed marking parent execution failed after await item continuation failure tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s",
-                record.tenantId(),
-                record.executionId(),
-                record.unitId(),
-                record.interactionId(),
-                record.itemIndex()));
+    return awaitCompletionFlow().complete(new QueueAsyncCommand.CompleteAwait(normalized), itemContinuationHandler);
   }
 
   Uni<List<AwaitInteractionRecord>> queryPendingAwaitInteractions(
@@ -878,152 +581,266 @@ class QueueAsyncCoordinator {
       String transitionKey,
       TransitionResultEnvelope result,
       AwaitItemContinuationHandler itemContinuationHandler) {
-    if (result == null) {
-      return executionFailureHandler.handleExecutionFailure(
-          record,
-          transitionKey,
-          new IllegalStateException("PipelineTransitionWorker returned null result"),
-          executionStateStore,
-          workDispatcher,
-          deadLetterPublisher);
-    }
-    if (result.outcome() == TransitionWorkerOutcome.COMPLETED) {
-      return handleCompletedTransition(record, transitionKey, result);
-    }
-    if (result.outcome() == TransitionWorkerOutcome.WAITING_EXTERNAL) {
-      return markWaitingExternal(record, result.awaitSuspension(), transitionKey, itemContinuationHandler);
-    }
-    return executionFailureHandler.handleExecutionFailure(
-        record,
-        transitionKey,
-        result.failure().toException(),
+    return transitionCommitFlow().commit(record, transitionKey, result, itemContinuationHandler);
+  }
+
+  private QueueAsyncExecutionFlow queueAsyncExecutionFlow() {
+    return new QueueAsyncExecutionFlow(
+        orchestratorConfig,
         executionStateStore,
         workDispatcher,
-        deadLetterPublisher);
-  }
+        transitionWorkerExecutor,
+        queueWorkerId,
+        new QueueAsyncExecutionFlow.Effects() {
+          @Override
+          public ControlPlaneTransitionAdmission admitTransition(ExecutionWorkItem workItem) {
+            return admissionPolicy().admitTransition(admissionRequest(
+                workItem.tenantId(),
+                ControlPlaneAdmissionOperation.PROCESS_WORK_ITEM,
+                workItem.executionId(),
+                "worker-dispatch",
+                true));
+          }
 
-  private Uni<Void> handleCompletedTransition(
-      ExecutionRecord<Object, Object> record,
-      String transitionKey,
-      TransitionResultEnvelope result) {
-    List<?> outputItems = result.coordinatorOutputItems();
-    if (record.resultShape() == ExecutionResultShape.SINGLE && outputItems.size() > 1) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue execution " + record.executionId()
-              + " produced " + outputItems.size()
-              + " terminal items for SINGLE result shape"));
-    }
-    return checkpointPublicationService
-        .publishIfConfigured(record, singleResult(outputItems))
-        .chain(() -> publishTerminalOutputsIfConfigured(result))
-        .replaceWith(outputItems)
-        .onItem().transformToUni(payload -> executionStateStore.markSucceeded(
-            record.tenantId(),
-            record.executionId(),
-            record.version(),
-            transitionKey,
-            payload,
-            System.currentTimeMillis()))
-        .replaceWithVoid();
-  }
+          @Override
+          public Duration saturatedDelay() {
+            return QueueAsyncCoordinator.this.saturatedDelay();
+          }
 
-  private Uni<Void> publishTerminalOutputsIfConfigured(TransitionResultEnvelope result) {
-    if (result.terminalOutputPublished()) {
-      return Uni.createFrom().voidItem();
-    }
-    if (objectPublishCompletionService == null) {
-      return Uni.createFrom().voidItem();
-    }
-    return objectPublishCompletionService.publishIfConfigured(() -> result.decodeOutputItems(payloadCodec()));
-  }
+          @Override
+          public Uni<TransitionCommandEnvelope> prepareTransitionCommand(
+              ExecutionRecord<Object, Object> record,
+              String transitionKey) {
+            return QueueAsyncCoordinator.this.prepareTransitionCommand(record, transitionKey);
+          }
 
-  private Uni<Void> markWaitingExternal(
-      ExecutionRecord<Object, Object> record,
-      TransitionAwaitSuspension suspended,
-      String transitionKey,
-      AwaitItemContinuationHandler itemContinuationHandler) {
-    return awaitCoordinator.importSuspension(suspended)
-        .onItem().transformToUni(ignored -> {
-          long nowEpochMs = System.currentTimeMillis();
-          return executionStateStore.markWaitingExternal(
-            record.tenantId(),
-            record.executionId(),
-            record.version(),
-            transitionKey,
-            suspended.unitId(),
-            suspended.stepIndex(),
-            nowEpochMs)
-              .onItem().transformToUni(updated -> {
-                if (updated.isPresent()) {
-                  LOG.infof(
-                      "Execution %s persisted WAITING_EXTERNAL at stepIndex=%d awaitUnitId=%s awaitInteractions=%d",
-                      record.executionId(),
-                      suspended.stepIndex(),
-                      suspended.unitId(),
-                      suspended.interactions().size());
-                  recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
-                      AwaitReplayLifecycleEvent.EXECUTION_WAITING,
-                      record.executionId(),
-                      suspended.unitId(),
-                      null,
-                      suspended.stepIndex(),
-                      ExecutionStatus.WAITING_EXTERNAL.name(),
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null));
-                  return releaseAlreadyCompletedAwaitUnit(updated.get(), suspended, nowEpochMs, itemContinuationHandler);
-                }
-                return Uni.createFrom().failure(new IllegalStateException(
-                    "Failed to persist WAITING_EXTERNAL state for execution "
-                        + record.executionId()
-                        + " at step "
-                        + suspended.stepIndex()
-                        + " (expectedVersion="
-                        + record.version()
-                        + ", awaitUnitId="
-                        + suspended.unitId()
-                        + ")"));
-              });
+          @Override
+          public Uni<Void> commitTransition(
+              ExecutionRecord<Object, Object> record,
+              String transitionKey,
+              TransitionResultEnvelope result,
+              AwaitItemContinuationHandler itemContinuationHandler) {
+            return handleTransitionResult(record, transitionKey, result, itemContinuationHandler);
+          }
+
+          @Override
+          public Uni<TransitionAwaitSuspension> suspensionSnapshot(Throwable failure) {
+            return awaitCoordinator.suspensionSnapshot(
+                org.pipelineframework.awaitable.AwaitThrowableSupport.extractAwaitSuspension(failure));
+          }
+
+          @Override
+          public Uni<Void> markWaitingExternal(
+              ExecutionRecord<Object, Object> record,
+              String transitionKey,
+              TransitionAwaitSuspension suspension,
+              AwaitItemContinuationHandler itemContinuationHandler) {
+            return transitionCommitFlow().markWaitingExternal(
+                new QueueAsyncCommand.TransitionSuspended(record, transitionKey, suspension),
+                itemContinuationHandler);
+          }
+
+          @Override
+          public Uni<Void> handleExecutionFailure(
+              ExecutionRecord<Object, Object> record,
+              String transitionKey,
+              Throwable failure) {
+            return executionFailureHandler.handleExecutionFailure(
+                record,
+                transitionKey,
+                failure,
+                executionStateStore,
+                workDispatcher,
+                deadLetterPublisher);
+          }
+
+          @Override
+          public void recordClaimed(ExecutionRecord<Object, Object> record) {
+            LOG.infof(
+                "Claimed async execution %s tenant=%s stepIndex=%d attempt=%d resultShape=%s awaitUnitId=%s",
+                record.executionId(),
+                record.tenantId(),
+                record.currentStepIndex(),
+                record.attempt(),
+                record.resultShape(),
+                record.awaitUnitId() == null ? "<none>" : record.awaitUnitId());
+          }
+
+          @Override
+          public void recordSkipped(ExecutionWorkItem workItem, ControlPlaneTransitionAdmission admission) {
+            LOG.warnf(
+                "Skipping async execution work item tenant=%s executionId=%s: %s",
+                workItem.tenantId(),
+                workItem.executionId(),
+                admission.decision().reason());
+          }
         });
+  }
+
+  private AwaitCompletionFlow awaitCompletionFlow() {
+    return new AwaitCompletionFlow(
+        awaitCoordinator,
+        awaitLiveCompletionRegistry,
+        new AwaitCompletionFlow.Effects() {
+          @Override
+          public Uni<Boolean> itemContinuationReady(
+              AwaitInteractionRecord record,
+              org.pipelineframework.awaitable.AwaitUnitRecord unit) {
+            return itemContinuationFlow().itemContinuationReady(record, unit);
+          }
+
+          @Override
+          public void dispatchItemContinuation(
+              AwaitInteractionRecord record,
+              org.pipelineframework.awaitable.AwaitUnitRecord unit,
+              AwaitItemContinuationHandler itemContinuationHandler,
+              long nowEpochMs) {
+            itemContinuationFlow().dispatchItemContinuation(record, unit, itemContinuationHandler, nowEpochMs);
+          }
+
+          @Override
+          public Uni<Void> releaseAwaitResume(
+              AwaitInteractionRecord record,
+              String awaitUnitId,
+              long nowEpochMs) {
+            return QueueAsyncCoordinator.this.releaseAwaitResume(record, awaitUnitId, nowEpochMs);
+          }
+
+          @Override
+          public void recordEarlyCompletionHeld(
+              AwaitInteractionRecord record,
+              org.pipelineframework.awaitable.AwaitUnitRecord unit) {
+            AwaitCompletionMetrics.recordEarlyCompletionHeld(record, unit);
+          }
+        });
+  }
+
+  private TransitionCommitFlow transitionCommitFlow() {
+    return new TransitionCommitFlow(
+        awaitCoordinator,
+        executionStateStore,
+        workDispatcher,
+        deadLetterPublisher,
+        executionFailureHandler,
+        terminalPublicationBarrier(),
+        new TransitionCommitFlow.Effects() {
+          @Override
+          public Uni<Void> releaseAlreadyCompletedAwaitUnit(
+              ExecutionRecord<Object, Object> record,
+              TransitionAwaitSuspension suspended,
+              long nowEpochMs,
+              AwaitItemContinuationHandler itemContinuationHandler) {
+            LOG.infof(
+                "Execution %s persisted WAITING_EXTERNAL at stepIndex=%d awaitUnitId=%s awaitInteractions=%d",
+                record.executionId(),
+                suspended.stepIndex(),
+                suspended.unitId(),
+                suspended.interactions().size());
+            return itemContinuationFlow().releaseAlreadyCompletedAwaitUnit(
+                record,
+                suspended,
+                nowEpochMs,
+                itemContinuationHandler);
+          }
+
+          @Override
+          public void recordExecutionWaiting(AwaitReplayLifecycleEvent lifecycleEvent) {
+            recordAwaitLifecycle(lifecycleEvent);
+          }
+        });
+  }
+
+  private TerminalPublicationBarrier terminalPublicationBarrier() {
+    return new TerminalPublicationFlow(
+        checkpointPublicationService,
+        new ObjectPublishTerminalPublisher(objectPublishCompletionService, payloadCodec()));
+  }
+
+  private ItemContinuationFlow itemContinuationFlow() {
+    return new ItemContinuationFlow(
+        awaitCoordinator,
+        executionStateStore,
+        workDispatcher,
+        transitionWorkerExecutor,
+        (task, delayMs) -> queueSweepExecutor.schedule(task, delayMs, TimeUnit.MILLISECONDS),
+        Infrastructure.getDefaultExecutor(),
+        this::saturatedDelay,
+        NOOP_ITEM_CONTINUATION_HANDLER,
+        (record, unit, suspended, nowEpochMs) -> releaseAwaitResume(
+            record.tenantId(),
+            record.executionId(),
+            unit.unitId(),
+            unit.stepId(),
+            suspended.stepIndex(),
+            null,
+            null,
+            null,
+            null,
+            nowEpochMs),
+        this::recordAwaitLifecycle);
   }
 
   private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
     return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
-        .onItem().transformToUni(records -> {
-          if (records.isEmpty()) {
+        .onItem().transformToMulti(Multi.createFrom()::iterable)
+        .onItem().transformToUniAndMerge(record -> captureFailure(handleTimedOutAwaitInteraction(record, now)))
+        .collect().asList()
+        .onItem().transformToUni(this::failIfAny);
+  }
+
+  private Uni<Void> handleTimedOutAwaitInteraction(AwaitInteractionRecord record, long now) {
+    return awaitCoordinator.markTimedOut(record, now)
+        .onItem().transformToUni(updated -> updated.isPresent()
+            ? executionStateStore.getExecution(record.tenantId(), record.executionId())
+                .onItem().transformToUni(execution -> markTimedOutExecutionIfStillWaiting(record, execution, now, true))
+            : Uni.createFrom().voidItem());
+  }
+
+  private Uni<Void> markTimedOutExecutionIfStillWaiting(
+      AwaitInteractionRecord record,
+      Optional<ExecutionRecord<Object, Object>> execution,
+      long now,
+      boolean retryOnLostRace) {
+    if (execution.isEmpty() || execution.get().status().terminal()) {
+      return Uni.createFrom().voidItem();
+    }
+    ExecutionRecord<Object, Object> executionRecord = execution.get();
+    if (executionRecord.status() != ExecutionStatus.WAITING_EXTERNAL
+        || !record.unitId().equals(executionRecord.awaitUnitId())) {
+      return Uni.createFrom().voidItem();
+    }
+    return executionStateStore.markTerminalFailure(
+            executionRecord.tenantId(),
+            executionRecord.executionId(),
+            executionRecord.version(),
+            ExecutionStatus.FAILED,
+            transitionKey(executionRecord.executionId(), executionRecord.currentStepIndex(), executionRecord.attempt()),
+            "AWAIT_TIMEOUT",
+            "Await interaction timed out: " + record.interactionId(),
+            now)
+        .onItem().transformToUni(updated -> {
+          if (updated.isPresent() || !retryOnLostRace) {
             return Uni.createFrom().voidItem();
           }
-          List<Uni<Void>> operations = new ArrayList<>(records.size());
-          for (AwaitInteractionRecord record : records) {
-            operations.add(awaitCoordinator.markTimedOut(record, now)
-                .onItem().transformToUni(updated -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
-                .onItem().transformToUni(execution -> {
-                  if (execution.isEmpty() || execution.get().status().terminal()) {
-                    return Uni.createFrom().voidItem();
-                  }
-                  ExecutionRecord<Object, Object> executionRecord = execution.get();
-                  if (executionRecord.status() != ExecutionStatus.WAITING_EXTERNAL
-                      || !record.unitId().equals(executionRecord.awaitUnitId())) {
-                    return Uni.createFrom().voidItem();
-                  }
-                  return executionStateStore.markTerminalFailure(
-                          executionRecord.tenantId(),
-                          executionRecord.executionId(),
-                          executionRecord.version(),
-                          ExecutionStatus.FAILED,
-                          transitionKey(executionRecord.executionId(), executionRecord.currentStepIndex(), executionRecord.attempt()),
-                          "AWAIT_TIMEOUT",
-                          "Await interaction timed out: " + record.interactionId(),
-                          now)
-                      .replaceWithVoid();
-                }));
-          }
-          return Uni.join().all(operations).andCollectFailures().replaceWithVoid();
+          return executionStateStore.getExecution(record.tenantId(), record.executionId())
+              .onItem().transformToUni(refreshed ->
+                  markTimedOutExecutionIfStillWaiting(record, refreshed, now, false));
         });
+  }
+
+  private Uni<Optional<Throwable>> captureFailure(Uni<Void> operation) {
+    return operation
+        .replaceWith(Optional.<Throwable>empty())
+        .onFailure().recoverWithItem(Optional::of);
+  }
+
+  private Uni<Void> failIfAny(List<Optional<Throwable>> outcomes) {
+    List<Throwable> failures = outcomes.stream()
+        .flatMap(Optional::stream)
+        .toList();
+    return failures.isEmpty()
+        ? Uni.createFrom().voidItem()
+        : Uni.createFrom().failure(new CompositeException(failures.toArray(Throwable[]::new)));
   }
 
   private Uni<List<?>> runAsyncExecution(
@@ -1127,13 +944,6 @@ class QueueAsyncCoordinator {
       return Duration.ofSeconds(1);
     }
     return workerConfig.saturatedDelay();
-  }
-
-  private Object singleResult(List<?> items) {
-    if (items == null || items.isEmpty()) {
-      return null;
-    }
-    return items.getFirst();
   }
 
   private Object coerceStoredResult(Object result, Class<?> outputType) {
@@ -1270,40 +1080,6 @@ class QueueAsyncCoordinator {
     return tenantId != null && !tenantId.isBlank();
   }
 
-  private Uni<Void> releaseAlreadyCompletedAwaitUnit(
-      ExecutionRecord<Object, Object> record,
-      TransitionAwaitSuspension suspended,
-      long nowEpochMs,
-      AwaitItemContinuationHandler itemContinuationHandler) {
-    return awaitCoordinator.getUnit(record.tenantId(), suspended.unitId())
-        .onItem().transformToUni(unit -> {
-          if (unit == null || unit.status() != AwaitUnitStatus.COMPLETED) {
-            return unit != null && usesItemContinuations(unit)
-                ? dispatchCompletedAwaitItemContinuations(record, unit, itemContinuationHandler, nowEpochMs)
-                : Uni.createFrom().voidItem();
-          }
-          if (usesItemContinuations(unit)) {
-            return dispatchCompletedAwaitItemContinuations(record, unit, itemContinuationHandler, nowEpochMs)
-                .onItem().transformToUni(ignored -> itemContinuationHandler.releaseAwaitParentIfReady(
-                    record,
-                    unit,
-                    suspended.stepIndex() + 1,
-                    nowEpochMs));
-          }
-          return releaseAwaitResume(
-              record.tenantId(),
-              record.executionId(),
-              unit.unitId(),
-              unit.stepId(),
-              suspended.stepIndex(),
-              null,
-              null,
-              null,
-              null,
-              nowEpochMs);
-        });
-  }
-
   Uni<Void> recordAwaitItemContinuation(
       AwaitInteractionRecord interaction,
       org.pipelineframework.awaitable.AwaitUnitRecord unit,
@@ -1311,67 +1087,13 @@ class QueueAsyncCoordinator {
       ExecutionInputSnapshot continuationInput,
       List<?> segmentOutputs,
       long nowEpochMs) {
-    if (!usesItemContinuations(interaction, unit)) {
-      return Uni.createFrom().voidItem();
-    }
-    if (interaction.itemIndex() == null) {
-      return Uni.createFrom().failure(new IllegalArgumentException("Itemized await continuation requires itemIndex"));
-    }
-    if (continuationInput == null) {
-      return Uni.createFrom().failure(new IllegalArgumentException(
-          "Itemized await continuation requires normalized continuation input"));
-    }
-    ExecutionInputSnapshot normalizedInput = copyInputSnapshot(continuationInput);
-    return executionStateStore.getExecution(interaction.tenantId(), interaction.executionId())
-        .onItem().transformToUni(parent -> {
-          if (parent.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          ExecutionRecord<Object, Object> parentRecord = parent.get();
-          String childKey = awaitItemContinuationKey(parentRecord, unit, interaction.itemIndex());
-          return executionStateStore.getExecutionByKey(interaction.tenantId(), childKey)
-              .onItem().transformToUni(existing -> {
-                if (existing.isPresent() && existing.get().status() == ExecutionStatus.SUCCEEDED) {
-                  return releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs);
-                }
-                long ttl = parentRecord.ttlEpochS();
-                ExecutionCreateCommand create = new ExecutionCreateCommand(
-                    interaction.tenantId(),
-                    childKey,
-                    parentRecord.pipelineId(),
-                    parentRecord.contractVersion(),
-                    parentRecord.releaseVersion(),
-                    normalizedInput,
-                    ExecutionResultShape.MATERIALIZED_MULTI,
-                    nowEpochMs,
-                    ttl);
-                return executionStateStore.createOrGetExecution(create)
-                    .onItem().transformToUni(created -> {
-                      ExecutionRecord<Object, Object> child = created.record();
-                      if (created.duplicate() && child.status() == ExecutionStatus.SUCCEEDED) {
-                        return releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs);
-                      }
-                      String transitionKey = "await-item-continuation:" + unit.unitId() + ":" + interaction.itemIndex();
-                      return executionStateStore.markSucceeded(
-                              child.tenantId(),
-                              child.executionId(),
-                              child.version(),
-                              transitionKey,
-                              List.copyOf(segmentOutputs == null ? List.of() : segmentOutputs),
-                              nowEpochMs)
-                          .onItem().transformToUni(ignored ->
-                              releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
-                    });
-              });
-        });
-  }
-
-  private static ExecutionInputSnapshot copyInputSnapshot(ExecutionInputSnapshot snapshot) {
-    Object payload = snapshot.payload();
-    if (payload instanceof List<?> list) {
-      payload = List.copyOf(list);
-    }
-    return new ExecutionInputSnapshot(snapshot.shape(), payload);
+    return itemContinuationFlow().recordAwaitItemContinuation(
+        interaction,
+        unit,
+        aggregateStepIndex,
+        continuationInput,
+        segmentOutputs,
+        nowEpochMs);
   }
 
   Uni<Void> releaseItemizedAwaitParentIfReady(
@@ -1379,84 +1101,11 @@ class QueueAsyncCoordinator {
       org.pipelineframework.awaitable.AwaitUnitRecord unit,
       int aggregateStepIndex,
       long nowEpochMs) {
-    if (parent == null || unit == null || !usesItemContinuations(unit)
-        || !unit.dispatchComplete() || unit.expectedItemCount() == null) {
-      return Uni.createFrom().voidItem();
-    }
-    List<Uni<Optional<ExecutionRecord<Object, Object>>>> lookups = new ArrayList<>();
-    for (int index = 0; index < unit.expectedItemCount(); index++) {
-      lookups.add(executionStateStore.getExecutionByKey(parent.tenantId(), awaitItemContinuationKey(parent, unit, index)));
-    }
-    return Uni.join().all(lookups).andCollectFailures()
-        .onItem().transformToUni(children -> {
-          List<Object> orderedOutputs = new ArrayList<>();
-          for (Object childObject : children) {
-            @SuppressWarnings("unchecked")
-            Optional<ExecutionRecord<Object, Object>> child = (Optional<ExecutionRecord<Object, Object>>) childObject;
-            if (child.isEmpty() || child.get().status() != ExecutionStatus.SUCCEEDED) {
-              return Uni.createFrom().voidItem();
-            }
-            Object payload = child.get().resultPayload();
-            if (payload instanceof Iterable<?> iterable) {
-              iterable.forEach(orderedOutputs::add);
-            } else if (payload != null) {
-              orderedOutputs.add(payload);
-            }
-          }
-          Object resumePayload = new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(orderedOutputs));
-          return executionStateStore.markAwaitItemContinuationsCompleted(
-                  parent.tenantId(),
-                  parent.executionId(),
-                  unit.unitId(),
-                  aggregateStepIndex,
-                  resumePayload,
-                  nowEpochMs)
-              .onItem().transformToUni(updated -> {
-                if (updated.isEmpty()) {
-                  return Uni.createFrom().voidItem();
-                }
-                recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
-                    AwaitReplayLifecycleEvent.RESUME_RELEASED,
-                    parent.executionId(),
-                    unit.unitId(),
-                    unit.stepId(),
-                    unit.stepIndex(),
-                    updated.get().status().name(),
-                    null,
-                    null,
-                    null,
-                    null,
-                    unit.expectedItemCount(),
-                    unit.completedItemCount(),
-                    unit.dispatchComplete()));
-                AwaitCompletionMetrics.recordResumeReleased(unit);
-                return workDispatcher.enqueueNow(new ExecutionWorkItem(
-                        updated.get().tenantId(),
-                        updated.get().executionId()))
-                    .replaceWithVoid();
-              });
-        });
-  }
-
-  private static boolean usesItemContinuations(
-      AwaitInteractionRecord record,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit) {
-    return record != null
-        && record.itemInteraction()
-        && usesItemContinuations(unit);
-  }
-
-  private static boolean usesItemContinuations(org.pipelineframework.awaitable.AwaitUnitRecord unit) {
-    return unit != null
-        && unit.primaryInteractionId() == null
-        && ONE_TO_ONE_CARDINALITY.equalsIgnoreCase(unit.cardinality());
-  }
-
-  private static String awaitItemContinuationKey(
-      ExecutionRecord<Object, Object> parent,
-      org.pipelineframework.awaitable.AwaitUnitRecord unit,
-      int itemIndex) {
-    return parent.executionKey() + ":await-item:" + unit.unitId() + ":" + itemIndex;
+    return itemContinuationFlow().releaseItemizedAwaitParentIfReady(
+        parent,
+        unit,
+        aggregateStepIndex,
+        nowEpochMs);
   }
 
   private Uni<Void> releaseAwaitResume(
@@ -1540,17 +1189,6 @@ class QueueAsyncCoordinator {
               stepIndex);
           return Uni.createFrom().voidItem();
         });
-  }
-
-  private Uni<AwaitCompletionResult> validateAwaitCompletionTenant(
-      AwaitCompletionResult result,
-      AwaitCompletionCommand command) {
-    if (!command.tenantId().equals(result.record().tenantId())) {
-      return Uni.createFrom().failure(new AwaitCompletionTenantMismatchException(
-          "Await completion tenant mismatch: command tenant=" + command.tenantId()
-              + ", record tenant=" + result.record().tenantId()));
-    }
-    return Uni.createFrom().item(result);
   }
 
   private void recordAwaitLifecycle(AwaitReplayLifecycleEvent lifecycleEvent) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncExecutionFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncExecutionFlow.java
@@ -1,0 +1,147 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitThrowableSupport;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneTransitionAdmission;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.PipelineTransitionWorker;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+final class QueueAsyncExecutionFlow {
+
+    private final PipelineOrchestratorConfig orchestratorConfig;
+    private final ExecutionStateStore executionStateStore;
+    private final WorkDispatcher workDispatcher;
+    private final TransitionWorkerExecutor transitionWorkerExecutor;
+    private final String queueWorkerId;
+    private final Effects effects;
+
+    QueueAsyncExecutionFlow(
+        PipelineOrchestratorConfig orchestratorConfig,
+        ExecutionStateStore executionStateStore,
+        WorkDispatcher workDispatcher,
+        TransitionWorkerExecutor transitionWorkerExecutor,
+        String queueWorkerId,
+        Effects effects) {
+        this.orchestratorConfig = orchestratorConfig;
+        this.executionStateStore = executionStateStore;
+        this.workDispatcher = workDispatcher;
+        this.transitionWorkerExecutor = transitionWorkerExecutor;
+        this.queueWorkerId = queueWorkerId;
+        this.effects = effects;
+    }
+
+    Uni<Void> processExecutionWorkItem(
+        ExecutionWorkItem workItem,
+        PipelineTransitionWorker worker,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || workItem == null) {
+            return Uni.createFrom().voidItem();
+        }
+        if (worker == null) {
+            return Uni.createFrom().failure(new IllegalArgumentException("PipelineTransitionWorker must not be null"));
+        }
+        Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
+        if (admission.isEmpty()) {
+            return workDispatcher.enqueueDelayed(workItem, effects.saturatedDelay());
+        }
+        TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
+        ControlPlaneTransitionAdmission tenantAdmission = effects.admitTransition(workItem);
+        if (!tenantAdmission.decision().allowed()) {
+            permit.close();
+            if (ControlPlaneAdmissionDecision.TENANT_TRANSITION_QUOTA_SATURATED.equals(
+                tenantAdmission.decision().errorCode())) {
+                return workDispatcher.enqueueDelayed(workItem, effects.saturatedDelay());
+            }
+            effects.recordSkipped(workItem, tenantAdmission);
+            return Uni.createFrom().voidItem();
+        }
+        long now = System.currentTimeMillis();
+        return executionStateStore.claimLease(
+                workItem.tenantId(),
+                workItem.executionId(),
+                queueWorkerId,
+                now,
+                orchestratorConfig.leaseMs())
+            .onItem().transformToUni(claimed ->
+                claimed
+                    .map(record -> executeClaimed(record, worker, itemContinuationHandler))
+                    .orElseGet(() -> Uni.createFrom().voidItem()))
+            .onTermination().invoke(() -> {
+                permit.close();
+                tenantAdmission.permit().close();
+            });
+    }
+
+    private Uni<Void> executeClaimed(
+        ExecutionRecord<Object, Object> record,
+        PipelineTransitionWorker worker,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        effects.recordClaimed(record);
+        String transitionKey = transitionKey(record);
+        return effects.prepareTransitionCommand(record, transitionKey)
+            .onItem().transformToUni(command -> transitionWorkerExecutor.execute(worker, command))
+            .onItem().transformToUni(result -> effects.commitTransition(
+                record,
+                transitionKey,
+                result,
+                itemContinuationHandler))
+            .onFailure(AwaitThrowableSupport::containsAwaitSuspension).recoverWithUni(failure ->
+                effects.suspensionSnapshot(failure)
+                    .onItem().transformToUni(suspension -> effects.markWaitingExternal(
+                        record,
+                        transitionKey,
+                        suspension,
+                        itemContinuationHandler)))
+            .onFailure().recoverWithUni(failure -> effects.handleExecutionFailure(record, transitionKey, failure));
+    }
+
+    private static String transitionKey(ExecutionRecord<Object, Object> record) {
+        return record.executionId() + ":" + record.currentStepIndex() + ":" + record.attempt();
+    }
+
+    interface Effects {
+        ControlPlaneTransitionAdmission admitTransition(ExecutionWorkItem workItem);
+
+        Duration saturatedDelay();
+
+        Uni<TransitionCommandEnvelope> prepareTransitionCommand(
+            ExecutionRecord<Object, Object> record,
+            String transitionKey);
+
+        Uni<Void> commitTransition(
+            ExecutionRecord<Object, Object> record,
+            String transitionKey,
+            TransitionResultEnvelope result,
+            AwaitItemContinuationHandler itemContinuationHandler);
+
+        Uni<TransitionAwaitSuspension> suspensionSnapshot(Throwable failure);
+
+        Uni<Void> markWaitingExternal(
+            ExecutionRecord<Object, Object> record,
+            String transitionKey,
+            TransitionAwaitSuspension suspension,
+            AwaitItemContinuationHandler itemContinuationHandler);
+
+        Uni<Void> handleExecutionFailure(
+            ExecutionRecord<Object, Object> record,
+            String transitionKey,
+            Throwable failure);
+
+        void recordClaimed(ExecutionRecord<Object, Object> record);
+
+        void recordSkipped(ExecutionWorkItem workItem, ControlPlaneTransitionAdmission admission);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalOutputPublisher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalOutputPublisher.java
@@ -1,0 +1,9 @@
+package org.pipelineframework;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+interface TerminalOutputPublisher {
+
+    Uni<Void> publishIfConfigured(TransitionResultEnvelope result);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationBarrier.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationBarrier.java
@@ -1,0 +1,12 @@
+package org.pipelineframework;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+interface TerminalPublicationBarrier {
+
+    Uni<Void> publishBeforeSuccess(
+        ExecutionRecord<Object, Object> record,
+        TransitionResultEnvelope result);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationFlow.java
@@ -1,0 +1,41 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+final class TerminalPublicationFlow implements TerminalPublicationBarrier {
+
+    private final CheckpointPublicationService checkpointPublicationService;
+    private final TerminalOutputPublisher terminalOutputPublisher;
+
+    TerminalPublicationFlow(
+        CheckpointPublicationService checkpointPublicationService,
+        TerminalOutputPublisher terminalOutputPublisher) {
+        this.checkpointPublicationService = checkpointPublicationService;
+        this.terminalOutputPublisher = terminalOutputPublisher;
+    }
+
+    @Override
+    public Uni<Void> publishBeforeSuccess(
+        ExecutionRecord<Object, Object> record,
+        TransitionResultEnvelope result) {
+        Objects.requireNonNull(record, "record must not be null");
+        Objects.requireNonNull(result, "result must not be null");
+
+        TerminalPublicationPlan plan = TerminalPublicationPlan.from(record, result);
+        Uni<Void> checkpointPublication = !plan.publishCheckpoint() || checkpointPublicationService == null
+            ? Uni.createFrom().voidItem()
+            : checkpointPublicationService.publishIfConfigured(plan.record(), plan.checkpointPayload());
+        return checkpointPublication.chain(() -> publishTerminalOutputIfConfigured(plan));
+    }
+
+    private Uni<Void> publishTerminalOutputIfConfigured(TerminalPublicationPlan plan) {
+        return !plan.publishTerminalOutput() || terminalOutputPublisher == null
+            ? Uni.createFrom().voidItem()
+            : terminalOutputPublisher.publishIfConfigured(plan.result());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationPlan.java
@@ -1,0 +1,34 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+record TerminalPublicationPlan(
+    ExecutionRecord<Object, Object> record,
+    TransitionResultEnvelope result,
+    List<?> outputItems,
+    boolean publishCheckpoint,
+    boolean publishTerminalOutput) {
+
+    TerminalPublicationPlan {
+        outputItems = List.copyOf(outputItems);
+    }
+
+    static TerminalPublicationPlan from(
+        ExecutionRecord<Object, Object> record,
+        TransitionResultEnvelope result) {
+        List<?> outputItems = result.coordinatorOutputItems();
+        return new TerminalPublicationPlan(
+            record,
+            result,
+            outputItems,
+            !outputItems.isEmpty(),
+            !result.terminalOutputPublished());
+    }
+
+    Object checkpointPayload() {
+        return outputItems.getFirst();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TransitionCommitFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TransitionCommitFlow.java
@@ -1,0 +1,166 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
+
+final class TransitionCommitFlow {
+
+    private final AwaitCoordinator awaitCoordinator;
+    private final ExecutionStateStore executionStateStore;
+    private final WorkDispatcher workDispatcher;
+    private final DeadLetterPublisher deadLetterPublisher;
+    private final ExecutionFailureHandler executionFailureHandler;
+    private final TerminalPublicationBarrier terminalPublicationBarrier;
+    private final Effects effects;
+
+    TransitionCommitFlow(
+        AwaitCoordinator awaitCoordinator,
+        ExecutionStateStore executionStateStore,
+        WorkDispatcher workDispatcher,
+        DeadLetterPublisher deadLetterPublisher,
+        ExecutionFailureHandler executionFailureHandler,
+        TerminalPublicationBarrier terminalPublicationBarrier,
+        Effects effects) {
+        this.awaitCoordinator = awaitCoordinator;
+        this.executionStateStore = executionStateStore;
+        this.workDispatcher = workDispatcher;
+        this.deadLetterPublisher = deadLetterPublisher;
+        this.executionFailureHandler = executionFailureHandler;
+        this.terminalPublicationBarrier = Objects.requireNonNull(
+            terminalPublicationBarrier,
+            "terminalPublicationBarrier must not be null");
+        this.effects = effects;
+    }
+
+    Uni<Void> commit(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionResultEnvelope result,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        return interpretPlan(
+            TransitionCommitPlan.from(record, transitionKey, result, System.currentTimeMillis()),
+            itemContinuationHandler);
+    }
+
+    Uni<Void> markWaitingExternal(
+        QueueAsyncCommand.TransitionSuspended command,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        return markWaitingExternal(
+            new TransitionCommitPlan.MarkWaitingExternal(
+                command.record(),
+                command.transitionKey(),
+                command.suspension(),
+                System.currentTimeMillis()),
+            itemContinuationHandler);
+    }
+
+    private Uni<Void> interpretPlan(
+        TransitionCommitPlan plan,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        return switch (plan) {
+            case TransitionCommitPlan.MarkSucceeded succeeded -> markSucceeded(succeeded);
+            case TransitionCommitPlan.MarkWaitingExternal waiting -> markWaitingExternal(waiting, itemContinuationHandler);
+            case TransitionCommitPlan.HandleFailure failed -> handleFailure(
+                failed.record(),
+                failed.transitionKey(),
+                failed.failure());
+        };
+    }
+
+    private Uni<Void> markWaitingExternal(
+        TransitionCommitPlan.MarkWaitingExternal plan,
+        AwaitItemContinuationHandler itemContinuationHandler) {
+        ExecutionRecord<Object, Object> record = plan.record();
+        TransitionAwaitSuspension suspended = plan.suspension();
+        return awaitCoordinator.importSuspension(suspended)
+            .onItem().transformToUni(ignored -> {
+                return executionStateStore.markWaitingExternal(
+                    record.tenantId(),
+                    record.executionId(),
+                    record.version(),
+                    plan.transitionKey(),
+                    suspended.unitId(),
+                    suspended.stepIndex(),
+                    plan.nowEpochMs())
+                    .onItem().transformToUni(updated -> {
+                        if (updated.isPresent()) {
+                            effects.recordExecutionWaiting(new AwaitReplayLifecycleEvent(
+                                AwaitReplayLifecycleEvent.EXECUTION_WAITING,
+                                record.executionId(),
+                                suspended.unitId(),
+                                null,
+                                suspended.stepIndex(),
+                                ExecutionStatus.WAITING_EXTERNAL.name(),
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null));
+                            return effects.releaseAlreadyCompletedAwaitUnit(
+                                updated.get(),
+                                suspended,
+                                plan.nowEpochMs(),
+                                itemContinuationHandler);
+                        }
+                        return Uni.createFrom().failure(new IllegalStateException(
+                            "Failed to persist WAITING_EXTERNAL state for execution "
+                                + record.executionId()
+                                + " at step "
+                                + suspended.stepIndex()
+                                + " (expectedVersion="
+                                + record.version()
+                                + ", awaitUnitId="
+                                + suspended.unitId()
+                                + ")"));
+                    });
+            });
+    }
+
+    private Uni<Void> markSucceeded(TransitionCommitPlan.MarkSucceeded plan) {
+        return terminalPublicationBarrier.publishBeforeSuccess(plan.record(), plan.result())
+            .replaceWith(plan.outputItems())
+            .onItem().transformToUni(payload -> executionStateStore.markSucceeded(
+                plan.record().tenantId(),
+                plan.record().executionId(),
+                plan.record().version(),
+                plan.transitionKey(),
+                payload,
+                plan.nowEpochMs()))
+            .replaceWithVoid();
+    }
+
+    private Uni<Void> handleFailure(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        Throwable failure) {
+        return executionFailureHandler.handleExecutionFailure(
+            record,
+            transitionKey,
+            failure,
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher);
+    }
+
+    interface Effects {
+        Uni<Void> releaseAlreadyCompletedAwaitUnit(
+            ExecutionRecord<Object, Object> record,
+            TransitionAwaitSuspension suspended,
+            long nowEpochMs,
+            AwaitItemContinuationHandler itemContinuationHandler);
+
+        void recordExecutionWaiting(AwaitReplayLifecycleEvent lifecycleEvent);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TransitionCommitPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TransitionCommitPlan.java
@@ -1,0 +1,89 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionFailureEnvelope;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.TransitionWorkerOutcome;
+
+sealed interface TransitionCommitPlan
+    permits TransitionCommitPlan.MarkSucceeded,
+    TransitionCommitPlan.MarkWaitingExternal,
+    TransitionCommitPlan.HandleFailure {
+
+    ExecutionRecord<Object, Object> record();
+
+    String transitionKey();
+
+    static TransitionCommitPlan from(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionResultEnvelope result,
+        long nowEpochMs) {
+        if (result == null) {
+            return new HandleFailure(
+                record,
+                transitionKey,
+                new IllegalStateException("PipelineTransitionWorker returned null result"));
+        }
+        if (result.outcome() == TransitionWorkerOutcome.WAITING_EXTERNAL) {
+            TransitionAwaitSuspension suspension = result.awaitSuspension();
+            if (suspension == null) {
+                return new HandleFailure(
+                    record,
+                    transitionKey,
+                    new IllegalStateException("WAITING_EXTERNAL result missing await suspension"));
+            }
+            return new MarkWaitingExternal(record, transitionKey, suspension, nowEpochMs);
+        }
+        if (result.outcome() == TransitionWorkerOutcome.FAILED) {
+            TransitionFailureEnvelope failure = result.failure();
+            if (failure == null) {
+                return new HandleFailure(
+                    record,
+                    transitionKey,
+                    new IllegalStateException("FAILED result missing failure payload"));
+            }
+            return new HandleFailure(record, transitionKey, failure.toException());
+        }
+
+        List<?> outputItems = result.coordinatorOutputItems();
+        if (record.resultShape() == ExecutionResultShape.SINGLE && outputItems.size() > 1) {
+            return new HandleFailure(
+                record,
+                transitionKey,
+                new IllegalStateException(
+                    "Async queue execution " + record.executionId()
+                        + " produced " + outputItems.size()
+                        + " terminal items for SINGLE result shape"));
+        }
+        return new MarkSucceeded(record, transitionKey, result, outputItems, nowEpochMs);
+    }
+
+    record MarkSucceeded(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionResultEnvelope result,
+        List<?> outputItems,
+        long nowEpochMs) implements TransitionCommitPlan {
+        public MarkSucceeded {
+            outputItems = List.copyOf(outputItems);
+        }
+    }
+
+    record MarkWaitingExternal(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionAwaitSuspension suspension,
+        long nowEpochMs) implements TransitionCommitPlan {
+    }
+
+    record HandleFailure(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        Throwable failure) implements TransitionCommitPlan {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitLiveCompletionRegistry.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitLiveCompletionRegistry.java
@@ -16,19 +16,10 @@
 
 package org.pipelineframework.awaitable;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Flow;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.smallrye.mutiny.Uni;
@@ -41,16 +32,18 @@ public class AwaitLiveCompletionRegistry {
 
     private final ConcurrentMap<Key, LiveAwaitSession<?>> sessions = new ConcurrentHashMap<>();
 
-    public <O> LiveAwaitSession<O> open(AwaitStepDescriptor descriptor, String tenantId, String unitId) {
+    <O> LiveAwaitSession<O> open(AwaitStepDescriptor descriptor, String tenantId, String unitId) {
         Objects.requireNonNull(descriptor, "descriptor must not be null");
         Objects.requireNonNull(tenantId, "tenantId must not be null");
         Objects.requireNonNull(unitId, "unitId must not be null");
         Class<?> outputType = resolveOutputType(descriptor);
         Key key = new Key(tenantId, unitId);
+        AtomicReference<LiveAwaitSession<?>> sessionRef = new AtomicReference<>();
         LiveAwaitSession<O> session = new LiveAwaitSession<>(
-            key,
+            unitId,
             outputType,
-            () -> sessions.remove(key));
+            () -> sessions.remove(key, sessionRef.get()));
+        sessionRef.set(session);
         LiveAwaitSession<?> existing = sessions.putIfAbsent(key, session);
         if (existing != null) {
             throw new IllegalStateException("A live await stream already owns await unit " + unitId);
@@ -69,9 +62,9 @@ public class AwaitLiveCompletionRegistry {
         return session.accept(record).replaceWith(Boolean.TRUE);
     }
 
-    public void close(String tenantId, String unitId) {
-        if (tenantId != null && unitId != null) {
-            sessions.remove(new Key(tenantId, unitId));
+    void close(String tenantId, String unitId, LiveAwaitSession<?> expectedSession) {
+        if (tenantId != null && unitId != null && expectedSession != null) {
+            sessions.remove(new Key(tenantId, unitId), expectedSession);
         }
     }
 
@@ -93,332 +86,4 @@ public class AwaitLiveCompletionRegistry {
     private record Key(String tenantId, String unitId) {
     }
 
-    public static final class LiveAwaitSession<O> implements Flow.Publisher<O> {
-        private final Key key;
-        private final Class<?> outputType;
-        private final Runnable closeHook;
-        private final Object lock = new Object();
-        private final ArrayDeque<Pending<O>> pending = new ArrayDeque<>();
-        private final Set<String> seenCompletions = new HashSet<>();
-        private final Set<String> acceptedCompletions = new HashSet<>();
-        private final Map<String, CompletableFuture<Void>> acceptedWaiters = new HashMap<>();
-        private final AtomicBoolean closed = new AtomicBoolean(false);
-        private Flow.Subscriber<? super O> subscriber;
-        private long requested;
-        private boolean dispatchComplete;
-        private int expectedItemCount;
-        private int emittedItemCount;
-        private boolean subscriberReady;
-        private boolean cancelled;
-        private boolean terminated;
-        private boolean terminalSignalDelivered;
-        private Throwable terminalFailure;
-        private boolean draining;
-        private boolean drainAgain;
-
-        private LiveAwaitSession(Key key, Class<?> outputType, Runnable closeHook) {
-            this.key = key;
-            this.outputType = outputType;
-            this.closeHook = closeHook;
-        }
-
-        @Override
-        public void subscribe(Flow.Subscriber<? super O> subscriber) {
-            Objects.requireNonNull(subscriber, "subscriber must not be null");
-            boolean reject = false;
-            synchronized (lock) {
-                if (this.subscriber == null) {
-                    this.subscriber = subscriber;
-                } else {
-                    reject = true;
-                }
-            }
-            if (reject) {
-                subscriber.onSubscribe(NoopSubscription.INSTANCE);
-                subscriber.onError(new IllegalStateException("Live await streams support a single subscriber"));
-                return;
-            }
-            subscriber.onSubscribe(new LiveSubscription());
-            synchronized (lock) {
-                subscriberReady = true;
-            }
-            drain();
-        }
-
-        public Uni<Void> accept(AwaitInteractionRecord record) {
-            Objects.requireNonNull(record, "record must not be null");
-            if (record.status() != AwaitInteractionStatus.COMPLETED) {
-                IllegalStateException failure = new IllegalStateException(
-                    "Live await stream received terminal interaction " + record.interactionId()
-                        + " with status " + record.status());
-                fail(failure);
-                return Uni.createFrom().failure(failure);
-            }
-            CompletableFuture<Void> accepted = new CompletableFuture<>();
-            String completionKey = completionKey(record);
-            O payload;
-            try {
-                @SuppressWarnings("unchecked")
-                O coerced = (O) AwaitPayloadSupport.coercePayload(record.responsePayload(), outputType);
-                payload = coerced;
-            } catch (Throwable failure) {
-                accepted.completeExceptionally(failure);
-                fail(failure);
-                return Uni.createFrom().completionStage(accepted);
-            }
-            synchronized (lock) {
-                if (cancelled || terminated) {
-                    accepted.completeExceptionally(new IllegalStateException(
-                        "Live await stream is no longer accepting completions for unit " + key.unitId()));
-                    return Uni.createFrom().completionStage(accepted);
-                }
-                if (!seenCompletions.add(completionKey)) {
-                    accepted.complete(null);
-                    return Uni.createFrom().completionStage(accepted);
-                }
-                pending.addLast(new Pending<>(completionKey, payload, accepted));
-            }
-            drain();
-            return Uni.createFrom().completionStage(accepted);
-        }
-
-        public Uni<Void> awaitAccepted(AwaitInteractionRecord record) {
-            String completionKey = completionKey(record);
-            synchronized (lock) {
-                if (acceptedCompletions.contains(completionKey)) {
-                    return Uni.createFrom().voidItem();
-                }
-                if (cancelled || terminated) {
-                    return Uni.createFrom().failure(new IllegalStateException(
-                        "Live await stream is no longer accepting completions for unit " + key.unitId()));
-                }
-                return Uni.createFrom().completionStage(
-                    acceptedWaiters.computeIfAbsent(completionKey, ignored -> new CompletableFuture<>()));
-            }
-        }
-
-        public void markDispatchComplete(int expectedItemCount) {
-            synchronized (lock) {
-                this.dispatchComplete = true;
-                this.expectedItemCount = Math.max(0, expectedItemCount);
-            }
-            drain();
-        }
-
-        public void fail(Throwable failure) {
-            Objects.requireNonNull(failure, "failure must not be null");
-            List<Pending<O>> rejected;
-            Flow.Subscriber<? super O> current;
-            synchronized (lock) {
-                if (terminated) {
-                    return;
-                }
-                terminated = true;
-                terminalFailure = failure;
-                rejected = new ArrayList<>(pending);
-                pending.clear();
-                if (subscriberReady && subscriber != null) {
-                    terminalSignalDelivered = true;
-                    current = subscriber;
-                } else {
-                    current = null;
-                }
-            }
-            for (Pending<O> item : rejected) {
-                item.accepted().completeExceptionally(failure);
-            }
-            failAcceptedWaiters(failure);
-            if (current != null) {
-                current.onError(failure);
-            }
-            close();
-        }
-
-        private void request(long n) {
-            if (n <= 0) {
-                fail(new IllegalArgumentException("request amount must be positive"));
-                return;
-            }
-            synchronized (lock) {
-                requested = addCap(requested, n);
-            }
-            drain();
-        }
-
-        private void cancel() {
-            List<Pending<O>> rejected;
-            synchronized (lock) {
-                if (terminated) {
-                    return;
-                }
-                cancelled = true;
-                terminated = true;
-                rejected = new ArrayList<>(pending);
-                pending.clear();
-            }
-            IllegalStateException failure = new IllegalStateException(
-                "Live await stream cancelled for unit " + key.unitId());
-            for (Pending<O> item : rejected) {
-                item.accepted().completeExceptionally(failure);
-            }
-            failAcceptedWaiters(failure);
-            close();
-        }
-
-        private void drain() {
-            synchronized (lock) {
-                if (draining) {
-                    drainAgain = true;
-                    return;
-                }
-                draining = true;
-            }
-            while (true) {
-                List<Pending<O>> toEmit = new ArrayList<>();
-                Flow.Subscriber<? super O> toComplete = null;
-                Throwable toFail = null;
-                synchronized (lock) {
-                    while (!terminated && subscriberReady && subscriber != null && requested > 0 && !pending.isEmpty()) {
-                        Pending<O> next = pending.removeFirst();
-                        if (requested != Long.MAX_VALUE) {
-                            requested--;
-                        }
-                        toEmit.add(next);
-                    }
-                }
-                for (Pending<O> item : toEmit) {
-                    try {
-                        subscriber.onNext(item.item());
-                        item.accepted().complete(null);
-                        completeAcceptedWaiter(item.completionKey());
-                    } catch (Throwable failure) {
-                        item.accepted().completeExceptionally(failure);
-                        failAcceptedWaiter(item.completionKey(), failure);
-                        fail(failure);
-                        finishDrain();
-                        return;
-                    }
-                }
-                synchronized (lock) {
-                    emittedItemCount += toEmit.size();
-                    if (!terminalSignalDelivered
-                        && terminated
-                        && terminalFailure != null
-                        && subscriberReady
-                        && subscriber != null) {
-                        terminalSignalDelivered = true;
-                        toFail = terminalFailure;
-                    } else if (!terminated
-                        && subscriber != null
-                        && subscriberReady
-                        && dispatchComplete
-                        && pending.isEmpty()
-                        && emittedItemCount >= expectedItemCount) {
-                        terminated = true;
-                        terminalSignalDelivered = true;
-                        toComplete = subscriber;
-                    }
-                    if (toComplete != null || toFail != null) {
-                        draining = false;
-                        drainAgain = false;
-                    } else if (!drainAgain) {
-                        draining = false;
-                    } else {
-                        drainAgain = false;
-                        continue;
-                    }
-                }
-                if (toFail != null) {
-                    subscriber.onError(toFail);
-                    close();
-                }
-                if (toComplete != null) {
-                    toComplete.onComplete();
-                    close();
-                }
-                return;
-            }
-        }
-
-        private void finishDrain() {
-            synchronized (lock) {
-                draining = false;
-                drainAgain = false;
-            }
-        }
-
-        private void close() {
-            if (closed.compareAndSet(false, true)) {
-                closeHook.run();
-            }
-        }
-
-        private void completeAcceptedWaiter(String completionKey) {
-            CompletableFuture<Void> waiter;
-            synchronized (lock) {
-                acceptedCompletions.add(completionKey);
-                waiter = acceptedWaiters.remove(completionKey);
-            }
-            if (waiter != null) {
-                waiter.complete(null);
-            }
-        }
-
-        private void failAcceptedWaiter(String completionKey, Throwable failure) {
-            CompletableFuture<Void> waiter;
-            synchronized (lock) {
-                waiter = acceptedWaiters.remove(completionKey);
-            }
-            if (waiter != null) {
-                waiter.completeExceptionally(failure);
-            }
-        }
-
-        private void failAcceptedWaiters(Throwable failure) {
-            List<CompletableFuture<Void>> waiters;
-            synchronized (lock) {
-                waiters = new ArrayList<>(acceptedWaiters.values());
-                acceptedWaiters.clear();
-            }
-            for (CompletableFuture<Void> waiter : waiters) {
-                waiter.completeExceptionally(failure);
-            }
-        }
-
-        private static long addCap(long current, long increment) {
-            long updated = current + increment;
-            return updated < 0 ? Long.MAX_VALUE : updated;
-        }
-
-        private static String completionKey(AwaitInteractionRecord record) {
-            return record.itemIndex() == null ? record.interactionId() : "item:" + record.itemIndex();
-        }
-
-        private final class LiveSubscription implements Flow.Subscription {
-            @Override
-            public void request(long n) {
-                LiveAwaitSession.this.request(n);
-            }
-
-            @Override
-            public void cancel() {
-                LiveAwaitSession.this.cancel();
-            }
-        }
-
-        private enum NoopSubscription implements Flow.Subscription {
-            INSTANCE;
-
-            @Override
-            public void request(long n) {
-            }
-
-            @Override
-            public void cancel() {
-            }
-        }
-
-        private record Pending<O>(String completionKey, O item, CompletableFuture<Void> accepted) {
-        }
-    }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/AwaitStepSupport.java
@@ -1,19 +1,12 @@
 package org.pipelineframework.awaitable;
 
-import java.lang.reflect.Array;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.subscription.Cancellable;
-import org.pipelineframework.config.ParallelismPolicy;
 import org.pipelineframework.config.PipelineConfig;
 import org.pipelineframework.orchestrator.OrchestratorMode;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
@@ -265,214 +258,12 @@ public class AwaitStepSupport {
         return new AwaitExecutionContext(context.tenantId(), context.executionId(), context.currentStepIndex());
     }
 
-    @SuppressWarnings("unchecked")
     private <I, O> Multi<O> awaitOneToOneStream(
         AwaitStepDescriptor descriptor,
         Multi<I> input,
-        AwaitExecutionContext context
-    ) {
-        if (isKafkaItemStream(descriptor)) {
-            return awaitOneToOneKafkaLiveStream(descriptor, input, context);
-        }
-        return awaitOneToOneStreamSuspending(descriptor, input, context);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <I, O> Multi<O> awaitOneToOneKafkaLiveStream(
-        AwaitStepDescriptor descriptor,
-        Multi<I> input,
-        AwaitExecutionContext context
-    ) {
-        int stepIndex = context.currentStepIndex();
-        String unitId = streamUnitId(descriptor, context, stepIndex);
-        return Multi.createFrom().deferred(() -> {
-            AwaitLiveCompletionRegistry.LiveAwaitSession<O> session;
-            try {
-                session = liveCompletionRegistry.open(descriptor, context.tenantId(), unitId);
-            } catch (Throwable failure) {
-                return Multi.createFrom().failure(failure);
-            }
-            AtomicInteger itemIndex = new AtomicInteger();
-            AtomicReference<Cancellable> dispatchSubscription = new AtomicReference<>();
-            Uni<Void> dispatch = dispatchLiveKafkaAwaitItems(descriptor, input, context, unitId, itemIndex, session)
-                .onItem().transformToUni(ignored -> {
-                    int dispatchedItems = itemIndex.get();
-                    if (dispatchedItems == 0) {
-                        session.markDispatchComplete(0);
-                        return Uni.createFrom().voidItem();
-                    }
-                    return awaitCoordinator.markDispatchComplete(
-                        context.tenantId(),
-                        unitId,
-                        dispatchedItems,
-                        System.currentTimeMillis())
-                        .invoke(unit -> session.markDispatchComplete(dispatchedItems))
-                        .replaceWithVoid();
-                })
-                .onFailure().invoke(session::fail)
-                .replaceWithVoid();
-            return Multi.createFrom().publisher(session)
-                .onSubscription().invoke(ignored -> dispatchSubscription.set(dispatch.subscribe().with(
-                    item -> {
-                    },
-                    session::fail)))
-                .onTermination().invoke((failure, cancelled) -> {
-                    Cancellable active = dispatchSubscription.get();
-                    if (cancelled && active != null) {
-                        active.cancel();
-                    }
-                    if (failure != null) {
-                        session.fail(failure);
-                    }
-                    liveCompletionRegistry.close(context.tenantId(), unitId);
-                });
-        });
-    }
-
-    private <I, O> Uni<Void> dispatchLiveKafkaAwaitItems(
-        AwaitStepDescriptor descriptor,
-        Multi<I> input,
-        AwaitExecutionContext context,
-        String unitId,
-        AtomicInteger itemIndex,
-        AwaitLiveCompletionRegistry.LiveAwaitSession<O> session
-    ) {
-        Multi<AwaitInteractionRecord> dispatches = input.onItem().transformToUni(item -> {
-            int index = itemIndex.getAndIncrement();
-            return dispatchLiveKafkaAwaitItem(descriptor, item, context, unitId, index, session);
-        }).merge(awaitMaxConcurrency());
-        if (pipelineConfig != null && pipelineConfig.parallelism() == ParallelismPolicy.SEQUENTIAL) {
-            dispatches = input.onItem().transformToUni(item -> {
-                int index = itemIndex.getAndIncrement();
-                return dispatchLiveKafkaAwaitItem(descriptor, item, context, unitId, index, session);
-            }).concatenate();
-        }
-        return dispatches.collect().in(() -> Boolean.TRUE, (ignored, record) -> {
-        }).replaceWithVoid();
-    }
-
-    private <I, O> Uni<AwaitInteractionRecord> dispatchLiveKafkaAwaitItem(
-        AwaitStepDescriptor descriptor,
-        I item,
-        AwaitExecutionContext context,
-        String unitId,
-        int index,
-        AwaitLiveCompletionRegistry.LiveAwaitSession<O> session
-    ) {
-        return withAwaitExecutionContext(context, () -> awaitCoordinator.createOrGetItem(
-            descriptor,
-            context.tenantId(),
-            context.executionId(),
-            context.currentStepIndex(),
-            context.executionId() + ":" + context.currentStepIndex() + ":" + index,
-            item,
-            unitId,
-            index,
-            null,
-            null)
-            .onItem().transformToUni(created -> {
-                AwaitInteractionRecord record = created.record();
-                if (record.status() == AwaitInteractionStatus.COMPLETED) {
-                    return session.accept(record).replaceWith(record);
-                }
-                if (record.status().terminal()) {
-                    return Uni.createFrom().failure(new IllegalStateException(
-                        "Await interaction " + record.interactionId()
-                            + " is terminal with status " + record.status()
-                            + " and cannot be accepted by the live await stream."));
-                }
-                Uni<Void> accepted = session.awaitAccepted(record);
-                if (record.status() == AwaitInteractionStatus.WAITING) {
-                    return awaitCoordinator.dispatch(descriptor, record)
-                        .chain(dispatched -> accepted.replaceWith(dispatched));
-                }
-                return accepted.replaceWith(record);
-            }));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <I, O> Multi<O> awaitOneToOneStreamSuspending(
-        AwaitStepDescriptor descriptor,
-        Multi<I> input,
-        AwaitExecutionContext context
-    ) {
-        int stepIndex = context.currentStepIndex();
-        String unitId = streamUnitId(descriptor, context, stepIndex);
-        AtomicInteger itemIndex = new AtomicInteger();
-        Multi<AwaitInteractionRecord> dispatched = input.onItem().transformToUniAndConcatenate(item -> {
-            int index = itemIndex.getAndIncrement();
-            return withAwaitExecutionContext(context, () -> awaitCoordinator.createOrGetItem(
-                descriptor,
-                context.tenantId(),
-                context.executionId(),
-                stepIndex,
-                context.executionId() + ":" + stepIndex + ":" + index,
-                item,
-                unitId,
-                index,
-                null,
-                null)
-                .onItem().transformToUni(created -> {
-                    AwaitInteractionRecord record = created.record();
-                    return record.status() == AwaitInteractionStatus.WAITING
-                        ? awaitCoordinator.dispatch(descriptor, record)
-                        : Uni.createFrom().item(record);
-                }));
-        });
-        return dispatched
-            .collect().in(() -> Boolean.TRUE, (ignored, record) -> {
-            })
-            .onItem().transformToMulti(ignored -> {
-                if (itemIndex.get() == 0) {
-                    return Multi.createFrom().empty();
-                }
-                return awaitCoordinator.markDispatchComplete(
-                    context.tenantId(),
-                    unitId,
-                    itemIndex.get(),
-                    System.currentTimeMillis())
-                    .onItem().transformToMulti(unit -> unit.status() == AwaitUnitStatus.COMPLETED
-                        ? awaitCoordinator.loadResumePayload(context.tenantId(), unitId)
-                            .toMulti()
-                            .onItem().transformToMultiAndConcatenate(payload -> {
-                                if (payload instanceof Iterable) {
-                                    return Multi.createFrom().<O>iterable((Iterable<O>) payload);
-                                } else if (payload != null && payload.getClass().isArray()) {
-                                    int length = Array.getLength(payload);
-                                    List<O> items = new ArrayList<>(length);
-                                    for (int i = 0; i < length; i++) {
-                                        items.add((O) Array.get(payload, i));
-                                    }
-                                    return Multi.createFrom().iterable(items);
-                                } else {
-                                    return Multi.createFrom().<O>item((O) payload);
-                                }
-                            })
-                        : Uni.createFrom().<O>failure(new AwaitSuspendedException(
-                            context.tenantId(),
-                            context.executionId(),
-                            unitId,
-                            stepIndex)).toMulti());
-            });
-    }
-
-    private static boolean isKafkaItemStream(AwaitStepDescriptor descriptor) {
-        return descriptor != null
-            && "ONE_TO_ONE".equalsIgnoreCase(descriptor.cardinality())
-            && "kafka".equalsIgnoreCase(descriptor.transportType());
-    }
-
-    private static String streamUnitId(AwaitStepDescriptor descriptor, AwaitExecutionContext context, int stepIndex) {
-        return UUID.nameUUIDFromBytes((context.tenantId() + ":" + context.executionId() + ":"
-            + descriptor.stepId() + ":" + stepIndex).getBytes(StandardCharsets.UTF_8)).toString();
-    }
-
-    private int awaitMaxConcurrency() {
-        int configured = pipelineConfig == null ? 128 : pipelineConfig.maxConcurrency();
-        if (configured < 1) {
-            return 1;
-        }
-        return Math.min(configured, 1024);
+        AwaitExecutionContext context) {
+        return new ItemizedAwaitStream(awaitCoordinator, liveCompletionRegistry, pipelineConfig)
+            .awaitOneToOneStream(descriptor, input, context);
     }
 
     private <T> Uni<T> withAwaitExecutionContext(AwaitExecutionContext context, java.util.function.Supplier<Uni<T>> supplier) {

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/ItemizedAwaitStream.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/ItemizedAwaitStream.java
@@ -1,0 +1,287 @@
+package org.pipelineframework.awaitable;
+
+import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import org.pipelineframework.config.ParallelismPolicy;
+import org.pipelineframework.config.PipelineConfig;
+
+final class ItemizedAwaitStream {
+
+    private final AwaitCoordinator awaitCoordinator;
+    private final AwaitLiveCompletionRegistry liveCompletionRegistry;
+    private final PipelineConfig pipelineConfig;
+
+    ItemizedAwaitStream(
+        AwaitCoordinator awaitCoordinator,
+        AwaitLiveCompletionRegistry liveCompletionRegistry,
+        PipelineConfig pipelineConfig) {
+        this.awaitCoordinator = awaitCoordinator;
+        this.liveCompletionRegistry = liveCompletionRegistry;
+        this.pipelineConfig = pipelineConfig;
+    }
+
+    @SuppressWarnings("unchecked")
+    <I, O> Multi<O> awaitOneToOneStream(
+        AwaitStepDescriptor descriptor,
+        Multi<I> input,
+        AwaitExecutionContext context) {
+        if (isKafkaItemStream(descriptor)) {
+            return awaitOneToOneKafkaLiveStream(descriptor, input, context);
+        }
+        return awaitOneToOneStreamSuspending(descriptor, input, context);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <I, O> Multi<O> awaitOneToOneKafkaLiveStream(
+        AwaitStepDescriptor descriptor,
+        Multi<I> input,
+        AwaitExecutionContext context) {
+        int stepIndex = context.currentStepIndex();
+        String unitId = streamUnitId(descriptor, context, stepIndex);
+        return Multi.createFrom().deferred(() -> openKafkaLiveSession(descriptor, input, context, unitId));
+    }
+
+    private <I, O> Multi<O> openKafkaLiveSession(
+        AwaitStepDescriptor descriptor,
+        Multi<I> input,
+        AwaitExecutionContext context,
+        String unitId) {
+        LiveAwaitSession<O> session;
+        try {
+            session = liveCompletionRegistry.open(descriptor, context.tenantId(), unitId);
+        } catch (Throwable failure) {
+            return Multi.createFrom().failure(failure);
+        }
+        AtomicInteger itemIndex = new AtomicInteger();
+        Uni<Void> dispatch = dispatchLiveKafkaAwaitItems(descriptor, input, context, unitId, itemIndex, session)
+            .chain(() -> markLiveDispatchComplete(context, unitId, itemIndex.get(), session))
+            .onFailure().invoke(session::fail)
+            .replaceWithVoid();
+        return liveSessionPublisher(context, unitId, session, dispatch);
+    }
+
+    private <O> Uni<Void> markLiveDispatchComplete(
+        AwaitExecutionContext context,
+        String unitId,
+        int dispatchedItems,
+        LiveAwaitSession<O> session) {
+        if (dispatchedItems == 0) {
+            session.markDispatchComplete(0);
+            return Uni.createFrom().voidItem();
+        }
+        return awaitCoordinator.markDispatchComplete(
+            context.tenantId(),
+            unitId,
+            dispatchedItems,
+            System.currentTimeMillis())
+            .invoke(unit -> session.markDispatchComplete(dispatchedItems))
+            .replaceWithVoid();
+    }
+
+    private <O> Multi<O> liveSessionPublisher(
+        AwaitExecutionContext context,
+        String unitId,
+        LiveAwaitSession<O> session,
+        Uni<Void> dispatch) {
+        AtomicReference<Cancellable> dispatchSubscription = new AtomicReference<>();
+        return Multi.createFrom().publisher(session)
+            .onSubscription().invoke(ignored -> dispatchSubscription.set(dispatch.subscribe().with(
+                item -> {
+                },
+                session::fail)))
+            .onTermination().invoke((failure, cancelled) ->
+                closeLiveSession(context, unitId, session, dispatchSubscription.get(), failure, cancelled));
+    }
+
+    private <O> void closeLiveSession(
+        AwaitExecutionContext context,
+        String unitId,
+        LiveAwaitSession<O> session,
+        Cancellable dispatchSubscription,
+        Throwable failure,
+        boolean cancelled) {
+        if ((cancelled || failure != null) && dispatchSubscription != null) {
+            dispatchSubscription.cancel();
+        }
+        if (failure != null) {
+            session.fail(failure);
+        }
+        liveCompletionRegistry.close(context.tenantId(), unitId, session);
+    }
+
+    private <I, O> Uni<Void> dispatchLiveKafkaAwaitItems(
+        AwaitStepDescriptor descriptor,
+        Multi<I> input,
+        AwaitExecutionContext context,
+        String unitId,
+        AtomicInteger itemIndex,
+        LiveAwaitSession<O> session) {
+        Multi<AwaitInteractionRecord> dispatches = input.onItem().transformToUni(item -> {
+            int index = itemIndex.getAndIncrement();
+            return dispatchLiveKafkaAwaitItem(descriptor, item, context, unitId, index, session);
+        }).merge(awaitMaxConcurrency());
+        if (pipelineConfig != null && pipelineConfig.parallelism() == ParallelismPolicy.SEQUENTIAL) {
+            dispatches = input.onItem().transformToUni(item -> {
+                int index = itemIndex.getAndIncrement();
+                return dispatchLiveKafkaAwaitItem(descriptor, item, context, unitId, index, session);
+            }).concatenate();
+        }
+        return dispatches.collect().in(() -> Boolean.TRUE, (ignored, record) -> {
+        }).replaceWithVoid();
+    }
+
+    private <I, O> Uni<AwaitInteractionRecord> dispatchLiveKafkaAwaitItem(
+        AwaitStepDescriptor descriptor,
+        I item,
+        AwaitExecutionContext context,
+        String unitId,
+        int index,
+        LiveAwaitSession<O> session) {
+        return withAwaitExecutionContext(context, () -> awaitCoordinator.createOrGetItem(
+            descriptor,
+            context.tenantId(),
+            context.executionId(),
+            context.currentStepIndex(),
+            context.executionId() + ":" + context.currentStepIndex() + ":" + index,
+            item,
+            unitId,
+            index,
+            null,
+            null)
+            .onItem().transformToUni(created -> {
+                AwaitInteractionRecord record = created.record();
+                if (record.status() == AwaitInteractionStatus.COMPLETED) {
+                    return session.accept(record).replaceWith(record);
+                }
+                if (record.status().terminal()) {
+                    return Uni.createFrom().failure(new IllegalStateException(
+                        "Await interaction " + record.interactionId()
+                            + " is terminal with status " + record.status()
+                            + " and cannot be accepted by the live await stream."));
+                }
+                Uni<Void> accepted = session.awaitAccepted(record);
+                if (record.status() == AwaitInteractionStatus.WAITING) {
+                    return awaitCoordinator.dispatch(descriptor, record)
+                        .chain(dispatched -> accepted.replaceWith(dispatched));
+                }
+                return accepted.replaceWith(record);
+            }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <I, O> Multi<O> awaitOneToOneStreamSuspending(
+        AwaitStepDescriptor descriptor,
+        Multi<I> input,
+        AwaitExecutionContext context) {
+        int stepIndex = context.currentStepIndex();
+        String unitId = streamUnitId(descriptor, context, stepIndex);
+        AtomicInteger itemIndex = new AtomicInteger();
+        Multi<AwaitInteractionRecord> dispatched = input.onItem().transformToUniAndConcatenate(item -> {
+            int index = itemIndex.getAndIncrement();
+            return withAwaitExecutionContext(context, () -> awaitCoordinator.createOrGetItem(
+                descriptor,
+                context.tenantId(),
+                context.executionId(),
+                stepIndex,
+                context.executionId() + ":" + stepIndex + ":" + index,
+                item,
+                unitId,
+                index,
+                null,
+                null)
+                .onItem().transformToUni(created -> {
+                    AwaitInteractionRecord record = created.record();
+                    return record.status() == AwaitInteractionStatus.WAITING
+                        ? awaitCoordinator.dispatch(descriptor, record)
+                        : Uni.createFrom().item(record);
+                }));
+        });
+        return dispatched
+            .collect().in(() -> Boolean.TRUE, (ignored, record) -> {
+            })
+            .onItem().transformToMulti(ignored -> {
+                if (itemIndex.get() == 0) {
+                    return Multi.createFrom().empty();
+                }
+                return awaitCoordinator.markDispatchComplete(
+                    context.tenantId(),
+                    unitId,
+                    itemIndex.get(),
+                    System.currentTimeMillis())
+                    .onItem().transformToMulti(unit -> unit.status() == AwaitUnitStatus.COMPLETED
+                        ? awaitCoordinator.loadResumePayload(context.tenantId(), unitId)
+                            .toMulti()
+                            .onItem().transformToMultiAndConcatenate(payload -> {
+                                if (payload instanceof Iterable) {
+                                    return Multi.createFrom().<O>iterable((Iterable<O>) payload);
+                                } else if (payload != null && payload.getClass().isArray()) {
+                                    int length = Array.getLength(payload);
+                                    List<O> items = new ArrayList<>(length);
+                                    for (int i = 0; i < length; i++) {
+                                        items.add((O) Array.get(payload, i));
+                                    }
+                                    return Multi.createFrom().iterable(items);
+                                } else {
+                                    return Multi.createFrom().<O>item((O) payload);
+                                }
+                            })
+                        : Uni.createFrom().<O>failure(new AwaitSuspendedException(
+                            context.tenantId(),
+                            context.executionId(),
+                            unitId,
+                            stepIndex)).toMulti());
+            });
+    }
+
+    private static boolean isKafkaItemStream(AwaitStepDescriptor descriptor) {
+        return descriptor != null
+            && "ONE_TO_ONE".equalsIgnoreCase(descriptor.cardinality())
+            && "kafka".equalsIgnoreCase(descriptor.transportType());
+    }
+
+    private static String streamUnitId(AwaitStepDescriptor descriptor, AwaitExecutionContext context, int stepIndex) {
+        return UUID.nameUUIDFromBytes((context.tenantId() + ":" + context.executionId() + ":"
+            + descriptor.stepId() + ":" + stepIndex).getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    private int awaitMaxConcurrency() {
+        int configured = pipelineConfig == null ? 128 : pipelineConfig.maxConcurrency();
+        if (configured < 1) {
+            return 1;
+        }
+        return Math.min(configured, 1024);
+    }
+
+    private <T> Uni<T> withAwaitExecutionContext(
+        AwaitExecutionContext context,
+        java.util.function.Supplier<Uni<T>> supplier) {
+        return Uni.createFrom().deferred(() -> {
+            AwaitExecutionContext previous = AwaitExecutionContextHolder.get();
+            AwaitExecutionContextHolder.set(context);
+            try {
+                return supplier.get();
+            } catch (Throwable failure) {
+                return Uni.createFrom().failure(failure);
+            } finally {
+                restoreAwaitExecutionContext(previous);
+            }
+        });
+    }
+
+    private void restoreAwaitExecutionContext(AwaitExecutionContext previous) {
+        if (previous == null) {
+            AwaitExecutionContextHolder.clear();
+        } else {
+            AwaitExecutionContextHolder.set(previous);
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSession.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSession.java
@@ -1,0 +1,299 @@
+package org.pipelineframework.awaitable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.smallrye.mutiny.Uni;
+
+final class LiveAwaitSession<O> implements Flow.Publisher<O> {
+
+    private final String unitId;
+    private final Class<?> outputType;
+    private final Runnable closeHook;
+    private final Object lock = new Object();
+    private final Map<String, CompletableFuture<Void>> acceptanceFutures = new HashMap<>();
+    private final Map<String, CompletableFuture<Void>> acceptedWaiters = new HashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private LiveAwaitSessionState<O> state = LiveAwaitSessionState.initial();
+    private Flow.Subscriber<? super O> subscriber;
+    private boolean draining;
+    private boolean drainAgain;
+
+    LiveAwaitSession(String unitId, Class<?> outputType, Runnable closeHook) {
+        this.unitId = Objects.requireNonNull(unitId, "unitId must not be null");
+        this.outputType = Objects.requireNonNull(outputType, "outputType must not be null");
+        this.closeHook = Objects.requireNonNull(closeHook, "closeHook must not be null");
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super O> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber must not be null");
+        boolean reject;
+        List<LiveAwaitSessionEffect<O>> effects = List.of();
+        synchronized (lock) {
+            reject = state.subscriberAttached();
+            if (!reject) {
+                effects = apply(state.attachSubscriber());
+                this.subscriber = subscriber;
+            }
+        }
+        interpret(effects);
+        if (reject) {
+            subscriber.onSubscribe(NoopSubscription.INSTANCE);
+            subscriber.onError(new IllegalStateException("Live await streams support a single subscriber"));
+            return;
+        }
+        subscriber.onSubscribe(new LiveSubscription());
+        List<LiveAwaitSessionEffect<O>> readyEffects;
+        synchronized (lock) {
+            readyEffects = apply(state.markSubscriberReady());
+        }
+        interpret(readyEffects);
+        drain();
+    }
+
+    public Uni<Void> accept(AwaitInteractionRecord record) {
+        Objects.requireNonNull(record, "record must not be null");
+        if (record.status() != AwaitInteractionStatus.COMPLETED) {
+            IllegalStateException failure = new IllegalStateException(
+                "Live await stream received terminal interaction " + record.interactionId()
+                    + " with status " + record.status());
+            fail(failure);
+            return Uni.createFrom().failure(failure);
+        }
+        String completionKey = completionKey(record);
+        O payload;
+        try {
+            @SuppressWarnings("unchecked")
+            O coerced = (O) AwaitPayloadSupport.coercePayload(record.responsePayload(), outputType);
+            payload = coerced;
+        } catch (Throwable failure) {
+            fail(failure);
+            return Uni.createFrom().failure(failure);
+        }
+
+        CompletableFuture<Void> accepted = new CompletableFuture<>();
+        List<LiveAwaitSessionEffect<O>> effects;
+        synchronized (lock) {
+            if (!state.canAcceptCompletion()) {
+                accepted.completeExceptionally(new IllegalStateException(
+                    "Live await stream is no longer accepting completions for unit " + unitId));
+                return Uni.createFrom().completionStage(accepted);
+            }
+            if (state.duplicate(completionKey)) {
+                accepted.complete(null);
+                return Uni.createFrom().completionStage(accepted);
+            }
+            acceptanceFutures.put(completionKey, accepted);
+            effects = apply(state.admitCompletion(completionKey, payload));
+        }
+        interpret(effects);
+        drain();
+        return Uni.createFrom().completionStage(accepted);
+    }
+
+    public Uni<Void> awaitAccepted(AwaitInteractionRecord record) {
+        String completionKey = completionKey(record);
+        synchronized (lock) {
+            if (state.accepted(completionKey)) {
+                return Uni.createFrom().voidItem();
+            }
+            if (!state.canAcceptCompletion()) {
+                return Uni.createFrom().failure(new IllegalStateException(
+                    "Live await stream is no longer accepting completions for unit " + unitId));
+            }
+            return Uni.createFrom().completionStage(
+                acceptedWaiters.computeIfAbsent(completionKey, ignored -> new CompletableFuture<>()));
+        }
+    }
+
+    public void markDispatchComplete(int expectedItemCount) {
+        List<LiveAwaitSessionEffect<O>> effects;
+        synchronized (lock) {
+            effects = apply(state.markDispatchComplete(expectedItemCount));
+        }
+        interpret(effects);
+        drain();
+    }
+
+    public void fail(Throwable failure) {
+        Objects.requireNonNull(failure, "failure must not be null");
+        List<LiveAwaitSessionEffect<O>> effects;
+        synchronized (lock) {
+            effects = apply(state.fail(failure));
+        }
+        interpret(effects);
+        drain();
+    }
+
+    private void request(long n) {
+        List<LiveAwaitSessionEffect<O>> effects;
+        synchronized (lock) {
+            effects = apply(state.request(n));
+        }
+        interpret(effects);
+        drain();
+    }
+
+    private void cancel() {
+        List<LiveAwaitSessionEffect<O>> effects;
+        synchronized (lock) {
+            effects = apply(state.cancel(unitId));
+        }
+        interpret(effects);
+        drain();
+    }
+
+    private void drain() {
+        synchronized (lock) {
+            if (draining) {
+                drainAgain = true;
+                return;
+            }
+            draining = true;
+        }
+        while (true) {
+            LiveAwaitSessionDecision<O> decision;
+            synchronized (lock) {
+                decision = state.drain();
+                state = decision.state();
+                if (decision.effects().isEmpty() && !drainAgain) {
+                    draining = false;
+                    return;
+                }
+                drainAgain = false;
+            }
+            interpret(decision.effects());
+            synchronized (lock) {
+                if (!drainAgain) {
+                    draining = false;
+                    return;
+                }
+            }
+        }
+    }
+
+    private List<LiveAwaitSessionEffect<O>> apply(LiveAwaitSessionDecision<O> decision) {
+        state = decision.state();
+        return decision.effects();
+    }
+
+    private void interpret(Iterable<LiveAwaitSessionEffect<O>> effects) {
+        for (LiveAwaitSessionEffect<O> effect : effects) {
+            switch (effect) {
+                case LiveAwaitSessionEffect.EmitItem<O> emit -> {
+                    if (!emit(emit)) {
+                        return;
+                    }
+                }
+                case LiveAwaitSessionEffect.CompleteStream<O> ignored -> {
+                    if (subscriber != null) {
+                        subscriber.onComplete();
+                    }
+                }
+                case LiveAwaitSessionEffect.FailStream<O> fail -> {
+                    if (subscriber != null) {
+                        subscriber.onError(fail.failure());
+                    }
+                }
+                case LiveAwaitSessionEffect.FailAcceptance<O> fail -> failAcceptance(
+                    fail.completionKey(),
+                    fail.failure());
+                case LiveAwaitSessionEffect.FailAcceptedWaiters<O> fail -> failAcceptedWaiters(fail.failure());
+                case LiveAwaitSessionEffect.CloseSession<O> ignored -> close();
+            }
+        }
+    }
+
+    private boolean emit(LiveAwaitSessionEffect.EmitItem<O> emit) {
+        try {
+            subscriber.onNext(emit.item());
+            completeAcceptance(emit.completionKey());
+            return true;
+        } catch (Throwable failure) {
+            failAcceptance(emit.completionKey(), failure);
+            fail(failure);
+            return false;
+        }
+    }
+
+    private void completeAcceptance(String completionKey) {
+        CompletableFuture<Void> accepted;
+        CompletableFuture<Void> waiter;
+        synchronized (lock) {
+            accepted = acceptanceFutures.remove(completionKey);
+            waiter = acceptedWaiters.remove(completionKey);
+            state = state.acceptanceCompleted(completionKey).state();
+        }
+        if (accepted != null) {
+            accepted.complete(null);
+        }
+        if (waiter != null) {
+            waiter.complete(null);
+        }
+    }
+
+    private void failAcceptance(String completionKey, Throwable failure) {
+        CompletableFuture<Void> accepted;
+        CompletableFuture<Void> waiter;
+        synchronized (lock) {
+            accepted = acceptanceFutures.remove(completionKey);
+            waiter = acceptedWaiters.remove(completionKey);
+        }
+        if (accepted != null) {
+            accepted.completeExceptionally(failure);
+        }
+        if (waiter != null) {
+            waiter.completeExceptionally(failure);
+        }
+    }
+
+    private void failAcceptedWaiters(Throwable failure) {
+        Map<String, CompletableFuture<Void>> waiters;
+        synchronized (lock) {
+            waiters = new HashMap<>(acceptedWaiters);
+            acceptedWaiters.clear();
+        }
+        waiters.values().forEach(waiter -> waiter.completeExceptionally(failure));
+    }
+
+    private void close() {
+        if (closed.compareAndSet(false, true)) {
+            closeHook.run();
+        }
+    }
+
+    private static String completionKey(AwaitInteractionRecord record) {
+        return record.itemIndex() == null ? record.interactionId() : "item:" + record.itemIndex();
+    }
+
+    private final class LiveSubscription implements Flow.Subscription {
+        @Override
+        public void request(long n) {
+            LiveAwaitSession.this.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            LiveAwaitSession.this.cancel();
+        }
+    }
+
+    private enum NoopSubscription implements Flow.Subscription {
+        INSTANCE;
+
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSessionDecision.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSessionDecision.java
@@ -1,0 +1,24 @@
+package org.pipelineframework.awaitable;
+
+import java.util.List;
+import java.util.Objects;
+
+record LiveAwaitSessionDecision<O>(
+    LiveAwaitSessionState<O> state,
+    List<LiveAwaitSessionEffect<O>> effects) {
+
+    LiveAwaitSessionDecision {
+        Objects.requireNonNull(state, "state must not be null");
+        effects = List.copyOf(Objects.requireNonNull(effects, "effects must not be null"));
+    }
+
+    static <O> LiveAwaitSessionDecision<O> of(
+        LiveAwaitSessionState<O> state,
+        List<LiveAwaitSessionEffect<O>> effects) {
+        return new LiveAwaitSessionDecision<>(state, effects);
+    }
+
+    static <O> LiveAwaitSessionDecision<O> unchanged(LiveAwaitSessionState<O> state) {
+        return new LiveAwaitSessionDecision<>(state, List.of());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSessionEffect.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSessionEffect.java
@@ -1,0 +1,34 @@
+package org.pipelineframework.awaitable;
+
+/**
+ * Effect emitted by the immutable live-await session state machine.
+ *
+ * <p>The session wrapper interprets these effects against Flow subscribers and
+ * completion waiters; the state machine itself only decides what should happen.
+ */
+sealed interface LiveAwaitSessionEffect<O>
+    permits LiveAwaitSessionEffect.EmitItem,
+    LiveAwaitSessionEffect.CompleteStream,
+    LiveAwaitSessionEffect.FailStream,
+    LiveAwaitSessionEffect.FailAcceptance,
+    LiveAwaitSessionEffect.FailAcceptedWaiters,
+    LiveAwaitSessionEffect.CloseSession {
+
+    record EmitItem<O>(String completionKey, O item) implements LiveAwaitSessionEffect<O> {
+    }
+
+    record CompleteStream<O>() implements LiveAwaitSessionEffect<O> {
+    }
+
+    record FailStream<O>(Throwable failure) implements LiveAwaitSessionEffect<O> {
+    }
+
+    record FailAcceptance<O>(String completionKey, Throwable failure) implements LiveAwaitSessionEffect<O> {
+    }
+
+    record FailAcceptedWaiters<O>(Throwable failure) implements LiveAwaitSessionEffect<O> {
+    }
+
+    record CloseSession<O>() implements LiveAwaitSessionEffect<O> {
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSessionState.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/awaitable/LiveAwaitSessionState.java
@@ -1,0 +1,345 @@
+package org.pipelineframework.awaitable;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+record LiveAwaitSessionState<O>(
+    boolean subscriberAttached,
+    boolean subscriberReady,
+    long requested,
+    List<Pending<O>> pending,
+    Set<String> seenCompletions,
+    Set<String> acceptedCompletions,
+    boolean dispatchComplete,
+    int expectedItemCount,
+    int emittedItemCount,
+    boolean cancelled,
+    boolean terminated,
+    boolean terminalSignalDelivered,
+    Throwable terminalFailure) {
+
+    LiveAwaitSessionState {
+        pending = List.copyOf(Objects.requireNonNull(pending, "pending must not be null"));
+        seenCompletions = Set.copyOf(Objects.requireNonNull(seenCompletions, "seenCompletions must not be null"));
+        acceptedCompletions = Set.copyOf(
+            Objects.requireNonNull(acceptedCompletions, "acceptedCompletions must not be null"));
+    }
+
+    static <O> LiveAwaitSessionState<O> initial() {
+        return new LiveAwaitSessionState<>(
+            false,
+            false,
+            0L,
+            List.of(),
+            Set.of(),
+            Set.of(),
+            false,
+            0,
+            0,
+            false,
+            false,
+            false,
+            null);
+    }
+
+    boolean duplicate(String completionKey) {
+        return seenCompletions.contains(completionKey);
+    }
+
+    boolean accepted(String completionKey) {
+        return acceptedCompletions.contains(completionKey);
+    }
+
+    boolean canAcceptCompletion() {
+        return !cancelled && !terminated;
+    }
+
+    LiveAwaitSessionDecision<O> attachSubscriber() {
+        if (subscriberAttached) {
+            return LiveAwaitSessionDecision.unchanged(this);
+        }
+        return LiveAwaitSessionDecision.unchanged(withSubscriberAttached(true));
+    }
+
+    LiveAwaitSessionDecision<O> markSubscriberReady() {
+        return withSubscriberReady(true).drain();
+    }
+
+    LiveAwaitSessionDecision<O> admitCompletion(String completionKey, O item) {
+        if (!canAcceptCompletion() || duplicate(completionKey)) {
+            return LiveAwaitSessionDecision.unchanged(this);
+        }
+        List<Pending<O>> nextPending = new ArrayList<>(pending);
+        nextPending.add(new Pending<>(completionKey, item));
+        Set<String> nextSeen = new HashSet<>(seenCompletions);
+        nextSeen.add(completionKey);
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            nextPending,
+            nextSeen,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure).drain();
+    }
+
+    LiveAwaitSessionDecision<O> markDispatchComplete(int expectedItemCount) {
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            pending,
+            seenCompletions,
+            acceptedCompletions,
+            true,
+            Math.max(0, expectedItemCount),
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure).drain();
+    }
+
+    LiveAwaitSessionDecision<O> request(long n) {
+        if (n <= 0) {
+            return fail(new IllegalArgumentException("request amount must be positive"));
+        }
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            addCap(requested, n),
+            pending,
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure).drain();
+    }
+
+    LiveAwaitSessionDecision<O> cancel(String unitId) {
+        if (terminated) {
+            return LiveAwaitSessionDecision.unchanged(this);
+        }
+        IllegalStateException failure = new IllegalStateException(
+            "Live await stream cancelled for unit " + unitId);
+        List<LiveAwaitSessionEffect<O>> effects = failPendingEffects(failure);
+        effects.add(new LiveAwaitSessionEffect.FailAcceptedWaiters<>(failure));
+        effects.add(new LiveAwaitSessionEffect.CloseSession<>());
+        return LiveAwaitSessionDecision.of(new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            List.of(),
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            true,
+            true,
+            terminalSignalDelivered,
+            terminalFailure), effects);
+    }
+
+    LiveAwaitSessionDecision<O> fail(Throwable failure) {
+        Objects.requireNonNull(failure, "failure must not be null");
+        if (terminated) {
+            return LiveAwaitSessionDecision.unchanged(this);
+        }
+        List<LiveAwaitSessionEffect<O>> effects = failPendingEffects(failure);
+        effects.add(new LiveAwaitSessionEffect.FailAcceptedWaiters<>(failure));
+        LiveAwaitSessionState<O> failed = new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            List.of(),
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            true,
+            terminalSignalDelivered,
+            failure);
+        LiveAwaitSessionDecision<O> decision = append(failed.drain(), effects);
+        List<LiveAwaitSessionEffect<O>> effectsWithClose = new ArrayList<>(decision.effects());
+        if (effectsWithClose.stream().noneMatch(LiveAwaitSessionEffect.CloseSession.class::isInstance)) {
+            effectsWithClose.add(new LiveAwaitSessionEffect.CloseSession<>());
+        }
+        return LiveAwaitSessionDecision.of(decision.state(), effectsWithClose);
+    }
+
+    LiveAwaitSessionDecision<O> acceptanceCompleted(String completionKey) {
+        Set<String> nextAccepted = new HashSet<>(acceptedCompletions);
+        nextAccepted.add(completionKey);
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            pending,
+            seenCompletions,
+            nextAccepted,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure).drain();
+    }
+
+    LiveAwaitSessionDecision<O> drain() {
+        LiveAwaitSessionState<O> current = this;
+        List<LiveAwaitSessionEffect<O>> effects = new ArrayList<>();
+        while (!current.terminated
+            && current.subscriberReady
+            && current.subscriberAttached
+            && current.requested > 0
+            && !current.pending.isEmpty()) {
+            ArrayDeque<Pending<O>> queue = new ArrayDeque<>(current.pending);
+            Pending<O> next = queue.removeFirst();
+            long nextRequested = current.requested == Long.MAX_VALUE ? Long.MAX_VALUE : current.requested - 1;
+            current = new LiveAwaitSessionState<>(
+                current.subscriberAttached,
+                current.subscriberReady,
+                nextRequested,
+                List.copyOf(queue),
+                current.seenCompletions,
+                current.acceptedCompletions,
+                current.dispatchComplete,
+                current.expectedItemCount,
+                current.emittedItemCount + 1,
+                current.cancelled,
+                current.terminated,
+                current.terminalSignalDelivered,
+                current.terminalFailure);
+            effects.add(new LiveAwaitSessionEffect.EmitItem<>(next.completionKey(), next.item()));
+        }
+        if (!current.terminalSignalDelivered
+            && current.terminated
+            && current.terminalFailure != null
+            && current.subscriberReady
+            && current.subscriberAttached) {
+            current = current.withTerminalSignalDelivered(true);
+            effects.add(new LiveAwaitSessionEffect.FailStream<>(current.terminalFailure));
+            effects.add(new LiveAwaitSessionEffect.CloseSession<>());
+        } else if (!current.terminated
+            && current.subscriberAttached
+            && current.subscriberReady
+            && current.dispatchComplete
+            && current.pending.isEmpty()
+            && current.emittedItemCount >= current.expectedItemCount) {
+            current = current.withTerminated(true).withTerminalSignalDelivered(true);
+            effects.add(new LiveAwaitSessionEffect.CompleteStream<>());
+            effects.add(new LiveAwaitSessionEffect.CloseSession<>());
+        }
+        return LiveAwaitSessionDecision.of(current, effects);
+    }
+
+    private List<LiveAwaitSessionEffect<O>> failPendingEffects(Throwable failure) {
+        List<LiveAwaitSessionEffect<O>> effects = new ArrayList<>();
+        for (Pending<O> item : pending) {
+            effects.add(new LiveAwaitSessionEffect.FailAcceptance<>(item.completionKey(), failure));
+        }
+        return effects;
+    }
+
+    private LiveAwaitSessionState<O> withSubscriberAttached(boolean subscriberAttached) {
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            pending,
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure);
+    }
+
+    private LiveAwaitSessionState<O> withSubscriberReady(boolean subscriberReady) {
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            pending,
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure);
+    }
+
+    private LiveAwaitSessionState<O> withTerminated(boolean terminated) {
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            pending,
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure);
+    }
+
+    private LiveAwaitSessionState<O> withTerminalSignalDelivered(boolean terminalSignalDelivered) {
+        return new LiveAwaitSessionState<>(
+            subscriberAttached,
+            subscriberReady,
+            requested,
+            pending,
+            seenCompletions,
+            acceptedCompletions,
+            dispatchComplete,
+            expectedItemCount,
+            emittedItemCount,
+            cancelled,
+            terminated,
+            terminalSignalDelivered,
+            terminalFailure);
+    }
+
+    private static <O> LiveAwaitSessionDecision<O> append(
+        LiveAwaitSessionDecision<O> decision,
+        List<LiveAwaitSessionEffect<O>> before) {
+        List<LiveAwaitSessionEffect<O>> effects = new ArrayList<>(before);
+        effects.addAll(decision.effects());
+        return LiveAwaitSessionDecision.of(decision.state(), effects);
+    }
+
+    private static long addCap(long current, long increment) {
+        long updated = current + increment;
+        return updated < 0 ? Long.MAX_VALUE : updated;
+    }
+
+    record Pending<O>(String completionKey, O item) {
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/AwaitCompletionFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/AwaitCompletionFlowTest.java
@@ -1,0 +1,257 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.awaitable.AwaitCompletionCommand;
+import org.pipelineframework.awaitable.AwaitCompletionResult;
+import org.pipelineframework.awaitable.AwaitCompletionTenantMismatchException;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitLiveCompletionRegistry;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AwaitCompletionFlowTest {
+
+    @Mock
+    private AwaitCoordinator awaitCoordinator;
+
+    @Mock
+    private AwaitLiveCompletionRegistry liveCompletionRegistry;
+
+    @Mock
+    private AwaitCompletionFlow.Effects effects;
+
+    @Mock
+    private AwaitItemContinuationHandler itemContinuationHandler;
+
+    private AwaitCompletionFlow flow;
+
+    @BeforeEach
+    void setUp() {
+        flow = new AwaitCompletionFlow(awaitCoordinator, liveCompletionRegistry, effects);
+    }
+
+    @Test
+    void tenantMismatchStopsBeforeRecordingCompletion() {
+        AwaitCompletionCommand command = command();
+        AwaitInteractionRecord record = itemRecord("tenant-2");
+        when(awaitCoordinator.complete(command)).thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record, false)));
+
+        AwaitCompletionTenantMismatchException failure = assertThrows(
+            AwaitCompletionTenantMismatchException.class,
+            () -> flow.complete(new QueueAsyncCommand.CompleteAwait(command), itemContinuationHandler)
+                .await().indefinitely());
+
+        assertEquals(
+            "Await completion tenant mismatch: command tenant=tenant-1, record tenant=tenant-2",
+            failure.getMessage());
+        verify(awaitCoordinator, never()).recordCompletion(any(), anyLong());
+        verify(liveCompletionRegistry, never()).signal(any(), any());
+    }
+
+    @Test
+    void liveSignalFailureFallsBackToDurableItemContinuation() {
+        AwaitCompletionCommand command = command();
+        AwaitInteractionRecord record = itemRecord();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, true, 1, 1);
+        when(awaitCoordinator.complete(command)).thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record, false)));
+        when(awaitCoordinator.recordCompletion(record, command.nowEpochMs())).thenReturn(Uni.createFrom().item(unit));
+        when(liveCompletionRegistry.signal(record, unit))
+            .thenReturn(Uni.createFrom().failure(new IllegalStateException("live registry unavailable")));
+        when(effects.itemContinuationReady(record, unit)).thenReturn(Uni.createFrom().item(true));
+
+        flow.complete(new QueueAsyncCommand.CompleteAwait(command), itemContinuationHandler).await().indefinitely();
+
+        verify(effects).dispatchItemContinuation(record, unit, itemContinuationHandler, command.nowEpochMs());
+    }
+
+    @Test
+    void liveAdmissionBypassesDurableItemContinuation() {
+        AwaitCompletionCommand command = command();
+        AwaitInteractionRecord record = itemRecord();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, true, 1, 1);
+        when(awaitCoordinator.complete(command)).thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record, false)));
+        when(awaitCoordinator.recordCompletion(record, command.nowEpochMs())).thenReturn(Uni.createFrom().item(unit));
+        when(liveCompletionRegistry.signal(record, unit)).thenReturn(Uni.createFrom().item(true));
+
+        flow.complete(new QueueAsyncCommand.CompleteAwait(command), itemContinuationHandler).await().indefinitely();
+
+        verify(liveCompletionRegistry).signal(record, unit);
+        verify(effects, never()).itemContinuationReady(any(), any());
+        verify(effects, never()).dispatchItemContinuation(any(), any(), any(), anyLong());
+    }
+
+    @Test
+    void durableFallbackDispatchesReadyItemContinuation() {
+        AwaitCompletionCommand command = command();
+        AwaitInteractionRecord record = itemRecord();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, true, 1, 1);
+        when(awaitCoordinator.complete(command)).thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record, false)));
+        when(awaitCoordinator.recordCompletion(record, command.nowEpochMs())).thenReturn(Uni.createFrom().item(unit));
+        when(liveCompletionRegistry.signal(record, unit)).thenReturn(Uni.createFrom().item(false));
+        when(effects.itemContinuationReady(record, unit)).thenReturn(Uni.createFrom().item(true));
+
+        flow.complete(new QueueAsyncCommand.CompleteAwait(command), itemContinuationHandler).await().indefinitely();
+
+        verify(effects).dispatchItemContinuation(record, unit, itemContinuationHandler, command.nowEpochMs());
+        verify(effects, never()).recordEarlyCompletionHeld(any(), any());
+    }
+
+    @Test
+    void durableFallbackRecordsEarlyItemCompletionWhenParentGateIsClosed() {
+        AwaitCompletionCommand command = command();
+        AwaitInteractionRecord record = itemRecord();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.WAITING_EXTERNAL, true, 2, 1);
+        when(awaitCoordinator.complete(command)).thenReturn(Uni.createFrom().item(new AwaitCompletionResult(record, false)));
+        when(awaitCoordinator.recordCompletion(record, command.nowEpochMs())).thenReturn(Uni.createFrom().item(unit));
+        when(liveCompletionRegistry.signal(record, unit)).thenReturn(Uni.createFrom().item(false));
+        when(effects.itemContinuationReady(record, unit)).thenReturn(Uni.createFrom().item(false));
+
+        flow.complete(new QueueAsyncCommand.CompleteAwait(command), itemContinuationHandler).await().indefinitely();
+
+        verify(effects).recordEarlyCompletionHeld(record, unit);
+        verify(effects, never()).dispatchItemContinuation(any(), any(), any(), anyLong());
+    }
+
+    @Test
+    void itemCompletionOutcomeDispatchesOnlyWhenParentGateIsReady() {
+        AwaitInteractionRecord record = itemRecord();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, true, 1, 1);
+
+        AwaitCompletionOutcome outcome = AwaitCompletionFlow.itemCompletionOutcome(record, unit, true, 42_000L);
+
+        AwaitCompletionOutcome.DispatchItemContinuation dispatch =
+            assertInstanceOf(AwaitCompletionOutcome.DispatchItemContinuation.class, outcome);
+        assertEquals(record, dispatch.record());
+        assertEquals(unit, dispatch.unit());
+        assertEquals(42_000L, dispatch.nowEpochMs());
+    }
+
+    @Test
+    void itemCompletionOutcomeRecordsOnlyWhenParentGateIsClosed() {
+        AwaitCompletionOutcome outcome = AwaitCompletionFlow.itemCompletionOutcome(
+            itemRecord(),
+            itemUnit(AwaitUnitStatus.COMPLETED, true, 1, 1),
+            false,
+            42_000L);
+
+        AwaitCompletionOutcome.RecordOnly recordOnly =
+            assertInstanceOf(AwaitCompletionOutcome.RecordOnly.class, outcome);
+        assertEquals("itemized-await-parent-not-ready", recordOnly.reason());
+    }
+
+    @Test
+    void aggregateCompletionOutcomeReleasesOnlyCompletedUnit() {
+        AwaitInteractionRecord record = itemRecord();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, true, 1, 1);
+
+        AwaitCompletionOutcome completed = AwaitCompletionFlow.aggregateCompletionOutcome(record, unit, 42_000L);
+        AwaitCompletionOutcome.ReleaseParent release =
+            assertInstanceOf(AwaitCompletionOutcome.ReleaseParent.class, completed);
+        assertEquals(record, release.record());
+        assertEquals(unit, release.unit());
+        assertEquals(42_000L, release.nowEpochMs());
+
+        AwaitCompletionOutcome waiting = AwaitCompletionFlow.aggregateCompletionOutcome(
+            record,
+            itemUnit(AwaitUnitStatus.WAITING_EXTERNAL, true, 2, 1),
+            42_000L);
+        AwaitCompletionOutcome.RecordOnly recordOnly =
+            assertInstanceOf(AwaitCompletionOutcome.RecordOnly.class, waiting);
+        assertEquals("await-unit-not-complete", recordOnly.reason());
+    }
+
+    private static AwaitCompletionCommand command() {
+        return new AwaitCompletionCommand(
+            "tenant-1",
+            "interaction-0",
+            "correlation-0",
+            null,
+            "idem-0",
+            "approved",
+            "tester",
+            42_000L);
+    }
+
+    private static AwaitInteractionRecord itemRecord() {
+        return itemRecord("tenant-1");
+    }
+
+    private static AwaitInteractionRecord itemRecord(String tenantId) {
+        return new AwaitInteractionRecord(
+            tenantId,
+            "exec-1",
+            "await",
+            2,
+            String.class.getName(),
+            "interaction-0",
+            "correlation-0",
+            "causation-0",
+            "idem-0",
+            0L,
+            AwaitInteractionStatus.COMPLETED,
+            "request",
+            "approved",
+            "unit-1",
+            0,
+            null,
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            50_000L,
+            40_000L,
+            42_000L,
+            86_400L);
+    }
+
+    private static AwaitUnitRecord itemUnit(
+        AwaitUnitStatus status,
+        boolean dispatchComplete,
+        Integer expectedCount,
+        int completedCount) {
+        return new AwaitUnitRecord(
+            "tenant-1",
+            "unit-1",
+            "exec-1",
+            "await",
+            2,
+            "ONE_TO_ONE",
+            0L,
+            status,
+            null,
+            expectedCount,
+            completedCount,
+            completedKeys(completedCount),
+            dispatchComplete,
+            40_000L,
+            42_000L,
+            86_400L);
+    }
+
+    private static Set<String> completedKeys(int completedCount) {
+        return IntStream.range(0, completedCount)
+            .mapToObj(index -> "item:" + index)
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ItemContinuationFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ItemContinuationFlowTest.java
@@ -1,0 +1,472 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.InMemoryExecutionStateStore;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+@ExtendWith(MockitoExtension.class)
+class ItemContinuationFlowTest {
+
+    @Mock
+    private AwaitCoordinator awaitCoordinator;
+
+    @Mock
+    private ExecutionStateStore executionStateStore;
+
+    @Mock
+    private WorkDispatcher workDispatcher;
+
+    @Mock
+    private TransitionWorkerExecutor transitionWorkerExecutor;
+
+    @Mock
+    private AwaitItemContinuationHandler itemContinuationHandler;
+
+    @Mock
+    private ItemContinuationFlow.Effects effects;
+
+    private CapturingScheduler scheduler;
+    private AwaitItemContinuationHandler noopHandler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new CapturingScheduler();
+        noopHandler = noopHandler();
+    }
+
+    @Test
+    void readinessRequiresDispatchCompleteParentWaitingAndMatchingUnit() {
+        ItemContinuationFlow runtime = runtime(executionStateStore, transitionWorkerExecutor);
+        AwaitInteractionRecord record = itemRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved");
+        AwaitUnitRecord incompleteUnit = itemUnit(AwaitUnitStatus.WAITING_EXTERNAL, 1, 1, false);
+        AwaitUnitRecord completeUnit = itemUnit(AwaitUnitStatus.COMPLETED, 1, 1, true);
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.empty()))
+            .thenReturn(Uni.createFrom().item(Optional.of(execution(ExecutionStatus.RUNNING, "other-unit"))))
+            .thenReturn(Uni.createFrom().item(Optional.of(execution(ExecutionStatus.WAITING_EXTERNAL, "other-unit"))))
+            .thenReturn(Uni.createFrom().item(Optional.of(execution(ExecutionStatus.WAITING_EXTERNAL, "unit-1"))));
+
+        assertFalse(runtime.itemContinuationReady(null, completeUnit).await().indefinitely());
+        assertFalse(runtime.itemContinuationReady(record, incompleteUnit).await().indefinitely());
+        assertFalse(runtime.itemContinuationReady(record, completeUnit).await().indefinitely());
+        assertFalse(runtime.itemContinuationReady(record, completeUnit).await().indefinitely());
+        assertFalse(runtime.itemContinuationReady(record, completeUnit).await().indefinitely());
+        assertTrue(runtime.itemContinuationReady(record, completeUnit).await().indefinitely());
+    }
+
+    @Test
+    void saturatedAdmissionSchedulesRetryWithoutInvokingHandler() {
+        ItemContinuationFlow runtime = runtime(executionStateStore, transitionWorkerExecutor);
+        AwaitInteractionRecord record = itemRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved");
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, 1, 1, true);
+        when(transitionWorkerExecutor.tryAdmit()).thenReturn(Optional.empty());
+
+        runtime.dispatchItemContinuation(record, unit, itemContinuationHandler, 42_000L);
+
+        assertEquals(1, scheduler.scheduled.size());
+        assertEquals(250L, scheduler.scheduled.getFirst().delayMs());
+        verify(itemContinuationHandler, never()).continueAwaitItem(any(), any(), anyInt(), any(), anyLong());
+    }
+
+    @Test
+    void saturatedAdmissionStopsAfterMaxAttemptsAndMarksParentFailed() {
+        ItemContinuationFlow runtime = runtime(executionStateStore, transitionWorkerExecutor);
+        AwaitInteractionRecord record = itemRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved");
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, 1, 1, true);
+        ExecutionRecord<Object, Object> waiting = execution(ExecutionStatus.WAITING_EXTERNAL, "unit-1");
+        when(transitionWorkerExecutor.tryAdmit()).thenReturn(Optional.empty());
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(executionStateStore.markTerminalFailure(
+                eq("tenant-1"),
+                eq("exec-1"),
+                eq(7L),
+                eq(ExecutionStatus.FAILED),
+                eq("await-item-continuation-failed:unit-1:0"),
+                eq("AWAIT_ITEM_CONTINUATION_FAILED"),
+                contains("admission remained saturated"),
+                anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+
+        runtime.dispatchItemContinuation(record, unit, itemContinuationHandler, 42_000L);
+        scheduler.runNext();
+        scheduler.runNext();
+
+        assertEquals(0, scheduler.scheduled.size());
+        verify(executionStateStore).markTerminalFailure(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(7L),
+            eq(ExecutionStatus.FAILED),
+            eq("await-item-continuation-failed:unit-1:0"),
+            eq("AWAIT_ITEM_CONTINUATION_FAILED"),
+            contains("admission remained saturated"),
+            anyLong());
+    }
+
+    @Test
+    void synchronousContinuationFailureReleasesAdmissionPermit() {
+        TransitionWorkerExecutor realExecutor = transitionExecutor(1);
+        ItemContinuationFlow runtime = runtime(executionStateStore, realExecutor);
+        AwaitInteractionRecord record = itemRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved");
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, 1, 1, true);
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenThrow(new IllegalStateException("store blew up"));
+
+        runtime.dispatchItemContinuation(record, unit, itemContinuationHandler, 42_000L);
+
+        assertEquals(0, realExecutor.activePermits());
+        assertEquals(1, scheduler.scheduled.size());
+    }
+
+    @Test
+    void continuationFailureRetriesThenMarksParentFailed() {
+        TransitionWorkerExecutor realExecutor = transitionExecutor(1);
+        ItemContinuationFlow runtime = runtime(executionStateStore, realExecutor);
+        AwaitInteractionRecord record = itemRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved");
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, 1, 1, true);
+        ExecutionRecord<Object, Object> waiting = execution(ExecutionStatus.WAITING_EXTERNAL, "unit-1");
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(itemContinuationHandler.continueAwaitItem(
+                eq(record),
+                eq(unit),
+                eq(3),
+                eq(Optional.of(waiting)),
+                eq(42_000L)))
+            .thenReturn(Uni.createFrom().failure(new IllegalStateException("segment failed")));
+        when(executionStateStore.markTerminalFailure(
+                eq("tenant-1"),
+                eq("exec-1"),
+                eq(7L),
+                eq(ExecutionStatus.FAILED),
+                eq("await-item-continuation-failed:unit-1:0"),
+                eq("AWAIT_ITEM_CONTINUATION_FAILED"),
+                contains("segment failed"),
+                anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+
+        runtime.dispatchItemContinuation(record, unit, itemContinuationHandler, 42_000L);
+        scheduler.runNext();
+        scheduler.runNext();
+
+        verify(itemContinuationHandler, times(3)).continueAwaitItem(
+            eq(record),
+            eq(unit),
+            eq(3),
+            eq(Optional.of(waiting)),
+            eq(42_000L));
+        verify(executionStateStore).markTerminalFailure(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(7L),
+            eq(ExecutionStatus.FAILED),
+            eq("await-item-continuation-failed:unit-1:0"),
+            eq("AWAIT_ITEM_CONTINUATION_FAILED"),
+            contains("segment failed"),
+            anyLong());
+    }
+
+    @Test
+    void earlyCompletedItemsDispatchAfterParentIsWaitingExternal() {
+        TransitionWorkerExecutor realExecutor = transitionExecutor(4);
+        ItemContinuationFlow runtime = runtime(executionStateStore, realExecutor);
+        ExecutionRecord<Object, Object> waiting = execution(ExecutionStatus.WAITING_EXTERNAL, "unit-1");
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, 2, 2, true);
+        AwaitInteractionRecord first = itemRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved-0");
+        AwaitInteractionRecord second = itemRecord("exec-1", 1, AwaitInteractionStatus.COMPLETED, "approved-1");
+        TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-1", "unit-1", 2);
+        when(awaitCoordinator.getUnit("tenant-1", "unit-1")).thenReturn(Uni.createFrom().item(unit));
+        when(awaitCoordinator.findByUnit("tenant-1", "unit-1")).thenReturn(Uni.createFrom().item(List.of(first, second)));
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(itemContinuationHandler.continueAwaitItem(
+                any(),
+                eq(unit),
+                eq(3),
+                eq(Optional.of(waiting)),
+                eq(42_000L)))
+            .thenReturn(Uni.createFrom().voidItem());
+        when(itemContinuationHandler.releaseAwaitParentIfReady(waiting, unit, 3, 42_000L))
+            .thenReturn(Uni.createFrom().voidItem());
+
+        runtime.releaseAlreadyCompletedAwaitUnit(waiting, suspension, 42_000L, itemContinuationHandler)
+            .await().indefinitely();
+
+        verify(itemContinuationHandler, times(2)).continueAwaitItem(
+            any(),
+            eq(unit),
+            eq(3),
+            eq(Optional.of(waiting)),
+            eq(42_000L));
+        verify(itemContinuationHandler).releaseAwaitParentIfReady(waiting, unit, 3, 42_000L);
+    }
+
+    @Test
+    void childContinuationRecordingIsIdempotentAndReleasesParentInOrder() {
+        InMemoryExecutionStateStore store = new InMemoryExecutionStateStore();
+        ItemContinuationFlow runtime = runtime(store, transitionWorkerExecutor);
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+        long now = System.currentTimeMillis();
+        CreateExecutionResult parent = store.createOrGetExecution(new ExecutionCreateCommand(
+                "tenant-1",
+                "parent-key",
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input"),
+                ExecutionResultShape.MATERIALIZED_MULTI,
+                now,
+                now + 100_000))
+            .await().indefinitely();
+        store.markWaitingExternal(
+                "tenant-1",
+                parent.record().executionId(),
+                parent.record().version(),
+                "transition",
+                "unit-1",
+                2,
+                now)
+            .await().indefinitely();
+        AwaitUnitRecord unit = itemUnit(AwaitUnitStatus.COMPLETED, 2, 2, true);
+
+        runtime.recordAwaitItemContinuation(
+                itemRecord(parent.record().executionId(), 0, AwaitInteractionStatus.COMPLETED, "first"),
+                unit,
+                4,
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "first-normalized"),
+                List.of("out-0"),
+                now)
+            .await().indefinitely();
+        runtime.recordAwaitItemContinuation(
+                itemRecord(parent.record().executionId(), 0, AwaitInteractionStatus.COMPLETED, "first-duplicate"),
+                unit,
+                4,
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "duplicate-normalized"),
+                List.of("duplicate-output"),
+                now)
+            .await().indefinitely();
+        runtime.recordAwaitItemContinuation(
+                itemRecord(parent.record().executionId(), 1, AwaitInteractionStatus.COMPLETED, "second"),
+                unit,
+                4,
+                new ExecutionInputSnapshot(ExecutionInputShape.UNI, "second-normalized"),
+                List.of("out-1"),
+                now)
+            .await().indefinitely();
+
+        ExecutionRecord<Object, Object> resumed = store.getExecution("tenant-1", parent.record().executionId())
+            .await().indefinitely()
+            .orElseThrow();
+        assertEquals(ExecutionStatus.QUEUED, resumed.status());
+        assertEquals(4, resumed.currentStepIndex());
+        assertNull(resumed.awaitUnitId());
+        assertInstanceOf(ExecutionInputSnapshot.class, resumed.inputPayload());
+        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) resumed.inputPayload();
+        assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
+        assertEquals(List.of("out-0", "out-1"), snapshot.payload());
+        ExecutionRecord<Object, Object> firstChild = store.getExecutionByKey(
+                "tenant-1",
+                "parent-key:await-item:unit-1:0")
+            .await().indefinitely()
+            .orElseThrow();
+        ExecutionInputSnapshot firstChildInput = (ExecutionInputSnapshot) firstChild.inputPayload();
+        assertEquals("first-normalized", firstChildInput.payload());
+        verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", parent.record().executionId()));
+    }
+
+    private ItemContinuationFlow runtime(
+        ExecutionStateStore store,
+        TransitionWorkerExecutor executor) {
+        return new ItemContinuationFlow(
+            awaitCoordinator,
+            store,
+            workDispatcher,
+            executor,
+            scheduler,
+            Runnable::run,
+            () -> Duration.ofMillis(250),
+            noopHandler,
+            (record, unit, suspended, nowEpochMs) -> Uni.createFrom().voidItem(),
+            effects);
+    }
+
+    private static AwaitItemContinuationHandler noopHandler() {
+        return new AwaitItemContinuationHandler() {
+            @Override
+            public Uni<Void> continueAwaitItem(
+                AwaitInteractionRecord record,
+                AwaitUnitRecord unit,
+                int nextStepIndex,
+                Optional<ExecutionRecord<Object, Object>> parent,
+                long nowEpochMs) {
+                return Uni.createFrom().voidItem();
+            }
+
+            @Override
+            public Uni<Void> releaseAwaitParentIfReady(
+                ExecutionRecord<Object, Object> parent,
+                AwaitUnitRecord unit,
+                int nextStepIndex,
+                long nowEpochMs) {
+                return Uni.createFrom().voidItem();
+            }
+        };
+    }
+
+    private static TransitionWorkerExecutor transitionExecutor(int maxInFlight) {
+        PipelineOrchestratorConfig config = mock(PipelineOrchestratorConfig.class);
+        PipelineOrchestratorConfig.WorkerConfig worker = mock(PipelineOrchestratorConfig.WorkerConfig.class);
+        when(config.worker()).thenReturn(worker);
+        when(worker.maxInFlight()).thenReturn(maxInFlight);
+        return new TransitionWorkerExecutor(config);
+    }
+
+    private static AwaitInteractionRecord itemRecord(
+        String executionId,
+        int itemIndex,
+        AwaitInteractionStatus status,
+        Object responsePayload) {
+        return new AwaitInteractionRecord(
+            "tenant-1",
+            executionId,
+            "await",
+            2,
+            String.class.getName(),
+            "interaction-" + itemIndex,
+            "correlation-" + itemIndex,
+            "causation-" + itemIndex,
+            "idem-" + itemIndex,
+            0L,
+            status,
+            "request-" + itemIndex,
+            responsePayload,
+            "unit-1",
+            itemIndex,
+            null,
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            50_000L,
+            40_000L,
+            42_000L,
+            86_400L);
+    }
+
+    private static AwaitUnitRecord itemUnit(
+        AwaitUnitStatus status,
+        Integer expectedCount,
+        int completedCount,
+        boolean dispatchComplete) {
+        return new AwaitUnitRecord(
+            "tenant-1",
+            "unit-1",
+            "exec-1",
+            "await",
+            2,
+            "ONE_TO_ONE",
+            0L,
+            status,
+            null,
+            expectedCount,
+            completedCount,
+            completedKeys(completedCount),
+            dispatchComplete,
+            40_000L,
+            42_000L,
+            86_400L);
+    }
+
+    private static ExecutionRecord<Object, Object> execution(ExecutionStatus status, String awaitUnitId) {
+        return new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "parent-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            status,
+            7L,
+            2,
+            0,
+            "worker",
+            0L,
+            0L,
+            "previous",
+            "input",
+            awaitUnitId,
+            null,
+            null,
+            null,
+            10_000L,
+            10_000L,
+            86_400L);
+    }
+
+    private static Set<String> completedKeys(int completedCount) {
+        return IntStream.range(0, completedCount)
+            .mapToObj(index -> "item:" + index)
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    private static final class CapturingScheduler implements ItemContinuationFlow.Scheduler {
+        private final List<ScheduledTask> scheduled = new ArrayList<>();
+
+        @Override
+        public void schedule(Runnable task, long delayMs) {
+            scheduled.add(new ScheduledTask(task, delayMs));
+        }
+
+        void runNext() {
+            scheduled.removeFirst().task().run();
+        }
+    }
+
+    private record ScheduledTask(Runnable task, long delayMs) {
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -1794,6 +1794,91 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.anyLong());
     }
 
+    @Test
+    void timeoutSweepStopsWhenFailureWriteLosesRaceToTerminalExecution() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        AwaitInteractionRecord interaction = awaitRecord();
+        ExecutionRecord<Object, Object> waiting = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.WAITING_EXTERNAL,
+            7L,
+            2,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            "unit-1",
+            null,
+            null,
+            null,
+            1L,
+            1L,
+            99999999L);
+        ExecutionRecord<Object, Object> succeeded = recordWithStatus(waiting, ExecutionStatus.SUCCEEDED, 8L, 0);
+        when(awaitCoordinator.findTimedOut(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of(interaction)));
+        when(awaitCoordinator.markTimedOut(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(waiting)))
+            .thenReturn(Uni.createFrom().item(Optional.of(succeeded)));
+        when(executionStateStore.markTerminalFailure(
+                org.mockito.ArgumentMatchers.eq("tenant-1"),
+                org.mockito.ArgumentMatchers.eq("exec-1"),
+                org.mockito.ArgumentMatchers.eq(7L),
+                org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+                org.mockito.ArgumentMatchers.eq("exec-1:2:0"),
+                org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
+                org.mockito.ArgumentMatchers.contains("interaction-1"),
+                org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.empty()));
+        when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of()));
+
+        coordinator.sweepDueExecutions();
+
+        verify(executionStateStore, timeout(500).times(1)).markTerminalFailure(
+            org.mockito.ArgumentMatchers.eq("tenant-1"),
+            org.mockito.ArgumentMatchers.eq("exec-1"),
+            org.mockito.ArgumentMatchers.eq(7L),
+            org.mockito.ArgumentMatchers.eq(ExecutionStatus.FAILED),
+            org.mockito.ArgumentMatchers.eq("exec-1:2:0"),
+            org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
+            org.mockito.ArgumentMatchers.contains("interaction-1"),
+            org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void timeoutSweepDoesNotFailParentWhenInteractionTimeoutMarkLosesRace() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        AwaitInteractionRecord interaction = awaitRecord();
+        when(awaitCoordinator.findTimedOut(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of(interaction)));
+        when(awaitCoordinator.markTimedOut(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
+            .thenReturn(Uni.createFrom().item(Optional.empty()));
+        when(executionStateStore.findDueExecutions(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.eq(100)))
+            .thenReturn(Uni.createFrom().item(java.util.List.of()));
+
+        coordinator.sweepDueExecutions();
+
+        verify(executionStateStore, after(200).never()).markTerminalFailure(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyLong());
+    }
+
     private void configureQueueModeDefaults() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.executionTtlDays()).thenReturn(7);

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncExecutionFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncExecutionFlowTest.java
@@ -1,0 +1,247 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.awaitable.AwaitSuspendedException;
+import org.pipelineframework.invocation.PipelineInvocationRuntime;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneTransitionAdmission;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.PipelineTransitionWorker;
+import org.pipelineframework.orchestrator.SerializedTransitionPayload;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutionMode;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAsyncExecutionFlowTest {
+
+    @Mock
+    private PipelineOrchestratorConfig orchestratorConfig;
+
+    @Mock
+    private PipelineOrchestratorConfig.WorkerConfig workerConfig;
+
+    @Mock
+    private ExecutionStateStore executionStateStore;
+
+    @Mock
+    private WorkDispatcher workDispatcher;
+
+    @Mock
+    private QueueAsyncExecutionFlow.Effects effects;
+
+    @Mock
+    private PipelineTransitionWorker worker;
+
+    @Mock
+    private AwaitItemContinuationHandler itemContinuationHandler;
+
+    private TransitionWorkerExecutor transitionWorkerExecutor;
+    private QueueAsyncExecutionFlow flow;
+
+    @BeforeEach
+    void setUp() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        lenient().when(orchestratorConfig.leaseMs()).thenReturn(1_000L);
+        when(orchestratorConfig.worker()).thenReturn(workerConfig);
+        when(workerConfig.maxInFlight()).thenReturn(4);
+        lenient().when(workerConfig.executionMode()).thenReturn(TransitionWorkerExecutionMode.SAME_THREAD);
+        transitionWorkerExecutor = new TransitionWorkerExecutor(orchestratorConfig, new PipelineInvocationRuntime());
+        flow = new QueueAsyncExecutionFlow(
+            orchestratorConfig,
+            executionStateStore,
+            workDispatcher,
+            transitionWorkerExecutor,
+            "worker-1",
+            effects);
+    }
+
+    @Test
+    void processWorkItemFlowsThroughClaimWorkerAndCommit() {
+        ExecutionWorkItem workItem = new ExecutionWorkItem("tenant-1", "exec-1");
+        ExecutionRecord<Object, Object> record = execution();
+        TransitionCommandEnvelope command = command();
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+        AtomicInteger tenantPermitCloses = new AtomicInteger();
+        when(effects.admitTransition(workItem))
+            .thenReturn(ControlPlaneTransitionAdmission.admitted(tenantPermitCloses::incrementAndGet));
+        when(executionStateStore.claimLease(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq("worker-1"),
+            anyLong(),
+            eq(1_000L))).thenReturn(Uni.createFrom().item(Optional.of(record)));
+        when(effects.prepareTransitionCommand(record, "exec-1:3:0")).thenReturn(Uni.createFrom().item(command));
+        when(worker.executeTransition(command)).thenReturn(Uni.createFrom().item(result));
+        when(effects.commitTransition(record, "exec-1:3:0", result, itemContinuationHandler))
+            .thenReturn(Uni.createFrom().voidItem());
+
+        flow.processExecutionWorkItem(workItem, worker, itemContinuationHandler).await().indefinitely();
+
+        InOrder inOrder = inOrder(effects, executionStateStore, worker);
+        inOrder.verify(effects).admitTransition(workItem);
+        inOrder.verify(executionStateStore).claimLease(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq("worker-1"),
+            anyLong(),
+            eq(1_000L));
+        inOrder.verify(effects).recordClaimed(record);
+        inOrder.verify(effects).prepareTransitionCommand(record, "exec-1:3:0");
+        inOrder.verify(worker).executeTransition(command);
+        inOrder.verify(effects).commitTransition(record, "exec-1:3:0", result, itemContinuationHandler);
+        assertEquals(1, tenantPermitCloses.get());
+        assertEquals(0, transitionWorkerExecutor.activePermits());
+    }
+
+    @Test
+    void saturatedTenantAdmissionRequeuesWithoutClaim() {
+        ExecutionWorkItem workItem = new ExecutionWorkItem("tenant-1", "exec-1");
+        Duration delay = Duration.ofMillis(250L);
+        when(effects.admitTransition(workItem)).thenReturn(ControlPlaneTransitionAdmission.denied(
+            ControlPlaneAdmissionDecision.deny(
+                ControlPlaneAdmissionDecision.TENANT_TRANSITION_QUOTA_SATURATED,
+                "tenant quota saturated")));
+        when(effects.saturatedDelay()).thenReturn(delay);
+        when(workDispatcher.enqueueDelayed(workItem, delay)).thenReturn(Uni.createFrom().voidItem());
+
+        flow.processExecutionWorkItem(workItem, worker, itemContinuationHandler).await().indefinitely();
+
+        verify(workDispatcher).enqueueDelayed(workItem, delay);
+        verify(executionStateStore, never()).claimLease(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq("worker-1"),
+            anyLong(),
+            eq(1_000L));
+        assertEquals(0, transitionWorkerExecutor.activePermits());
+    }
+
+    @Test
+    void workerFailureRoutesThroughFailureEffect() {
+        ExecutionWorkItem workItem = new ExecutionWorkItem("tenant-1", "exec-1");
+        ExecutionRecord<Object, Object> record = execution();
+        TransitionCommandEnvelope command = command();
+        IllegalStateException failure = new IllegalStateException("worker failed");
+        when(effects.admitTransition(workItem))
+            .thenReturn(ControlPlaneTransitionAdmission.admitted(() -> {
+            }));
+        when(executionStateStore.claimLease(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq("worker-1"),
+            anyLong(),
+            eq(1_000L))).thenReturn(Uni.createFrom().item(Optional.of(record)));
+        when(effects.prepareTransitionCommand(record, "exec-1:3:0")).thenReturn(Uni.createFrom().item(command));
+        when(worker.executeTransition(command)).thenReturn(Uni.createFrom().failure(failure));
+        when(effects.handleExecutionFailure(record, "exec-1:3:0", failure)).thenReturn(Uni.createFrom().voidItem());
+
+        flow.processExecutionWorkItem(workItem, worker, itemContinuationHandler).await().indefinitely();
+
+        verify(effects).handleExecutionFailure(record, "exec-1:3:0", failure);
+        verify(effects, never()).commitTransition(any(), any(), any(), any());
+    }
+
+    @Test
+    void awaitSuspensionRoutesThroughWaitingExternalEffect() {
+        ExecutionWorkItem workItem = new ExecutionWorkItem("tenant-1", "exec-1");
+        ExecutionRecord<Object, Object> record = execution();
+        TransitionCommandEnvelope command = command();
+        AwaitSuspendedException failure = new AwaitSuspendedException("tenant-1", "exec-1", "unit-1", 3);
+        TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-1", "unit-1", 3);
+        when(effects.admitTransition(workItem))
+            .thenReturn(ControlPlaneTransitionAdmission.admitted(() -> {
+            }));
+        when(executionStateStore.claimLease(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq("worker-1"),
+            anyLong(),
+            eq(1_000L))).thenReturn(Uni.createFrom().item(Optional.of(record)));
+        when(effects.prepareTransitionCommand(record, "exec-1:3:0")).thenReturn(Uni.createFrom().item(command));
+        when(worker.executeTransition(command)).thenReturn(Uni.createFrom().failure(failure));
+        when(effects.suspensionSnapshot(failure)).thenReturn(Uni.createFrom().item(suspension));
+        when(effects.markWaitingExternal(record, "exec-1:3:0", suspension, itemContinuationHandler))
+            .thenReturn(Uni.createFrom().voidItem());
+
+        flow.processExecutionWorkItem(workItem, worker, itemContinuationHandler).await().indefinitely();
+
+        verify(effects).suspensionSnapshot(failure);
+        verify(effects).markWaitingExternal(record, "exec-1:3:0", suspension, itemContinuationHandler);
+        verify(effects, never()).handleExecutionFailure(eq(record), eq("exec-1:3:0"), eq(failure));
+    }
+
+    private static TransitionCommandEnvelope command() {
+        return new TransitionCommandEnvelope(
+            "tenant-1",
+            "exec-1",
+            "pipeline",
+            "release",
+            3,
+            0,
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            1L,
+            "exec-1:3:0",
+            "trace-1",
+            String.class.getName(),
+            "plain",
+            "input");
+    }
+
+    private static ExecutionRecord<Object, Object> execution() {
+        return new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "exec-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            ExecutionStatus.RUNNING,
+            1L,
+            3,
+            0,
+            "worker",
+            0L,
+            0L,
+            "previous",
+            new SerializedTransitionPayload(String.class.getName(), "plain", "input"),
+            null,
+            null,
+            null,
+            null,
+            10_000L,
+            10_000L,
+            86_400L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationFlowTest.java
@@ -1,0 +1,189 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
+import org.pipelineframework.orchestrator.SerializedTransitionPayload;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+@ExtendWith(MockitoExtension.class)
+class TerminalPublicationFlowTest {
+
+    @Mock
+    private CheckpointPublicationService checkpointPublicationService;
+
+    @Mock
+    private TerminalOutputPublisher terminalOutputPublisher;
+
+    @Mock
+    private ObjectPublishCompletionService objectPublishCompletionService;
+
+    @Test
+    void checkpointPublicationHappensBeforeTerminalOutputPublication() {
+        ExecutionRecord<Object, Object> record = execution();
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+        TerminalPublicationFlow runtime = new TerminalPublicationFlow(
+            checkpointPublicationService,
+            terminalOutputPublisher);
+        when(checkpointPublicationService.publishIfConfigured(record, "out-1"))
+            .thenReturn(Uni.createFrom().voidItem());
+        when(terminalOutputPublisher.publishIfConfigured(result)).thenReturn(Uni.createFrom().voidItem());
+
+        runtime.publishBeforeSuccess(record, result).await().indefinitely();
+
+        InOrder inOrder = inOrder(checkpointPublicationService, terminalOutputPublisher);
+        inOrder.verify(checkpointPublicationService).publishIfConfigured(record, "out-1");
+        inOrder.verify(terminalOutputPublisher).publishIfConfigured(result);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void remoteEncodedOutputIsDecodedLazilyForObjectPublish() {
+        CountingPayloadCodec codec = new CountingPayloadCodec();
+        TransitionResultEnvelope result = TransitionResultEnvelope.completed(codec, List.of("published-output"));
+        ObjectPublishTerminalPublisher publisher = new ObjectPublishTerminalPublisher(
+            objectPublishCompletionService,
+            codec);
+        ArgumentCaptor<Supplier<List<?>>> supplier = ArgumentCaptor.forClass(Supplier.class);
+        when(objectPublishCompletionService.publishIfConfigured(supplier.capture()))
+            .thenReturn(Uni.createFrom().voidItem());
+
+        publisher.publishIfConfigured(result).await().indefinitely();
+
+        assertEquals(0, codec.decodeCount());
+        assertEquals(List.of("published-output"), supplier.getValue().get());
+        assertEquals(1, codec.decodeCount());
+    }
+
+    @Test
+    void alreadyPublishedTerminalOutputSkipsObjectPublish() {
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"), true);
+        ObjectPublishTerminalPublisher publisher = new ObjectPublishTerminalPublisher(
+            objectPublishCompletionService,
+            new JsonTransitionPayloadCodec());
+
+        publisher.publishIfConfigured(result).await().indefinitely();
+
+        verifyNoInteractions(objectPublishCompletionService);
+    }
+
+    @Test
+    void nullObjectPublishServiceIsNoOp() {
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+        ObjectPublishTerminalPublisher publisher = new ObjectPublishTerminalPublisher(
+            null,
+            new JsonTransitionPayloadCodec());
+
+        publisher.publishIfConfigured(result).await().indefinitely();
+    }
+
+    @Test
+    void emptyTerminalOutputSkipsCheckpointButStillRunsTerminalPublicationNoOp() {
+        ExecutionRecord<Object, Object> record = execution();
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of());
+        TerminalPublicationFlow runtime = new TerminalPublicationFlow(
+            checkpointPublicationService,
+            terminalOutputPublisher);
+        when(terminalOutputPublisher.publishIfConfigured(result)).thenReturn(Uni.createFrom().voidItem());
+
+        runtime.publishBeforeSuccess(record, result).await().indefinitely();
+
+        verify(checkpointPublicationService, never()).publishIfConfigured(any(), any());
+        verify(terminalOutputPublisher).publishIfConfigured(result);
+    }
+
+    @Test
+    void terminalPublicationFailurePropagates() {
+        ExecutionRecord<Object, Object> record = execution();
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+        TerminalPublicationFlow runtime = new TerminalPublicationFlow(
+            checkpointPublicationService,
+            terminalOutputPublisher);
+        IllegalStateException failure = new IllegalStateException("publish failed");
+        when(checkpointPublicationService.publishIfConfigured(record, "out-1"))
+            .thenReturn(Uni.createFrom().voidItem());
+        when(terminalOutputPublisher.publishIfConfigured(result)).thenReturn(Uni.createFrom().failure(failure));
+
+        IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> runtime.publishBeforeSuccess(record, result).await().indefinitely());
+
+        assertEquals(failure, thrown);
+    }
+
+    private static ExecutionRecord<Object, Object> execution() {
+        return new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "exec-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            ExecutionStatus.RUNNING,
+            1L,
+            3,
+            0,
+            "worker",
+            0L,
+            0L,
+            "previous",
+            "input",
+            null,
+            null,
+            null,
+            null,
+            10_000L,
+            10_000L,
+            86_400L);
+    }
+
+    private static final class CountingPayloadCodec implements TransitionPayloadCodec {
+        private final JsonTransitionPayloadCodec delegate = new JsonTransitionPayloadCodec();
+        private final AtomicInteger decodeCount = new AtomicInteger();
+
+        @Override
+        public String encoding() {
+            return delegate.encoding();
+        }
+
+        @Override
+        public SerializedTransitionPayload encode(Object payload) {
+            return delegate.encode(payload);
+        }
+
+        @Override
+        public Object decode(SerializedTransitionPayload payload) {
+            decodeCount.incrementAndGet();
+            return delegate.decode(payload);
+        }
+
+        int decodeCount() {
+            return decodeCount.get();
+        }
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationPlanTest.java
@@ -1,0 +1,78 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+class TerminalPublicationPlanTest {
+
+    @Test
+    void nonEmptyUnpublishedOutputPlansCheckpointAndTerminalPublish() {
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+
+        TerminalPublicationPlan plan = TerminalPublicationPlan.from(execution(), result);
+
+        assertTrue(plan.publishCheckpoint());
+        assertTrue(plan.publishTerminalOutput());
+        assertEquals(List.of("out-1"), plan.outputItems());
+        assertEquals("out-1", plan.checkpointPayload());
+        assertThrows(UnsupportedOperationException.class, () -> plan.outputItems().clear());
+    }
+
+    @Test
+    void emptyOutputSkipsCheckpointButStillLetsTerminalPublisherNoOp() {
+        TerminalPublicationPlan plan = TerminalPublicationPlan.from(
+            execution(),
+            TransitionResultEnvelope.completedInProcess(List.of()));
+
+        assertFalse(plan.publishCheckpoint());
+        assertTrue(plan.publishTerminalOutput());
+        assertEquals(List.of(), plan.outputItems());
+    }
+
+    @Test
+    void alreadyPublishedOutputSkipsTerminalPublish() {
+        TerminalPublicationPlan plan = TerminalPublicationPlan.from(
+            execution(),
+            TransitionResultEnvelope.completedInProcess(List.of("out-1"), true));
+
+        assertTrue(plan.publishCheckpoint());
+        assertFalse(plan.publishTerminalOutput());
+    }
+
+    private static ExecutionRecord<Object, Object> execution() {
+        return new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "exec-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            ExecutionStatus.RUNNING,
+            1L,
+            3,
+            0,
+            "worker",
+            0L,
+            0L,
+            "previous",
+            "input",
+            null,
+            null,
+            null,
+            null,
+            10_000L,
+            10_000L,
+            86_400L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/TransitionCommitFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TransitionCommitFlowTest.java
@@ -1,0 +1,209 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+@ExtendWith(MockitoExtension.class)
+class TransitionCommitFlowTest {
+
+    @Mock
+    private AwaitCoordinator awaitCoordinator;
+
+    @Mock
+    private ExecutionStateStore executionStateStore;
+
+    @Mock
+    private WorkDispatcher workDispatcher;
+
+    @Mock
+    private DeadLetterPublisher deadLetterPublisher;
+
+    @Mock
+    private ExecutionFailureHandler executionFailureHandler;
+
+    @Mock
+    private TerminalPublicationBarrier terminalPublicationBarrier;
+
+    @Mock
+    private TransitionCommitFlow.Effects effects;
+
+    @Mock
+    private AwaitItemContinuationHandler itemContinuationHandler;
+
+    private TransitionCommitFlow runtime;
+
+    @BeforeEach
+    void setUp() {
+        runtime = new TransitionCommitFlow(
+            awaitCoordinator,
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher,
+            executionFailureHandler,
+            terminalPublicationBarrier,
+            effects);
+    }
+
+    @Test
+    void completedTransitionPublishesThroughBarrierBeforeMarkSuccess() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionStatus.RUNNING, 1L);
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+        when(terminalPublicationBarrier.publishBeforeSuccess(record, result)).thenReturn(Uni.createFrom().voidItem());
+        when(executionStateStore.markSucceeded(
+            eq(record.tenantId()),
+            eq(record.executionId()),
+            eq(record.version()),
+            eq("transition-1"),
+            eq(List.of("out-1")),
+            anyLong())).thenReturn(Uni.createFrom().item(Optional.of(execution(ExecutionStatus.SUCCEEDED, 2L))));
+
+        runtime.commit(record, "transition-1", result, itemContinuationHandler).await().indefinitely();
+
+        InOrder inOrder = inOrder(terminalPublicationBarrier, executionStateStore);
+        inOrder.verify(terminalPublicationBarrier).publishBeforeSuccess(record, result);
+        inOrder.verify(executionStateStore).markSucceeded(
+            eq(record.tenantId()),
+            eq(record.executionId()),
+            eq(record.version()),
+            eq("transition-1"),
+            eq(List.of("out-1")),
+            anyLong());
+    }
+
+    @Test
+    void publicationFailureDoesNotMarkSuccess() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionStatus.RUNNING, 1L);
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1"));
+        IllegalStateException failure = new IllegalStateException("publish failed");
+        when(terminalPublicationBarrier.publishBeforeSuccess(record, result))
+            .thenReturn(Uni.createFrom().failure(failure));
+
+        IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> runtime.commit(record, "transition-1", result, itemContinuationHandler).await().indefinitely());
+
+        assertEquals(failure, thrown);
+        verify(executionStateStore, never()).markSucceeded(any(), any(), anyLong(), any(), any(), anyLong());
+    }
+
+    @Test
+    void suspendedTransitionImportsWaitStateThenReleasesCompletedWork() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionStatus.RUNNING, 1L);
+        ExecutionRecord<Object, Object> waiting = execution(ExecutionStatus.WAITING_EXTERNAL, 2L);
+        TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-1", "unit-1", 3);
+        when(awaitCoordinator.importSuspension(suspension)).thenReturn(Uni.createFrom().voidItem());
+        when(executionStateStore.markWaitingExternal(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(1L),
+            eq("transition-1"),
+            eq("unit-1"),
+            eq(3),
+            anyLong())).thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+        when(effects.releaseAlreadyCompletedAwaitUnit(
+            eq(waiting),
+            eq(suspension),
+            anyLong(),
+            eq(itemContinuationHandler))).thenReturn(Uni.createFrom().voidItem());
+
+        runtime.commit(record, "transition-1", TransitionResultEnvelope.waiting(suspension), itemContinuationHandler)
+            .await().indefinitely();
+
+        InOrder inOrder = inOrder(awaitCoordinator, executionStateStore, effects);
+        inOrder.verify(awaitCoordinator).importSuspension(suspension);
+        inOrder.verify(executionStateStore).markWaitingExternal(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(1L),
+            eq("transition-1"),
+            eq("unit-1"),
+            eq(3),
+            anyLong());
+        verify(effects).recordExecutionWaiting(any());
+        verify(effects).releaseAlreadyCompletedAwaitUnit(
+            eq(waiting),
+            eq(suspension),
+            anyLong(),
+            eq(itemContinuationHandler));
+    }
+
+    @Test
+    void suspendedTransitionDoesNotReleaseWorkWhenWaitStateWriteLosesRace() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionStatus.RUNNING, 1L);
+        TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-1", "unit-1", 3);
+        when(awaitCoordinator.importSuspension(suspension)).thenReturn(Uni.createFrom().voidItem());
+        when(executionStateStore.markWaitingExternal(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(1L),
+            eq("transition-1"),
+            eq("unit-1"),
+            eq(3),
+            anyLong())).thenReturn(Uni.createFrom().item(Optional.empty()));
+
+        IllegalStateException failure = assertThrows(
+            IllegalStateException.class,
+            () -> runtime.commit(record, "transition-1", TransitionResultEnvelope.waiting(suspension), itemContinuationHandler)
+                .await().indefinitely());
+
+        assertEquals(
+            "Failed to persist WAITING_EXTERNAL state for execution exec-1 at step 3 (expectedVersion=1, awaitUnitId=unit-1)",
+            failure.getMessage());
+        verify(effects, never()).recordExecutionWaiting(any());
+        verify(effects, never()).releaseAlreadyCompletedAwaitUnit(any(), any(), anyLong(), any());
+    }
+
+    private static ExecutionRecord<Object, Object> execution(ExecutionStatus status, long version) {
+        return new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "exec-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            status,
+            version,
+            3,
+            0,
+            "worker",
+            0L,
+            0L,
+            "previous",
+            "input",
+            null,
+            null,
+            null,
+            null,
+            10_000L,
+            10_000L,
+            86_400L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/TransitionCommitPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TransitionCommitPlanTest.java
@@ -1,0 +1,137 @@
+package org.pipelineframework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.TransitionWorkerOutcome;
+
+class TransitionCommitPlanTest {
+
+    @Test
+    void completedTransitionPlansSuccessWithImmutableOutputItems() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionResultShape.MATERIALIZED_MULTI);
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1", "out-2"));
+
+        TransitionCommitPlan plan = TransitionCommitPlan.from(record, "transition-1", result, 42_000L);
+
+        TransitionCommitPlan.MarkSucceeded success =
+            assertInstanceOf(TransitionCommitPlan.MarkSucceeded.class, plan);
+        assertEquals(record, success.record());
+        assertEquals("transition-1", success.transitionKey());
+        assertEquals(result, success.result());
+        assertEquals(List.of("out-1", "out-2"), success.outputItems());
+        assertEquals(42_000L, success.nowEpochMs());
+        assertThrows(UnsupportedOperationException.class, () -> success.outputItems().clear());
+    }
+
+    @Test
+    void singleResultShapeViolationPlansFailure() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionResultShape.SINGLE);
+        TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1", "out-2"));
+
+        TransitionCommitPlan plan = TransitionCommitPlan.from(record, "transition-1", result, 42_000L);
+
+        TransitionCommitPlan.HandleFailure failure =
+            assertInstanceOf(TransitionCommitPlan.HandleFailure.class, plan);
+        assertEquals(record, failure.record());
+        assertEquals("transition-1", failure.transitionKey());
+        assertTrue(failure.failure().getMessage().contains("produced 2 terminal items"));
+    }
+
+    @Test
+    void waitingTransitionPlansExternalWaitCommit() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionResultShape.MATERIALIZED_MULTI);
+        TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-1", "unit-1", 3);
+
+        TransitionCommitPlan plan = TransitionCommitPlan.from(
+            record,
+            "transition-1",
+            TransitionResultEnvelope.waiting(suspension),
+            42_000L);
+
+        TransitionCommitPlan.MarkWaitingExternal waiting =
+            assertInstanceOf(TransitionCommitPlan.MarkWaitingExternal.class, plan);
+        assertEquals(record, waiting.record());
+        assertEquals("transition-1", waiting.transitionKey());
+        assertEquals(suspension, waiting.suspension());
+        assertEquals(42_000L, waiting.nowEpochMs());
+    }
+
+    @Test
+    void waitingTransitionMissingSuspensionPlansFailure() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionResultShape.MATERIALIZED_MULTI);
+        TransitionResultEnvelope result = mock(TransitionResultEnvelope.class);
+        when(result.outcome()).thenReturn(TransitionWorkerOutcome.WAITING_EXTERNAL);
+        when(result.awaitSuspension()).thenReturn(null);
+
+        TransitionCommitPlan plan = TransitionCommitPlan.from(record, "transition-1", result, 42_000L);
+
+        TransitionCommitPlan.HandleFailure failure =
+            assertInstanceOf(TransitionCommitPlan.HandleFailure.class, plan);
+        assertTrue(failure.failure().getMessage().contains("missing await suspension"));
+    }
+
+    @Test
+    void failedTransitionMissingFailurePayloadPlansFailure() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionResultShape.MATERIALIZED_MULTI);
+        TransitionResultEnvelope result = mock(TransitionResultEnvelope.class);
+        when(result.outcome()).thenReturn(TransitionWorkerOutcome.FAILED);
+        when(result.failure()).thenReturn(null);
+
+        TransitionCommitPlan plan = TransitionCommitPlan.from(record, "transition-1", result, 42_000L);
+
+        TransitionCommitPlan.HandleFailure failure =
+            assertInstanceOf(TransitionCommitPlan.HandleFailure.class, plan);
+        assertTrue(failure.failure().getMessage().contains("missing failure payload"));
+    }
+
+    @Test
+    void nullResultPlansFailure() {
+        ExecutionRecord<Object, Object> record = execution(ExecutionResultShape.MATERIALIZED_MULTI);
+
+        TransitionCommitPlan plan = TransitionCommitPlan.from(record, "transition-1", null, 42_000L);
+
+        TransitionCommitPlan.HandleFailure failure =
+            assertInstanceOf(TransitionCommitPlan.HandleFailure.class, plan);
+        assertTrue(failure.failure().getMessage().contains("returned null result"));
+    }
+
+    private static ExecutionRecord<Object, Object> execution(ExecutionResultShape resultShape) {
+        return new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "exec-key",
+            "pipeline",
+            "contract",
+            "release",
+            resultShape,
+            ExecutionStatus.RUNNING,
+            1L,
+            3,
+            0,
+            "worker",
+            0L,
+            0L,
+            "previous",
+            "input",
+            null,
+            null,
+            null,
+            null,
+            10_000L,
+            10_000L,
+            86_400L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitLiveCompletionRegistryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitLiveCompletionRegistryTest.java
@@ -1,0 +1,39 @@
+package org.pipelineframework.awaitable;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class AwaitLiveCompletionRegistryTest {
+
+    @Test
+    void closeOnlyRemovesTheOwningLiveSession() {
+        AwaitLiveCompletionRegistry registry = new AwaitLiveCompletionRegistry();
+        AwaitStepDescriptor descriptor = new AwaitStepDescriptor(
+            "await",
+            String.class.getName(),
+            String.class.getName(),
+            "ONE_TO_ONE",
+            Duration.ofSeconds(30),
+            "interactionId",
+            "kafka",
+            Map.of(),
+            List.of());
+        LiveAwaitSession<String> owner = registry.open(descriptor, "tenant-1", "unit-1");
+        LiveAwaitSession<String> unrelated = new LiveAwaitSession<>("unit-1", String.class, () -> {
+        });
+
+        registry.close("tenant-1", "unit-1", unrelated);
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> registry.open(descriptor, "tenant-1", "unit-1"));
+        registry.close("tenant-1", "unit-1", owner);
+        assertDoesNotThrow(() -> registry.open(descriptor, "tenant-1", "unit-1"));
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/AwaitStepSupportTest.java
@@ -653,7 +653,7 @@ class AwaitStepSupportTest {
         boolean dispatchComplete) {
         return new AwaitUnitRecord(
             "tenant1",
-            streamUnitId(),
+            unitId,
             "exec123",
             "review",
             2,

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/LiveAwaitSessionStateTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/LiveAwaitSessionStateTest.java
@@ -1,0 +1,92 @@
+package org.pipelineframework.awaitable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LiveAwaitSessionStateTest {
+
+    @Test
+    void zeroItemDispatchCompletesAfterSubscriberIsReady() {
+        LiveAwaitSessionState<String> state = attachedReadyState();
+
+        LiveAwaitSessionDecision<String> decision = state.markDispatchComplete(0);
+
+        assertTrue(decision.state().terminated());
+        assertEquals(2, decision.effects().size());
+        assertInstanceOf(LiveAwaitSessionEffect.CompleteStream.class, decision.effects().get(0));
+        assertInstanceOf(LiveAwaitSessionEffect.CloseSession.class, decision.effects().get(1));
+    }
+
+    @Test
+    void completionBeforeSubscriberReadinessDoesNotEmitTerminalSignalsEarly() {
+        LiveAwaitSessionState<String> state = LiveAwaitSessionState.<String>initial()
+            .attachSubscriber()
+            .state()
+            .request(1)
+            .state();
+
+        LiveAwaitSessionDecision<String> dispatchComplete = state.markDispatchComplete(1);
+        assertTrue(dispatchComplete.effects().isEmpty());
+
+        LiveAwaitSessionDecision<String> admitted = dispatchComplete.state().admitCompletion("item:0", "approved");
+        assertTrue(admitted.effects().isEmpty());
+        assertFalse(admitted.state().terminated());
+
+        LiveAwaitSessionDecision<String> ready = admitted.state().markSubscriberReady();
+        assertEquals(3, ready.effects().size());
+        assertInstanceOf(LiveAwaitSessionEffect.EmitItem.class, ready.effects().get(0));
+        assertInstanceOf(LiveAwaitSessionEffect.CompleteStream.class, ready.effects().get(1));
+        assertInstanceOf(LiveAwaitSessionEffect.CloseSession.class, ready.effects().get(2));
+    }
+
+    @Test
+    void duplicateCompletionsAreIdempotent() {
+        LiveAwaitSessionState<String> state = attachedReadyState().request(1).state();
+
+        LiveAwaitSessionDecision<String> first = state.admitCompletion("item:0", "approved");
+        assertEquals(1, first.effects().size());
+        assertInstanceOf(LiveAwaitSessionEffect.EmitItem.class, first.effects().getFirst());
+
+        LiveAwaitSessionDecision<String> accepted = first.state().acceptanceCompleted("item:0");
+        LiveAwaitSessionDecision<String> duplicate = accepted.state().admitCompletion("item:0", "duplicate");
+
+        assertTrue(duplicate.effects().isEmpty());
+        assertTrue(duplicate.state().duplicate("item:0"));
+        assertTrue(duplicate.state().accepted("item:0"));
+    }
+
+    @Test
+    void demandControlsEmission() {
+        LiveAwaitSessionState<String> state = attachedReadyState();
+
+        state = state.admitCompletion("item:0", "first").state();
+        state = state.admitCompletion("item:1", "second").state();
+        assertEquals(2, state.pending().size());
+
+        LiveAwaitSessionDecision<String> firstDemand = state.request(1);
+        assertEquals(1, firstDemand.effects().size());
+        LiveAwaitSessionEffect.EmitItem<?> firstEmit =
+            assertInstanceOf(LiveAwaitSessionEffect.EmitItem.class, firstDemand.effects().getFirst());
+        assertEquals("item:0", firstEmit.completionKey());
+        assertEquals(1, firstDemand.state().pending().size());
+
+        LiveAwaitSessionDecision<String> secondDemand = firstDemand.state().request(1);
+        assertEquals(1, secondDemand.effects().size());
+        LiveAwaitSessionEffect.EmitItem<?> secondEmit =
+            assertInstanceOf(LiveAwaitSessionEffect.EmitItem.class, secondDemand.effects().getFirst());
+        assertEquals("item:1", secondEmit.completionKey());
+        assertTrue(secondDemand.state().pending().isEmpty());
+    }
+
+    private static LiveAwaitSessionState<String> attachedReadyState() {
+        return LiveAwaitSessionState.<String>initial()
+            .attachSubscriber()
+            .state()
+            .markSubscriberReady()
+            .state();
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/awaitable/LiveAwaitSessionTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/awaitable/LiveAwaitSessionTest.java
@@ -1,0 +1,100 @@
+package org.pipelineframework.awaitable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+class LiveAwaitSessionTest {
+
+    @Test
+    void failedPayloadCoercionDoesNotMarkCompletionAccepted() {
+        AtomicInteger closed = new AtomicInteger();
+        LiveAwaitSession<Integer> session = new LiveAwaitSession<>("unit-1", Integer.class, closed::incrementAndGet);
+        RecordingSubscriber<Integer> subscriber = new RecordingSubscriber<>();
+        session.subscribe(subscriber);
+        subscriber.subscription().request(1);
+        AwaitInteractionRecord record = itemRecord("unit-1", 0, Map.of("not", "an-integer"));
+
+        assertThrows(IllegalStateException.class, () -> session.accept(record).await().atMost(Duration.ofSeconds(5)));
+        assertThrows(IllegalStateException.class, () -> session.awaitAccepted(record).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(subscriber.items().isEmpty());
+        assertTrue(subscriber.failure() instanceof IllegalStateException);
+        assertEquals(1, closed.get());
+    }
+
+    private static AwaitInteractionRecord itemRecord(String unitId, int index, Object responsePayload) {
+        long now = System.currentTimeMillis();
+        return new AwaitInteractionRecord(
+            "tenant1",
+            "exec123",
+            "review",
+            2,
+            Integer.class.getName(),
+            "interaction-" + index,
+            "correlation-" + index,
+            "causation-" + index,
+            "idem-" + index,
+            0L,
+            AwaitInteractionStatus.COMPLETED,
+            "request-" + index,
+            responsePayload,
+            unitId,
+            index,
+            null,
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            now + 300000,
+            now,
+            now,
+            now + 86400);
+    }
+
+    private static final class RecordingSubscriber<T> implements Flow.Subscriber<T> {
+        private final List<T> items = new ArrayList<>();
+        private Flow.Subscription subscription;
+        private Throwable failure;
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+        }
+
+        @Override
+        public void onNext(T item) {
+            items.add(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            failure = throwable;
+        }
+
+        @Override
+        public void onComplete() {
+        }
+
+        private Flow.Subscription subscription() {
+            return subscription;
+        }
+
+        private List<T> items() {
+            return items;
+        }
+
+        private Throwable failure() {
+            return failure;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- splits queue-async semantic behavior out of `QueueAsyncCoordinator` into focused internal flow objects
- adds immutable decision records for await completion, transition commit, and terminal publication planning
- extracts itemized await streaming and live await session state into explicit state-machine objects
- updates internal await-unit docs and diagrams for the new flow model

## Scope
This is PR 1 for issue #439. It intentionally does not add the terminal publication outbox/idempotency boundary, complete the final coordinator facade cleanup, or regenerate replay/homepage assets.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime test -Dmaven.repo.local="$PWD/.m2/repository" -q`
- `npm --prefix docs test`
- `npm --prefix docs run build`

Refs #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved queue-based await processing with clearer live and durable paths.
  * Added more reliable terminal publication before successful completion.
  * Expanded support for item-level continuation and resumption handling.

* **Bug Fixes**
  * Better handling of suspended, retried, and failed transitions.
  * Added stricter validation for completion routing and tenant consistency.
  * Improved behavior when live streaming is unavailable or payloads are invalid.

* **Documentation**
  * Updated await/runtime docs to reflect the new flow model and sequence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->