### PR TITLE
Introduce immutable queue-async control plane

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -260,6 +260,7 @@ const mainSidebar = [
         items: [
             {text: 'Overview', link: '/evolve/'},
             {text: 'Architecture', link: '/evolve/architecture'},
+            {text: 'Queue-Async Immutable Boundaries', link: '/evolve/queue-async-immutable-boundaries'},
             {text: 'Architecture Reference', link: '/evolve/architecture-reference'},
             {text: 'I/O Shell Absorption', link: '/evolve/io-shell-absorption'},
             {

--- a/docs/evolve/architecture.md
+++ b/docs/evolve/architecture.md
@@ -12,6 +12,7 @@ Use public Design/Develop/Deploy docs for application usage. Use this page when 
 | Generated artifacts and module ownership | [Pipeline Compilation](/develop/pipeline-compilation/) |
 | Runtime layout vs build topology | [Runtime Layouts](/deploy/runtime-layouts/) |
 | Queue-async durable execution | [Queue-Async Runtime](/deploy/orchestrator-runtime/queue-async) |
+| Queue-async immutable segment/boundary model | [Queue-Async Immutable Boundaries](/evolve/queue-async-immutable-boundaries) |
 | Await and callback admission | [Await Boundaries](/design/await-boundaries) and [Await Runtime Setup](/deploy/orchestrator-runtime/await) |
 | Checkpoint handoff | [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) |
 | Brokered runtime boundaries | [Brokered Runtime Boundaries](/evolve/brokered-boundaries/) |
@@ -30,7 +31,7 @@ The current durable direction is a queue-driven async control plane:
 6. state is committed,
 7. terminal state is exposed through status/result APIs or failures move to the configured DLQ.
 
-This is not a full event-sourced runtime in the current milestone. New durable control-plane storage should prefer immutable records, conditional writes, and append-only event records.
+This is not a full event-sourced runtime in the current milestone. The target direction is described in [Queue-Async Immutable Boundaries](/evolve/queue-async-immutable-boundaries): immutable segment and boundary facts first, with stores maintaining projections for efficient lookup.
 
 ## Legacy Reference
 

--- a/docs/evolve/await-unit-runtime/index.md
+++ b/docs/evolve/await-unit-runtime/index.md
@@ -4,7 +4,7 @@ Await units are the durable suspend/resume model for `kind: await` steps. The un
 
 This guide is implementation-facing. Application-facing design guidance lives in [Await Boundaries](/design/await-boundaries). Runtime setup lives in [Await runtime setup](/deploy/orchestrator-runtime/await).
 
-For the longer-term orchestration boundary that can move await units out of each app-hosted orchestrator, see [Durable Coordinator](/evolve/durable-coordinator/).
+For the longer-term orchestration boundary that can move await units out of each app-hosted orchestrator, see [Durable Coordinator](/evolve/durable-coordinator/). For the immutable queue-async model that treats await completion and checkpoint handoff as the same boundary-admission shape, see [Queue-Async Immutable Boundaries](/evolve/queue-async-immutable-boundaries).
 
 ## Guide Pages
 
@@ -83,7 +83,9 @@ classDiagram
     AwaitCoordinator --> AwaitTransportAdapter : dispatch
 ```
 
-`AwaitUnitRecord` is the source of truth for completion of the authored await boundary. `AwaitInteractionRecord` is the transport-facing projection. That distinction prevents execution state, dispatch strategy, and step cardinality from collapsing into one ambiguous record.
+`AwaitUnitRecord` is the current compatibility projection for completion of the authored await boundary. `AwaitInteractionRecord` is the transport-facing projection. The target queue-async model represents the same behavior as immutable `BoundaryUnit` and `BoundaryInteraction` projections derived from appended facts.
+
+In that model, `PipelineRunner` still runs synchronous step segments. An await step suspends one `ExecutionSegment` by appending a `SegmentSuspended` fact. Kafka, webhook, or interaction-api completion appends `BoundaryCompletionAdmitted`. If a live await session is present, the admitted completion can flow into the active downstream `Multi`; if not, the same durable facts create continuation segment work.
 
 ## CSV Payments Applied Model
 

--- a/docs/evolve/queue-async-immutable-boundaries.md
+++ b/docs/evolve/queue-async-immutable-boundaries.md
@@ -1,0 +1,125 @@
+# Queue-Async Immutable Boundaries
+
+Queue-async should be modeled as immutable facts flowing through reducers, not as one mutable execution record being marked from state to state.
+
+This page describes the target internal model introduced for the first in-memory slice. The current `ExecutionStateStore`, `AwaitUnitStore`, and `AwaitInteractionStore` remain compatibility projections until the Dynamo append-only storage design in issue #396 replaces their update-oriented implementations.
+
+## Core Model
+
+`PipelineRunner` remains the synchronous segment runner. Queue-async adds durable boundaries between those synchronous segments:
+
+1. A `PipelineRun` is the logical submitted run.
+2. An `ExecutionSegment` is one synchronous step range between async boundaries.
+3. A `SegmentAttempt` is one worker attempt for a segment.
+4. A `BoundaryUnit` is an async handoff boundary: await, checkpoint handoff, or terminal publication.
+5. A `BoundaryInteraction` is the transport-facing correlation/idempotency item within the boundary.
+
+The model is intentionally append-only. A timeout is not "mark this execution timed out"; it is an `InteractionTimedOut` fact. Reducers derive the current run, segment, boundary, and due-work projections from that fact stream.
+
+```mermaid
+classDiagram
+    class PipelineRun {
+      runId
+      executionKey
+      status
+      version
+    }
+
+    class ExecutionSegment {
+      segmentId
+      startStepIndex
+      stopBeforeStepIndex
+      status
+      inputPayload
+    }
+
+    class SegmentAttempt {
+      attemptId
+      attemptNumber
+      status
+    }
+
+    class BoundaryUnit {
+      unitId
+      kind
+      status
+      expectedItemCount
+      completedItemCount
+    }
+
+    class BoundaryInteraction {
+      interactionId
+      correlationId
+      idempotencyKey
+      status
+      transportType
+    }
+
+    class ControlPlaneFact
+    class ControlPlaneReducer
+    class ControlPlaneProjection
+    class ControlPlaneJournal
+
+    PipelineRun "1" --> "1..n" ExecutionSegment
+    ExecutionSegment "1" --> "0..n" SegmentAttempt
+    ExecutionSegment "0..1" --> BoundaryUnit
+    BoundaryUnit "1" --> "0..n" BoundaryInteraction
+    ControlPlaneFact --> ControlPlaneReducer : append / reduce
+    ControlPlaneReducer --> ControlPlaneProjection : derives
+    ControlPlaneJournal --> ControlPlaneFact : conditional append
+```
+
+## Fact Flow
+
+The first slice introduces facts such as:
+
+- `RunSubmitted`
+- `SegmentAttemptStarted`
+- `SegmentCompleted`
+- `SegmentSuspended`
+- `BoundaryInteractionDispatched`
+- `BoundaryDispatchCompleted`
+- `BoundaryCompletionAdmitted`
+- `InteractionTimedOut`
+- `ContinuationSegmentCreated`
+- `TerminalPublicationCompleted`
+- `RunSucceeded`
+- `RunFailed`
+
+These facts are immutable. The in-memory `ControlPlaneJournal` appends them conditionally by expected projection version, assigns monotonically increasing event sequences, and rebuilds projections through `ControlPlaneReducer`.
+
+Duplicate completions and terminal publications are handled by fact keys. Retrying the same append is a no-op when the fact key already exists; retrying a different fact against a stale version fails with an append conflict.
+
+## Boundary Admission
+
+Await completion and checkpoint handoff are the same architectural shape: a transport message admits a correlated payload into a TPF-owned boundary.
+
+```mermaid
+sequenceDiagram
+    participant Broker as "Broker / transport"
+    participant Admission as "Boundary admission"
+    participant Journal as "ControlPlaneJournal"
+    participant Reducer as "ControlPlaneReducer"
+    participant Projection as "Current projection"
+    participant Effects as "Effect interpreter"
+
+    Broker->>Admission: "completion or handoff message"
+    Admission->>Journal: "append BoundaryCompletionAdmitted"
+    Journal->>Reducer: "reduce immutable facts"
+    Reducer-->>Projection: "boundary/run/segment view"
+    Projection-->>Effects: "live handoff or durable continuation"
+```
+
+`BoundaryAdmissionFacts` is deliberately transport-agnostic. Kafka await completions and Kafka checkpoint handoffs should produce the same `BoundaryCompletionAdmitted` fact shape after their protocol-specific decoding.
+
+## Relationship To Existing Stores
+
+The existing stores are still update-oriented compatibility projections:
+
+- `ExecutionStateStore`
+- `AwaitUnitStore`
+- `AwaitInteractionStore`
+
+They remain in the hot path until the control-plane journal is integrated. The new package draws the semantic boundary first so the next storage work can replace update verbs with append-only writes without inventing the model inside the Dynamo implementation.
+
+The next storage slice should implement the Dynamo append-only design tracked by issue #396. It must answer the table/index and stale-candidate questions there before replacing production store providers.

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryAdmissionFacts.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryAdmissionFacts.java
@@ -1,0 +1,18 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public final class BoundaryAdmissionFacts {
+
+    private BoundaryAdmissionFacts() {
+    }
+
+    public static ControlPlaneFact.BoundaryCompletionAdmitted completion(BoundaryAdmissionRequest request) {
+        return new ControlPlaneFact.BoundaryCompletionAdmitted(
+            request.tenantId(),
+            request.runId(),
+            request.boundaryUnitId(),
+            request.boundaryKind(),
+            request.interactionId(),
+            request.idempotencyKey(),
+            request.responsePayload());
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryAdmissionRequest.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryAdmissionRequest.java
@@ -1,0 +1,22 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+
+public record BoundaryAdmissionRequest(
+    String tenantId,
+    String runId,
+    String boundaryUnitId,
+    BoundaryKind boundaryKind,
+    String interactionId,
+    String idempotencyKey,
+    Object responsePayload
+) {
+    public BoundaryAdmissionRequest {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+        Objects.requireNonNull(boundaryKind, "boundaryKind must not be null");
+        interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
+        idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryInteraction.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryInteraction.java
@@ -31,6 +31,8 @@ public record BoundaryInteraction(
         if (itemIndex != null && itemIndex < 0) {
             throw new IllegalArgumentException("itemIndex must not be negative");
         }
+        requestPayload = ControlPlaneChecks.freezePayload(requestPayload);
+        responsePayload = ControlPlaneChecks.freezePayload(responsePayload);
         transportType = ControlPlaneChecks.requireText(transportType, "transportType");
         ControlPlaneChecks.requireNonNegative(deadlineEpochMs, "deadlineEpochMs");
         ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryInteraction.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryInteraction.java
@@ -1,0 +1,74 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+
+public record BoundaryInteraction(
+    String tenantId,
+    String runId,
+    String unitId,
+    String interactionId,
+    BoundaryKind kind,
+    BoundaryInteractionStatus status,
+    String correlationId,
+    String idempotencyKey,
+    Integer itemIndex,
+    Object requestPayload,
+    Object responsePayload,
+    String transportType,
+    long deadlineEpochMs,
+    long createdAtEpochMs,
+    long updatedAtEpochMs
+) {
+    public BoundaryInteraction {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        unitId = ControlPlaneChecks.requireText(unitId, "unitId");
+        interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        correlationId = ControlPlaneChecks.requireText(correlationId, "correlationId");
+        idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+        if (itemIndex != null && itemIndex < 0) {
+            throw new IllegalArgumentException("itemIndex must not be negative");
+        }
+        transportType = ControlPlaneChecks.requireText(transportType, "transportType");
+        ControlPlaneChecks.requireNonNegative(deadlineEpochMs, "deadlineEpochMs");
+        ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
+        ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
+    }
+
+    BoundaryInteraction completed(Object nextResponsePayload, long nowEpochMs) {
+        return terminal(BoundaryInteractionStatus.COMPLETED, nextResponsePayload, nowEpochMs);
+    }
+
+    BoundaryInteraction timedOut(long nowEpochMs) {
+        return terminal(BoundaryInteractionStatus.TIMED_OUT, responsePayload, nowEpochMs);
+    }
+
+    BoundaryInteraction failed(long nowEpochMs) {
+        return terminal(BoundaryInteractionStatus.FAILED, responsePayload, nowEpochMs);
+    }
+
+    private BoundaryInteraction terminal(
+        BoundaryInteractionStatus nextStatus,
+        Object nextResponsePayload,
+        long nowEpochMs
+    ) {
+        return new BoundaryInteraction(
+            tenantId,
+            runId,
+            unitId,
+            interactionId,
+            kind,
+            nextStatus,
+            correlationId,
+            idempotencyKey,
+            itemIndex,
+            requestPayload,
+            nextResponsePayload,
+            transportType,
+            deadlineEpochMs,
+            createdAtEpochMs,
+            nowEpochMs);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryInteractionStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryInteractionStatus.java
@@ -1,0 +1,12 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public enum BoundaryInteractionStatus {
+    DISPATCHED,
+    COMPLETED,
+    TIMED_OUT,
+    FAILED;
+
+    public boolean terminal() {
+        return this == COMPLETED || this == TIMED_OUT || this == FAILED;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryKind.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryKind.java
@@ -1,0 +1,7 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public enum BoundaryKind {
+    AWAIT,
+    CHECKPOINT,
+    TERMINAL_PUBLICATION
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryUnit.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryUnit.java
@@ -1,0 +1,105 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record BoundaryUnit(
+    String tenantId,
+    String runId,
+    String unitId,
+    BoundaryKind kind,
+    BoundaryUnitStatus status,
+    String segmentId,
+    int stepIndex,
+    Integer expectedItemCount,
+    int completedItemCount,
+    Set<String> completedInteractionKeys,
+    boolean dispatchComplete,
+    long createdAtEpochMs,
+    long updatedAtEpochMs
+) {
+    public BoundaryUnit {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        unitId = ControlPlaneChecks.requireText(unitId, "unitId");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+        ControlPlaneChecks.requireNonNegative(stepIndex, "stepIndex");
+        if (expectedItemCount != null && expectedItemCount < 0) {
+            throw new IllegalArgumentException("expectedItemCount must not be negative");
+        }
+        ControlPlaneChecks.requireNonNegative(completedItemCount, "completedItemCount");
+        completedInteractionKeys = ControlPlaneChecks.copySet(completedInteractionKeys);
+        ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
+        ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
+    }
+
+    BoundaryUnit withDispatchComplete(int expectedCount, long nowEpochMs) {
+        BoundaryUnitStatus nextStatus = completedInteractionKeys.size() >= expectedCount
+            ? BoundaryUnitStatus.COMPLETED
+            : BoundaryUnitStatus.DISPATCH_COMPLETE;
+        return new BoundaryUnit(
+            tenantId,
+            runId,
+            unitId,
+            kind,
+            nextStatus,
+            segmentId,
+            stepIndex,
+            expectedCount,
+            completedInteractionKeys.size(),
+            completedInteractionKeys,
+            true,
+            createdAtEpochMs,
+            nowEpochMs);
+    }
+
+    BoundaryUnit withCompletion(String completionKey, long nowEpochMs) {
+        Set<String> nextKeys = new java.util.HashSet<>(completedInteractionKeys);
+        nextKeys.add(ControlPlaneChecks.requireText(completionKey, "completionKey"));
+        int expected = expectedItemCount == null ? -1 : expectedItemCount;
+        BoundaryUnitStatus nextStatus = dispatchComplete && expected >= 0 && nextKeys.size() >= expected
+            ? BoundaryUnitStatus.COMPLETED
+            : status;
+        return new BoundaryUnit(
+            tenantId,
+            runId,
+            unitId,
+            kind,
+            nextStatus,
+            segmentId,
+            stepIndex,
+            expectedItemCount,
+            nextKeys.size(),
+            nextKeys,
+            dispatchComplete,
+            createdAtEpochMs,
+            nowEpochMs);
+    }
+
+    BoundaryUnit timedOut(long nowEpochMs) {
+        return terminal(BoundaryUnitStatus.TIMED_OUT, nowEpochMs);
+    }
+
+    BoundaryUnit failed(long nowEpochMs) {
+        return terminal(BoundaryUnitStatus.FAILED, nowEpochMs);
+    }
+
+    private BoundaryUnit terminal(BoundaryUnitStatus nextStatus, long nowEpochMs) {
+        return new BoundaryUnit(
+            tenantId,
+            runId,
+            unitId,
+            kind,
+            nextStatus,
+            segmentId,
+            stepIndex,
+            expectedItemCount,
+            completedItemCount,
+            completedInteractionKeys,
+            dispatchComplete,
+            createdAtEpochMs,
+            nowEpochMs);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryUnit.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryUnit.java
@@ -10,6 +10,7 @@ public record BoundaryUnit(
     BoundaryKind kind,
     BoundaryUnitStatus status,
     String segmentId,
+    String attemptId,
     int stepIndex,
     Integer expectedItemCount,
     int completedItemCount,
@@ -25,17 +26,24 @@ public record BoundaryUnit(
         Objects.requireNonNull(kind, "kind must not be null");
         Objects.requireNonNull(status, "status must not be null");
         segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+        attemptId = ControlPlaneChecks.requireText(attemptId, "attemptId");
         ControlPlaneChecks.requireNonNegative(stepIndex, "stepIndex");
         if (expectedItemCount != null && expectedItemCount < 0) {
             throw new IllegalArgumentException("expectedItemCount must not be negative");
         }
         ControlPlaneChecks.requireNonNegative(completedItemCount, "completedItemCount");
         completedInteractionKeys = ControlPlaneChecks.copySet(completedInteractionKeys);
+        if (completedItemCount != completedInteractionKeys.size()) {
+            throw new IllegalArgumentException("completedItemCount must match completedInteractionKeys size");
+        }
         ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
         ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
     }
 
     BoundaryUnit withDispatchComplete(int expectedCount, long nowEpochMs) {
+        if (status.terminal()) {
+            return this;
+        }
         BoundaryUnitStatus nextStatus = completedInteractionKeys.size() >= expectedCount
             ? BoundaryUnitStatus.COMPLETED
             : BoundaryUnitStatus.DISPATCH_COMPLETE;
@@ -46,6 +54,7 @@ public record BoundaryUnit(
             kind,
             nextStatus,
             segmentId,
+            attemptId,
             stepIndex,
             expectedCount,
             completedInteractionKeys.size(),
@@ -56,6 +65,9 @@ public record BoundaryUnit(
     }
 
     BoundaryUnit withCompletion(String completionKey, long nowEpochMs) {
+        if (status.terminal()) {
+            return this;
+        }
         Set<String> nextKeys = new java.util.HashSet<>(completedInteractionKeys);
         nextKeys.add(ControlPlaneChecks.requireText(completionKey, "completionKey"));
         int expected = expectedItemCount == null ? -1 : expectedItemCount;
@@ -69,6 +81,7 @@ public record BoundaryUnit(
             kind,
             nextStatus,
             segmentId,
+            attemptId,
             stepIndex,
             expectedItemCount,
             nextKeys.size(),
@@ -94,6 +107,7 @@ public record BoundaryUnit(
             kind,
             nextStatus,
             segmentId,
+            attemptId,
             stepIndex,
             expectedItemCount,
             completedItemCount,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryUnitStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/BoundaryUnitStatus.java
@@ -1,0 +1,13 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public enum BoundaryUnitStatus {
+    OPEN,
+    DISPATCH_COMPLETE,
+    COMPLETED,
+    TIMED_OUT,
+    FAILED;
+
+    public boolean terminal() {
+        return this == COMPLETED || this == TIMED_OUT || this == FAILED;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneAppendConflictException.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneAppendConflictException.java
@@ -1,0 +1,8 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public class ControlPlaneAppendConflictException extends RuntimeException {
+
+    public ControlPlaneAppendConflictException(String message) {
+        super(message);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneAppendResult.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneAppendResult.java
@@ -1,0 +1,14 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ControlPlaneAppendResult(
+    ControlPlaneProjection projection,
+    List<ControlPlaneEvent> appendedEvents
+) {
+    public ControlPlaneAppendResult {
+        Objects.requireNonNull(projection, "projection must not be null");
+        appendedEvents = ControlPlaneChecks.copyList(appendedEvents);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneChecks.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneChecks.java
@@ -95,15 +95,21 @@ final class ControlPlaneChecks {
             }
             return List.copyOf(frozen);
         }
+        Object normalized;
         try {
-            Object normalized = PipelineJson.mapper().convertValue(value, Object.class);
-            if (normalized == value) {
-                return value.toString();
-            }
-            return freezePayload(normalized);
-        } catch (IllegalArgumentException ignored) {
-            return value.toString();
+            normalized = PipelineJson.mapper().convertValue(value, Object.class);
+        } catch (IllegalArgumentException failure) {
+            throw unsupportedPayload(value, failure);
         }
+        if (normalized == value) {
+            throw unsupportedPayload(value, null);
+        }
+        return freezePayload(normalized);
+    }
+
+    private static IllegalArgumentException unsupportedPayload(Object value, Throwable cause) {
+        String message = "Unsupported control-plane payload type: " + value.getClass().getName();
+        return cause == null ? new IllegalArgumentException(message) : new IllegalArgumentException(message, cause);
     }
 
     private static boolean immutableScalar(Object value) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneChecks.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneChecks.java
@@ -1,8 +1,24 @@
 package org.pipelineframework.orchestrator.controlplane;
 
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+
+import org.pipelineframework.config.pipeline.PipelineJson;
 
 final class ControlPlaneChecks {
 
@@ -30,6 +46,16 @@ final class ControlPlaneChecks {
         return value;
     }
 
+    static int requireSegmentStopAfterStart(int startStepIndex, int stopBeforeStepIndex) {
+        if (stopBeforeStepIndex < -1) {
+            throw new IllegalArgumentException("stopBeforeStepIndex must be -1 or greater than or equal to startStepIndex");
+        }
+        if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
+            throw new IllegalArgumentException("stopBeforeStepIndex must be -1 or greater than or equal to startStepIndex");
+        }
+        return stopBeforeStepIndex;
+    }
+
     static <T> List<T> copyList(List<T> value) {
         return value == null ? List.of() : List.copyOf(value);
     }
@@ -40,5 +66,66 @@ final class ControlPlaneChecks {
 
     static <K, V> Map<K, V> copyMap(Map<K, V> value) {
         return value == null ? Map.of() : Map.copyOf(value);
+    }
+
+    static Object freezePayload(Object value) {
+        if (value == null || immutableScalar(value)) {
+            return value;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> frozen = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                frozen.put(freezePayload(entry.getKey()), freezePayload(entry.getValue()));
+            }
+            return Collections.unmodifiableMap(frozen);
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<Object> frozen = new ArrayList<>();
+            for (Object item : iterable) {
+                frozen.add(freezePayload(item));
+            }
+            return List.copyOf(frozen);
+        }
+        Class<?> type = value.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(value);
+            List<Object> frozen = new ArrayList<>(length);
+            for (int i = 0; i < length; i++) {
+                frozen.add(freezePayload(Array.get(value, i)));
+            }
+            return List.copyOf(frozen);
+        }
+        try {
+            Object normalized = PipelineJson.mapper().convertValue(value, Object.class);
+            if (normalized == value) {
+                return value.toString();
+            }
+            return freezePayload(normalized);
+        } catch (IllegalArgumentException ignored) {
+            return value.toString();
+        }
+    }
+
+    private static boolean immutableScalar(Object value) {
+        return value instanceof String
+            || value instanceof Integer
+            || value instanceof Long
+            || value instanceof Double
+            || value instanceof Float
+            || value instanceof Short
+            || value instanceof Byte
+            || value instanceof BigDecimal
+            || value instanceof BigInteger
+            || value instanceof Boolean
+            || value instanceof Character
+            || value instanceof Enum<?>
+            || value instanceof UUID
+            || value instanceof URI
+            || value instanceof URL
+            || value instanceof Instant
+            || value instanceof LocalDate
+            || value instanceof LocalDateTime
+            || value instanceof OffsetDateTime
+            || value instanceof ZonedDateTime;
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneChecks.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneChecks.java
@@ -1,0 +1,44 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class ControlPlaneChecks {
+
+    private ControlPlaneChecks() {
+    }
+
+    static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+
+    static int requireNonNegative(int value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+        return value;
+    }
+
+    static long requireNonNegative(long value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+        return value;
+    }
+
+    static <T> List<T> copyList(List<T> value) {
+        return value == null ? List.of() : List.copyOf(value);
+    }
+
+    static <T> Set<T> copySet(Set<T> value) {
+        return value == null ? Set.of() : Set.copyOf(value);
+    }
+
+    static <K, V> Map<K, V> copyMap(Map<K, V> value) {
+        return value == null ? Map.of() : Map.copyOf(value);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneEvent.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneEvent.java
@@ -1,0 +1,17 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+
+public record ControlPlaneEvent(
+    long sequence,
+    long occurredAtEpochMs,
+    ControlPlaneFact fact
+) {
+    public ControlPlaneEvent {
+        if (sequence <= 0) {
+            throw new IllegalArgumentException("sequence must be positive");
+        }
+        ControlPlaneChecks.requireNonNegative(occurredAtEpochMs, "occurredAtEpochMs");
+        Objects.requireNonNull(fact, "fact must not be null");
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneFact.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneFact.java
@@ -1,0 +1,320 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import java.util.Objects;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+public sealed interface ControlPlaneFact permits
+    ControlPlaneFact.RunSubmitted,
+    ControlPlaneFact.SegmentAttemptStarted,
+    ControlPlaneFact.SegmentCompleted,
+    ControlPlaneFact.SegmentSuspended,
+    ControlPlaneFact.BoundaryInteractionDispatched,
+    ControlPlaneFact.BoundaryDispatchCompleted,
+    ControlPlaneFact.BoundaryCompletionAdmitted,
+    ControlPlaneFact.InteractionTimedOut,
+    ControlPlaneFact.ContinuationSegmentCreated,
+    ControlPlaneFact.TerminalPublicationCompleted,
+    ControlPlaneFact.RunSucceeded,
+    ControlPlaneFact.RunFailed {
+
+    String tenantId();
+
+    String runId();
+
+    String factKey();
+
+    record RunSubmitted(
+        String tenantId,
+        String runId,
+        String executionKey,
+        String pipelineId,
+        String contractVersion,
+        String releaseVersion,
+        ExecutionResultShape resultShape,
+        String initialSegmentId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload,
+        long ttlEpochS
+    ) implements ControlPlaneFact {
+        public RunSubmitted {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            executionKey = ControlPlaneChecks.requireText(executionKey, "executionKey");
+            pipelineId = ControlPlaneChecks.requireText(pipelineId, "pipelineId");
+            contractVersion = ControlPlaneChecks.requireText(contractVersion, "contractVersion");
+            releaseVersion = ControlPlaneChecks.requireText(releaseVersion, "releaseVersion");
+            Objects.requireNonNull(resultShape, "resultShape must not be null");
+            initialSegmentId = ControlPlaneChecks.requireText(initialSegmentId, "initialSegmentId");
+            ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
+            if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
+                throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
+            }
+            ControlPlaneChecks.requireNonNegative(ttlEpochS, "ttlEpochS");
+        }
+
+        @Override
+        public String factKey() {
+            return "run-submitted:" + tenantId + ":" + runId;
+        }
+    }
+
+    record SegmentAttemptStarted(
+        String tenantId,
+        String runId,
+        String segmentId,
+        String attemptId,
+        int attemptNumber
+    ) implements ControlPlaneFact {
+        public SegmentAttemptStarted {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            attemptId = ControlPlaneChecks.requireText(attemptId, "attemptId");
+            ControlPlaneChecks.requireNonNegative(attemptNumber, "attemptNumber");
+        }
+
+        @Override
+        public String factKey() {
+            return "segment-attempt-started:" + attemptId;
+        }
+    }
+
+    record SegmentCompleted(
+        String tenantId,
+        String runId,
+        String segmentId,
+        String attemptId,
+        List<?> outputItems,
+        boolean terminalSegment
+    ) implements ControlPlaneFact {
+        public SegmentCompleted {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            attemptId = ControlPlaneChecks.requireText(attemptId, "attemptId");
+            outputItems = ControlPlaneChecks.copyList(outputItems);
+        }
+
+        @Override
+        public String factKey() {
+            return "segment-completed:" + attemptId;
+        }
+    }
+
+    record SegmentSuspended(
+        String tenantId,
+        String runId,
+        String segmentId,
+        String attemptId,
+        String boundaryUnitId,
+        BoundaryKind boundaryKind,
+        int boundaryStepIndex,
+        Integer expectedItemCount
+    ) implements ControlPlaneFact {
+        public SegmentSuspended {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            attemptId = ControlPlaneChecks.requireText(attemptId, "attemptId");
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            Objects.requireNonNull(boundaryKind, "boundaryKind must not be null");
+            ControlPlaneChecks.requireNonNegative(boundaryStepIndex, "boundaryStepIndex");
+            if (expectedItemCount != null && expectedItemCount < 0) {
+                throw new IllegalArgumentException("expectedItemCount must not be negative");
+            }
+        }
+
+        @Override
+        public String factKey() {
+            return "segment-suspended:" + attemptId + ":" + boundaryUnitId;
+        }
+    }
+
+    record BoundaryInteractionDispatched(
+        String tenantId,
+        String runId,
+        String boundaryUnitId,
+        BoundaryKind boundaryKind,
+        String interactionId,
+        String correlationId,
+        String idempotencyKey,
+        Integer itemIndex,
+        Object requestPayload,
+        String transportType,
+        long deadlineEpochMs
+    ) implements ControlPlaneFact {
+        public BoundaryInteractionDispatched {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            Objects.requireNonNull(boundaryKind, "boundaryKind must not be null");
+            interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
+            correlationId = ControlPlaneChecks.requireText(correlationId, "correlationId");
+            idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+            if (itemIndex != null && itemIndex < 0) {
+                throw new IllegalArgumentException("itemIndex must not be negative");
+            }
+            transportType = ControlPlaneChecks.requireText(transportType, "transportType");
+            ControlPlaneChecks.requireNonNegative(deadlineEpochMs, "deadlineEpochMs");
+        }
+
+        @Override
+        public String factKey() {
+            return "boundary-interaction-dispatched:" + boundaryUnitId + ":" + interactionId;
+        }
+    }
+
+    record BoundaryDispatchCompleted(
+        String tenantId,
+        String runId,
+        String boundaryUnitId,
+        int expectedItemCount
+    ) implements ControlPlaneFact {
+        public BoundaryDispatchCompleted {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            ControlPlaneChecks.requireNonNegative(expectedItemCount, "expectedItemCount");
+        }
+
+        @Override
+        public String factKey() {
+            return "boundary-dispatch-completed:" + boundaryUnitId;
+        }
+    }
+
+    record BoundaryCompletionAdmitted(
+        String tenantId,
+        String runId,
+        String boundaryUnitId,
+        BoundaryKind boundaryKind,
+        String interactionId,
+        String idempotencyKey,
+        Object responsePayload
+    ) implements ControlPlaneFact {
+        public BoundaryCompletionAdmitted {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            Objects.requireNonNull(boundaryKind, "boundaryKind must not be null");
+            interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
+            idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+        }
+
+        @Override
+        public String factKey() {
+            return "boundary-completion-admitted:" + boundaryUnitId + ":" + idempotencyKey;
+        }
+    }
+
+    record InteractionTimedOut(
+        String tenantId,
+        String runId,
+        String boundaryUnitId,
+        String interactionId,
+        String reason
+    ) implements ControlPlaneFact {
+        public InteractionTimedOut {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
+            reason = reason == null || reason.isBlank() ? "Boundary interaction timed out" : reason;
+        }
+
+        @Override
+        public String factKey() {
+            return "interaction-timed-out:" + boundaryUnitId + ":" + interactionId;
+        }
+    }
+
+    record ContinuationSegmentCreated(
+        String tenantId,
+        String runId,
+        String parentSegmentId,
+        String segmentId,
+        String boundaryUnitId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload
+    ) implements ControlPlaneFact {
+        public ContinuationSegmentCreated {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            parentSegmentId = ControlPlaneChecks.requireText(parentSegmentId, "parentSegmentId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
+            if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
+                throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
+            }
+        }
+
+        @Override
+        public String factKey() {
+            return "continuation-segment-created:" + segmentId;
+        }
+    }
+
+    record TerminalPublicationCompleted(
+        String tenantId,
+        String runId,
+        String segmentId,
+        String publicationId,
+        String idempotencyKey
+    ) implements ControlPlaneFact {
+        public TerminalPublicationCompleted {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            publicationId = ControlPlaneChecks.requireText(publicationId, "publicationId");
+            idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+        }
+
+        @Override
+        public String factKey() {
+            return "terminal-publication-completed:" + publicationId + ":" + idempotencyKey;
+        }
+    }
+
+    record RunSucceeded(
+        String tenantId,
+        String runId,
+        String segmentId,
+        Object resultPayload
+    ) implements ControlPlaneFact {
+        public RunSucceeded {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+        }
+
+        @Override
+        public String factKey() {
+            return "run-succeeded:" + runId;
+        }
+    }
+
+    record RunFailed(
+        String tenantId,
+        String runId,
+        String segmentId,
+        String errorCode,
+        String errorMessage
+    ) implements ControlPlaneFact {
+        public RunFailed {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            errorCode = ControlPlaneChecks.requireText(errorCode, "errorCode");
+            errorMessage = errorMessage == null ? "" : errorMessage;
+        }
+
+        @Override
+        public String factKey() {
+            return "run-failed:" + runId + ":" + errorCode;
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneFact.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneFact.java
@@ -48,9 +48,8 @@ public sealed interface ControlPlaneFact permits
             Objects.requireNonNull(resultShape, "resultShape must not be null");
             initialSegmentId = ControlPlaneChecks.requireText(initialSegmentId, "initialSegmentId");
             ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
-            if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
-                throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
-            }
+            stopBeforeStepIndex = ControlPlaneChecks.requireSegmentStopAfterStart(startStepIndex, stopBeforeStepIndex);
+            inputPayload = ControlPlaneChecks.freezePayload(inputPayload);
             ControlPlaneChecks.requireNonNegative(ttlEpochS, "ttlEpochS");
         }
 
@@ -94,7 +93,9 @@ public sealed interface ControlPlaneFact permits
             runId = ControlPlaneChecks.requireText(runId, "runId");
             segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
             attemptId = ControlPlaneChecks.requireText(attemptId, "attemptId");
-            outputItems = ControlPlaneChecks.copyList(outputItems);
+            outputItems = ControlPlaneChecks.copyList(outputItems).stream()
+                .map(ControlPlaneChecks::freezePayload)
+                .toList();
         }
 
         @Override
@@ -156,6 +157,7 @@ public sealed interface ControlPlaneFact permits
             if (itemIndex != null && itemIndex < 0) {
                 throw new IllegalArgumentException("itemIndex must not be negative");
             }
+            requestPayload = ControlPlaneChecks.freezePayload(requestPayload);
             transportType = ControlPlaneChecks.requireText(transportType, "transportType");
             ControlPlaneChecks.requireNonNegative(deadlineEpochMs, "deadlineEpochMs");
         }
@@ -201,6 +203,7 @@ public sealed interface ControlPlaneFact permits
             Objects.requireNonNull(boundaryKind, "boundaryKind must not be null");
             interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
             idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+            responsePayload = ControlPlaneChecks.freezePayload(responsePayload);
         }
 
         @Override
@@ -247,9 +250,8 @@ public sealed interface ControlPlaneFact permits
             segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
             boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
             ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
-            if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
-                throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
-            }
+            stopBeforeStepIndex = ControlPlaneChecks.requireSegmentStopAfterStart(startStepIndex, stopBeforeStepIndex);
+            inputPayload = ControlPlaneChecks.freezePayload(inputPayload);
         }
 
         @Override
@@ -289,6 +291,7 @@ public sealed interface ControlPlaneFact permits
             tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
             runId = ControlPlaneChecks.requireText(runId, "runId");
             segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            resultPayload = ControlPlaneChecks.freezePayload(resultPayload);
         }
 
         @Override

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneJournal.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneJournal.java
@@ -1,0 +1,20 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import io.smallrye.mutiny.Uni;
+
+public interface ControlPlaneJournal {
+
+    Uni<ControlPlaneAppendResult> append(
+        String tenantId,
+        String runId,
+        long expectedVersion,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs);
+
+    Uni<ControlPlaneProjection> projection(String tenantId, String runId);
+
+    Uni<List<DueSegment>> findDueSegments(long nowEpochMs, int limit);
+
+    Uni<List<DueBoundaryInteraction>> findTimedOutInteractions(long nowEpochMs, int limit);
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneProjection.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneProjection.java
@@ -1,0 +1,49 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public record ControlPlaneProjection(
+    String tenantId,
+    String runId,
+    long version,
+    Optional<PipelineRun> run,
+    Map<String, ExecutionSegment> segments,
+    Map<String, SegmentAttempt> attempts,
+    Map<String, BoundaryUnit> boundaries,
+    Map<String, BoundaryInteraction> interactions,
+    Set<String> terminalPublicationKeys,
+    Set<String> factKeys
+) {
+    public ControlPlaneProjection {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        ControlPlaneChecks.requireNonNegative(version, "version");
+        run = run == null ? Optional.empty() : run;
+        segments = ControlPlaneChecks.copyMap(segments);
+        attempts = ControlPlaneChecks.copyMap(attempts);
+        boundaries = ControlPlaneChecks.copyMap(boundaries);
+        interactions = ControlPlaneChecks.copyMap(interactions);
+        terminalPublicationKeys = ControlPlaneChecks.copySet(terminalPublicationKeys);
+        factKeys = ControlPlaneChecks.copySet(factKeys);
+    }
+
+    public static ControlPlaneProjection empty(String tenantId, String runId) {
+        return new ControlPlaneProjection(
+            tenantId,
+            runId,
+            0L,
+            Optional.empty(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Set.of(),
+            Set.of());
+    }
+
+    public PipelineRunStatus status() {
+        return run.map(PipelineRun::status).orElse(PipelineRunStatus.ACCEPTED);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducer.java
@@ -1,0 +1,272 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public final class ControlPlaneReducer {
+
+    private ControlPlaneReducer() {
+    }
+
+    public static ControlPlaneProjection reduce(String tenantId, String runId, List<ControlPlaneEvent> events) {
+        Accumulator accumulator = new Accumulator(tenantId, runId);
+        ControlPlaneChecks.copyList(events).stream()
+            .sorted(Comparator.comparingLong(ControlPlaneEvent::sequence))
+            .forEach(accumulator::apply);
+        return accumulator.projection();
+    }
+
+    private static final class Accumulator {
+        private final String tenantId;
+        private final String runId;
+        private long version;
+        private PipelineRun run;
+        private final Map<String, ExecutionSegment> segments = new HashMap<>();
+        private final Map<String, SegmentAttempt> attempts = new HashMap<>();
+        private final Map<String, BoundaryUnit> boundaries = new HashMap<>();
+        private final Map<String, BoundaryInteraction> interactions = new HashMap<>();
+        private final Set<String> terminalPublicationKeys = new HashSet<>();
+        private final Set<String> factKeys = new HashSet<>();
+
+        private Accumulator(String tenantId, String runId) {
+            this.tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            this.runId = ControlPlaneChecks.requireText(runId, "runId");
+        }
+
+        private void apply(ControlPlaneEvent event) {
+            if (!tenantId.equals(event.fact().tenantId()) || !runId.equals(event.fact().runId())) {
+                throw new IllegalArgumentException("event does not belong to projection " + tenantId + "/" + runId);
+            }
+            version = Math.max(version, event.sequence());
+            factKeys.add(event.fact().factKey());
+            switch (event.fact()) {
+                case ControlPlaneFact.RunSubmitted fact -> applyRunSubmitted(event, fact);
+                case ControlPlaneFact.SegmentAttemptStarted fact -> applySegmentAttemptStarted(event, fact);
+                case ControlPlaneFact.SegmentCompleted fact -> applySegmentCompleted(event, fact);
+                case ControlPlaneFact.SegmentSuspended fact -> applySegmentSuspended(event, fact);
+                case ControlPlaneFact.BoundaryInteractionDispatched fact -> applyBoundaryInteractionDispatched(event, fact);
+                case ControlPlaneFact.BoundaryDispatchCompleted fact -> applyBoundaryDispatchCompleted(event, fact);
+                case ControlPlaneFact.BoundaryCompletionAdmitted fact -> applyBoundaryCompletionAdmitted(event, fact);
+                case ControlPlaneFact.InteractionTimedOut fact -> applyInteractionTimedOut(event, fact);
+                case ControlPlaneFact.ContinuationSegmentCreated fact -> applyContinuationSegmentCreated(event, fact);
+                case ControlPlaneFact.TerminalPublicationCompleted fact -> terminalPublicationKeys.add(fact.factKey());
+                case ControlPlaneFact.RunSucceeded fact -> applyRunSucceeded(event, fact);
+                case ControlPlaneFact.RunFailed fact -> applyRunFailed(event, fact);
+            }
+        }
+
+        private void applyRunSubmitted(ControlPlaneEvent event, ControlPlaneFact.RunSubmitted fact) {
+            run = new PipelineRun(
+                fact.tenantId(),
+                fact.runId(),
+                fact.executionKey(),
+                fact.pipelineId(),
+                fact.contractVersion(),
+                fact.releaseVersion(),
+                fact.resultShape(),
+                PipelineRunStatus.ACCEPTED,
+                fact.inputPayload(),
+                null,
+                null,
+                null,
+                event.sequence(),
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs(),
+                fact.ttlEpochS());
+            segments.put(fact.initialSegmentId(), new ExecutionSegment(
+                fact.tenantId(),
+                fact.runId(),
+                fact.initialSegmentId(),
+                fact.startStepIndex(),
+                fact.stopBeforeStepIndex(),
+                SegmentStatus.QUEUED,
+                fact.inputPayload(),
+                List.of(),
+                null,
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs()));
+        }
+
+        private void applySegmentAttemptStarted(ControlPlaneEvent event, ControlPlaneFact.SegmentAttemptStarted fact) {
+            ExecutionSegment segment = segments.get(fact.segmentId());
+            if (segment != null) {
+                segments.put(fact.segmentId(), segment.running(event.occurredAtEpochMs()));
+            }
+            attempts.put(fact.attemptId(), new SegmentAttempt(
+                fact.tenantId(),
+                fact.runId(),
+                fact.segmentId(),
+                fact.attemptId(),
+                fact.attemptNumber(),
+                SegmentAttemptStatus.RUNNING,
+                null,
+                null,
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs()));
+            if (run != null && !run.status().terminal()) {
+                run = run.withStatus(PipelineRunStatus.RUNNING, event.sequence(), event.occurredAtEpochMs());
+            }
+        }
+
+        private void applySegmentCompleted(ControlPlaneEvent event, ControlPlaneFact.SegmentCompleted fact) {
+            ExecutionSegment segment = segments.get(fact.segmentId());
+            if (segment != null) {
+                segments.put(fact.segmentId(), segment.completed(fact.outputItems(), event.occurredAtEpochMs()));
+            }
+            SegmentAttempt attempt = attempts.get(fact.attemptId());
+            if (attempt != null) {
+                attempts.put(fact.attemptId(), attempt.withStatus(SegmentAttemptStatus.COMPLETED, event.occurredAtEpochMs()));
+            }
+        }
+
+        private void applySegmentSuspended(ControlPlaneEvent event, ControlPlaneFact.SegmentSuspended fact) {
+            ExecutionSegment segment = segments.get(fact.segmentId());
+            if (segment != null) {
+                segments.put(fact.segmentId(), segment.suspended(fact.boundaryUnitId(), event.occurredAtEpochMs()));
+            }
+            SegmentAttempt attempt = attempts.get(fact.attemptId());
+            if (attempt != null) {
+                attempts.put(fact.attemptId(), attempt.withStatus(SegmentAttemptStatus.SUSPENDED, event.occurredAtEpochMs()));
+            }
+            boundaries.put(fact.boundaryUnitId(), new BoundaryUnit(
+                fact.tenantId(),
+                fact.runId(),
+                fact.boundaryUnitId(),
+                fact.boundaryKind(),
+                BoundaryUnitStatus.OPEN,
+                fact.segmentId(),
+                fact.boundaryStepIndex(),
+                fact.expectedItemCount(),
+                0,
+                Set.of(),
+                false,
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs()));
+            if (run != null && !run.status().terminal()) {
+                run = run.withStatus(PipelineRunStatus.WAITING_BOUNDARY, event.sequence(), event.occurredAtEpochMs());
+            }
+        }
+
+        private void applyBoundaryInteractionDispatched(
+            ControlPlaneEvent event,
+            ControlPlaneFact.BoundaryInteractionDispatched fact
+        ) {
+            interactions.put(fact.interactionId(), new BoundaryInteraction(
+                fact.tenantId(),
+                fact.runId(),
+                fact.boundaryUnitId(),
+                fact.interactionId(),
+                fact.boundaryKind(),
+                BoundaryInteractionStatus.DISPATCHED,
+                fact.correlationId(),
+                fact.idempotencyKey(),
+                fact.itemIndex(),
+                fact.requestPayload(),
+                null,
+                fact.transportType(),
+                fact.deadlineEpochMs(),
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs()));
+        }
+
+        private void applyBoundaryDispatchCompleted(ControlPlaneEvent event, ControlPlaneFact.BoundaryDispatchCompleted fact) {
+            BoundaryUnit unit = boundaries.get(fact.boundaryUnitId());
+            if (unit != null) {
+                boundaries.put(fact.boundaryUnitId(), unit.withDispatchComplete(
+                    fact.expectedItemCount(),
+                    event.occurredAtEpochMs()));
+            }
+        }
+
+        private void applyBoundaryCompletionAdmitted(
+            ControlPlaneEvent event,
+            ControlPlaneFact.BoundaryCompletionAdmitted fact
+        ) {
+            BoundaryInteraction interaction = interactions.get(fact.interactionId());
+            if (interaction != null && interaction.status() != BoundaryInteractionStatus.COMPLETED) {
+                interactions.put(fact.interactionId(), interaction.completed(
+                    fact.responsePayload(),
+                    event.occurredAtEpochMs()));
+            }
+            BoundaryUnit unit = boundaries.get(fact.boundaryUnitId());
+            if (unit != null) {
+                boundaries.put(fact.boundaryUnitId(), unit.withCompletion(
+                    fact.idempotencyKey(),
+                    event.occurredAtEpochMs()));
+            }
+        }
+
+        private void applyInteractionTimedOut(ControlPlaneEvent event, ControlPlaneFact.InteractionTimedOut fact) {
+            BoundaryInteraction interaction = interactions.get(fact.interactionId());
+            if (interaction != null && !interaction.status().terminal()) {
+                interactions.put(fact.interactionId(), interaction.timedOut(event.occurredAtEpochMs()));
+            }
+            BoundaryUnit unit = boundaries.get(fact.boundaryUnitId());
+            if (unit != null && !unit.status().terminal()) {
+                boundaries.put(fact.boundaryUnitId(), unit.timedOut(event.occurredAtEpochMs()));
+                ExecutionSegment segment = segments.get(unit.segmentId());
+                if (segment != null) {
+                    segments.put(segment.segmentId(), segment.failed(event.occurredAtEpochMs()));
+                }
+            }
+            if (run != null && !run.status().terminal()) {
+                run = run.failed("BOUNDARY_TIMEOUT", fact.reason(), event.sequence(), event.occurredAtEpochMs());
+            }
+        }
+
+        private void applyContinuationSegmentCreated(
+            ControlPlaneEvent event,
+            ControlPlaneFact.ContinuationSegmentCreated fact
+        ) {
+            segments.put(fact.segmentId(), new ExecutionSegment(
+                fact.tenantId(),
+                fact.runId(),
+                fact.segmentId(),
+                fact.startStepIndex(),
+                fact.stopBeforeStepIndex(),
+                SegmentStatus.QUEUED,
+                fact.inputPayload(),
+                List.of(),
+                fact.boundaryUnitId(),
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs(),
+                event.occurredAtEpochMs()));
+            if (run != null && !run.status().terminal()) {
+                run = run.withStatus(PipelineRunStatus.RUNNING, event.sequence(), event.occurredAtEpochMs());
+            }
+        }
+
+        private void applyRunSucceeded(ControlPlaneEvent event, ControlPlaneFact.RunSucceeded fact) {
+            if (run != null && !run.status().terminal()) {
+                run = run.succeeded(fact.resultPayload(), event.sequence(), event.occurredAtEpochMs());
+            }
+        }
+
+        private void applyRunFailed(ControlPlaneEvent event, ControlPlaneFact.RunFailed fact) {
+            if (run != null && !run.status().terminal()) {
+                run = run.failed(fact.errorCode(), fact.errorMessage(), event.sequence(), event.occurredAtEpochMs());
+            }
+        }
+
+        private ControlPlaneProjection projection() {
+            return new ControlPlaneProjection(
+                tenantId,
+                runId,
+                version,
+                Optional.ofNullable(run),
+                new HashMap<>(segments),
+                new HashMap<>(attempts),
+                new HashMap<>(boundaries),
+                new HashMap<>(interactions),
+                new HashSet<>(terminalPublicationKeys),
+                new HashSet<>(factKeys));
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducer.java
@@ -142,6 +142,7 @@ public final class ControlPlaneReducer {
                 fact.boundaryKind(),
                 BoundaryUnitStatus.OPEN,
                 fact.segmentId(),
+                fact.attemptId(),
                 fact.boundaryStepIndex(),
                 fact.expectedItemCount(),
                 0,
@@ -190,13 +191,13 @@ public final class ControlPlaneReducer {
             ControlPlaneFact.BoundaryCompletionAdmitted fact
         ) {
             BoundaryInteraction interaction = interactions.get(fact.interactionId());
-            if (interaction != null && interaction.status() != BoundaryInteractionStatus.COMPLETED) {
+            if (interaction != null && !interaction.status().terminal()) {
                 interactions.put(fact.interactionId(), interaction.completed(
                     fact.responsePayload(),
                     event.occurredAtEpochMs()));
             }
             BoundaryUnit unit = boundaries.get(fact.boundaryUnitId());
-            if (unit != null) {
+            if (unit != null && !unit.status().terminal()) {
                 boundaries.put(fact.boundaryUnitId(), unit.withCompletion(
                     fact.idempotencyKey(),
                     event.occurredAtEpochMs()));
@@ -214,6 +215,13 @@ public final class ControlPlaneReducer {
                 ExecutionSegment segment = segments.get(unit.segmentId());
                 if (segment != null) {
                     segments.put(segment.segmentId(), segment.failed(event.occurredAtEpochMs()));
+                }
+                SegmentAttempt attempt = attempts.get(unit.attemptId());
+                if (attempt != null) {
+                    attempts.put(unit.attemptId(), attempt.failed(
+                        "BOUNDARY_TIMEOUT",
+                        fact.reason(),
+                        event.occurredAtEpochMs()));
                 }
             }
             if (run != null && !run.status().terminal()) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/DueBoundaryInteraction.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/DueBoundaryInteraction.java
@@ -1,0 +1,19 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public record DueBoundaryInteraction(
+    String tenantId,
+    String runId,
+    String boundaryUnitId,
+    String interactionId,
+    BoundaryKind kind,
+    long deadlineEpochMs
+) {
+    public DueBoundaryInteraction {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+        interactionId = ControlPlaneChecks.requireText(interactionId, "interactionId");
+        java.util.Objects.requireNonNull(kind, "kind must not be null");
+        ControlPlaneChecks.requireNonNegative(deadlineEpochMs, "deadlineEpochMs");
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/DueSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/DueSegment.java
@@ -1,0 +1,20 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public record DueSegment(
+    String tenantId,
+    String runId,
+    String segmentId,
+    int startStepIndex,
+    int stopBeforeStepIndex,
+    Object inputPayload
+) {
+    public DueSegment {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+        ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
+        if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
+            throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/DueSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/DueSegment.java
@@ -13,8 +13,7 @@ public record DueSegment(
         runId = ControlPlaneChecks.requireText(runId, "runId");
         segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
         ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
-        if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
-            throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
-        }
+        stopBeforeStepIndex = ControlPlaneChecks.requireSegmentStopAfterStart(startStepIndex, stopBeforeStepIndex);
+        inputPayload = ControlPlaneChecks.freezePayload(inputPayload);
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ExecutionSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ExecutionSegment.java
@@ -22,11 +22,12 @@ public record ExecutionSegment(
         runId = ControlPlaneChecks.requireText(runId, "runId");
         segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
         ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
-        if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
-            throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
-        }
+        stopBeforeStepIndex = ControlPlaneChecks.requireSegmentStopAfterStart(startStepIndex, stopBeforeStepIndex);
         Objects.requireNonNull(status, "status must not be null");
-        outputItems = ControlPlaneChecks.copyList(outputItems);
+        inputPayload = ControlPlaneChecks.freezePayload(inputPayload);
+        outputItems = ControlPlaneChecks.copyList(outputItems).stream()
+            .map(ControlPlaneChecks::freezePayload)
+            .toList();
         ControlPlaneChecks.requireNonNegative(nextDueEpochMs, "nextDueEpochMs");
         ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
         ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ExecutionSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ExecutionSegment.java
@@ -1,0 +1,72 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ExecutionSegment(
+    String tenantId,
+    String runId,
+    String segmentId,
+    int startStepIndex,
+    int stopBeforeStepIndex,
+    SegmentStatus status,
+    Object inputPayload,
+    List<?> outputItems,
+    String boundaryUnitId,
+    long nextDueEpochMs,
+    long createdAtEpochMs,
+    long updatedAtEpochMs
+) {
+    public ExecutionSegment {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+        ControlPlaneChecks.requireNonNegative(startStepIndex, "startStepIndex");
+        if (stopBeforeStepIndex >= 0 && stopBeforeStepIndex < startStepIndex) {
+            throw new IllegalArgumentException("stopBeforeStepIndex must be greater than or equal to startStepIndex");
+        }
+        Objects.requireNonNull(status, "status must not be null");
+        outputItems = ControlPlaneChecks.copyList(outputItems);
+        ControlPlaneChecks.requireNonNegative(nextDueEpochMs, "nextDueEpochMs");
+        ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
+        ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
+    }
+
+    ExecutionSegment running(long nowEpochMs) {
+        return withStatus(SegmentStatus.RUNNING, null, outputItems, nextDueEpochMs, nowEpochMs);
+    }
+
+    ExecutionSegment completed(List<?> outputItems, long nowEpochMs) {
+        return withStatus(SegmentStatus.COMPLETED, null, outputItems, nextDueEpochMs, nowEpochMs);
+    }
+
+    ExecutionSegment suspended(String boundaryUnitId, long nowEpochMs) {
+        return withStatus(SegmentStatus.SUSPENDED, boundaryUnitId, outputItems, nextDueEpochMs, nowEpochMs);
+    }
+
+    ExecutionSegment failed(long nowEpochMs) {
+        return withStatus(SegmentStatus.FAILED, boundaryUnitId, outputItems, nextDueEpochMs, nowEpochMs);
+    }
+
+    private ExecutionSegment withStatus(
+        SegmentStatus nextStatus,
+        String nextBoundaryUnitId,
+        List<?> nextOutputItems,
+        long nextDueEpochMs,
+        long nowEpochMs
+    ) {
+        return new ExecutionSegment(
+            tenantId,
+            runId,
+            segmentId,
+            startStepIndex,
+            stopBeforeStepIndex,
+            nextStatus,
+            inputPayload,
+            nextOutputItems,
+            nextBoundaryUnitId,
+            nextDueEpochMs,
+            createdAtEpochMs,
+            nowEpochMs);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournal.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournal.java
@@ -1,0 +1,177 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import io.smallrye.mutiny.Uni;
+
+public class InMemoryControlPlaneJournal implements ControlPlaneJournal {
+
+    private final Object lock = new Object();
+    private final Map<Key, List<ControlPlaneEvent>> eventsByRun = new HashMap<>();
+
+    @Override
+    public Uni<ControlPlaneAppendResult> append(
+        String tenantId,
+        String runId,
+        long expectedVersion,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs
+    ) {
+        try {
+            return Uni.createFrom().item(appendBlocking(tenantId, runId, expectedVersion, facts, nowEpochMs));
+        } catch (Throwable failure) {
+            return Uni.createFrom().failure(failure);
+        }
+    }
+
+    @Override
+    public Uni<ControlPlaneProjection> projection(String tenantId, String runId) {
+        try {
+            return Uni.createFrom().item(projectionBlocking(tenantId, runId));
+        } catch (Throwable failure) {
+            return Uni.createFrom().failure(failure);
+        }
+    }
+
+    @Override
+    public Uni<List<DueSegment>> findDueSegments(long nowEpochMs, int limit) {
+        try {
+            return Uni.createFrom().item(findDueSegmentsBlocking(nowEpochMs, limit));
+        } catch (Throwable failure) {
+            return Uni.createFrom().failure(failure);
+        }
+    }
+
+    @Override
+    public Uni<List<DueBoundaryInteraction>> findTimedOutInteractions(long nowEpochMs, int limit) {
+        try {
+            return Uni.createFrom().item(findTimedOutInteractionsBlocking(nowEpochMs, limit));
+        } catch (Throwable failure) {
+            return Uni.createFrom().failure(failure);
+        }
+    }
+
+    private ControlPlaneAppendResult appendBlocking(
+        String tenantId,
+        String runId,
+        long expectedVersion,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs
+    ) {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        ControlPlaneChecks.requireNonNegative(expectedVersion, "expectedVersion");
+        ControlPlaneChecks.requireNonNegative(nowEpochMs, "nowEpochMs");
+        List<ControlPlaneFact> requestedFacts = ControlPlaneChecks.copyList(facts);
+        if (requestedFacts.isEmpty()) {
+            return new ControlPlaneAppendResult(projectionBlocking(tenantId, runId), List.of());
+        }
+        for (ControlPlaneFact fact : requestedFacts) {
+            if (!tenantId.equals(fact.tenantId()) || !runId.equals(fact.runId())) {
+                throw new IllegalArgumentException("fact does not belong to append target " + tenantId + "/" + runId);
+            }
+        }
+
+        synchronized (lock) {
+            Key key = new Key(tenantId, runId);
+            List<ControlPlaneEvent> currentEvents = eventsByRun.computeIfAbsent(key, ignored -> new ArrayList<>());
+            ControlPlaneProjection current = ControlPlaneReducer.reduce(tenantId, runId, currentEvents);
+            Set<String> knownFactKeys = new HashSet<>(current.factKeys());
+            List<ControlPlaneFact> newFacts = requestedFacts.stream()
+                .filter(fact -> !knownFactKeys.contains(fact.factKey()))
+                .toList();
+            if (newFacts.isEmpty()) {
+                return new ControlPlaneAppendResult(current, List.of());
+            }
+            if (current.version() != expectedVersion) {
+                throw new ControlPlaneAppendConflictException(
+                    "Control-plane append expected version " + expectedVersion
+                        + " but current version is " + current.version()
+                        + " for run " + tenantId + "/" + runId);
+            }
+
+            long sequence = current.version();
+            List<ControlPlaneEvent> appended = new ArrayList<>();
+            for (ControlPlaneFact fact : newFacts) {
+                ControlPlaneEvent event = new ControlPlaneEvent(++sequence, nowEpochMs, fact);
+                currentEvents.add(event);
+                appended.add(event);
+            }
+            ControlPlaneProjection updated = ControlPlaneReducer.reduce(tenantId, runId, currentEvents);
+            return new ControlPlaneAppendResult(updated, appended);
+        }
+    }
+
+    private ControlPlaneProjection projectionBlocking(String tenantId, String runId) {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        synchronized (lock) {
+            List<ControlPlaneEvent> events = eventsByRun.getOrDefault(new Key(tenantId, runId), List.of());
+            return ControlPlaneReducer.reduce(tenantId, runId, events);
+        }
+    }
+
+    private List<DueSegment> findDueSegmentsBlocking(long nowEpochMs, int limit) {
+        ControlPlaneChecks.requireNonNegative(nowEpochMs, "nowEpochMs");
+        if (limit <= 0) {
+            return List.of();
+        }
+        synchronized (lock) {
+            return projections().stream()
+                .flatMap(projection -> projection.segments().values().stream())
+                .filter(segment -> segment.status() == SegmentStatus.QUEUED)
+                .filter(segment -> segment.nextDueEpochMs() <= nowEpochMs)
+                .sorted(Comparator.comparingLong(ExecutionSegment::nextDueEpochMs))
+                .limit(limit)
+                .map(segment -> new DueSegment(
+                    segment.tenantId(),
+                    segment.runId(),
+                    segment.segmentId(),
+                    segment.startStepIndex(),
+                    segment.stopBeforeStepIndex(),
+                    segment.inputPayload()))
+                .toList();
+        }
+    }
+
+    private List<DueBoundaryInteraction> findTimedOutInteractionsBlocking(long nowEpochMs, int limit) {
+        ControlPlaneChecks.requireNonNegative(nowEpochMs, "nowEpochMs");
+        if (limit <= 0) {
+            return List.of();
+        }
+        synchronized (lock) {
+            return projections().stream()
+                .flatMap(projection -> projection.interactions().values().stream())
+                .filter(interaction -> !interaction.status().terminal())
+                .filter(interaction -> interaction.deadlineEpochMs() <= nowEpochMs)
+                .sorted(Comparator.comparingLong(BoundaryInteraction::deadlineEpochMs))
+                .limit(limit)
+                .map(interaction -> new DueBoundaryInteraction(
+                    interaction.tenantId(),
+                    interaction.runId(),
+                    interaction.unitId(),
+                    interaction.interactionId(),
+                    interaction.kind(),
+                    interaction.deadlineEpochMs()))
+                .toList();
+        }
+    }
+
+    private List<ControlPlaneProjection> projections() {
+        return eventsByRun.entrySet().stream()
+            .map(entry -> ControlPlaneReducer.reduce(entry.getKey().tenantId(), entry.getKey().runId(), entry.getValue()))
+            .toList();
+    }
+
+    private record Key(String tenantId, String runId) {
+        private Key {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournal.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournal.java
@@ -22,38 +22,22 @@ public class InMemoryControlPlaneJournal implements ControlPlaneJournal {
         List<ControlPlaneFact> facts,
         long nowEpochMs
     ) {
-        try {
-            return Uni.createFrom().item(appendBlocking(tenantId, runId, expectedVersion, facts, nowEpochMs));
-        } catch (Throwable failure) {
-            return Uni.createFrom().failure(failure);
-        }
+        return Uni.createFrom().item(() -> appendBlocking(tenantId, runId, expectedVersion, facts, nowEpochMs));
     }
 
     @Override
     public Uni<ControlPlaneProjection> projection(String tenantId, String runId) {
-        try {
-            return Uni.createFrom().item(projectionBlocking(tenantId, runId));
-        } catch (Throwable failure) {
-            return Uni.createFrom().failure(failure);
-        }
+        return Uni.createFrom().item(() -> projectionBlocking(tenantId, runId));
     }
 
     @Override
     public Uni<List<DueSegment>> findDueSegments(long nowEpochMs, int limit) {
-        try {
-            return Uni.createFrom().item(findDueSegmentsBlocking(nowEpochMs, limit));
-        } catch (Throwable failure) {
-            return Uni.createFrom().failure(failure);
-        }
+        return Uni.createFrom().item(() -> findDueSegmentsBlocking(nowEpochMs, limit));
     }
 
     @Override
     public Uni<List<DueBoundaryInteraction>> findTimedOutInteractions(long nowEpochMs, int limit) {
-        try {
-            return Uni.createFrom().item(findTimedOutInteractionsBlocking(nowEpochMs, limit));
-        } catch (Throwable failure) {
-            return Uni.createFrom().failure(failure);
-        }
+        return Uni.createFrom().item(() -> findTimedOutInteractionsBlocking(nowEpochMs, limit));
     }
 
     private ControlPlaneAppendResult appendBlocking(
@@ -82,9 +66,12 @@ public class InMemoryControlPlaneJournal implements ControlPlaneJournal {
             List<ControlPlaneEvent> currentEvents = eventsByRun.computeIfAbsent(key, ignored -> new ArrayList<>());
             ControlPlaneProjection current = ControlPlaneReducer.reduce(tenantId, runId, currentEvents);
             Set<String> knownFactKeys = new HashSet<>(current.factKeys());
-            List<ControlPlaneFact> newFacts = requestedFacts.stream()
-                .filter(fact -> !knownFactKeys.contains(fact.factKey()))
-                .toList();
+            List<ControlPlaneFact> newFacts = new ArrayList<>();
+            for (ControlPlaneFact fact : requestedFacts) {
+                if (knownFactKeys.add(fact.factKey())) {
+                    newFacts.add(fact);
+                }
+            }
             if (newFacts.isEmpty()) {
                 return new ControlPlaneAppendResult(current, List.of());
             }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/PipelineRun.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/PipelineRun.java
@@ -30,6 +30,8 @@ public record PipelineRun(
         releaseVersion = ControlPlaneChecks.requireText(releaseVersion, "releaseVersion");
         Objects.requireNonNull(resultShape, "resultShape must not be null");
         Objects.requireNonNull(status, "status must not be null");
+        inputPayload = ControlPlaneChecks.freezePayload(inputPayload);
+        resultPayload = ControlPlaneChecks.freezePayload(resultPayload);
         ControlPlaneChecks.requireNonNegative(version, "version");
         ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
         ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
@@ -77,6 +79,8 @@ public record PipelineRun(
     }
 
     PipelineRun failed(String errorCode, String errorMessage, long version, long nowEpochMs) {
+        errorCode = ControlPlaneChecks.requireText(errorCode, "errorCode");
+        errorMessage = errorMessage == null ? "" : errorMessage;
         return new PipelineRun(
             tenantId,
             runId,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/PipelineRun.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/PipelineRun.java
@@ -1,0 +1,98 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+public record PipelineRun(
+    String tenantId,
+    String runId,
+    String executionKey,
+    String pipelineId,
+    String contractVersion,
+    String releaseVersion,
+    ExecutionResultShape resultShape,
+    PipelineRunStatus status,
+    Object inputPayload,
+    Object resultPayload,
+    String errorCode,
+    String errorMessage,
+    long version,
+    long createdAtEpochMs,
+    long updatedAtEpochMs,
+    long ttlEpochS
+) {
+    public PipelineRun {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        executionKey = ControlPlaneChecks.requireText(executionKey, "executionKey");
+        pipelineId = ControlPlaneChecks.requireText(pipelineId, "pipelineId");
+        contractVersion = ControlPlaneChecks.requireText(contractVersion, "contractVersion");
+        releaseVersion = ControlPlaneChecks.requireText(releaseVersion, "releaseVersion");
+        Objects.requireNonNull(resultShape, "resultShape must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        ControlPlaneChecks.requireNonNegative(version, "version");
+        ControlPlaneChecks.requireNonNegative(createdAtEpochMs, "createdAtEpochMs");
+        ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
+        ControlPlaneChecks.requireNonNegative(ttlEpochS, "ttlEpochS");
+    }
+
+    PipelineRun withStatus(PipelineRunStatus nextStatus, long version, long nowEpochMs) {
+        return new PipelineRun(
+            tenantId,
+            runId,
+            executionKey,
+            pipelineId,
+            contractVersion,
+            releaseVersion,
+            resultShape,
+            nextStatus,
+            inputPayload,
+            resultPayload,
+            errorCode,
+            errorMessage,
+            version,
+            createdAtEpochMs,
+            nowEpochMs,
+            ttlEpochS);
+    }
+
+    PipelineRun succeeded(Object resultPayload, long version, long nowEpochMs) {
+        return new PipelineRun(
+            tenantId,
+            runId,
+            executionKey,
+            pipelineId,
+            contractVersion,
+            releaseVersion,
+            resultShape,
+            PipelineRunStatus.SUCCEEDED,
+            inputPayload,
+            resultPayload,
+            null,
+            null,
+            version,
+            createdAtEpochMs,
+            nowEpochMs,
+            ttlEpochS);
+    }
+
+    PipelineRun failed(String errorCode, String errorMessage, long version, long nowEpochMs) {
+        return new PipelineRun(
+            tenantId,
+            runId,
+            executionKey,
+            pipelineId,
+            contractVersion,
+            releaseVersion,
+            resultShape,
+            PipelineRunStatus.FAILED,
+            inputPayload,
+            resultPayload,
+            errorCode,
+            errorMessage,
+            version,
+            createdAtEpochMs,
+            nowEpochMs,
+            ttlEpochS);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/PipelineRunStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/PipelineRunStatus.java
@@ -1,0 +1,14 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public enum PipelineRunStatus {
+    ACCEPTED,
+    RUNNING,
+    WAITING_BOUNDARY,
+    SUCCEEDED,
+    FAILED,
+    DLQ;
+
+    public boolean terminal() {
+        return this == SUCCEEDED || this == FAILED || this == DLQ;
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentAttempt.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentAttempt.java
@@ -40,6 +40,8 @@ public record SegmentAttempt(
     }
 
     SegmentAttempt failed(String failureCode, String failureMessage, long nowEpochMs) {
+        failureCode = ControlPlaneChecks.requireText(failureCode, "failureCode");
+        failureMessage = failureMessage == null ? "" : failureMessage;
         return new SegmentAttempt(
             tenantId,
             runId,

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentAttempt.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentAttempt.java
@@ -1,0 +1,55 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+
+public record SegmentAttempt(
+    String tenantId,
+    String runId,
+    String segmentId,
+    String attemptId,
+    int attemptNumber,
+    SegmentAttemptStatus status,
+    String failureCode,
+    String failureMessage,
+    long startedAtEpochMs,
+    long updatedAtEpochMs
+) {
+    public SegmentAttempt {
+        tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+        runId = ControlPlaneChecks.requireText(runId, "runId");
+        segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+        attemptId = ControlPlaneChecks.requireText(attemptId, "attemptId");
+        ControlPlaneChecks.requireNonNegative(attemptNumber, "attemptNumber");
+        Objects.requireNonNull(status, "status must not be null");
+        ControlPlaneChecks.requireNonNegative(startedAtEpochMs, "startedAtEpochMs");
+        ControlPlaneChecks.requireNonNegative(updatedAtEpochMs, "updatedAtEpochMs");
+    }
+
+    SegmentAttempt withStatus(SegmentAttemptStatus nextStatus, long nowEpochMs) {
+        return new SegmentAttempt(
+            tenantId,
+            runId,
+            segmentId,
+            attemptId,
+            attemptNumber,
+            nextStatus,
+            failureCode,
+            failureMessage,
+            startedAtEpochMs,
+            nowEpochMs);
+    }
+
+    SegmentAttempt failed(String failureCode, String failureMessage, long nowEpochMs) {
+        return new SegmentAttempt(
+            tenantId,
+            runId,
+            segmentId,
+            attemptId,
+            attemptNumber,
+            SegmentAttemptStatus.FAILED,
+            failureCode,
+            failureMessage,
+            startedAtEpochMs,
+            nowEpochMs);
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentAttemptStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentAttemptStatus.java
@@ -1,0 +1,8 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public enum SegmentAttemptStatus {
+    RUNNING,
+    COMPLETED,
+    SUSPENDED,
+    FAILED
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentOutcome.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentOutcome.java
@@ -1,0 +1,38 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+
+public sealed interface SegmentOutcome permits
+    SegmentOutcome.Completed,
+    SegmentOutcome.Suspended,
+    SegmentOutcome.Failed {
+
+    record Completed(List<?> outputItems, boolean terminalSegment) implements SegmentOutcome {
+        public Completed {
+            outputItems = ControlPlaneChecks.copyList(outputItems);
+        }
+    }
+
+    record Suspended(
+        String boundaryUnitId,
+        BoundaryKind boundaryKind,
+        int boundaryStepIndex,
+        Integer expectedItemCount
+    ) implements SegmentOutcome {
+        public Suspended {
+            boundaryUnitId = ControlPlaneChecks.requireText(boundaryUnitId, "boundaryUnitId");
+            java.util.Objects.requireNonNull(boundaryKind, "boundaryKind must not be null");
+            ControlPlaneChecks.requireNonNegative(boundaryStepIndex, "boundaryStepIndex");
+            if (expectedItemCount != null && expectedItemCount < 0) {
+                throw new IllegalArgumentException("expectedItemCount must not be negative");
+            }
+        }
+    }
+
+    record Failed(String errorCode, String errorMessage) implements SegmentOutcome {
+        public Failed {
+            errorCode = ControlPlaneChecks.requireText(errorCode, "errorCode");
+            errorMessage = errorMessage == null ? "" : errorMessage;
+        }
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentStatus.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentStatus.java
@@ -1,0 +1,13 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+public enum SegmentStatus {
+    QUEUED,
+    RUNNING,
+    SUSPENDED,
+    COMPLETED,
+    FAILED;
+
+    public boolean terminal() {
+        return this == COMPLETED || this == FAILED;
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/BoundaryAdmissionFactsTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/BoundaryAdmissionFactsTest.java
@@ -1,0 +1,34 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
+class BoundaryAdmissionFactsTest {
+
+    @Test
+    void awaitKafkaCompletionAndCheckpointKafkaHandoffUseSameCompletionFactShape() {
+        ControlPlaneFact awaitCompletion = BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+            "tenant",
+            "run-1",
+            "await-unit",
+            BoundaryKind.AWAIT,
+            "await-interaction",
+            "await-idem",
+            "payment-status"));
+        ControlPlaneFact checkpointCompletion = BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+            "tenant",
+            "run-1",
+            "checkpoint-unit",
+            BoundaryKind.CHECKPOINT,
+            "checkpoint-interaction",
+            "checkpoint-idem",
+            "handoff-payload"));
+
+        assertInstanceOf(ControlPlaneFact.BoundaryCompletionAdmitted.class, awaitCompletion);
+        assertInstanceOf(ControlPlaneFact.BoundaryCompletionAdmitted.class, checkpointCompletion);
+        assertEquals("boundary-completion-admitted:await-unit:await-idem", awaitCompletion.factKey());
+        assertEquals("boundary-completion-admitted:checkpoint-unit:checkpoint-idem", checkpointCompletion.factKey());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
@@ -1,0 +1,178 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+class ControlPlaneReducerTest {
+
+    @Test
+    void terminalSegmentAndPublicationProduceSucceededRunProjection() {
+        ControlPlaneProjection projection = ControlPlaneReducer.reduce("tenant", "run-1", List.of(
+            event(1, submitted()),
+            event(2, new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+            event(3, new ControlPlaneFact.SegmentCompleted(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "attempt-0",
+                List.of("out-1", "out-2"),
+                true)),
+            event(4, new ControlPlaneFact.TerminalPublicationCompleted(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "object-publish",
+                "run-1:publish")),
+            event(5, new ControlPlaneFact.RunSucceeded("tenant", "run-1", "segment-0", List.of("out-1", "out-2")))));
+
+        assertEquals(5, projection.version());
+        assertEquals(PipelineRunStatus.SUCCEEDED, projection.run().orElseThrow().status());
+        assertEquals(SegmentStatus.COMPLETED, projection.segments().get("segment-0").status());
+        assertEquals(SegmentAttemptStatus.COMPLETED, projection.attempts().get("attempt-0").status());
+        assertTrue(projection.terminalPublicationKeys().contains("terminal-publication-completed:object-publish:run-1:publish"));
+    }
+
+    @Test
+    void awaitAndCheckpointCompletionsUseTheSameBoundaryCompletionFact() {
+        ControlPlaneProjection projection = ControlPlaneReducer.reduce("tenant", "run-1", List.of(
+            event(1, submitted()),
+            event(2, new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+            event(3, new ControlPlaneFact.SegmentSuspended(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "attempt-0",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                1,
+                2)),
+            event(4, dispatched("await-unit", BoundaryKind.AWAIT, "interaction-0", "idem-0", 0)),
+            event(5, dispatched("await-unit", BoundaryKind.AWAIT, "interaction-1", "idem-1", 1)),
+            event(6, BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+                "tenant",
+                "run-1",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                "interaction-0",
+                "idem-0",
+                "status-0"))),
+            event(7, new ControlPlaneFact.BoundaryDispatchCompleted("tenant", "run-1", "await-unit", 2)),
+            event(8, BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+                "tenant",
+                "run-1",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                "interaction-1",
+                "idem-1",
+                "status-1")))));
+
+        assertEquals(PipelineRunStatus.WAITING_BOUNDARY, projection.run().orElseThrow().status());
+        assertEquals(BoundaryUnitStatus.COMPLETED, projection.boundaries().get("await-unit").status());
+        assertEquals(2, projection.boundaries().get("await-unit").completedItemCount());
+        assertEquals(BoundaryInteractionStatus.COMPLETED, projection.interactions().get("interaction-0").status());
+        assertEquals(BoundaryInteractionStatus.COMPLETED, projection.interactions().get("interaction-1").status());
+    }
+
+    @Test
+    void timeoutFactDerivesFailedRunAndTimedOutBoundaryProjection() {
+        ControlPlaneProjection projection = ControlPlaneReducer.reduce("tenant", "run-1", List.of(
+            event(1, submitted()),
+            event(2, new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+            event(3, new ControlPlaneFact.SegmentSuspended(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "attempt-0",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                1,
+                1)),
+            event(4, dispatched("await-unit", BoundaryKind.AWAIT, "interaction-0", "idem-0", 0)),
+            event(5, new ControlPlaneFact.InteractionTimedOut(
+                "tenant",
+                "run-1",
+                "await-unit",
+                "interaction-0",
+                "provider timeout"))));
+
+        assertEquals(PipelineRunStatus.FAILED, projection.run().orElseThrow().status());
+        assertEquals("BOUNDARY_TIMEOUT", projection.run().orElseThrow().errorCode());
+        assertEquals(SegmentStatus.FAILED, projection.segments().get("segment-0").status());
+        assertEquals(BoundaryUnitStatus.TIMED_OUT, projection.boundaries().get("await-unit").status());
+        assertEquals(BoundaryInteractionStatus.TIMED_OUT, projection.interactions().get("interaction-0").status());
+    }
+
+    @Test
+    void continuationSegmentCreatesNewDuePipelineSegmentAfterBoundaryCompletion() {
+        ControlPlaneProjection projection = ControlPlaneReducer.reduce("tenant", "run-1", List.of(
+            event(1, submitted()),
+            event(2, new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+            event(3, new ControlPlaneFact.SegmentSuspended(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "attempt-0",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                1,
+                1)),
+            event(4, new ControlPlaneFact.ContinuationSegmentCreated(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "segment-1",
+                "await-unit",
+                2,
+                -1,
+                "status-0"))));
+
+        assertEquals(PipelineRunStatus.RUNNING, projection.run().orElseThrow().status());
+        assertEquals(SegmentStatus.QUEUED, projection.segments().get("segment-1").status());
+        assertEquals("status-0", projection.segments().get("segment-1").inputPayload());
+    }
+
+    private static ControlPlaneFact.RunSubmitted submitted() {
+        return new ControlPlaneFact.RunSubmitted(
+            "tenant",
+            "run-1",
+            "execution-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            "segment-0",
+            0,
+            -1,
+            "input",
+            1000L);
+    }
+
+    private static ControlPlaneFact.BoundaryInteractionDispatched dispatched(
+        String unitId,
+        BoundaryKind kind,
+        String interactionId,
+        String idempotencyKey,
+        int itemIndex
+    ) {
+        return new ControlPlaneFact.BoundaryInteractionDispatched(
+            "tenant",
+            "run-1",
+            unitId,
+            kind,
+            interactionId,
+            "correlation-" + itemIndex,
+            idempotencyKey,
+            itemIndex,
+            "request-" + itemIndex,
+            "kafka",
+            900L);
+    }
+
+    private static ControlPlaneEvent event(long sequence, ControlPlaneFact fact) {
+        return new ControlPlaneEvent(sequence, 100L + sequence, fact);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.orchestrator.controlplane;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -102,6 +103,45 @@ class ControlPlaneReducerTest {
         assertEquals(PipelineRunStatus.FAILED, projection.run().orElseThrow().status());
         assertEquals("BOUNDARY_TIMEOUT", projection.run().orElseThrow().errorCode());
         assertEquals(SegmentStatus.FAILED, projection.segments().get("segment-0").status());
+        assertEquals(SegmentAttemptStatus.FAILED, projection.attempts().get("attempt-0").status());
+        assertEquals("BOUNDARY_TIMEOUT", projection.attempts().get("attempt-0").failureCode());
+        assertEquals(BoundaryUnitStatus.TIMED_OUT, projection.boundaries().get("await-unit").status());
+        assertEquals(BoundaryInteractionStatus.TIMED_OUT, projection.interactions().get("interaction-0").status());
+    }
+
+    @Test
+    void lateDispatchAndCompletionFactsDoNotReopenTimedOutBoundaryState() {
+        ControlPlaneProjection projection = ControlPlaneReducer.reduce("tenant", "run-1", List.of(
+            event(1, submitted()),
+            event(2, new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+            event(3, new ControlPlaneFact.SegmentSuspended(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "attempt-0",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                1,
+                1)),
+            event(4, dispatched("await-unit", BoundaryKind.AWAIT, "interaction-0", "idem-0", 0)),
+            event(5, new ControlPlaneFact.InteractionTimedOut(
+                "tenant",
+                "run-1",
+                "await-unit",
+                "interaction-0",
+                "provider timeout")),
+            event(6, new ControlPlaneFact.BoundaryDispatchCompleted("tenant", "run-1", "await-unit", 1)),
+            event(7, BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+                "tenant",
+                "run-1",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                "interaction-0",
+                "idem-0",
+                "late-status")))));
+
+        assertEquals(PipelineRunStatus.FAILED, projection.run().orElseThrow().status());
+        assertEquals(SegmentAttemptStatus.FAILED, projection.attempts().get("attempt-0").status());
         assertEquals(BoundaryUnitStatus.TIMED_OUT, projection.boundaries().get("await-unit").status());
         assertEquals(BoundaryInteractionStatus.TIMED_OUT, projection.interactions().get("interaction-0").status());
     }
@@ -133,6 +173,60 @@ class ControlPlaneReducerTest {
         assertEquals(PipelineRunStatus.RUNNING, projection.run().orElseThrow().status());
         assertEquals(SegmentStatus.QUEUED, projection.segments().get("segment-1").status());
         assertEquals("status-0", projection.segments().get("segment-1").inputPayload());
+    }
+
+    @Test
+    void segmentBoundsOnlyAllowUnboundedSentinelOrForwardStopIndex() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new DueSegment("tenant", "run-1", "segment-0", 2, -2, "input"));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ExecutionSegment(
+                "tenant",
+                "run-1",
+                "segment-0",
+                2,
+                -2,
+                SegmentStatus.QUEUED,
+                "input",
+                List.of(),
+                null,
+                100L,
+                100L,
+                100L));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ControlPlaneFact.RunSubmitted(
+                "tenant",
+                "run-1",
+                "execution-key",
+                "pipeline",
+                "contract",
+                "release",
+                ExecutionResultShape.SINGLE,
+                "segment-0",
+                2,
+                -2,
+                "input",
+                1000L));
+    }
+
+    @Test
+    void boundaryUnitRejectsContradictoryCompletedCount() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new BoundaryUnit(
+                "tenant",
+                "run-1",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                BoundaryUnitStatus.DISPATCH_COMPLETE,
+                "segment-0",
+                "attempt-0",
+                1,
+                3,
+                2,
+                java.util.Set.of("idem-0"),
+                true,
+                100L,
+                101L));
     }
 
     private static ControlPlaneFact.RunSubmitted submitted() {

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
@@ -160,7 +160,17 @@ class ControlPlaneReducerTest {
                 BoundaryKind.AWAIT,
                 1,
                 1)),
-            event(4, new ControlPlaneFact.ContinuationSegmentCreated(
+            event(4, dispatched("await-unit", BoundaryKind.AWAIT, "interaction-0", "idem-0", 0)),
+            event(5, BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+                "tenant",
+                "run-1",
+                "await-unit",
+                BoundaryKind.AWAIT,
+                "interaction-0",
+                "idem-0",
+                "status-0"))),
+            event(6, new ControlPlaneFact.BoundaryDispatchCompleted("tenant", "run-1", "await-unit", 1)),
+            event(7, new ControlPlaneFact.ContinuationSegmentCreated(
                 "tenant",
                 "run-1",
                 "segment-0",
@@ -171,6 +181,7 @@ class ControlPlaneReducerTest {
                 "status-0"))));
 
         assertEquals(PipelineRunStatus.RUNNING, projection.run().orElseThrow().status());
+        assertEquals(BoundaryUnitStatus.COMPLETED, projection.boundaries().get("await-unit").status());
         assertEquals(SegmentStatus.QUEUED, projection.segments().get("segment-1").status());
         assertEquals("status-0", projection.segments().get("segment-1").inputPayload());
     }

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneSemanticApiTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneSemanticApiTest.java
@@ -1,0 +1,36 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class ControlPlaneSemanticApiTest {
+
+    private static final Pattern MUTABLE_MARK_VERB = Pattern.compile("\\bmark[A-Z][A-Za-z0-9_]*\\b");
+
+    @Test
+    void immutableSemanticPackageDoesNotExposeMarkStyleOperations() throws Exception {
+        Path sourceDir = Path.of("src/main/java/org/pipelineframework/orchestrator/controlplane");
+        try (var files = Files.walk(sourceDir)) {
+            String offenders = files
+                .filter(path -> path.toString().endsWith(".java"))
+                .filter(path -> !path.getFileName().toString().equals("ControlPlaneSemanticApiTest.java"))
+                .filter(this::containsMarkVerb)
+                .map(Path::toString)
+                .sorted()
+                .reduce("", (left, right) -> left.isBlank() ? right : left + "\n" + right);
+            assertTrue(offenders.isBlank(), "new immutable control-plane model must not expose mark* verbs:\n" + offenders);
+        }
+    }
+
+    private boolean containsMarkVerb(Path path) {
+        try {
+            return MUTABLE_MARK_VERB.matcher(Files.readString(path)).find();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed reading " + path, e);
+        }
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournalTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournalTest.java
@@ -1,0 +1,182 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+class InMemoryControlPlaneJournalTest {
+
+    @Test
+    void appendsFactsWithMonotonicSequenceAndRebuildsProjection() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+
+        ControlPlaneAppendResult created = journal.append("tenant", "run-1", 0, List.of(submitted()), 100L)
+            .await().indefinitely();
+        ControlPlaneAppendResult started = journal.append(
+                "tenant",
+                "run-1",
+                created.projection().version(),
+                List.of(new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+                101L)
+            .await().indefinitely();
+
+        assertEquals(1, created.appendedEvents().getFirst().sequence());
+        assertEquals(2, started.appendedEvents().getFirst().sequence());
+        assertEquals(PipelineRunStatus.RUNNING, started.projection().run().orElseThrow().status());
+        assertEquals(SegmentStatus.RUNNING, started.projection().segments().get("segment-0").status());
+    }
+
+    @Test
+    void duplicateAppendIsIdempotentEvenWhenExpectedVersionIsStale() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        ControlPlaneFact.RunSubmitted fact = submitted();
+
+        ControlPlaneAppendResult first = journal.append("tenant", "run-1", 0, List.of(fact), 100L)
+            .await().indefinitely();
+        ControlPlaneAppendResult duplicate = journal.append("tenant", "run-1", 0, List.of(fact), 101L)
+            .await().indefinitely();
+
+        assertEquals(1, first.appendedEvents().size());
+        assertTrue(duplicate.appendedEvents().isEmpty());
+        assertEquals(1, duplicate.projection().version());
+    }
+
+    @Test
+    void staleAppendWithNewFactsFailsOptimisticAppend() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+
+        journal.append("tenant", "run-1", 0, List.of(submitted()), 100L).await().indefinitely();
+
+        assertThrows(ControlPlaneAppendConflictException.class, () -> journal.append(
+                "tenant",
+                "run-1",
+                0,
+                List.of(new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0)),
+                101L)
+            .await().indefinitely());
+    }
+
+    @Test
+    void findsDueSegmentsAndTimedOutBoundaryInteractionsFromCurrentProjections() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+
+        ControlPlaneAppendResult created = journal.append("tenant", "run-1", 0, List.of(submitted()), 100L)
+            .await().indefinitely();
+        ControlPlaneAppendResult suspended = journal.append(
+                "tenant",
+                "run-1",
+                created.projection().version(),
+                List.of(
+                    new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0),
+                    new ControlPlaneFact.SegmentSuspended(
+                        "tenant",
+                        "run-1",
+                        "segment-0",
+                        "attempt-0",
+                        "await-unit",
+                        BoundaryKind.AWAIT,
+                        1,
+                        1),
+                    new ControlPlaneFact.BoundaryInteractionDispatched(
+                        "tenant",
+                        "run-1",
+                        "await-unit",
+                        BoundaryKind.AWAIT,
+                        "interaction-0",
+                        "correlation-0",
+                        "idem-0",
+                        0,
+                        "request-0",
+                        "kafka",
+                        150L)),
+                110L)
+            .await().indefinitely();
+
+        assertTrue(journal.findDueSegments(100L, 10).await().indefinitely().isEmpty());
+        List<DueBoundaryInteraction> timedOut = journal.findTimedOutInteractions(151L, 10).await().indefinitely();
+
+        assertEquals(3, suspended.appendedEvents().size());
+        assertEquals(1, timedOut.size());
+        assertEquals("interaction-0", timedOut.getFirst().interactionId());
+    }
+
+    @Test
+    void completionFactsAreIdempotentByBoundaryIdempotencyKey() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        ControlPlaneAppendResult created = journal.append("tenant", "run-1", 0, List.of(submitted()), 100L)
+            .await().indefinitely();
+        ControlPlaneAppendResult opened = journal.append(
+                "tenant",
+                "run-1",
+                created.projection().version(),
+                List.of(
+                    new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0),
+                    new ControlPlaneFact.SegmentSuspended(
+                        "tenant",
+                        "run-1",
+                        "segment-0",
+                        "attempt-0",
+                        "await-unit",
+                        BoundaryKind.AWAIT,
+                        1,
+                        1),
+                    dispatched(),
+                    new ControlPlaneFact.BoundaryDispatchCompleted("tenant", "run-1", "await-unit", 1)),
+                101L)
+            .await().indefinitely();
+        ControlPlaneFact.BoundaryCompletionAdmitted admitted = BoundaryAdmissionFacts.completion(
+            new BoundaryAdmissionRequest("tenant", "run-1", "await-unit", BoundaryKind.AWAIT, "interaction-0", "idem-0", "ok"));
+
+        ControlPlaneAppendResult first = journal.append(
+            "tenant",
+            "run-1",
+            opened.projection().version(),
+            List.of(admitted),
+            102L).await().indefinitely();
+        ControlPlaneAppendResult duplicate = journal.append(
+            "tenant",
+            "run-1",
+            opened.projection().version(),
+            List.of(admitted),
+            103L).await().indefinitely();
+
+        assertEquals(BoundaryUnitStatus.COMPLETED, first.projection().boundaries().get("await-unit").status());
+        assertTrue(duplicate.appendedEvents().isEmpty());
+        assertEquals(first.projection().version(), duplicate.projection().version());
+    }
+
+    private static ControlPlaneFact.RunSubmitted submitted() {
+        return new ControlPlaneFact.RunSubmitted(
+            "tenant",
+            "run-1",
+            "execution-key",
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            "segment-0",
+            0,
+            -1,
+            "input",
+            1000L);
+    }
+
+    private static ControlPlaneFact.BoundaryInteractionDispatched dispatched() {
+        return new ControlPlaneFact.BoundaryInteractionDispatched(
+            "tenant",
+            "run-1",
+            "await-unit",
+            BoundaryKind.AWAIT,
+            "interaction-0",
+            "correlation-0",
+            "idem-0",
+            0,
+            "request-0",
+            "kafka",
+            150L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournalTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/InMemoryControlPlaneJournalTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.orchestrator.ExecutionResultShape;
 
@@ -43,6 +45,34 @@ class InMemoryControlPlaneJournalTest {
         assertEquals(1, first.appendedEvents().size());
         assertTrue(duplicate.appendedEvents().isEmpty());
         assertEquals(1, duplicate.projection().version());
+    }
+
+    @Test
+    void appendIsLazyUntilSubscribed() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+
+        var append = journal.append("tenant", "run-1", 0, List.of(submitted()), 100L);
+
+        assertTrue(journal.projection("tenant", "run-1").await().indefinitely().factKeys().isEmpty());
+
+        append.await().indefinitely();
+
+        assertTrue(journal.projection("tenant", "run-1")
+            .await().indefinitely()
+            .factKeys()
+            .contains("run-submitted:tenant:run-1"));
+    }
+
+    @Test
+    void duplicateFactsInsideSingleAppendAreIdempotent() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        ControlPlaneFact.RunSubmitted fact = submitted();
+
+        ControlPlaneAppendResult result = journal.append("tenant", "run-1", 0, List.of(fact, fact), 100L)
+            .await().indefinitely();
+
+        assertEquals(1, result.appendedEvents().size());
+        assertEquals(1, result.projection().version());
     }
 
     @Test
@@ -147,6 +177,50 @@ class InMemoryControlPlaneJournalTest {
         assertEquals(BoundaryUnitStatus.COMPLETED, first.projection().boundaries().get("await-unit").status());
         assertTrue(duplicate.appendedEvents().isEmpty());
         assertEquals(first.projection().version(), duplicate.projection().version());
+    }
+
+    @Test
+    void mutablePayloadsAreFrozenBeforeStorage() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        Map<String, Object> requestPayload = new LinkedHashMap<>();
+        requestPayload.put("amount", 10);
+        requestPayload.put("labels", new java.util.ArrayList<>(List.of("initial")));
+        ControlPlaneFact.BoundaryInteractionDispatched dispatched = new ControlPlaneFact.BoundaryInteractionDispatched(
+            "tenant",
+            "run-1",
+            "await-unit",
+            BoundaryKind.AWAIT,
+            "interaction-0",
+            "correlation-0",
+            "idem-0",
+            0,
+            requestPayload,
+            "kafka",
+            150L);
+
+        requestPayload.put("amount", 99);
+        @SuppressWarnings("unchecked")
+        List<String> labels = (List<String>) requestPayload.get("labels");
+        labels.add("mutated");
+        ControlPlaneAppendResult result = journal.append("tenant", "run-1", 0, List.of(
+                submitted(),
+                new ControlPlaneFact.SegmentAttemptStarted("tenant", "run-1", "segment-0", "attempt-0", 0),
+                new ControlPlaneFact.SegmentSuspended(
+                    "tenant",
+                    "run-1",
+                    "segment-0",
+                    "attempt-0",
+                    "await-unit",
+                    BoundaryKind.AWAIT,
+                    1,
+                    1),
+                dispatched),
+            100L).await().indefinitely();
+
+        Object stored = result.projection().interactions().get("interaction-0").requestPayload();
+
+        assertEquals(Map.of("amount", 10, "labels", List.of("initial")), stored);
+        assertThrows(UnsupportedOperationException.class, () -> ((Map<?, ?>) stored).clear());
     }
 
     private static ControlPlaneFact.RunSubmitted submitted() {


### PR DESCRIPTION
## Summary
- add an immutable queue-async control-plane model for pipeline runs, execution segments, segment attempts, boundary units, and boundary interactions
- add append-only facts, pure projection reducers, an in-memory conditional journal, and shared boundary admission facts for await/checkpoint-style handoffs
- document the segment/boundary model under /evolve and link it from architecture and await-unit internals

## Validation
- ./mvnw -f framework/pom.xml -Dtest=ControlPlaneReducerTest,InMemoryControlPlaneJournalTest,BoundaryAdmissionFactsTest,ControlPlaneSemanticApiTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="/Users/mari/tpf4-queue-async-immutable-boundaries/.m2/repository"
- ./mvnw -f framework/pom.xml test -Dmaven.repo.local="/Users/mari/tpf4-queue-async-immutable-boundaries/.m2/repository"
- npm --prefix docs test
- npm --prefix docs run build

## Notes
- this replaces the procedural queue-async refactor direction with a model-first slice
- this is not wired into the queue-async hot path yet; CSV 1k/10k was not rerun for this slice
- Dynamo append-only persistence remains the follow-up under issue #396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation/navigation for queue-async immutable boundary concepts.
  * Expanded the control-plane semantic model with new run/segment/boundary/interaction states and immutable “fact” projections.
  * Introduced control-plane journal APIs for appending facts, building projections, and querying due/timeout work.
* **Bug Fixes**
  * Strengthened validation, immutability, and idempotency; added explicit handling for append conflicts and late/duplicate events.
* **Documentation**
  * Updated architecture and runtime guides to clarify the queue-async flow and projection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->