### PR TITLE
[codex] Add queue async control-plane ledger bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ When changing layout support in csv-payments, update all of:
 3. Topology test(s)
 4. E2E IT path (through `AbstractCsvPaymentsEndToEnd`)
 5. Relevant CI workflows under `.github/workflows/` (at minimum `full-tests.yml` and any `e2e-csv-*.yml` jobs that cover the changed layout)
-6. Build docs under `docs/guide/build/runtime-layouts/`
+6. Runtime-layout docs under `docs/deploy/runtime-layouts/`
 
 ## Runtime and Build Commands
 
@@ -152,34 +152,34 @@ Keep both forms aligned in docs and processor behavior.
 
 ## Docs Source of Truth
 
-Application-user docs:
+Canonical docs live under top-level route directories:
 
-- Build/runtime-layout docs: `docs/guide/build/runtime-layouts/`
-- Build mechanics: `docs/guide/build/`
-- Operations and usage: `docs/guide/operations/`, `docs/guide/development/`
+- Architecture and concepts: `docs/design/`
+- Implementation and usage: `docs/develop/`
+- Runtime topology and deployment mechanics: `docs/deploy/`
+- Observability and operations: `docs/operate/`
+- Implementation internals, design notes, and backlog material: `docs/evolve/`
+- Product/value framing: `docs/value/`
 
-Implementation/developer-internal docs:
-
-- `docs/guide/evolve/`
-- `docs/guide/evolve/tpfgo/` (TPFGo reference guide and DDD alignment)
+`docs/guide/**` files are redirect/noindex compatibility stubs only. Do not add real content there. Move or merge useful guide-stub content into the canonical top-level route.
 
 Use links between these areas when a feature spans both implementation and app usage.
-Prefer the split annotation-processor guide under `docs/guide/evolve/annotation-processor/` over older compatibility pages when both exist.
+Prefer the split annotation-processor guide under `docs/evolve/annotation-processor/` over older compatibility pages when both exist.
 
 ## Canonical Entry Docs
 
-- `docs/guide/build/runtime-layouts/index.md`
-- `docs/guide/build/pipeline-compilation.md`
-- `docs/guide/build/operators.md`
-- `docs/guide/development/testing.md`
-- `docs/guide/plugins/persistence.md`
-- `docs/guide/development/using-plugins.md`
-- `docs/guide/evolve/annotation-processor/index.md`
-- `docs/guide/evolve/compiler-pipeline-architecture.md`
-- `docs/guide/evolve/plugins-architecture.md`
-- `docs/guide/evolve/publishing.md`
-- `docs/guide/evolve/ci-guidelines.md`
-- `docs/guide/evolve/tpfgo/index.md`
+- `docs/deploy/runtime-layouts/index.md`
+- `docs/develop/pipeline-compilation/index.md`
+- `docs/develop/operators.md`
+- `docs/develop/testing.md`
+- `docs/design/persistence.md`
+- `docs/develop/using-plugins.md`
+- `docs/evolve/annotation-processor/index.md`
+- `docs/evolve/compiler-pipeline-architecture.md`
+- `docs/evolve/plugins-architecture.md`
+- `docs/evolve/publishing.md`
+- `docs/evolve/ci-guidelines.md`
+- `docs/evolve/tpfgo/index.md`
 
 ## Agent Working Rules for This Repo
 
@@ -188,14 +188,15 @@ Prefer the split annotation-processor guide under `docs/guide/evolve/annotation-
 - Do not commit/push unless explicitly requested.
 - If unexpected unrelated working-tree changes appear mid-task, stop and ask.
 - Treat `examples/` and `ai-sdk/` as compatibility/reference surfaces, not disposable demos, when framework semantics change.
-- Keep user-facing docs (`build`/`development`/`operations`) free of internal planning terminology unless the topic is explicitly implementation-internal (`docs/guide/evolve/`).
-- Prefer enriching existing guide pages over introducing standalone “feature islands” that duplicate navigation.
-- Do not add “audience declaration” sections in user-facing docs. Make docs audience-fit by placing content in the right guide area:
-  - `development`: implementation and usage
-  - `operations`: observability and response
-  - `build`: topology/configuration/application of features
+- Keep user-facing docs (`design`/`develop`/`deploy`/`operate`/`value`) free of internal planning terminology unless the topic is explicitly implementation-internal (`docs/evolve/`).
+- Prefer enriching existing canonical docs pages over introducing standalone “feature islands” that duplicate navigation.
+- Do not add “audience declaration” sections in user-facing docs. Make docs audience-fit by placing content in the right canonical docs area:
+  - `design`: architecture, concepts, and user-facing design rationale
+  - `develop`: implementation and usage
+  - `deploy`: runtime topology and deployment mechanics
+  - `operate`: observability and response
   - `evolve`: internals, design notes, and backlog-oriented material
-- Keep risk registers, update reports, and future-work tracking out of user-facing docs unless they are actionable operator runbooks; place backlog/planning artifacts under `docs/guide/evolve/` or external issue trackers.
+- Keep risk registers, update reports, and future-work tracking out of user-facing docs unless they are actionable operator runbooks; place backlog/planning artifacts under `docs/evolve/` or external issue trackers.
 - When changing operator or mapper semantics, update code + tests + docs together in the same change set.
 - When adding or changing a semantic step kind (`kind: await`, `kind: command`, query steps, object I/O, or future DSL-owned I/O shells), update compiler/runtime support, validation tests, user docs, telemetry/replay metadata, replay-viewer node rendering/legend, and any affected example replay datasets or generation paths in the same change set.
 - When changing runtime-layout, generator, or Canvas/web UI semantics, update `web-ui`, affected docs, tests, and the separate `The-Pipeline-Framework/tpf-mcp-bridge` repository when applicable.

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -260,6 +260,7 @@ const mainSidebar = [
         items: [
             {text: 'Overview', link: '/evolve/'},
             {text: 'Architecture', link: '/evolve/architecture'},
+            {text: 'Queue-Async Immutable Boundaries', link: '/evolve/queue-async-immutable-boundaries'},
             {text: 'Architecture Reference', link: '/evolve/architecture-reference'},
             {text: 'I/O Shell Absorption', link: '/evolve/io-shell-absorption'},
             {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -260,7 +260,6 @@ const mainSidebar = [
         items: [
             {text: 'Overview', link: '/evolve/'},
             {text: 'Architecture', link: '/evolve/architecture'},
-            {text: 'Queue-Async Immutable Boundaries', link: '/evolve/queue-async-immutable-boundaries'},
             {text: 'Architecture Reference', link: '/evolve/architecture-reference'},
             {text: 'I/O Shell Absorption', link: '/evolve/io-shell-absorption'},
             {
@@ -405,6 +404,7 @@ const mainSidebar = [
                 collapsed: true,
                 items: [
                     {text: 'Model', link: '/evolve/await-unit-runtime/'},
+                    {text: 'Immutable Boundaries', link: '/evolve/await-unit-runtime/immutable-boundaries'},
                     {text: 'Sequences', link: '/evolve/await-unit-runtime/sequences'},
                     {text: 'Patterns', link: '/evolve/await-unit-runtime/patterns'},
                     {text: 'Limitations And Debt', link: '/evolve/await-unit-runtime/operations-and-debt'}

--- a/docs/evolve/architecture.md
+++ b/docs/evolve/architecture.md
@@ -12,7 +12,7 @@ Use public Design/Develop/Deploy docs for application usage. Use this page when 
 | Generated artifacts and module ownership | [Pipeline Compilation](/develop/pipeline-compilation/) |
 | Runtime layout vs build topology | [Runtime Layouts](/deploy/runtime-layouts/) |
 | Queue-async durable execution | [Queue-Async Runtime](/deploy/orchestrator-runtime/queue-async) |
-| Queue-async immutable segment/boundary model | [Queue-Async Immutable Boundaries](/evolve/queue-async-immutable-boundaries) |
+| Queue-async immutable segment/boundary model | [Immutable Segment And Boundary Model](/evolve/await-unit-runtime/immutable-boundaries) |
 | Await and callback admission | [Await Boundaries](/design/await-boundaries) and [Await Runtime Setup](/deploy/orchestrator-runtime/await) |
 | Checkpoint handoff | [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) |
 | Brokered runtime boundaries | [Brokered Runtime Boundaries](/evolve/brokered-boundaries/) |
@@ -31,7 +31,7 @@ The current durable direction is a queue-driven async control plane:
 6. state is committed,
 7. terminal state is exposed through status/result APIs or failures move to the configured DLQ.
 
-This is not a full event-sourced runtime in the current milestone. The target direction is described in [Queue-Async Immutable Boundaries](/evolve/queue-async-immutable-boundaries): immutable segment and boundary facts first, with stores maintaining projections for efficient lookup.
+This is not a full event-sourced runtime in the current milestone. The target direction is described in [Immutable Segment And Boundary Model](/evolve/await-unit-runtime/immutable-boundaries): immutable segment and boundary facts first, with stores maintaining projections for efficient lookup.
 
 ## Legacy Reference
 

--- a/docs/evolve/await-unit-runtime/immutable-boundaries.md
+++ b/docs/evolve/await-unit-runtime/immutable-boundaries.md
@@ -1,0 +1,125 @@
+# Immutable Segment And Boundary Model
+
+Queue-async should be modeled as immutable facts flowing through reducers, not as one mutable execution record being marked from state to state.
+
+This page describes the internal segment and boundary model used to connect synchronous pipeline execution segments across await, checkpoint, and terminal publication boundaries. The current `ExecutionStateStore`, `AwaitUnitStore`, and `AwaitInteractionStore` are projection stores for the active runtime path. The immutable model gives queue-async a stable semantic vocabulary for those projections and for future append-only storage providers.
+
+## Core Model
+
+`PipelineRunner` remains the synchronous segment runner. Queue-async adds durable boundaries between those synchronous segments:
+
+1. A `PipelineRun` is the logical submitted run.
+2. An `ExecutionSegment` is one synchronous step range between async boundaries.
+3. A `SegmentAttempt` is one worker attempt for a segment.
+4. A `BoundaryUnit` is an async handoff boundary: await, checkpoint handoff, or terminal publication.
+5. A `BoundaryInteraction` is the transport-facing correlation/idempotency item within the boundary.
+
+The model is intentionally append-only. A timeout is not "mark this execution timed out"; it is an `InteractionTimedOut` fact. Reducers derive the current run, segment, boundary, and due-work projections from that fact stream.
+
+```mermaid
+classDiagram
+    class PipelineRun {
+      runId
+      executionKey
+      status
+      version
+    }
+
+    class ExecutionSegment {
+      segmentId
+      startStepIndex
+      stopBeforeStepIndex
+      status
+      inputPayload
+    }
+
+    class SegmentAttempt {
+      attemptId
+      attemptNumber
+      status
+    }
+
+    class BoundaryUnit {
+      unitId
+      kind
+      status
+      expectedItemCount
+      completedItemCount
+    }
+
+    class BoundaryInteraction {
+      interactionId
+      correlationId
+      idempotencyKey
+      status
+      transportType
+    }
+
+    class ControlPlaneFact
+    class ControlPlaneReducer
+    class ControlPlaneProjection
+    class ControlPlaneJournal
+
+    PipelineRun "1" --> "1..n" ExecutionSegment
+    ExecutionSegment "1" --> "0..n" SegmentAttempt
+    ExecutionSegment "0..1" --> BoundaryUnit
+    BoundaryUnit "1" --> "0..n" BoundaryInteraction
+    ControlPlaneFact --> ControlPlaneReducer : append / reduce
+    ControlPlaneReducer --> ControlPlaneProjection : derives
+    ControlPlaneJournal --> ControlPlaneFact : conditional append
+```
+
+## Fact Flow
+
+The control-plane model uses facts such as:
+
+- `RunSubmitted`
+- `SegmentAttemptStarted`
+- `SegmentCompleted`
+- `SegmentSuspended`
+- `BoundaryInteractionDispatched`
+- `BoundaryDispatchCompleted`
+- `BoundaryCompletionAdmitted`
+- `InteractionTimedOut`
+- `ContinuationSegmentCreated`
+- `TerminalPublicationCompleted`
+- `RunSucceeded`
+- `RunFailed`
+
+These facts are immutable. A `ControlPlaneJournal` appends them conditionally by expected projection version, assigns monotonically increasing event sequences, and rebuilds projections through `ControlPlaneReducer`.
+
+Duplicate completions and terminal publications are handled by fact keys. Retrying the same append is a no-op when the fact key already exists; retrying a different fact against a stale version fails with an append conflict.
+
+## Boundary Admission
+
+Await completion and checkpoint handoff are the same architectural shape: a transport message admits a correlated payload into a TPF-owned boundary.
+
+```mermaid
+sequenceDiagram
+    participant Broker as "Broker / transport"
+    participant Admission as "Boundary admission"
+    participant Journal as "ControlPlaneJournal"
+    participant Reducer as "ControlPlaneReducer"
+    participant Projection as "Current projection"
+    participant Effects as "Effect interpreter"
+
+    Broker->>Admission: "completion or handoff message"
+    Admission->>Journal: "append BoundaryCompletionAdmitted"
+    Journal->>Reducer: "reduce immutable facts"
+    Reducer-->>Projection: "boundary/run/segment view"
+    Projection-->>Effects: "live handoff or durable continuation"
+```
+
+`BoundaryAdmissionFacts` is deliberately transport-agnostic. Kafka await completions and Kafka checkpoint handoffs should produce the same `BoundaryCompletionAdmitted` fact shape after their protocol-specific decoding.
+
+## Relationship To Projection Stores
+
+The existing stores are projection stores for efficient runtime lookup:
+
+- `ExecutionStateStore`
+- `AwaitUnitStore`
+- `AwaitInteractionStore`
+
+The queue-async runtime records semantic facts around those projection updates. The projection stores keep existing lookup and recovery paths stable, while the journal records the immutable story of a run: submitted, attempted, suspended, completed, admitted, continued, published, succeeded, or failed.
+
+Dynamo append-only storage design remains tracked by issue #396. That work should implement the same fact model with explicit table, index, retention, and stale-candidate handling.

--- a/docs/evolve/await-unit-runtime/index.md
+++ b/docs/evolve/await-unit-runtime/index.md
@@ -4,14 +4,15 @@ Await units are the durable suspend/resume model for `kind: await` steps. The un
 
 This guide is implementation-facing. Application-facing design guidance lives in [Await Boundaries](/design/await-boundaries). Runtime setup lives in [Await runtime setup](/deploy/orchestrator-runtime/await).
 
-For the longer-term orchestration boundary that can move await units out of each app-hosted orchestrator, see [Durable Coordinator](/evolve/durable-coordinator/). For the immutable queue-async model that treats await completion and checkpoint handoff as the same boundary-admission shape, see [Queue-Async Immutable Boundaries](/evolve/queue-async-immutable-boundaries).
+For the longer-term orchestration boundary that can move await units out of each app-hosted orchestrator, see [Durable Coordinator](/evolve/durable-coordinator/). For the immutable queue-async model that treats await completion and checkpoint handoff as the same boundary-admission shape, see [Immutable Segment And Boundary Model](/evolve/await-unit-runtime/immutable-boundaries).
 
 ## Guide Pages
 
 1. [Model](/evolve/await-unit-runtime/) explains the durable records and cardinality semantics.
-2. [Sequences](/evolve/await-unit-runtime/sequences) shows unary, stream, aggregate, timeout, and resume flows.
-3. [Patterns](/evolve/await-unit-runtime/patterns) explains the architectural patterns and why the unit model fixed the design.
-4. [Limitations And Debt](/evolve/await-unit-runtime/operations-and-debt) tracks implementation limitations and follow-up work.
+2. [Immutable Boundaries](/evolve/await-unit-runtime/immutable-boundaries) explains the segment, boundary, fact, and projection model behind queue-async.
+3. [Sequences](/evolve/await-unit-runtime/sequences) shows unary, stream, aggregate, timeout, and resume flows.
+4. [Patterns](/evolve/await-unit-runtime/patterns) explains the architectural patterns and why the unit model fixed the design.
+5. [Limitations And Debt](/evolve/await-unit-runtime/operations-and-debt) tracks implementation limitations and follow-up work.
 
 ## Core Model
 

--- a/docs/evolve/brokered-boundaries/boundary-taxonomy.md
+++ b/docs/evolve/brokered-boundaries/boundary-taxonomy.md
@@ -33,6 +33,8 @@ Kafka replay means re-reading records from a log. SQS redrive means making queue
 
 Serialization choices such as protobuf, JSON, bytes, or payload references belong to payload policy, not broker fit. See [Envelope And Data Policy](/evolve/brokered-boundaries/envelope-and-data-policy).
 
+Await completion and checkpoint handoff both admit transport messages into TPF-owned boundaries. The immutable queue-async facts for those admissions are described in [Immutable Segment And Boundary Model](/evolve/await-unit-runtime/immutable-boundaries).
+
 ```mermaid
 flowchart TB
     Runtime["TPF runtime boundary"]

--- a/docs/evolve/brokered-boundaries/dispatch-substrates.md
+++ b/docs/evolve/brokered-boundaries/dispatch-substrates.md
@@ -58,6 +58,7 @@ This guide extends existing boundary seams:
 - [Step-Aware Invocation Runtime](/evolve/durable-coordinator/boundary-invocation-model) defines shared invocation points for step, transition-worker, and transport-boundary execution.
 - [Worker Protocols](/evolve/durable-coordinator/worker-protocols) already model transition-worker command/result envelopes over local, REST, gRPC, and SQS.
 - [Await Unit Runtime](/evolve/await-unit-runtime/) defines durable suspend/resume semantics that can use different transports.
+- [Immutable Segment And Boundary Model](/evolve/await-unit-runtime/immutable-boundaries) defines the internal fact model shared by await completion and checkpoint handoff admissions.
 - [Checkpoint Handoff](/deploy/orchestrator-runtime/checkpoint-handoff) is the natural user-facing shape for pipeline-to-pipeline publication.
 - [Runtime Core Decoupling](/evolve/runtime-core-decoupling) keeps runtime-adapter concerns out of core semantics.
 

--- a/docs/evolve/brokered-boundaries/index.md
+++ b/docs/evolve/brokered-boundaries/index.md
@@ -35,6 +35,8 @@ The important separation is:
 3. [Envelope And Data Policy](/evolve/brokered-boundaries/envelope-and-data-policy) separates loose payloads from strict TPF control metadata.
 4. [Adoption And Slices](/evolve/brokered-boundaries/adoption-and-slices) captures the value proposition and implementation ordering.
 
+For the queue-async segment and boundary facts that await and checkpoint handoffs share, see [Immutable Segment And Boundary Model](/evolve/await-unit-runtime/immutable-boundaries).
+
 ## Naming
 
 Use **step host** for an external process, service, pod, or function that executes a TPF step boundary.

--- a/docs/evolve/queue-async-immutable-boundaries.md
+++ b/docs/evolve/queue-async-immutable-boundaries.md
@@ -1,125 +1,26 @@
-# Queue-Async Immutable Boundaries
+---
+title: Redirecting...
+search: false
+head:
+  - - meta
+    - name: robots
+      content: noindex
+  - - meta
+    - http-equiv: refresh
+      content: 0;url=/evolve/await-unit-runtime/immutable-boundaries
+---
 
-Queue-async should be modeled as immutable facts flowing through reducers, not as one mutable execution record being marked from state to state.
+<script setup>
+import {onMounted} from 'vue'
+import {withBase} from 'vitepress'
 
-This page describes the target internal model introduced for the first in-memory slice. The current `ExecutionStateStore`, `AwaitUnitStore`, and `AwaitInteractionStore` remain compatibility projections until the Dynamo append-only storage design in issue #396 replaces their update-oriented implementations.
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.location.replace(withBase('/evolve/await-unit-runtime/immutable-boundaries'))
+  }
+})
+</script>
 
-## Core Model
+# Redirecting...
 
-`PipelineRunner` remains the synchronous segment runner. Queue-async adds durable boundaries between those synchronous segments:
-
-1. A `PipelineRun` is the logical submitted run.
-2. An `ExecutionSegment` is one synchronous step range between async boundaries.
-3. A `SegmentAttempt` is one worker attempt for a segment.
-4. A `BoundaryUnit` is an async handoff boundary: await, checkpoint handoff, or terminal publication.
-5. A `BoundaryInteraction` is the transport-facing correlation/idempotency item within the boundary.
-
-The model is intentionally append-only. A timeout is not "mark this execution timed out"; it is an `InteractionTimedOut` fact. Reducers derive the current run, segment, boundary, and due-work projections from that fact stream.
-
-```mermaid
-classDiagram
-    class PipelineRun {
-      runId
-      executionKey
-      status
-      version
-    }
-
-    class ExecutionSegment {
-      segmentId
-      startStepIndex
-      stopBeforeStepIndex
-      status
-      inputPayload
-    }
-
-    class SegmentAttempt {
-      attemptId
-      attemptNumber
-      status
-    }
-
-    class BoundaryUnit {
-      unitId
-      kind
-      status
-      expectedItemCount
-      completedItemCount
-    }
-
-    class BoundaryInteraction {
-      interactionId
-      correlationId
-      idempotencyKey
-      status
-      transportType
-    }
-
-    class ControlPlaneFact
-    class ControlPlaneReducer
-    class ControlPlaneProjection
-    class ControlPlaneJournal
-
-    PipelineRun "1" --> "1..n" ExecutionSegment
-    ExecutionSegment "1" --> "0..n" SegmentAttempt
-    ExecutionSegment "0..1" --> BoundaryUnit
-    BoundaryUnit "1" --> "0..n" BoundaryInteraction
-    ControlPlaneFact --> ControlPlaneReducer : append / reduce
-    ControlPlaneReducer --> ControlPlaneProjection : derives
-    ControlPlaneJournal --> ControlPlaneFact : conditional append
-```
-
-## Fact Flow
-
-The first slice introduces facts such as:
-
-- `RunSubmitted`
-- `SegmentAttemptStarted`
-- `SegmentCompleted`
-- `SegmentSuspended`
-- `BoundaryInteractionDispatched`
-- `BoundaryDispatchCompleted`
-- `BoundaryCompletionAdmitted`
-- `InteractionTimedOut`
-- `ContinuationSegmentCreated`
-- `TerminalPublicationCompleted`
-- `RunSucceeded`
-- `RunFailed`
-
-These facts are immutable. The in-memory `ControlPlaneJournal` appends them conditionally by expected projection version, assigns monotonically increasing event sequences, and rebuilds projections through `ControlPlaneReducer`.
-
-Duplicate completions and terminal publications are handled by fact keys. Retrying the same append is a no-op when the fact key already exists; retrying a different fact against a stale version fails with an append conflict.
-
-## Boundary Admission
-
-Await completion and checkpoint handoff are the same architectural shape: a transport message admits a correlated payload into a TPF-owned boundary.
-
-```mermaid
-sequenceDiagram
-    participant Broker as "Broker / transport"
-    participant Admission as "Boundary admission"
-    participant Journal as "ControlPlaneJournal"
-    participant Reducer as "ControlPlaneReducer"
-    participant Projection as "Current projection"
-    participant Effects as "Effect interpreter"
-
-    Broker->>Admission: "completion or handoff message"
-    Admission->>Journal: "append BoundaryCompletionAdmitted"
-    Journal->>Reducer: "reduce immutable facts"
-    Reducer-->>Projection: "boundary/run/segment view"
-    Projection-->>Effects: "live handoff or durable continuation"
-```
-
-`BoundaryAdmissionFacts` is deliberately transport-agnostic. Kafka await completions and Kafka checkpoint handoffs should produce the same `BoundaryCompletionAdmitted` fact shape after their protocol-specific decoding.
-
-## Relationship To Existing Stores
-
-The existing stores are still update-oriented compatibility projections:
-
-- `ExecutionStateStore`
-- `AwaitUnitStore`
-- `AwaitInteractionStore`
-
-They remain in the hot path until the control-plane journal is integrated. The new package draws the semantic boundary first so the next storage work can replace update verbs with append-only writes without inventing the model inside the Dynamo implementation.
-
-The next storage slice should implement the Dynamo append-only design tracked by issue #396. It must answer the table/index and stale-candidate questions there before replacing production store providers.
+This page moved to [/evolve/await-unit-runtime/immutable-boundaries](/evolve/await-unit-runtime/immutable-boundaries).

--- a/docs/guide/evolve/queue-async-immutable-boundaries.md
+++ b/docs/guide/evolve/queue-async-immutable-boundaries.md
@@ -1,0 +1,26 @@
+---
+title: Redirecting...
+search: false
+head:
+  - - meta
+    - name: robots
+      content: noindex
+  - - meta
+    - http-equiv: refresh
+      content: 0;url=/evolve/await-unit-runtime/immutable-boundaries
+---
+
+<script setup>
+import {onMounted} from 'vue'
+import {withBase} from 'vitepress'
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.location.replace(withBase('/evolve/await-unit-runtime/immutable-boundaries'))
+  }
+})
+</script>
+
+# Redirecting...
+
+This page moved to [/evolve/await-unit-runtime/immutable-boundaries](/evolve/await-unit-runtime/immutable-boundaries).

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionFailureHandler.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionFailureHandler.java
@@ -18,6 +18,7 @@ import org.pipelineframework.orchestrator.ExecutionStatus;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.step.NonRetryableException;
 import org.pipelineframework.step.PipelineControlFlowException;
 
@@ -33,6 +34,9 @@ class ExecutionFailureHandler {
 
   @Inject
   PipelineOrchestratorConfig orchestratorConfig;
+
+  @Inject
+  SegmentBoundaryLedger segmentBoundaryLedger;
 
   Uni<Void> handleExecutionFailure(
       ExecutionRecord<Object, Object> record,
@@ -114,8 +118,18 @@ class ExecutionFailureHandler {
               .retriesObserved(record.attempt())
               .createdAtEpochMs(now)
               .build();
-          return deadLetterPublisher.publish(envelope);
+          return segmentBoundaryLedger()
+              .recordRunFailed(
+                  updated.get(),
+                  classifiedFailure.getClass().getSimpleName(),
+                  classifiedFailure.getMessage(),
+                  now)
+              .chain(() -> deadLetterPublisher.publish(envelope));
         });
+  }
+
+  private SegmentBoundaryLedger segmentBoundaryLedger() {
+    return segmentBoundaryLedger == null ? new SegmentBoundaryLedger() : segmentBoundaryLedger;
   }
 
   long retryDelayMillis(int nextAttempt) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -1464,8 +1464,10 @@ class QueueAsyncCoordinator {
                   return Uni.createFrom().voidItem();
                 }
                 Uni<Void> recordedContinuation = segmentBoundaryLedger().recordContinuationSegmentCreated(
-                    updated.get(),
-                    unit,
+                    parent.tenantId(),
+                    parent.executionId(),
+                    SegmentBoundaryLedger.segmentId(parent),
+                    unit.unitId(),
                     SegmentBoundaryLedger.segmentId(updated.get()),
                     aggregateStepIndex,
                     -1,
@@ -1578,16 +1580,18 @@ class QueueAsyncCoordinator {
                 awaitUnitId,
                 stepId,
                 stepIndex,
-                updated.get().status().name(),
-                interactionId,
-                correlationId,
-                transportType,
-                itemIndex,
-                null,
-                null,
-                null));
+            updated.get().status().name(),
+            interactionId,
+            correlationId,
+            transportType,
+            itemIndex,
+            null,
+            null,
+            null));
             Uni<Void> recordedContinuation = segmentBoundaryLedger().recordContinuationSegmentCreated(
-                updated.get(),
+                tenantId,
+                executionId,
+                SegmentBoundaryLedger.segmentId(executionId, stepIndex),
                 awaitUnitId,
                 SegmentBoundaryLedger.segmentId(updated.get()),
                 stepIndex + 1,

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -69,6 +69,7 @@ import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
 import org.pipelineframework.orchestrator.TransitionWorkerCommand;
 import org.pipelineframework.orchestrator.TransitionWorkerOutcome;
 import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
 import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
@@ -149,6 +150,9 @@ class QueueAsyncCoordinator {
 
   @Inject
   ControlPlaneAdmissionPolicy controlPlaneAdmissionPolicy;
+
+  @Inject
+  SegmentBoundaryLedger segmentBoundaryLedger;
 
   private volatile TransitionPayloadCodec fallbackTransitionPayloadCodec;
   private volatile PipelineReleaseIdentityResolver fallbackReleaseIdentityResolver;
@@ -305,12 +309,17 @@ class QueueAsyncCoordinator {
               ttlEpochS);
           return executionStateStore.createOrGetExecution(command)
               .onItem().transformToUni(created -> {
+                Uni<Void> recordSubmitted = created.duplicate()
+                    ? Uni.createFrom().voidItem()
+                    : segmentBoundaryLedger().recordRunSubmitted(created, command, now);
                 Uni<Void> enqueue = created.duplicate()
                     ? Uni.createFrom().voidItem()
                     : workDispatcher.enqueueNow(new ExecutionWorkItem(
                         created.record().tenantId(),
                         created.record().executionId()));
-                return enqueue.onItem().transform(ignored -> toRunAccepted(created, now));
+                return recordSubmitted
+                    .chain(() -> enqueue)
+                    .onItem().transform(ignored -> toRunAccepted(created, now));
               });
         });
   }
@@ -552,7 +561,8 @@ class QueueAsyncCoordinator {
               record.resultShape(),
               record.awaitUnitId() == null ? "<none>" : record.awaitUnitId());
           String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-          return prepareTransitionCommand(record, transitionKey)
+          return segmentBoundaryLedger().recordSegmentAttemptStarted(record, transitionKey, now)
+              .chain(() -> prepareTransitionCommand(record, transitionKey))
               .onItem().transformToUni(command -> transitionWorkerExecutor.execute(worker, command))
               .onItem().transformToUni(result -> handleTransitionResult(record, transitionKey, result, itemContinuationHandler))
               .onFailure(AwaitThrowableSupport::containsAwaitSuspension).recoverWithUni(failure ->
@@ -640,7 +650,9 @@ class QueueAsyncCoordinator {
         .onItem().transformToUni(result -> validateAwaitCompletionTenant(result, normalized)
             .onItem().transformToUni(validated -> {
               return awaitCoordinator.recordCompletion(validated.record(), normalized.nowEpochMs())
-                  .onItem().transformToUni(unit -> signalLiveAwaitCompletion(validated.record(), unit)
+                  .onItem().transformToUni(unit -> segmentBoundaryLedger()
+                      .recordBoundaryCompletionAdmitted(validated.record(), unit, normalized.nowEpochMs())
+                      .chain(() -> signalLiveAwaitCompletion(validated.record(), unit))
                       .onFailure().recoverWithItem(false)
                       .onItem().transformToUni(liveAccepted -> liveAccepted
                           ? Uni.createFrom().item(validated)
@@ -913,9 +925,10 @@ class QueueAsyncCoordinator {
               + " produced " + outputItems.size()
               + " terminal items for SINGLE result shape"));
     }
-    return checkpointPublicationService
-        .publishIfConfigured(record, singleResult(outputItems))
-        .chain(() -> publishTerminalOutputsIfConfigured(result))
+    long nowEpochMs = System.currentTimeMillis();
+    return segmentBoundaryLedger().recordSegmentCompleted(record, transitionKey, result, nowEpochMs)
+        .chain(() -> checkpointPublicationService.publishIfConfigured(record, singleResult(outputItems)))
+        .chain(() -> publishTerminalOutputsIfConfigured(record, transitionKey, result, nowEpochMs))
         .replaceWith(outputItems)
         .onItem().transformToUni(payload -> executionStateStore.markSucceeded(
             record.tenantId(),
@@ -923,18 +936,26 @@ class QueueAsyncCoordinator {
             record.version(),
             transitionKey,
             payload,
-            System.currentTimeMillis()))
+            nowEpochMs))
+        .onItem().transformToUni(updated -> updated
+            .map(succeeded -> segmentBoundaryLedger().recordRunSucceeded(succeeded, outputItems, nowEpochMs))
+            .orElseGet(() -> Uni.createFrom().voidItem()))
         .replaceWithVoid();
   }
 
-  private Uni<Void> publishTerminalOutputsIfConfigured(TransitionResultEnvelope result) {
+  private Uni<Void> publishTerminalOutputsIfConfigured(
+      ExecutionRecord<Object, Object> record,
+      String transitionKey,
+      TransitionResultEnvelope result,
+      long nowEpochMs) {
     if (result.terminalOutputPublished()) {
-      return Uni.createFrom().voidItem();
+      return segmentBoundaryLedger().recordTerminalPublicationCompleted(record, transitionKey, nowEpochMs);
     }
     if (objectPublishCompletionService == null) {
       return Uni.createFrom().voidItem();
     }
-    return objectPublishCompletionService.publishIfConfigured(() -> result.decodeOutputItems(payloadCodec()));
+    return objectPublishCompletionService.publishIfConfigured(() -> result.decodeOutputItems(payloadCodec()))
+        .chain(() -> segmentBoundaryLedger().recordTerminalPublicationCompleted(record, transitionKey, nowEpochMs));
   }
 
   private Uni<Void> markWaitingExternal(
@@ -975,7 +996,12 @@ class QueueAsyncCoordinator {
                       null,
                       null,
                       null));
-                  return releaseAlreadyCompletedAwaitUnit(updated.get(), suspended, nowEpochMs, itemContinuationHandler);
+                  return segmentBoundaryLedger().recordSegmentSuspended(record, transitionKey, suspended, nowEpochMs)
+                      .chain(() -> releaseAlreadyCompletedAwaitUnit(
+                          updated.get(),
+                          suspended,
+                          nowEpochMs,
+                          itemContinuationHandler));
                 }
                 return Uni.createFrom().failure(new IllegalStateException(
                     "Failed to persist WAITING_EXTERNAL state for execution "
@@ -1000,7 +1026,10 @@ class QueueAsyncCoordinator {
           List<Uni<Void>> operations = new ArrayList<>(records.size());
           for (AwaitInteractionRecord record : records) {
             operations.add(awaitCoordinator.markTimedOut(record, now)
-                .onItem().transformToUni(updated -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
+                .onItem().transformToUni(updated -> updated.isPresent()
+                    ? segmentBoundaryLedger().recordInteractionTimedOut(updated.get(), now)
+                    : Uni.createFrom().voidItem())
+                .onItem().transformToUni(ignored -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
                 .onItem().transformToUni(execution -> {
                   if (execution.isEmpty() || execution.get().status().terminal()) {
                     return Uni.createFrom().voidItem();
@@ -1019,6 +1048,13 @@ class QueueAsyncCoordinator {
                           "AWAIT_TIMEOUT",
                           "Await interaction timed out: " + record.interactionId(),
                           now)
+                      .onItem().transformToUni(updated -> updated
+                          .map(failed -> segmentBoundaryLedger().recordRunFailed(
+                              failed,
+                              "AWAIT_TIMEOUT",
+                              "Await interaction timed out: " + record.interactionId(),
+                              now))
+                          .orElseGet(() -> Uni.createFrom().voidItem()))
                       .replaceWithVoid();
                 }));
           }
@@ -1359,6 +1395,18 @@ class QueueAsyncCoordinator {
                               transitionKey,
                               List.copyOf(segmentOutputs == null ? List.of() : segmentOutputs),
                               nowEpochMs)
+                          .onItem().transformToUni(ignored -> segmentBoundaryLedger()
+                              .recordContinuationSegmentCreated(
+                                  parentRecord,
+                                  unit,
+                                  SegmentBoundaryLedger.itemContinuationSegmentId(
+                                      parentRecord.executionId(),
+                                      unit.unitId(),
+                                      interaction.itemIndex()),
+                                  interaction.stepIndex() + 1,
+                                  aggregateStepIndex,
+                                  normalizedInput,
+                                  nowEpochMs))
                           .onItem().transformToUni(ignored ->
                               releaseItemizedAwaitParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
                     });
@@ -1415,6 +1463,14 @@ class QueueAsyncCoordinator {
                 if (updated.isEmpty()) {
                   return Uni.createFrom().voidItem();
                 }
+                Uni<Void> recordedContinuation = segmentBoundaryLedger().recordContinuationSegmentCreated(
+                    updated.get(),
+                    unit,
+                    SegmentBoundaryLedger.segmentId(updated.get()),
+                    aggregateStepIndex,
+                    -1,
+                    resumePayload,
+                    nowEpochMs);
                 recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
                     AwaitReplayLifecycleEvent.RESUME_RELEASED,
                     parent.executionId(),
@@ -1430,9 +1486,11 @@ class QueueAsyncCoordinator {
                     unit.completedItemCount(),
                     unit.dispatchComplete()));
                 AwaitCompletionMetrics.recordResumeReleased(unit);
-                return workDispatcher.enqueueNow(new ExecutionWorkItem(
-                        updated.get().tenantId(),
-                        updated.get().executionId()))
+                ExecutionRecord<Object, Object> released = updated.get();
+                return recordedContinuation
+                    .chain(() -> workDispatcher.enqueueNow(new ExecutionWorkItem(
+                        released.tenantId(),
+                        released.executionId())))
                     .replaceWithVoid();
               });
         });
@@ -1528,9 +1586,19 @@ class QueueAsyncCoordinator {
                 null,
                 null,
                 null));
-            return workDispatcher.enqueueNow(new ExecutionWorkItem(
-                    updated.get().tenantId(),
-                    updated.get().executionId()))
+            Uni<Void> recordedContinuation = segmentBoundaryLedger().recordContinuationSegmentCreated(
+                updated.get(),
+                awaitUnitId,
+                SegmentBoundaryLedger.segmentId(updated.get()),
+                stepIndex + 1,
+                -1,
+                updated.get().inputPayload(),
+                nowEpochMs);
+            ExecutionRecord<Object, Object> released = updated.get();
+            return recordedContinuation
+                .chain(() -> workDispatcher.enqueueNow(new ExecutionWorkItem(
+                    released.tenantId(),
+                    released.executionId())))
                 .replaceWithVoid();
           }
           LOG.debugf(
@@ -1540,6 +1608,10 @@ class QueueAsyncCoordinator {
               stepIndex);
           return Uni.createFrom().voidItem();
         });
+  }
+
+  private SegmentBoundaryLedger segmentBoundaryLedger() {
+    return segmentBoundaryLedger == null ? new SegmentBoundaryLedger() : segmentBoundaryLedger;
   }
 
   private Uni<AwaitCompletionResult> validateAwaitCompletionTenant(

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
@@ -231,6 +231,39 @@ public class SegmentBoundaryLedger {
             nowEpochMs);
     }
 
+    public Uni<Void> recordContinuationSegmentCreated(
+        String tenantId,
+        String runId,
+        String sourceSegmentId,
+        String boundaryUnitId,
+        String segmentId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload,
+        long nowEpochMs
+    ) {
+        if (tenantId == null || tenantId.isBlank()
+            || runId == null || runId.isBlank()
+            || sourceSegmentId == null || sourceSegmentId.isBlank()
+            || boundaryUnitId == null || boundaryUnitId.isBlank()
+            || segmentId == null || segmentId.isBlank()) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            tenantId,
+            runId,
+            List.of(new ControlPlaneFact.ContinuationSegmentCreated(
+                tenantId,
+                runId,
+                sourceSegmentId,
+                segmentId,
+                boundaryUnitId,
+                startStepIndex,
+                stopBeforeStepIndex,
+                inputPayload)),
+            nowEpochMs);
+    }
+
     public Uni<Void> recordTerminalPublicationCompleted(
         ExecutionRecord<Object, Object> record,
         String transitionKey,
@@ -316,11 +349,14 @@ public class SegmentBoundaryLedger {
         }
         return appendWithRetry(journal.get(), tenantId, runId, List.copyOf(facts), nowEpochMs, 1)
             .replaceWithVoid()
-            .onFailure().invoke(failure -> LOG.warnf(
-                failure,
-                "Failed appending queue-async control-plane facts tenant=%s runId=%s",
-                tenantId,
-                runId));
+            .onFailure().recoverWithUni(failure -> {
+                LOG.warnf(
+                    failure,
+                    "Failed appending queue-async control-plane facts tenant=%s runId=%s",
+                    tenantId,
+                    runId);
+                return Uni.createFrom().voidItem();
+            });
     }
 
     private Uni<ControlPlaneAppendResult> appendWithRetry(

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
@@ -1,0 +1,393 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+/**
+ * Compatibility bridge from existing queue-async projection writes to immutable segment/boundary facts.
+ */
+@ApplicationScoped
+public class SegmentBoundaryLedger {
+
+    private static final Logger LOG = Logger.getLogger(SegmentBoundaryLedger.class);
+    private static final int MAX_APPEND_ATTEMPTS = 3;
+
+    @Inject
+    Instance<ControlPlaneJournal> journals;
+
+    private final ControlPlaneJournal explicitJournal;
+
+    public SegmentBoundaryLedger() {
+        this(null);
+    }
+
+    public SegmentBoundaryLedger(ControlPlaneJournal journal) {
+        this.explicitJournal = journal;
+    }
+
+    public Uni<Void> recordRunSubmitted(
+        CreateExecutionResult created,
+        ExecutionCreateCommand command,
+        long nowEpochMs
+    ) {
+        if (created == null || created.duplicate() || created.record() == null || command == null) {
+            return Uni.createFrom().voidItem();
+        }
+        ExecutionRecord<Object, Object> record = created.record();
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.RunSubmitted(
+                record.tenantId(),
+                record.executionId(),
+                record.executionKey(),
+                record.pipelineId(),
+                record.contractVersion(),
+                record.releaseVersion(),
+                record.resultShape(),
+                segmentId(record.executionId(), record.currentStepIndex()),
+                record.currentStepIndex(),
+                -1,
+                command.inputPayload(),
+                record.ttlEpochS())),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordSegmentAttemptStarted(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.SegmentAttemptStarted(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                attemptId(record, transitionKey),
+                record.attempt())),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordSegmentCompleted(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionResultEnvelope result,
+        long nowEpochMs
+    ) {
+        if (record == null || result == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.SegmentCompleted(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                attemptId(record, transitionKey),
+                result.coordinatorOutputItems(),
+                true)),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordSegmentSuspended(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionAwaitSuspension suspension,
+        long nowEpochMs
+    ) {
+        if (record == null || suspension == null) {
+            return Uni.createFrom().voidItem();
+        }
+        List<ControlPlaneFact> facts = new ArrayList<>();
+        AwaitUnitRecord unit = suspension.unit();
+        facts.add(new ControlPlaneFact.SegmentSuspended(
+            record.tenantId(),
+            record.executionId(),
+            segmentId(record),
+            attemptId(record, transitionKey),
+            suspension.unitId(),
+            BoundaryKind.AWAIT,
+            suspension.stepIndex(),
+            unit == null ? null : unit.expectedItemCount()));
+        for (AwaitInteractionRecord interaction : suspension.interactions()) {
+            facts.add(boundaryInteractionDispatched(record.executionId(), interaction));
+        }
+        if (unit != null && unit.dispatchComplete() && unit.expectedItemCount() != null) {
+            facts.add(new ControlPlaneFact.BoundaryDispatchCompleted(
+                unit.tenantId(),
+                unit.executionId(),
+                unit.unitId(),
+                unit.expectedItemCount()));
+        }
+        return append(record.tenantId(), record.executionId(), facts, nowEpochMs);
+    }
+
+    public Uni<Void> recordBoundaryCompletionAdmitted(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit,
+        long nowEpochMs
+    ) {
+        if (record == null || unit == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+                record.tenantId(),
+                record.executionId(),
+                unit.unitId(),
+                BoundaryKind.AWAIT,
+                record.interactionId(),
+                completionIdempotencyKey(record),
+                record.responsePayload()))),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordInteractionTimedOut(AwaitInteractionRecord record, long nowEpochMs) {
+        if (record == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.InteractionTimedOut(
+                record.tenantId(),
+                record.executionId(),
+                record.unitId(),
+                record.interactionId(),
+                "Await interaction timed out: " + record.interactionId())),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordContinuationSegmentCreated(
+        ExecutionRecord<Object, Object> parent,
+        AwaitUnitRecord unit,
+        String segmentId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload,
+        long nowEpochMs
+    ) {
+        if (parent == null || unit == null || segmentId == null || segmentId.isBlank()) {
+            return Uni.createFrom().voidItem();
+        }
+        return recordContinuationSegmentCreated(
+            parent,
+            unit.unitId(),
+            segmentId,
+            startStepIndex,
+            stopBeforeStepIndex,
+            inputPayload,
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordContinuationSegmentCreated(
+        ExecutionRecord<Object, Object> parent,
+        String boundaryUnitId,
+        String segmentId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload,
+        long nowEpochMs
+    ) {
+        if (parent == null || boundaryUnitId == null || boundaryUnitId.isBlank()
+            || segmentId == null || segmentId.isBlank()) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            parent.tenantId(),
+            parent.executionId(),
+            List.of(new ControlPlaneFact.ContinuationSegmentCreated(
+                parent.tenantId(),
+                parent.executionId(),
+                segmentId(parent),
+                segmentId,
+                boundaryUnitId,
+                startStepIndex,
+                stopBeforeStepIndex,
+                inputPayload)),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordTerminalPublicationCompleted(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().voidItem();
+        }
+        String idempotencyKey = attemptId(record, transitionKey) + ":terminal-publication";
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.TerminalPublicationCompleted(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                record.executionId() + ":terminal-output",
+                idempotencyKey)),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordRunSucceeded(
+        ExecutionRecord<Object, Object> record,
+        Object resultPayload,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.RunSucceeded(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                resultPayload)),
+            nowEpochMs);
+    }
+
+    public Uni<Void> recordRunFailed(
+        ExecutionRecord<Object, Object> record,
+        String errorCode,
+        String errorMessage,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return append(
+            record.tenantId(),
+            record.executionId(),
+            List.of(new ControlPlaneFact.RunFailed(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                errorCode == null || errorCode.isBlank() ? "EXECUTION_FAILED" : errorCode,
+                errorMessage == null ? "" : errorMessage)),
+            nowEpochMs);
+    }
+
+    public static String segmentId(ExecutionRecord<Object, Object> record) {
+        return segmentId(record.executionId(), record.currentStepIndex());
+    }
+
+    public static String segmentId(String executionId, int stepIndex) {
+        return executionId + ":segment:" + stepIndex;
+    }
+
+    public static String itemContinuationSegmentId(String executionId, String unitId, int itemIndex) {
+        return executionId + ":segment:await-item:" + unitId + ":" + itemIndex;
+    }
+
+    private Uni<Void> append(
+        String tenantId,
+        String runId,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs
+    ) {
+        Optional<ControlPlaneJournal> journal = journal();
+        if (journal.isEmpty() || facts == null || facts.isEmpty()) {
+            return Uni.createFrom().voidItem();
+        }
+        return appendWithRetry(journal.get(), tenantId, runId, List.copyOf(facts), nowEpochMs, 1)
+            .replaceWithVoid()
+            .onFailure().invoke(failure -> LOG.warnf(
+                failure,
+                "Failed appending queue-async control-plane facts tenant=%s runId=%s",
+                tenantId,
+                runId));
+    }
+
+    private Uni<ControlPlaneAppendResult> appendWithRetry(
+        ControlPlaneJournal journal,
+        String tenantId,
+        String runId,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs,
+        int attempt
+    ) {
+        return journal.projection(tenantId, runId)
+            .onItem().transformToUni(projection -> {
+                List<ControlPlaneFact> missingFacts = facts.stream()
+                    .filter(fact -> !projection.factKeys().contains(fact.factKey()))
+                    .toList();
+                if (missingFacts.isEmpty()) {
+                    return Uni.createFrom().item(new ControlPlaneAppendResult(projection, List.of()));
+                }
+                return journal.append(tenantId, runId, projection.version(), missingFacts, nowEpochMs);
+            })
+            .onFailure(ControlPlaneAppendConflictException.class).recoverWithUni(failure -> {
+                if (attempt >= MAX_APPEND_ATTEMPTS) {
+                    return Uni.createFrom().failure(failure);
+                }
+                return appendWithRetry(journal, tenantId, runId, facts, nowEpochMs, attempt + 1);
+            });
+    }
+
+    private Optional<ControlPlaneJournal> journal() {
+        if (explicitJournal != null) {
+            return Optional.of(explicitJournal);
+        }
+        if (journals == null || journals.isUnsatisfied()) {
+            return Optional.empty();
+        }
+        return Optional.of(journals.get());
+    }
+
+    private static ControlPlaneFact.BoundaryInteractionDispatched boundaryInteractionDispatched(
+        String runId,
+        AwaitInteractionRecord interaction
+    ) {
+        return new ControlPlaneFact.BoundaryInteractionDispatched(
+            interaction.tenantId(),
+            runId,
+            interaction.unitId(),
+            BoundaryKind.AWAIT,
+            interaction.interactionId(),
+            interaction.correlationId(),
+            interaction.idempotencyKey(),
+            interaction.itemIndex(),
+            interaction.requestPayload(),
+            interaction.transportType(),
+            interaction.deadlineEpochMs());
+    }
+
+    private static String completionIdempotencyKey(AwaitInteractionRecord record) {
+        if (record.itemIndex() != null) {
+            return "item:" + record.itemIndex();
+        }
+        return record.idempotencyKey();
+    }
+
+    private static String attemptId(ExecutionRecord<Object, Object> record, String transitionKey) {
+        if (transitionKey != null && !transitionKey.isBlank()) {
+            return transitionKey;
+        }
+        return record.executionId() + ":" + record.currentStepIndex() + ":" + record.attempt();
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -51,6 +52,11 @@ import org.pipelineframework.orchestrator.TransitionResultEnvelope;
 import org.pipelineframework.orchestrator.TransitionWorkerOutcome;
 import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
+import org.pipelineframework.orchestrator.controlplane.BoundaryUnitStatus;
+import org.pipelineframework.orchestrator.controlplane.ControlPlaneProjection;
+import org.pipelineframework.orchestrator.controlplane.InMemoryControlPlaneJournal;
+import org.pipelineframework.orchestrator.controlplane.PipelineRunStatus;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
 import org.pipelineframework.awaitable.AwaitCompletionResult;
@@ -356,6 +362,23 @@ class QueueAsyncCoordinatorTest {
     }
 
     @Test
+    void executePipelineAsyncAppendsRunSubmittedForNewExecution() {
+        configureQueueModeDefaults();
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
+        ExecutionRecord<Object, Object> record = createRecord("tenant-1", "exec-ledger", "key-ledger");
+        when(executionStateStore.createOrGetExecution(any()))
+            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record, false)));
+        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+        coordinator.executePipelineAsync("input", "tenant-1", null, false).await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant-1", "exec-ledger").await().indefinitely();
+        assertEquals(PipelineRunStatus.ACCEPTED, projection.status());
+        assertTrue(projection.factKeys().contains("run-submitted:tenant-1:exec-ledger"));
+    }
+
+    @Test
     void executePipelineAsyncRejectsDeniedTenantBeforeStoreAccess() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         PipelineOrchestratorConfig.TenancyConfig tenancy = mock(PipelineOrchestratorConfig.TenancyConfig.class);
@@ -460,6 +483,8 @@ class QueueAsyncCoordinatorTest {
     void processExecutionWorkItemMarksWaitingExternalWhenAwaitSuspends() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         ExecutionRecord<Object, Object> claimed = createRecord("tenant-1", "exec-await", "key-await");
         when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
@@ -499,6 +524,9 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.anyInt(),
             org.mockito.ArgumentMatchers.anyLong());
         verify(workDispatcher, never()).enqueueNow(any());
+        ControlPlaneProjection projection = journal.projection("tenant-1", "exec-await").await().indefinitely();
+        assertTrue(projection.factKeys().contains("segment-suspended:exec-await:0:0:unit-1"));
+        assertEquals(BoundaryUnitStatus.OPEN, projection.boundaries().get("unit-1").status());
     }
 
     @Test
@@ -680,6 +708,8 @@ class QueueAsyncCoordinatorTest {
     void processExecutionWorkItemPersistsCollectedStreamingOutputs() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         ExecutionRecord<Object, Object> claimed = createRecord(
             "tenant-1",
             "exec-stream",
@@ -731,6 +761,10 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.eq("exec-stream:0:0"),
             org.mockito.ArgumentMatchers.eq(List.of("out-1", "out-2")),
             org.mockito.ArgumentMatchers.anyLong());
+        ControlPlaneProjection projection = journal.projection("tenant-1", "exec-stream").await().indefinitely();
+        assertTrue(projection.factKeys().contains("segment-attempt-started:exec-stream:0:0"));
+        assertTrue(projection.factKeys().contains("segment-completed:exec-stream:0:0"));
+        assertTrue(projection.factKeys().contains("run-succeeded:exec-stream"));
     }
 
     @Test
@@ -877,6 +911,8 @@ class QueueAsyncCoordinatorTest {
     void processExecutionWorkItemPublishesDecodedRemoteOutputWhenObjectPublishConfigured() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         ExecutionRecord<Object, Object> claimed = createRecord("tenant-1", "exec-publish", "key-publish");
         SerializedTransitionPayload serialized = payloadCodec.encode("published-output");
         ObjectPublishCompletionService publishService = mock(ObjectPublishCompletionService.class);
@@ -921,6 +957,9 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.anyLong());
         List<?> persisted = assertInstanceOf(List.class, resultCaptor.getValue());
         assertEquals(serialized, persisted.getFirst());
+        ControlPlaneProjection projection = journal.projection("tenant-1", "exec-publish").await().indefinitely();
+        assertTrue(projection.terminalPublicationKeys()
+            .contains("terminal-publication-completed:exec-publish:terminal-output:exec-publish:0:0:terminal-publication"));
     }
 
     @Test
@@ -1148,7 +1187,27 @@ class QueueAsyncCoordinatorTest {
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, false)));
         when(awaitCoordinator.recordCompletion(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(completedUnit));
-        ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        ExecutionRecord<Object, Object> resumed = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.QUEUED,
+            8L,
+            3,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            null,
+            null,
+            null,
+            null,
+            1L,
+            2L,
+            99999999L);
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-1"),
@@ -1210,7 +1269,27 @@ class QueueAsyncCoordinatorTest {
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, false)));
         when(awaitCoordinator.recordCompletion(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, null, 0, true, "interaction-1")));
-        ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        ExecutionRecord<Object, Object> resumed = new ExecutionRecord<>(
+            "tenant-1",
+            "exec-1",
+            "key-1",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.QUEUED,
+            8L,
+            3,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            null,
+            null,
+            null,
+            null,
+            1L,
+            2L,
+            99999999L);
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-1"),
@@ -1246,7 +1325,7 @@ class QueueAsyncCoordinatorTest {
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(interaction, true)));
         when(awaitCoordinator.recordCompletion(org.mockito.ArgumentMatchers.eq(interaction), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, null, 0, true, "interaction-1")));
-        ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        ExecutionRecord<Object, Object> resumed = createRecordAtStep("tenant-1", "exec-1", "key-1", 3);
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-1"),
@@ -1636,6 +1715,8 @@ class QueueAsyncCoordinatorTest {
     @Test
     void completeAwaitResumesCompletedItemUnitAndEnqueuesExecution() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         AwaitInteractionRecord second = awaitRecord();
         AwaitCompletionCommand command = new AwaitCompletionCommand(
             "tenant-1",
@@ -1649,7 +1730,13 @@ class QueueAsyncCoordinatorTest {
             .thenReturn(Uni.createFrom().item(new AwaitCompletionResult(second, false)));
         when(awaitCoordinator.recordCompletion(org.mockito.ArgumentMatchers.eq(second), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(awaitUnit("unit-1", AwaitUnitStatus.COMPLETED, null, 0, false, "interaction-1")));
-        ExecutionRecord<Object, Object> resumed = createRecord("tenant-1", "exec-1", "key-1");
+        when(awaitLiveCompletionRegistry.signal(org.mockito.ArgumentMatchers.eq(second), any()))
+            .thenAnswer(invocation -> {
+                ControlPlaneProjection projection = journal.projection("tenant-1", "exec-1").await().indefinitely();
+                assertTrue(projection.factKeys().contains("boundary-completion-admitted:unit-1:idem-1"));
+                return Uni.createFrom().item(false);
+            });
+        ExecutionRecord<Object, Object> resumed = createRecordAtStep("tenant-1", "exec-1", "key-1", 3);
         when(executionStateStore.markAwaitCompleted(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-1"),
@@ -1668,12 +1755,16 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.eq(3),
             org.mockito.ArgumentMatchers.anyLong());
         verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+        ControlPlaneProjection projection = journal.projection("tenant-1", "exec-1").await().indefinitely();
+        assertTrue(projection.factKeys().contains("continuation-segment-created:exec-1:segment:3"));
     }
 
     @Test
     void recordAwaitItemContinuationStoresChildrenAndReleasesParentAtAggregateBoundaryInOrder() {
         InMemoryExecutionStateStore store = new InMemoryExecutionStateStore();
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
         coordinator.executionStateStore = store;
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
         long now = System.currentTimeMillis();
         CreateExecutionResult parent = store.createOrGetExecution(new org.pipelineframework.orchestrator.ExecutionCreateCommand(
@@ -1734,12 +1825,21 @@ class QueueAsyncCoordinatorTest {
         assertEquals(ExecutionInputShape.UNI, firstChildInput.shape());
         assertEquals("first-normalized", firstChildInput.payload());
         verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", parent.record().executionId()));
+        ControlPlaneProjection projection = journal.projection("tenant-1", parent.record().executionId()).await().indefinitely();
+        assertTrue(projection.factKeys().contains("continuation-segment-created:"
+            + parent.record().executionId() + ":segment:await-item:unit-1:0"));
+        assertTrue(projection.factKeys().contains("continuation-segment-created:"
+            + parent.record().executionId() + ":segment:await-item:unit-1:1"));
+        assertTrue(projection.factKeys().contains("continuation-segment-created:"
+            + parent.record().executionId() + ":segment:4"));
     }
 
     @Test
     void sweepTimesOutAwaitInteractionsAndFailsOwningExecution() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
         when(orchestratorConfig.sweepLimit()).thenReturn(100);
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         AwaitInteractionRecord interaction = awaitRecord();
         ExecutionRecord<Object, Object> waiting = new ExecutionRecord<>(
             "tenant-1",
@@ -1792,6 +1892,34 @@ class QueueAsyncCoordinatorTest {
             org.mockito.ArgumentMatchers.eq("AWAIT_TIMEOUT"),
             org.mockito.ArgumentMatchers.contains("interaction-1"),
             org.mockito.ArgumentMatchers.anyLong());
+        assertEventually(() -> {
+            ControlPlaneProjection projection = journal.projection("tenant-1", "exec-1").await().indefinitely();
+            assertTrue(projection.factKeys().contains("interaction-timed-out:unit-1:interaction-1"));
+            assertTrue(projection.factKeys().contains("run-failed:exec-1:AWAIT_TIMEOUT"));
+        });
+    }
+
+    private static void assertEventually(Runnable assertion) {
+        AssertionError last = null;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+        while (System.nanoTime() < deadline) {
+            try {
+                assertion.run();
+                return;
+            } catch (AssertionError error) {
+                last = error;
+                try {
+                    Thread.sleep(10L);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw error;
+                }
+            }
+        }
+        if (last != null) {
+            throw last;
+        }
+        assertion.run();
     }
 
     private void configureQueueModeDefaults() {
@@ -1803,6 +1931,38 @@ class QueueAsyncCoordinatorTest {
 
     private ExecutionRecord<Object, Object> createRecord(String tenantId, String executionId, String executionKey) {
         return createRecord(tenantId, executionId, executionKey, ExecutionResultShape.SINGLE);
+    }
+
+    private ExecutionRecord<Object, Object> createRecordAtStep(
+        String tenantId,
+        String executionId,
+        String executionKey,
+        int currentStepIndex) {
+        ExecutionRecord<Object, Object> source = createRecord(tenantId, executionId, executionKey);
+        return new ExecutionRecord<>(
+            source.tenantId(),
+            source.executionId(),
+            source.executionKey(),
+            source.pipelineId(),
+            source.contractVersion(),
+            source.releaseVersion(),
+            source.resultShape(),
+            source.status(),
+            source.version(),
+            currentStepIndex,
+            source.attempt(),
+            source.leaseOwner(),
+            source.leaseExpiresEpochMs(),
+            source.nextDueEpochMs(),
+            source.lastTransitionKey(),
+            source.inputPayload(),
+            source.awaitUnitId(),
+            source.resultPayload(),
+            source.errorCode(),
+            source.errorMessage(),
+            source.createdAtEpochMs(),
+            source.updatedAtEpochMs(),
+            source.ttlEpochS());
     }
 
     private ExecutionRecord<Object, Object> recordWithStatus(

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncFailureMatrixTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncFailureMatrixTest.java
@@ -22,6 +22,9 @@ import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.TransitionFailureEnvelope;
 import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.ControlPlaneProjection;
+import org.pipelineframework.orchestrator.controlplane.InMemoryControlPlaneJournal;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.step.NonRetryableException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -95,6 +98,8 @@ class QueueAsyncFailureMatrixTest {
     @Test
     void terminalPathClassifiesNonRetryableFailure() {
         when(orchestratorConfig.maxRetries()).thenReturn(0);
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        failureHandler.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
         ExecutionRecord<Object, Object> record = record("tenant-a", "exec-9", 3L, 0);
         when(executionStateStore.markTerminalFailure(
             anyString(), anyString(), anyLong(), any(), anyString(), anyString(), anyString(), anyLong()))
@@ -115,6 +120,8 @@ class QueueAsyncFailureMatrixTest {
         assertEquals("non_retryable", envelope.terminalReason());
         assertFalse(envelope.retryable());
         assertEquals("NonRetryableException", envelope.errorCode());
+        ControlPlaneProjection projection = journal.projection("tenant-a", "exec-9").await().indefinitely();
+        assertTrue(projection.factKeys().contains("run-failed:exec-9:NonRetryableException"));
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedgerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedgerTest.java
@@ -1,0 +1,151 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+class SegmentBoundaryLedgerTest {
+
+    @Test
+    void recordRunSubmittedIsIdempotentByFactKey() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(journal);
+        ExecutionRecord<Object, Object> record = record("run-1");
+        ExecutionCreateCommand command = command(record);
+
+        ledger.recordRunSubmitted(new CreateExecutionResult(record, false), command, 10L).await().indefinitely();
+        ledger.recordRunSubmitted(new CreateExecutionResult(record, false), command, 11L).await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant", "run-1").await().indefinitely();
+        assertEquals(1L, projection.version());
+        assertEquals(PipelineRunStatus.ACCEPTED, projection.status());
+        assertTrue(projection.factKeys().contains("run-submitted:tenant:run-1"));
+    }
+
+    @Test
+    void appendRetriesWhenProjectionVersionChangesBeforeAppend() {
+        InMemoryControlPlaneJournal delegate = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(new ConflictOnceJournal(delegate));
+        ExecutionRecord<Object, Object> record = record("run-2");
+
+        ledger.recordSegmentAttemptStarted(record, "run-2:0:0", 20L).await().indefinitely();
+
+        ControlPlaneProjection projection = delegate.projection("tenant", "run-2").await().indefinitely();
+        assertEquals(1L, projection.version());
+        assertTrue(projection.factKeys().contains("segment-attempt-started:run-2:0:0"));
+    }
+
+    @Test
+    void duplicateSegmentAttemptAppendIsNoOp() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(journal);
+        ExecutionRecord<Object, Object> record = record("run-3");
+
+        ledger.recordSegmentAttemptStarted(record, "run-3:0:0", 30L).await().indefinitely();
+        ledger.recordSegmentAttemptStarted(record, "run-3:0:0", 31L).await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant", "run-3").await().indefinitely();
+        assertEquals(1L, projection.version());
+        assertEquals(1, projection.attempts().size());
+    }
+
+    @Test
+    void segmentFactCanBeRecordedBeforeRunProjectionExists() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(journal);
+
+        ledger.recordSegmentAttemptStarted(record("run-4"), "run-4:0:0", 40L).await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant", "run-4").await().indefinitely();
+        assertFalse(projection.run().isPresent());
+        assertTrue(projection.attempts().containsKey("run-4:0:0"));
+    }
+
+    private static ExecutionCreateCommand command(ExecutionRecord<Object, Object> record) {
+        return new ExecutionCreateCommand(
+            record.tenantId(),
+            record.executionKey(),
+            record.pipelineId(),
+            record.contractVersion(),
+            record.releaseVersion(),
+            "input",
+            record.resultShape(),
+            10L,
+            record.ttlEpochS());
+    }
+
+    private static ExecutionRecord<Object, Object> record(String executionId) {
+        return new ExecutionRecord<>(
+            "tenant",
+            executionId,
+            "key-" + executionId,
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.QUEUED,
+            0L,
+            0,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            null,
+            null,
+            null,
+            null,
+            1L,
+            1L,
+            999999L);
+    }
+
+    private static final class ConflictOnceJournal implements ControlPlaneJournal {
+        private final InMemoryControlPlaneJournal delegate;
+        private final AtomicBoolean conflict = new AtomicBoolean(true);
+
+        private ConflictOnceJournal(InMemoryControlPlaneJournal delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Uni<ControlPlaneAppendResult> append(
+            String tenantId,
+            String runId,
+            long expectedVersion,
+            List<ControlPlaneFact> facts,
+            long nowEpochMs
+        ) {
+            if (conflict.getAndSet(false)) {
+                return Uni.createFrom().failure(new ControlPlaneAppendConflictException("synthetic conflict"));
+            }
+            return delegate.append(tenantId, runId, expectedVersion, facts, nowEpochMs);
+        }
+
+        @Override
+        public Uni<ControlPlaneProjection> projection(String tenantId, String runId) {
+            return delegate.projection(tenantId, runId);
+        }
+
+        @Override
+        public Uni<List<DueSegment>> findDueSegments(long nowEpochMs, int limit) {
+            return delegate.findDueSegments(nowEpochMs, limit);
+        }
+
+        @Override
+        public Uni<List<DueBoundaryInteraction>> findTimedOutInteractions(long nowEpochMs, int limit) {
+            return delegate.findTimedOutInteractions(nowEpochMs, limit);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- move the immutable queue-async boundary documentation into the await-unit runtime cluster and leave the old route as a redirect/noindex stub
- add `SegmentBoundaryLedger` as an internal bridge from existing queue-async projection wins into immutable control-plane facts
- record ledger facts for submission, claim, success/failure, await suspension/completion, continuations, timeouts, and terminal publication without replacing existing stores

## Notes

This is intentionally stacked on #442. The ledger is not authoritative in this slice; it is a compatibility bridge over the existing `ExecutionStateStore`, `AwaitUnitStore`, and `AwaitInteractionStore` paths. Public YAML, connector SPI, telemetry schema, replay JSON, and homepage assets are unchanged.

## Validation

- `./mvnw -q -f framework/pom.xml -pl runtime -DskipExtensionValidation=true -Dtest=SegmentBoundaryLedgerTest,QueueAsyncCoordinatorTest,QueueAsyncFailureMatrixTest,InMemoryControlPlaneJournalTest,ControlPlaneReducerTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="$PWD/.m2/repository"`
- `./mvnw -q -f framework/pom.xml -pl runtime -DskipExtensionValidation=true test -Dmaven.repo.local="$PWD/.m2/repository"`
- `./mvnw -q -f framework/pom.xml test -DskipExtensionValidation=true -Dmaven.repo.local="$PWD/.m2/repository"`
- `npm --prefix docs test`
- `npm --prefix docs run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added control-plane “segment & boundary” tracking across the queue-asynchronous orchestration lifecycle (submissions, segment attempts, completions/suspensions, continuations, terminal publications, successes/failures).
* **Bug Fixes**
  * Improved reliability of lifecycle accounting on terminal failures and resume/sweep flows, with idempotent handling to avoid duplicate fact recording.
* **Documentation**
  * Reorganized documentation to the new canonical directory structure and updated evolve navigation.
  * Added the new “Immutable Segment And Boundary Model” page and redirected the legacy immutable-boundaries guide to it.
* **Tests**
  * Extended coordinator and ledger tests to validate emitted tracking facts and conflict/idempotency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->