### PR TITLE
Support unary delegated Spring bean steps

### DIFF
--- a/docs/develop/spring-support.md
+++ b/docs/develop/spring-support.md
@@ -13,6 +13,7 @@ Current Spring work proves a narrow generated application path:
 - generated Spring `@Component` local step beans,
 - Spring WebFlux `@RestController` resources for the supported smoke path,
 - `Mono<Out>` authored service methods for YAML-declared Spring-profile unary services,
+- unary delegated Spring bean steps for local pipeline execution,
 - shared runner-core sequencing through the neutral runtime seam.
 
 ## Not Yet Supported
@@ -23,7 +24,7 @@ Spring does not yet have parity for:
 - function handlers,
 - await, checkpoint, durable coordinator, or broker paths,
 - persistence providers,
-- delegated/operator steps,
+- arbitrary `Class::method` operator invokers and non-local delegated/operator paths,
 - side effects and plugins,
 - REST client-step remote boundaries,
 - streaming or non-unary shapes,
@@ -37,10 +38,11 @@ Use Quarkus for production TPF applications today.
 
 Use the Spring path only when you are validating the emerging renderer/runtime seam or contributing to portability work. Keep business contracts neutral: typed inputs, typed outputs, mappers, and YAML declarations should not rely on Quarkus-only application code unless the application is explicitly Quarkus-targeted.
 
+Delegated Spring beans are supported only for unary local steps declared from YAML with a Spring bean class and a supported service shape such as `process(In): Mono<Out>` or `processBlocking(In): Out`. They do not imply gRPC, function, await/checkpoint, broker, durable coordinator, or production parity with the Quarkus runtime.
+
 ## Deeper Architecture
 
 - [Runtime Core Decoupling](/evolve/runtime-core-decoupling)
 - [Framework Portability Assessment](/evolve/framework-portability-assessment/)
 - [Runtime Split](/evolve/framework-portability-assessment/runtime-split)
 - [Code Generation Portability](/evolve/framework-portability-assessment/code-generation)
-

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -705,7 +705,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             PipelineCompilationContext ctx,
             org.pipelineframework.processor.ir.StepDefinition stepDef) {
 
-        // Validate that the delegate service exists and implements a reactive service interface
+        // Validate that the delegate service exists and exposes a supported step contract.
         TypeElement delegateElement = ctx.getProcessingEnv().getElementUtils()
             .getTypeElement(stepDef.executionClass().canonicalName());
 
@@ -718,23 +718,22 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         }
 
         var typeUtils = ctx.getProcessingEnv().getTypeUtils();
-        ReactiveSignature reactiveSignature = resolveReactiveSignature(
+        Optional<SupportedServiceSignature> delegateSignature = resolveSupportedDelegatedSignature(
+            ctx,
             delegateElement,
             typeUtils,
             ctx.getProcessingEnv().getMessager());
-        if (reactiveSignature == null) {
+        if (delegateSignature.isEmpty()) {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Delegate service '" + stepDef.executionClass().canonicalName() +
-                "' must implement one of: ReactiveService, ReactiveStreamingService, "
-                    + "ReactiveStreamingClientService, "
-                    + "ReactiveBidirectionalStreamingService for step '" +
-                stepDef.name() + "'");
+                    "' must expose a supported step contract for step '" + stepDef.name() + "'");
             return null;
         }
+        SupportedServiceSignature resolvedDelegateSignature = delegateSignature.get();
 
-        TypeName inputType = stepDef.inputType() != null ? stepDef.inputType() : reactiveSignature.inputType();
-        TypeName outputType = stepDef.outputType() != null ? stepDef.outputType() : reactiveSignature.outputType();
+        TypeName inputType = stepDef.inputType() != null ? stepDef.inputType() : resolvedDelegateSignature.inputType();
+        TypeName outputType = stepDef.outputType() != null ? stepDef.outputType() : resolvedDelegateSignature.outputType();
         if (inputType == null || outputType == null) {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
@@ -745,8 +744,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
 
         boolean fallbackGloballyEnabled = isMapperFallbackGloballyEnabled(ctx);
         boolean fallbackRequested = stepDef.mapperFallback() == MapperFallbackMode.JACKSON;
-        boolean typesDiffer = !inputType.equals(reactiveSignature.inputType())
-            || !outputType.equals(reactiveSignature.outputType());
+        boolean typesDiffer = !inputType.equals(resolvedDelegateSignature.inputType())
+            || !outputType.equals(resolvedDelegateSignature.outputType());
         boolean allowFallbackNoMapper = stepDef.externalMapper() == null
             && fallbackRequested
             && fallbackGloballyEnabled
@@ -757,8 +756,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             stepDef,
             inputType,
             outputType,
-            reactiveSignature.inputType(),
-            reactiveSignature.outputType(),
+            resolvedDelegateSignature.inputType(),
+            resolvedDelegateSignature.outputType(),
             allowFallbackNoMapper);
         MapperFallbackMode effectiveFallback = MapperFallbackMode.NONE;
 
@@ -787,7 +786,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                     + "': no operator mapper provided and YAML types ["
                     + inputType + " -> " + outputType
                     + "] do not match delegate types ["
-                    + reactiveSignature.inputType() + " -> " + reactiveSignature.outputType() + "]."
+                    + resolvedDelegateSignature.inputType() + " -> " + resolvedDelegateSignature.outputType() + "]."
                     + fallbackMessage);
             return null;
         }
@@ -802,8 +801,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         }
 
         // Create type mappings based on the input/output types specified in the YAML
-        TypeMapping inputMapping = new TypeMapping(inputType, null, false, reactiveSignature.inputType());
-        TypeMapping outputMapping = new TypeMapping(outputType, null, false, reactiveSignature.outputType());
+        TypeMapping inputMapping = new TypeMapping(inputType, null, false, resolvedDelegateSignature.inputType());
+        TypeMapping outputMapping = new TypeMapping(outputType, null, false, resolvedDelegateSignature.outputType());
 
         // Derive package from execution class or use default
         String servicePackage = stepDef.executionClass().packageName().isEmpty()
@@ -819,7 +818,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .serviceClassName(stepDef.executionClass())
             .inputMapping(inputMapping)
             .outputMapping(outputMapping)
-            .streamingShape(reactiveSignature.shape())
+            .streamingShape(resolvedDelegateSignature.shape())
             .enabledTargets(targets)
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
@@ -830,6 +829,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .delegateService(stepDef.executionClass())
             .externalMapper(externalMapper)
             .mapperFallbackMode(effectiveFallback)
+            .serviceApiKind(resolvedDelegateSignature.apiKind())
+            .reactiveReturnKind(resolvedDelegateSignature.reactiveReturnKind())
             .build();
     }
 
@@ -1150,6 +1151,27 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return null;
         }
         return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    private Optional<SupportedServiceSignature> resolveSupportedDelegatedSignature(
+            PipelineCompilationContext ctx,
+            TypeElement delegateElement,
+            Types typeUtils,
+            javax.annotation.processing.Messager messager) {
+        if (isSpringRendererProfile(ctx)) {
+            return Optional.ofNullable(resolveSupportedInternalSignature(ctx, delegateElement, typeUtils, messager));
+        }
+        ReactiveSignature reactiveSignature = resolveReactiveSignature(delegateElement, typeUtils, messager);
+        if (reactiveSignature == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new SupportedServiceSignature(
+            ServiceApiKind.REACTIVE,
+            reactiveSignature.shape(),
+            reactiveSignature.inputType(),
+            reactiveSignature.outputType(),
+            ReactiveReturnKind.MUTINY_UNI,
+            null));
     }
 
     private SupportedServiceSignature resolveSupportedInternalSignature(

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -162,7 +162,8 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
         Set<String> enabledAspects = computeEnabledAspects(ctx);
 
         // Generate artifacts for each step model
-        for (PipelineStepModel model : ctx.getStepModels()) {
+        for (int stepIndex = 0; stepIndex < ctx.getStepModels().size(); stepIndex++) {
+            PipelineStepModel model = ctx.getStepModels().get(stepIndex);
             // Check if this is a delegation step
             Object externalAdapterBindingObj = bindingsMap.get(model.serviceName() + "_external_adapter");
             ExternalAdapterBinding externalAdapterBinding = null;
@@ -240,6 +241,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             generateArtifacts(
                 ctx,
                 model,
+                stepIndex,
                 grpcBinding,
                 restBinding,
                 localBinding,
@@ -696,6 +698,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
     private void generateArtifacts(
             PipelineCompilationContext ctx,
             PipelineStepModel model,
+            int stepIndex,
             GrpcBinding grpcBinding,
             RestBinding restBinding,
             LocalBinding localBinding,
@@ -718,6 +721,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
         stepArtifactGenerationService.generateArtifactsForModel(
             ctx,
             model,
+            stepIndex,
             grpcBinding,
             restBinding,
             localBinding,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
@@ -20,6 +20,7 @@ import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.PipelineCompilationPhase;
 import org.pipelineframework.processor.ir.PipelineAspectModel;
 import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
 
 /**
@@ -449,6 +450,9 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
         // Validate the step models created from YAML
         for (PipelineStepModel model : ctx.getStepModels()) {
             if (model.delegateService() != null) {
+                if (isSpringLocalDelegate(ctx, model)) {
+                    continue;
+                }
                 // Validate that the delegate service exists
                 var delegateElement = elementUtils.getTypeElement(model.delegateService().canonicalName());
                 if (delegateElement == null) {
@@ -536,6 +540,14 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
                 }
             }
         }
+    }
+
+    private boolean isSpringLocalDelegate(PipelineCompilationContext ctx, PipelineStepModel model) {
+        return SpringRendererProfileSupport.isSpringProfile(ctx)
+            && model.remoteExecution() == null
+            && !model.sideEffect()
+            && model.streamingShape() == StreamingShape.UNARY_UNARY
+            && (model.serviceApiKind() == ServiceApiKind.REACTIVE || model.serviceApiKind() == ServiceApiKind.BLOCKING);
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
@@ -80,6 +80,10 @@ final class SpringRendererProfileSupport {
             errors.add("Spring renderer profile currently supports only " + supportedTargets + " generation; step '"
                 + model.serviceName() + "' resolved targets " + model.enabledTargets() + ".");
         }
+        if (model.delegateService() != null && !model.enabledTargets().equals(Set.of(GenerationTarget.LOCAL_CLIENT_STEP))) {
+            errors.add("Spring renderer profile supports delegated Spring beans only as unary local client steps; step '"
+                + model.serviceName() + "' resolved targets " + model.enabledTargets() + ".");
+        }
         if (model.streamingShape() != StreamingShape.UNARY_UNARY) {
             errors.add("Spring renderer profile currently supports only unary-unary steps; step '"
                 + model.serviceName() + "' has shape " + model.streamingShape() + ".");
@@ -93,8 +97,8 @@ final class SpringRendererProfileSupport {
             errors.add("Spring renderer profile does not yet support side-effect steps; step '"
                 + model.serviceName() + "'.");
         }
-        if (model.delegateService() != null || model.remoteExecution() != null) {
-            errors.add("Spring renderer profile currently supports only internal local steps; step '"
+        if (model.remoteExecution() != null) {
+            errors.add("Spring renderer profile does not support remote execution; step '"
                 + model.serviceName() + "'.");
         }
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -79,6 +79,7 @@ class StepArtifactGenerationService {
     void generateArtifactsForModel(
             PipelineCompilationContext ctx,
             PipelineStepModel model,
+            Integer stepIndex,
             GrpcBinding grpcBinding,
             RestBinding restBinding,
             LocalBinding localBinding,
@@ -275,7 +276,10 @@ class StepArtifactGenerationService {
                         localClientRole,
                         enabledAspects,
                         cacheKeyGenerator,
-                        descriptorSet));
+                        descriptorSet,
+                        ctx.getTransportMode(),
+                        ctx.getPipelineTemplateConfig() instanceof PipelineTemplateConfig config ? config.basePackage() : null,
+                        stepIndex));
                     roleMetadataGenerator.recordClassWithRole(localClientClassName, localClientRole.name());
                 }
                 case REST_RESOURCE -> {
@@ -409,6 +413,7 @@ class StepArtifactGenerationService {
         generateArtifactsForModel(
             ctx,
             model,
+            null,
             grpcBinding,
             restBinding,
             localBinding,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepBindingConstructionService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepBindingConstructionService.java
@@ -39,7 +39,7 @@ class StepBindingConstructionService {
         for (PipelineStepModel model : ctx.getStepModels()) {
             String modelKey = model.serviceName();
 
-            if (model.delegateService() != null) {
+            if (model.delegateService() != null && !isSpringLocalDelegatedStep(ctx, model)) {
                 warnIfDelegatedStepHasServerTargets(ctx, model);
                 ExternalAdapterBinding externalAdapterBinding = new ExternalAdapterBinding(
                     model,
@@ -75,6 +75,13 @@ class StepBindingConstructionService {
             }
         }
         return bindingsMap;
+    }
+
+    private boolean isSpringLocalDelegatedStep(PipelineCompilationContext ctx, PipelineStepModel model) {
+        return ctx != null
+            && "spring".equalsIgnoreCase(ctx.getRendererProfile())
+            && model.delegateService() != null
+            && model.enabledTargets().equals(Set.of(GenerationTarget.LOCAL_CLIENT_STEP));
     }
 
     private void warnIfDelegatedStepHasServerTargets(PipelineCompilationContext ctx, PipelineStepModel model) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/GenerationContext.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/GenerationContext.java
@@ -20,17 +20,35 @@ import org.pipelineframework.processor.ir.PipelineTransport;
  * @param descriptorSet Gets the optional protobuf descriptor set for gRPC type resolution.
  * @param transportMode Gets the resolved pipeline transport mode when available.
  * @param pipelineBasePackage Gets the resolved pipeline base package when available.
+ * @param stepOrder Gets the zero-based resolved step order when rendering an ordered pipeline step.
  */
 public record GenerationContext(ProcessingEnvironment processingEnv, Path outputDir, DeploymentRole role,
                                 Set<String> enabledAspects, ClassName cacheKeyGenerator,
                                 DescriptorProtos.FileDescriptorSet descriptorSet,
                                 PipelineTransport transportMode,
-                                String pipelineBasePackage) {
+                                String pipelineBasePackage,
+                                Integer stepOrder) {
     /**
      * Creates a new GenerationContext instance.
      */
     public GenerationContext {
         enabledAspects = enabledAspects == null ? Set.of() : Set.copyOf(enabledAspects);
+    }
+
+    public GenerationContext(ProcessingEnvironment processingEnv, Path outputDir, DeploymentRole role,
+                             Set<String> enabledAspects, ClassName cacheKeyGenerator,
+                             DescriptorProtos.FileDescriptorSet descriptorSet,
+                             PipelineTransport transportMode,
+                             String pipelineBasePackage) {
+        this(processingEnv,
+            outputDir,
+            role,
+            enabledAspects,
+            cacheKeyGenerator,
+            descriptorSet,
+            transportMode,
+            pipelineBasePackage,
+            null);
     }
 
     public GenerationContext(
@@ -40,6 +58,6 @@ public record GenerationContext(ProcessingEnvironment processingEnv, Path output
             Set<String> enabledAspects,
             ClassName cacheKeyGenerator,
             DescriptorProtos.FileDescriptorSet descriptorSet) {
-        this(processingEnv, outputDir, role, enabledAspects, cacheKeyGenerator, descriptorSet, null, null);
+        this(processingEnv, outputDir, role, enabledAspects, cacheKeyGenerator, descriptorSet, null, null, null);
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
@@ -52,13 +52,13 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
         PipelineStepModel model = binding.model();
         validateSupported(model);
 
-        TypeSpec clientStepClass = buildClientStepClass(model);
+        TypeSpec clientStepClass = buildClientStepClass(model, ctx.stepOrder());
         JavaFile.builder(model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX, clientStepClass)
             .build()
             .writeTo(ctx.outputDir());
     }
 
-    private TypeSpec buildClientStepClass(PipelineStepModel model) {
+    private TypeSpec buildClientStepClass(PipelineStepModel model, Integer stepOrder) {
         TypeName inputType = resolveDomainType(model.inboundDomainType());
         TypeName outputType = resolveDomainType(model.outboundDomainType());
         TypeName stepInterface = ParameterizedTypeName.get(
@@ -66,8 +66,9 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
             inputType,
             outputType);
         TypeName completionStage = ParameterizedTypeName.get(ClassName.get(CompletionStage.class), outputType);
-        TypeName serviceType = model.serviceClassName();
-        String serviceFieldName = decapitalize(model.serviceClassName().simpleName());
+        ClassName targetServiceClass = targetServiceClass(model);
+        TypeName serviceType = targetServiceClass;
+        String serviceFieldName = decapitalize(targetServiceClass.simpleName());
 
         FieldSpec serviceField = FieldSpec.builder(serviceType, serviceFieldName, Modifier.PRIVATE, Modifier.FINAL)
             .build();
@@ -84,14 +85,23 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
             .addStatement(applyStatement(model), applyStatementArgs(model, serviceFieldName))
             .build();
 
-        return TypeSpec.classBuilder(getClientStepClassName(model))
+        TypeSpec.Builder classBuilder = TypeSpec.classBuilder(getClientStepClassName(model))
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.stereotype", "Component")).build())
             .addSuperinterface(stepInterface)
             .addField(serviceField)
             .addMethod(constructor)
-            .addMethod(applyMethod)
-            .build();
+            .addMethod(applyMethod);
+        if (stepOrder != null) {
+            classBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.core.annotation", "Order"))
+                .addMember("value", "$L", stepOrder)
+                .build());
+        }
+        return classBuilder.build();
+    }
+
+    private ClassName targetServiceClass(PipelineStepModel model) {
+        return model.delegateService() != null ? model.delegateService() : model.serviceClassName();
     }
 
     private String completionStageAdapter(PipelineStepModel model) {
@@ -138,9 +148,9 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
             throw new IllegalArgumentException(
                 "Spring renderer profile does not yet support side-effect steps; step '" + model.serviceName() + "'");
         }
-        if (model.delegateService() != null || model.remoteExecution() != null) {
+        if (model.remoteExecution() != null) {
             throw new IllegalArgumentException(
-                "Spring renderer profile currently supports only internal local steps; step '" + model.serviceName() + "'");
+                "Spring renderer profile does not support remote local steps; step '" + model.serviceName() + "'");
         }
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
@@ -321,6 +321,41 @@ class YamlDrivenStepGenerationTest {
     }
 
     @Test
+    void generatesYamlDelegatedStepFromPlainMonoProcessMethodWithSpringProfile() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-delegated-plain-mono.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "audit"
+                operator: "com.example.app.PaymentAuditService"
+                input: "com.example.app.PaymentStatus"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentAuditService = writeSource("PaymentAuditService.java", """
+            package com.example.app;
+
+            import reactor.core.publisher.Mono;
+
+            public class PaymentAuditService {
+                public Mono<PaymentStatus> process(PaymentStatus input) {
+                    return Mono.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus, monoStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertTrue(result.success(), "Expected Spring delegated Mono operator compilation to succeed: " + result.errorSummary());
+    }
+
+    @Test
     void failsYamlInternalStepFromPlainMonoProcessMethodWithoutSpringProfile() throws IOException {
         Path yamlFile = tempDir.resolve("pipeline-internal-plain-mono-quarkus.yaml");
         Files.writeString(yamlFile, """

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineBindingConstructionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineBindingConstructionPhaseTest.java
@@ -168,6 +168,24 @@ class PipelineBindingConstructionPhaseTest {
     }
 
     @Test
+    void springDelegatedLocalClientStepBuildsLocalBindingOnly() throws Exception {
+        PipelineBindingConstructionPhase phase = new PipelineBindingConstructionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);
+        context.setRendererProfile("spring");
+
+        PipelineStepModel delegatedModel = TestModelFactory
+            .createTestModelWithTargets("DelegatedLocalService", Set.of(GenerationTarget.LOCAL_CLIENT_STEP))
+            .toBuilder()
+            .delegateService(ClassName.get("com.example.lib", "EmbeddingService"))
+            .build();
+        context.setStepModels(List.of(delegatedModel));
+
+        assertDoesNotThrow(() -> phase.execute(context));
+        Map<String, Object> bindings = context.getRendererBindings();
+        assertEquals(Set.of("DelegatedLocalService_local"), bindings.keySet());
+    }
+
+    @Test
     void delegatedStepWithServerTargetsEmitsWarning() throws Exception {
         PipelineBindingConstructionPhase phase = new PipelineBindingConstructionPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(processingEnv, roundEnv);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
@@ -34,6 +34,7 @@ import org.pipelineframework.processor.ir.TypeMapping;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SpringRendererProfileSupportTest {
 
@@ -61,6 +62,17 @@ class SpringRendererProfileSupportTest {
         PipelineCompilationContext context = context();
         context.setStepModels(List.of(step(Set.of(GenerationTarget.LOCAL_CLIENT_STEP), StreamingShape.UNARY_UNARY,
             ServiceApiKind.BLOCKING)));
+
+        assertDoesNotThrow(() -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
+    void acceptsUnaryDelegatedSpringBeanStep() {
+        PipelineCompilationContext context = context();
+        context.setStepModels(List.of(delegatedStep(
+            Set.of(GenerationTarget.LOCAL_CLIENT_STEP),
+            StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE)));
 
         assertDoesNotThrow(() -> SpringRendererProfileSupport.validateGenerationSupported(context));
     }
@@ -103,6 +115,34 @@ class SpringRendererProfileSupportTest {
             () -> SpringRendererProfileSupport.validateGenerationSupported(context));
     }
 
+    @Test
+    void rejectsDelegatedNonUnaryStep() {
+        PipelineCompilationContext context = context();
+        context.setStepModels(List.of(delegatedStep(
+            Set.of(GenerationTarget.LOCAL_CLIENT_STEP),
+            StreamingShape.UNARY_STREAMING,
+            ServiceApiKind.REACTIVE)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+        assertTrue(error.getMessage().contains("supports only unary-unary steps"), error.getMessage());
+    }
+
+    @Test
+    void rejectsDelegatedRestResourceTarget() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(delegatedStep(
+            Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP),
+            StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+        assertTrue(error.getMessage().contains("delegated Spring beans only as unary local client steps"),
+            error.getMessage());
+    }
+
     private PipelineCompilationContext context() {
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);
         context.setRendererProfile("spring");
@@ -129,6 +169,27 @@ class SpringRendererProfileSupportTest {
             .enabledTargets(targets)
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .serviceApiKind(apiKind)
+            .build();
+    }
+
+    private PipelineStepModel delegatedStep(
+        Set<GenerationTarget> targets,
+        StreamingShape shape,
+        ServiceApiKind apiKind
+    ) {
+        return new PipelineStepModel.Builder()
+            .serviceName("AuditService")
+            .generatedName("AuditService")
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", "AuditService"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentStatus"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentStatus"), null, false))
+            .streamingShape(shape)
+            .enabledTargets(targets)
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .delegateService(ClassName.get("com.example.service", "PaymentAuditBean"))
             .serviceApiKind(apiKind)
             .build();
     }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepBindingConstructionServiceTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/StepBindingConstructionServiceTest.java
@@ -66,6 +66,24 @@ class StepBindingConstructionServiceTest {
     }
 
     @Test
+    void springDelegatedLocalStepBuildsLocalBindingWithoutExternalAdapter() {
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, null);
+        ctx.setRendererProfile("spring");
+        PipelineStepModel delegated = TestModelFactory
+            .createTestModelWithTargets("DelegatedService", Set.of(GenerationTarget.LOCAL_CLIENT_STEP))
+            .toBuilder()
+            .delegateService(ClassName.get("com.example.lib", "EmbeddingService"))
+            .build();
+        ctx.setStepModels(List.of(delegated));
+
+        Map<String, Object> bindings = service.buildBindings(ctx, null);
+
+        assertFalse(bindings.containsKey("DelegatedService_external_adapter"));
+        assertTrue(bindings.containsKey("DelegatedService_local"));
+        assertFalse(bindings.containsKey("DelegatedService_grpc"));
+    }
+
+    @Test
     void delegatedStepWithServerTargetsEmitsWarning() {
         when(processingEnv.getMessager()).thenReturn(messager);
         PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, null);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
@@ -53,6 +53,8 @@ class SpringLocalClientStepRendererTest {
         String source = Files.readString(clientStep);
         assertTrue(source.contains("import org.pipelineframework.runtime.core.PipelineUnaryStep;"));
         assertTrue(source.contains("import org.springframework.stereotype.Component;"));
+        assertFalse(source.contains("import org.springframework.core.annotation.Order;"));
+        assertFalse(source.contains("@Order"));
         assertTrue(source.contains("public class PaymentLocalClientStep implements PipelineUnaryStep<PaymentRecord, PaymentStatus>"));
         assertTrue(source.contains("private final PaymentService paymentService;"));
         assertTrue(source.contains("public PaymentLocalClientStep(PaymentService paymentService)"));
@@ -74,10 +76,12 @@ class SpringLocalClientStepRendererTest {
                 StreamingShape.UNARY_UNARY,
                 ServiceApiKind.REACTIVE,
                 ReactiveReturnKind.REACTOR_MONO)),
-            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null,
+                null, null, 1));
 
         Path clientStep = tempDir.resolve("com/example/service/pipeline/PaymentLocalClientStep.java");
         String source = Files.readString(clientStep);
+        assertTrue(source.contains("@Order(1)"));
         assertTrue(source.contains("return this.paymentService.process(input).toFuture();"));
         assertFalse(source.contains("subscribeAsCompletionStage"));
         assertFalse(source.contains("io.smallrye.mutiny"));
@@ -86,6 +90,39 @@ class SpringLocalClientStepRendererTest {
         assertFalse(source.contains("io.vertx."));
         assertFalse(source.contains("org.jboss.resteasy."));
         assertFalse(source.contains("jakarta.ws.rs."));
+    }
+
+    @Test
+    void rendersDelegatedSpringBeanLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(delegatedModel(ServiceApiKind.REACTIVE, ReactiveReturnKind.REACTOR_MONO)),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null,
+                null, null, 2));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/AuditLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("import com.example.operator.PaymentAuditBean;"));
+        assertTrue(source.contains("@Order(2)"));
+        assertTrue(source.contains("public class AuditLocalClientStep implements PipelineUnaryStep<PaymentStatus, PaymentStatus>"));
+        assertTrue(source.contains("private final PaymentAuditBean paymentAuditBean;"));
+        assertTrue(source.contains("public AuditLocalClientStep(PaymentAuditBean paymentAuditBean)"));
+        assertTrue(source.contains("return this.paymentAuditBean.process(input).toFuture();"));
+        assertFalse(source.contains("private final AuditService auditService;"));
+        assertFalse(source.contains("AuditService auditService"));
+    }
+
+    @Test
+    void rendersDelegatedBlockingSpringBeanLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(delegatedModel(ServiceApiKind.BLOCKING, ReactiveReturnKind.MUTINY_UNI)),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/AuditLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("private final PaymentAuditBean paymentAuditBean;"));
+        assertTrue(source.contains("return RuntimeAdapters.executeBlocking(() -> this.paymentAuditBean.processBlocking(input), false);"));
     }
 
     @Test
@@ -173,6 +210,24 @@ class SpringLocalClientStepRendererTest {
             .enabledTargets(Set.of(GenerationTarget.LOCAL_CLIENT_STEP))
             .executionMode(executionMode)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .serviceApiKind(apiKind)
+            .reactiveReturnKind(reactiveReturnKind)
+            .build();
+    }
+
+    private PipelineStepModel delegatedModel(ServiceApiKind apiKind, ReactiveReturnKind reactiveReturnKind) {
+        return new PipelineStepModel.Builder()
+            .serviceName("AuditService")
+            .generatedName("AuditService")
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", "AuditService"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentStatus"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.service", "PaymentStatus"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.LOCAL_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.PIPELINE_SERVER)
+            .delegateService(ClassName.get("com.example.operator", "PaymentAuditBean"))
             .serviceApiKind(apiKind)
             .reactiveReturnKind(reactiveReturnKind)
             .build();

--- a/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentAuditService.java
+++ b/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentAuditService.java
@@ -1,0 +1,15 @@
+package com.example.smoke.service;
+
+import com.example.smoke.domain.PaymentStatus;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class PaymentAuditService {
+    public Mono<PaymentStatus> process(PaymentStatus input) {
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Payment status must not be null"));
+        }
+        return Mono.just(new PaymentStatus(input.paymentId(), input.status() + ":DELEGATED"));
+    }
+}

--- a/framework/spring-smoke-tests/src/main/resources/pipeline.yaml
+++ b/framework/spring-smoke-tests/src/main/resources/pipeline.yaml
@@ -9,3 +9,7 @@ steps:
     inboundMapper: "com.example.smoke.mapper.PaymentRecordMapper"
     output: "com.example.smoke.domain.PaymentStatus"
     outboundMapper: "com.example.smoke.mapper.PaymentStatusMapper"
+  - name: "audit"
+    operator: "com.example.smoke.service.PaymentAuditService"
+    input: "com.example.smoke.domain.PaymentStatus"
+    output: "com.example.smoke.domain.PaymentStatus"

--- a/framework/spring-smoke-tests/src/test/java/com/example/smoke/GeneratedSpringRestSmokeTest.java
+++ b/framework/spring-smoke-tests/src/test/java/com/example/smoke/GeneratedSpringRestSmokeTest.java
@@ -22,7 +22,7 @@ class GeneratedSpringRestSmokeTest {
 
     @Test
     void generatedRestEndpointRunsThroughSpringPipelineRunner() {
-        assertEquals(1, pipelineRunner.stepCount());
+        assertEquals(2, pipelineRunner.stepCount());
 
         WebTestClient.bindToServer()
             .baseUrl("http://localhost:" + port)
@@ -36,7 +36,7 @@ class GeneratedSpringRestSmokeTest {
             .expectBody(PaymentStatusDto.class)
             .value(response -> {
                 assertEquals("pay-123", response.paymentId());
-                assertEquals("APPROVED:42", response.status());
+                assertEquals("APPROVED:42:DELEGATED", response.status());
             });
     }
 }


### PR DESCRIPTION
## Summary

Adds the next Spring Boot adoption slice: Spring-profile pipelines can use unary delegated Spring beans as local pipeline steps.

This keeps Spring support COMPUTE-only and does not touch queue-async, await, checkpoint, broker, or coordinator internals.

## Changes

- Accept Spring-profile delegated unary local bean steps in renderer validation.
- Extract Spring delegated bean signatures using the existing supported unary Spring method shapes.
- Render Spring local client steps against the delegate bean type when `delegateService` is present.
- Preserve Quarkus delegated external-adapter behavior outside the Spring local delegate path.
- Add generated Spring step ordering for deterministic multi-step smoke execution.
- Extend Spring REST smoke with an internal step plus delegated Spring `@Component` step.
- Update `/develop/spring-support` to mark delegated Spring beans as partially supported with v1 constraints.

## Scope Control

Out of scope:

- Queue-async FCIS/coordinator internals.
- Await/checkpoint/broker/durable paths.
- gRPC/function parity.
- Arbitrary `Class::method` operator invoker generation.

Local CodeRabbit classification:

- Fixed docs wording to avoid roadmap/internal phrasing.
- Fixed nullable/absent generated ordering for legacy renderer paths.
- Tightened Spring delegate semantic-analysis shortcut and tests.
- Rejected repeated `operator:` -> `service:` / `Class::method` suggestions because this slice intentionally extends the existing delegated YAML `operator: <SpringBeanClass>` surface; `Class::method` operator invokers remain deferred.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime-core,runtime-spring,deployment,spring-smoke-tests,spring-blocking-smoke-tests -am -Dtest=SpringRendererProfileSupportTest,SpringLocalClientStepRendererTest,YamlDrivenStepGenerationTest,StepBindingConstructionServiceTest,PipelineBindingConstructionPhaseTest,GeneratedSpringRestSmokeTest,GeneratedSpringBlockingRestSmokeTest,SpringSmokeDependencyGuardTest,SpringBlockingSmokeDependencyGuardTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `npm --prefix docs run build`
- `git diff --check`
