### PR TITLE
[codex] Support Spring Class::method operator beans

### DIFF
--- a/docs/develop/spring-support.md
+++ b/docs/develop/spring-support.md
@@ -14,6 +14,7 @@ Current Spring work proves a narrow generated application path:
 - Spring WebFlux `@RestController` resources for the supported smoke path,
 - `Mono<Out>` authored service methods for YAML-declared Spring-profile unary services,
 - unary delegated Spring bean steps for local pipeline execution,
+- unary `Class::method` Spring operator beans for local pipeline execution,
 - shared runner-core sequencing through the neutral runtime seam.
 
 ## Not Yet Supported
@@ -24,7 +25,7 @@ Spring does not yet have parity for:
 - function handlers,
 - await, checkpoint, durable coordinator, or broker paths,
 - persistence providers,
-- arbitrary `Class::method` operator invokers and non-local delegated/operator paths,
+- non-local delegated/operator paths,
 - side effects and plugins,
 - REST client-step remote boundaries,
 - streaming or non-unary shapes,
@@ -38,7 +39,9 @@ Use Quarkus for production TPF applications today.
 
 Use the Spring path only when you are validating the emerging renderer/runtime seam or contributing to portability work. Keep business contracts neutral: typed inputs, typed outputs, mappers, and YAML declarations should not rely on Quarkus-only application code unless the application is explicitly Quarkus-targeted.
 
-Delegated Spring beans are supported only for unary local steps declared from YAML with a Spring bean class and a supported service shape such as `process(In): Mono<Out>` or `processBlocking(In): Out`. They do not imply gRPC, function, await/checkpoint, broker, durable coordinator, or production parity with the Quarkus runtime.
+Delegated Spring beans are supported only for unary local steps declared from YAML with either a Spring bean class or an explicit `Class::method` operator reference. Class-only delegates use supported TPF-style service shapes such as `process(In): Mono<Out>` or `processBlocking(In): Out`. `Class::method` delegates support narrow unary Spring bean methods: `Out method(In)`, `Mono<Out> method(In)`, or `CompletionStage<Out> method(In)`.
+
+This support does not imply gRPC, function, await/checkpoint, broker, durable coordinator, streaming/non-unary, or production parity with the Quarkus runtime.
 
 ## Deeper Architecture
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/PipelineStepModel.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.processor.ir;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import com.squareup.javapoet.ClassName;
@@ -28,6 +29,7 @@ import org.pipelineframework.parallelism.ThreadSafety;
  * @param orderingRequirement Gets the ordering requirement for the generated client step.
  * @param threadSafety Gets the thread safety declaration for the generated client step.
  * @param delegateService Gets the delegate service class if this is a delegation step, otherwise null.
+ * @param delegateMethodName Gets the delegate method name when a delegated step uses Class::method syntax.
  * @param externalMapper Gets the operator mapper class if operator mapping is used, otherwise null.
  * @param mapperFallbackMode Gets mapper fallback mode used when no explicit/inferred mapper matches.
  * @param remoteExecution Gets remote operator execution metadata when the step is remote, otherwise null.
@@ -50,6 +52,7 @@ public record PipelineStepModel(
         OrderingRequirement orderingRequirement,
         ThreadSafety threadSafety,
         ClassName delegateService,
+        Optional<String> delegateMethodName,
         ClassName externalMapper,
         MapperFallbackMode mapperFallbackMode,
         PipelineTemplateStepExecution remoteExecution,
@@ -99,6 +102,52 @@ public record PipelineStepModel(
             PipelineTemplateStepExecution remoteExecution,
             ServiceApiKind serviceApiKind,
             ReactiveReturnKind reactiveReturnKind) {
+        this(serviceName,
+            generatedName,
+            servicePackage,
+            serviceClassName,
+            inputMapping,
+            outputMapping,
+            streamingShape,
+            enabledTargets,
+            executionMode,
+            deploymentRole,
+            sideEffect,
+            cacheKeyGenerator,
+            orderingRequirement,
+            threadSafety,
+            delegateService,
+            Optional.empty(),
+            externalMapper,
+            mapperFallbackMode,
+            remoteExecution,
+            serviceApiKind,
+            reactiveReturnKind);
+    }
+
+    @SuppressWarnings("ConstantValue")
+    @Deprecated
+    public PipelineStepModel(String serviceName,
+            String generatedName,
+            String servicePackage,
+            ClassName serviceClassName,
+            TypeMapping inputMapping,
+            TypeMapping outputMapping,
+            StreamingShape streamingShape,
+            Set<GenerationTarget> enabledTargets,
+            ExecutionMode executionMode,
+            DeploymentRole deploymentRole,
+            boolean sideEffect,
+            ClassName cacheKeyGenerator,
+            OrderingRequirement orderingRequirement,
+            ThreadSafety threadSafety,
+            ClassName delegateService,
+            Optional<String> delegateMethodName,
+            ClassName externalMapper,
+            MapperFallbackMode mapperFallbackMode,
+            PipelineTemplateStepExecution remoteExecution,
+            ServiceApiKind serviceApiKind,
+            ReactiveReturnKind reactiveReturnKind) {
         // Validate non-null invariants
         if (serviceName == null)
             throw new IllegalArgumentException("serviceName cannot be null");
@@ -132,6 +181,7 @@ public record PipelineStepModel(
         this.orderingRequirement = orderingRequirement != null ? orderingRequirement : OrderingRequirement.RELAXED;
         this.threadSafety = threadSafety != null ? threadSafety : ThreadSafety.SAFE;
         this.delegateService = delegateService;
+        this.delegateMethodName = normalizeOptionalString(delegateMethodName);
         this.externalMapper = externalMapper;
         this.mapperFallbackMode = mapperFallbackMode == null ? MapperFallbackMode.NONE : mapperFallbackMode;
         this.remoteExecution = remoteExecution;
@@ -177,6 +227,7 @@ public record PipelineStepModel(
             orderingRequirement,
             threadSafety,
             delegateService,
+            Optional.empty(),
             externalMapper,
             mapperFallbackMode,
             remoteExecution,
@@ -219,10 +270,12 @@ public record PipelineStepModel(
             orderingRequirement,
             threadSafety,
             delegateService,
+            Optional.empty(),
             externalMapper,
             MapperFallbackMode.NONE,
             null,
-            ServiceApiKind.REACTIVE);
+            ServiceApiKind.REACTIVE,
+            ReactiveReturnKind.MUTINY_UNI);
     }
 
     /**
@@ -261,10 +314,12 @@ public record PipelineStepModel(
             orderingRequirement,
             threadSafety,
             delegateService,
+            Optional.empty(),
             externalMapper,
             mapperFallbackMode,
             null,
-            ServiceApiKind.REACTIVE);
+            ServiceApiKind.REACTIVE,
+            ReactiveReturnKind.MUTINY_UNI);
     }
 
     /**
@@ -314,10 +369,12 @@ public record PipelineStepModel(
             OrderingRequirement.RELAXED,
             ThreadSafety.SAFE,
             null,
+            Optional.empty(),
             null,
             MapperFallbackMode.NONE,
             null,
-            ServiceApiKind.REACTIVE);
+            ServiceApiKind.REACTIVE,
+            ReactiveReturnKind.MUTINY_UNI);
     }
 
     /**
@@ -336,6 +393,14 @@ public record PipelineStepModel(
      */
     public TypeName outboundDomainType() {
         return outputMapping.domainType();
+    }
+
+    private static Optional<String> normalizeOptionalString(Optional<String> value) {
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+        String normalized = value.get().trim();
+        return normalized.isBlank() ? Optional.empty() : Optional.of(normalized);
     }
 
     /**
@@ -364,6 +429,7 @@ public record PipelineStepModel(
         private OrderingRequirement orderingRequirement = OrderingRequirement.RELAXED;
         private ThreadSafety threadSafety = ThreadSafety.SAFE;
         private ClassName delegateService;
+        private Optional<String> delegateMethodName = Optional.empty();
         private ClassName externalMapper;
         private MapperFallbackMode mapperFallbackMode = MapperFallbackMode.NONE;
         private PipelineTemplateStepExecution remoteExecution;
@@ -547,6 +613,28 @@ public record PipelineStepModel(
         }
 
         /**
+         * Configure the delegate method name for Class::method delegated steps.
+         *
+         * @param delegateMethodName the delegate method name, or {@code null} for default service methods
+         * @return this builder instance
+         */
+        public Builder delegateMethodName(String delegateMethodName) {
+            this.delegateMethodName = normalizeOptionalString(Optional.ofNullable(delegateMethodName));
+            return this;
+        }
+
+        /**
+         * Configure the delegate method name for Class::method delegated steps.
+         *
+         * @param delegateMethodName optional delegate method name
+         * @return this builder instance
+         */
+        public Builder delegateMethodName(Optional<String> delegateMethodName) {
+            this.delegateMethodName = normalizeOptionalString(delegateMethodName);
+            return this;
+        }
+
+        /**
          * Specifies a custom operator mapper class used to map between domain and operator types.
          *
          * @param externalMapper the operator mapper ClassName to use, or {@code null} to indicate no operator mapping
@@ -642,6 +730,7 @@ public record PipelineStepModel(
                 orderingRequirement,
                 threadSafety,
                 delegateService,
+                delegateMethodName,
                 externalMapper,
                 mapperFallbackMode,
                 remoteExecution,
@@ -673,6 +762,7 @@ public record PipelineStepModel(
             orderingRequirement,
             threadSafety,
             delegateService,
+            delegateMethodName,
             externalMapper,
             mapperFallbackMode,
             remoteExecution,
@@ -710,6 +800,7 @@ public record PipelineStepModel(
             .orderingRequirement(orderingRequirement)
             .threadSafety(threadSafety)
             .delegateService(delegateService)
+            .delegateMethodName(delegateMethodName)
             .externalMapper(externalMapper)
             .mapperFallbackMode(mapperFallbackMode)
             .remoteExecution(remoteExecution)

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/ReactiveReturnKind.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/ReactiveReturnKind.java
@@ -5,5 +5,6 @@ package org.pipelineframework.processor.ir;
  */
 public enum ReactiveReturnKind {
     MUTINY_UNI,
-    REACTOR_MONO
+    REACTOR_MONO,
+    COMPLETION_STAGE
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
@@ -19,6 +19,7 @@ package org.pipelineframework.processor.ir;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import com.squareup.javapoet.ClassName;
 import org.pipelineframework.config.template.PipelineTemplateStepExecution;
@@ -30,6 +31,7 @@ import org.pipelineframework.config.template.PipelineTemplateStepExecution;
  * @param name The name of the step
  * @param kind The kind of step (INTERNAL, DELEGATED, REMOTE, AWAIT, COMMAND, or QUERY)
  * @param executionClass The class that provides the execution implementation
+ * @param delegatedMethodName Optional delegated/operator method name when YAML uses Class::method syntax
  * @param remoteExecution remote execution metadata for REMOTE steps
  * @param awaitConfig raw await configuration for AWAIT steps
  * @param timeout await timeout string for AWAIT steps
@@ -54,6 +56,7 @@ public record StepDefinition(
         String name,
         StepKind kind,
         @Nullable ClassName executionClass,
+        Optional<String> delegatedMethodName,
         @Nullable PipelineTemplateStepExecution remoteExecution,
         Map<String, Object> awaitConfig,
         @Nullable String timeout,
@@ -82,6 +85,56 @@ public record StepDefinition(
         Map<String, Object> awaitConfig,
         @Nullable String timeout,
         List<String> idempotencyKeyFields,
+        @Nullable String command,
+        @Nullable ClassName commandIdGenerator,
+        @Nullable String duplicatePolicy,
+        Map<String, Object> commandConfig,
+        @Nullable String queryId,
+        Map<String, Object> queryConfig,
+        List<String> queryKeyFields,
+        @Nullable ClassName inboundMapper,
+        @Nullable ClassName outboundMapper,
+        @Nullable ClassName externalMapper,
+        MapperFallbackMode mapperFallback,
+        @Nullable ClassName inputType,
+        @Nullable ClassName outputType,
+        @Nullable StreamingShape streamingShapeHint,
+        boolean runOnVirtualThreads
+    ) {
+        this(
+            name,
+            kind,
+            executionClass,
+            Optional.empty(),
+            remoteExecution,
+            awaitConfig,
+            timeout,
+            idempotencyKeyFields,
+            command,
+            commandIdGenerator,
+            duplicatePolicy,
+            commandConfig,
+            queryId,
+            queryConfig,
+            queryKeyFields,
+            inboundMapper,
+            outboundMapper,
+            externalMapper,
+            mapperFallback,
+            inputType,
+            outputType,
+            streamingShapeHint,
+            runOnVirtualThreads);
+    }
+
+    public StepDefinition(
+        String name,
+        StepKind kind,
+        @Nullable ClassName executionClass,
+        @Nullable PipelineTemplateStepExecution remoteExecution,
+        Map<String, Object> awaitConfig,
+        @Nullable String timeout,
+        List<String> idempotencyKeyFields,
         @Nullable ClassName inboundMapper,
         @Nullable ClassName outboundMapper,
         @Nullable ClassName externalMapper,
@@ -94,6 +147,7 @@ public record StepDefinition(
             name,
             kind,
             executionClass,
+            Optional.empty(),
             remoteExecution,
             awaitConfig,
             timeout,
@@ -139,6 +193,7 @@ public record StepDefinition(
             name,
             kind,
             executionClass,
+            Optional.empty(),
             remoteExecution,
             copyObjectMap(awaitConfig),
             timeout,
@@ -174,6 +229,7 @@ public record StepDefinition(
             name,
             requireNonRemoteKind(kind),
             executionClass,
+            Optional.empty(),
             null,
             Map.of(),
             null,
@@ -210,6 +266,7 @@ public record StepDefinition(
             name,
             requireNonRemoteKind(kind),
             executionClass,
+            Optional.empty(),
             null,
             Map.of(),
             null,
@@ -235,6 +292,46 @@ public record StepDefinition(
         String name,
         StepKind kind,
         ClassName executionClass,
+        Optional<String> delegatedMethodName,
+        @Nullable ClassName inboundMapper,
+        @Nullable ClassName outboundMapper,
+        @Nullable ClassName externalMapper,
+        MapperFallbackMode mapperFallback,
+        @Nullable ClassName inputType,
+        @Nullable ClassName outputType,
+        @Nullable StreamingShape streamingShapeHint,
+        boolean runOnVirtualThreads
+    ) {
+        this(
+            name,
+            requireNonRemoteKind(kind),
+            executionClass,
+            delegatedMethodName,
+            null,
+            Map.of(),
+            null,
+            List.of(),
+            null,
+            null,
+            null,
+            Map.of(),
+            null,
+            Map.of(),
+            List.of(),
+            inboundMapper,
+            outboundMapper,
+            externalMapper,
+            mapperFallback,
+            inputType,
+            outputType,
+            streamingShapeHint,
+            runOnVirtualThreads);
+    }
+
+    public StepDefinition(
+        String name,
+        StepKind kind,
+        ClassName executionClass,
         @Nullable ClassName inboundMapper,
         @Nullable ClassName outboundMapper,
         @Nullable ClassName externalMapper,
@@ -247,6 +344,7 @@ public record StepDefinition(
             name,
             requireNonRemoteKind(kind),
             executionClass,
+            Optional.empty(),
             null,
             Map.of(),
             null,
@@ -280,6 +378,7 @@ public record StepDefinition(
         if (executionClass != null && remoteExecution != null) {
             throw new IllegalArgumentException("executionClass and remoteExecution are mutually exclusive");
         }
+        delegatedMethodName = normalizeOptionalString(delegatedMethodName);
         if (kind == StepKind.REMOTE) {
             Objects.requireNonNull(remoteExecution, "Remote execution cannot be null for REMOTE steps");
         } else if (kind == StepKind.AWAIT || kind == StepKind.COMMAND || kind == StepKind.QUERY) {
@@ -316,6 +415,14 @@ public record StepDefinition(
             throw new IllegalArgumentException("Convenience constructor cannot be used for " + kind);
         }
         return kind;
+    }
+
+    private static Optional<String> normalizeOptionalString(Optional<String> value) {
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+        String normalized = value.get().trim();
+        return normalized.isBlank() ? Optional.empty() : Optional.of(normalized);
     }
 
     private static Map<String, Object> copyObjectMap(Map<?, ?> values) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
@@ -219,6 +220,7 @@ public class StepDefinitionParser {
         boolean commandStep = "command".equalsIgnoreCase(rawKind);
         boolean queryStep = "query".equalsIgnoreCase(rawKind);
         String delegatedClassName = null;
+        Optional<String> delegatedMethodName = Optional.empty();
 
         if (!isBlank(operatorClassName) && !isBlank(delegateClassName)) {
             String message = "Skipping step '" + name + "': 'operator' and 'delegate' are aliases and are mutually exclusive";
@@ -227,9 +229,19 @@ public class StepDefinitionParser {
             return null;
         }
         if (!isBlank(operatorClassName)) {
-            delegatedClassName = normalizeDelegatedExecutionClassName(operatorClassName);
+            Optional<DelegatedReference> delegatedReference = parseDelegatedReference(operatorClassName, name, "operator");
+            if (delegatedReference.isEmpty()) {
+                return null;
+            }
+            delegatedClassName = delegatedReference.get().className();
+            delegatedMethodName = delegatedReference.get().methodName();
         } else if (!isBlank(delegateClassName)) {
-            delegatedClassName = normalizeDelegatedExecutionClassName(delegateClassName);
+            Optional<DelegatedReference> delegatedReference = parseDelegatedReference(delegateClassName, name, "delegate");
+            if (delegatedReference.isEmpty()) {
+                return null;
+            }
+            delegatedClassName = delegatedReference.get().className();
+            delegatedMethodName = delegatedReference.get().methodName();
         }
 
         if (!isBlank(delegatedClassName) && !isBlank(serviceClassName)) {
@@ -702,17 +714,7 @@ public class StepDefinitionParser {
             name,
             kind,
             executionClass,
-            null,
-            Map.of(),
-            null,
-            List.of(),
-            null,
-            null,
-            null,
-            Map.of(),
-            null,
-            Map.of(),
-            List.of(),
+            delegatedMethodName,
             inboundMapper,
             outboundMapper,
             externalMapper,
@@ -1439,15 +1441,31 @@ public class StepDefinitionParser {
         diagnosticReporter.accept(kind, message);
     }
 
-    private String normalizeDelegatedExecutionClassName(String delegatedValue) {
+    private Optional<DelegatedReference> parseDelegatedReference(String delegatedValue, String stepName, String fieldName) {
         if (isBlank(delegatedValue)) {
-            return delegatedValue;
+            return Optional.empty();
         }
         int separator = delegatedValue.indexOf("::");
-        if (separator <= 0) {
-            return delegatedValue;
+        if (separator < 0) {
+            return Optional.of(new DelegatedReference(delegatedValue.trim(), Optional.empty()));
         }
-        return delegatedValue.substring(0, separator).trim();
+        String className = delegatedValue.substring(0, separator).trim();
+        String methodName = delegatedValue.substring(separator + 2).trim();
+        if (className.isBlank() || methodName.isBlank() || delegatedValue.indexOf("::", separator + 2) >= 0) {
+            String message = "Skipping step '" + stepName + "': invalid " + fieldName
+                + " reference '" + delegatedValue + "'. Expected <class> or <class>::<method>";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return Optional.empty();
+        }
+        if (!isValidIdentifier(methodName)) {
+            String message = "Skipping step '" + stepName + "': invalid " + fieldName
+                + " method name '" + methodName + "'";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            return Optional.empty();
+        }
+        return Optional.of(new DelegatedReference(className, Optional.of(methodName)));
     }
 
     /**
@@ -1551,6 +1569,9 @@ public class StepDefinitionParser {
      */
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private record DelegatedReference(String className, Optional<String> methodName) {
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -722,15 +722,27 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             ctx,
             delegateElement,
             typeUtils,
-            ctx.getProcessingEnv().getMessager());
+            ctx.getProcessingEnv().getMessager(),
+            stepDef.delegatedMethodName());
         if (delegateSignature.isEmpty()) {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Delegate service '" + stepDef.executionClass().canonicalName() +
-                    "' must expose a supported step contract for step '" + stepDef.name() + "'");
+                    stepDef.delegatedMethodName().map(method -> "::" + method).orElse("")
+                    + "' must expose a supported step contract for step '" + stepDef.name() + "'");
             return null;
         }
         SupportedServiceSignature resolvedDelegateSignature = delegateSignature.get();
+        StreamingShape yamlShape = stepDef.streamingShapeHint();
+        if (yamlShape != null && yamlShape != resolvedDelegateSignature.shape()) {
+            ctx.getProcessingEnv().getMessager().printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Delegated step '" + stepDef.name() + "' declares cardinality "
+                    + yamlShape + " in YAML, but delegate '" + stepDef.executionClass().canonicalName()
+                    + stepDef.delegatedMethodName().map(method -> "::" + method).orElse("")
+                    + "' implements " + resolvedDelegateSignature.shape() + " semantics.");
+            return null;
+        }
 
         TypeName inputType = stepDef.inputType() != null ? stepDef.inputType() : resolvedDelegateSignature.inputType();
         TypeName outputType = stepDef.outputType() != null ? stepDef.outputType() : resolvedDelegateSignature.outputType();
@@ -827,6 +839,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             .orderingRequirement(OrderingRequirement.RELAXED)
             .threadSafety(ThreadSafety.SAFE)
             .delegateService(stepDef.executionClass())
+            .delegateMethodName(stepDef.delegatedMethodName())
             .externalMapper(externalMapper)
             .mapperFallbackMode(effectiveFallback)
             .serviceApiKind(resolvedDelegateSignature.apiKind())
@@ -1157,7 +1170,17 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             PipelineCompilationContext ctx,
             TypeElement delegateElement,
             Types typeUtils,
-            javax.annotation.processing.Messager messager) {
+            javax.annotation.processing.Messager messager,
+            Optional<String> delegatedMethodName) {
+        if (delegatedMethodName.isPresent() && isSpringRendererProfile(ctx)) {
+            return resolveSpringDelegatedMethodSignature(ctx, delegateElement, messager, delegatedMethodName.get());
+        }
+        if (delegatedMethodName.isPresent()) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Class::method delegated operators are currently supported only by the Spring renderer profile.");
+            return Optional.empty();
+        }
         if (isSpringRendererProfile(ctx)) {
             return Optional.ofNullable(resolveSupportedInternalSignature(ctx, delegateElement, typeUtils, messager));
         }
@@ -1170,6 +1193,111 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             reactiveSignature.shape(),
             reactiveSignature.inputType(),
             reactiveSignature.outputType(),
+            ReactiveReturnKind.MUTINY_UNI,
+            null));
+    }
+
+    private Optional<SupportedServiceSignature> resolveSpringDelegatedMethodSignature(
+            PipelineCompilationContext ctx,
+            TypeElement delegateElement,
+            javax.annotation.processing.Messager messager,
+            String delegatedMethodName) {
+        List<ExecutableElement> publicInstanceMatches = new ArrayList<>();
+        boolean staticMatch = false;
+        boolean namedMethodExists = false;
+        for (Element enclosed : delegateElement.getEnclosedElements()) {
+            if (!(enclosed instanceof ExecutableElement method)
+                || !delegatedMethodName.contentEquals(method.getSimpleName())) {
+                continue;
+            }
+            namedMethodExists = true;
+            if (method.getModifiers().contains(Modifier.STATIC)) {
+                staticMatch = true;
+                continue;
+            }
+            if (method.getModifiers().contains(Modifier.PUBLIC)) {
+                publicInstanceMatches.add(method);
+            }
+        }
+        if (publicInstanceMatches.isEmpty()) {
+            String reason = staticMatch
+                ? "is static, but Spring delegated operator methods must be instance bean methods"
+                : namedMethodExists
+                    ? "is not public"
+                    : "was not found";
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Spring delegated operator '" + delegateElement.getQualifiedName() + "::" + delegatedMethodName
+                    + "' " + reason + ".");
+            return Optional.empty();
+        }
+        if (publicInstanceMatches.size() > 1) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Spring delegated operator '" + delegateElement.getQualifiedName() + "::" + delegatedMethodName
+                    + "' is overloaded. Declare exactly one public instance method with that name.");
+            return Optional.empty();
+        }
+
+        ExecutableElement method = publicInstanceMatches.getFirst();
+        if (method.getParameters().size() != 1) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Spring delegated operator '" + delegateElement.getQualifiedName() + "::" + delegatedMethodName
+                    + "' must declare exactly one input parameter.");
+            return Optional.empty();
+        }
+        TypeMirror returnType = method.getReturnType();
+        if (returnType.getKind() == TypeKind.VOID) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Spring delegated operator '" + delegateElement.getQualifiedName() + "::" + delegatedMethodName
+                    + "' must return an output value.");
+            return Optional.empty();
+        }
+
+        TypeName inputType = TypeName.get(method.getParameters().getFirst().asType());
+        if (returnType instanceof DeclaredType declaredReturn && declaredReturn.getTypeArguments().size() == 1) {
+            if (isDeclaredType(declaredReturn, "reactor.core.publisher.Mono")) {
+                return Optional.of(new SupportedServiceSignature(
+                    ServiceApiKind.REACTIVE,
+                    StreamingShape.UNARY_UNARY,
+                    inputType,
+                    TypeName.get(declaredReturn.getTypeArguments().getFirst()),
+                    ReactiveReturnKind.REACTOR_MONO,
+                    null));
+            }
+            if (isDeclaredType(declaredReturn, "java.util.concurrent.CompletionStage")) {
+                return Optional.of(new SupportedServiceSignature(
+                    ServiceApiKind.REACTIVE,
+                    StreamingShape.UNARY_UNARY,
+                    inputType,
+                    TypeName.get(declaredReturn.getTypeArguments().getFirst()),
+                    ReactiveReturnKind.COMPLETION_STAGE,
+                    null));
+            }
+        }
+
+        if (returnType instanceof DeclaredType declaredReturn && (
+            isDeclaredType(declaredReturn, "reactor.core.publisher.Mono")
+                || isDeclaredType(declaredReturn, "java.util.concurrent.CompletionStage")
+                || isDeclaredType(declaredReturn, "io.smallrye.mutiny.Uni")
+                || isDeclaredType(declaredReturn, "io.smallrye.mutiny.Multi")
+                || isDeclaredType(declaredReturn, "reactor.core.publisher.Flux"))) {
+            String kind = ((TypeElement) declaredReturn.asElement()).getQualifiedName().toString();
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Spring delegated operator '" + delegateElement.getQualifiedName() + "::" + delegatedMethodName
+                    + "' does not support return type '" + kind
+                    + "'; use Mono<Out>, CompletionStage<Out>, or a blocking return value.");
+            return Optional.empty();
+        }
+
+        return Optional.of(new SupportedServiceSignature(
+            ServiceApiKind.BLOCKING,
+            StreamingShape.UNARY_UNARY,
+            inputType,
+            TypeName.get(returnType),
             ReactiveReturnKind.MUTINY_UNI,
             null));
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -1256,14 +1256,14 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return Optional.empty();
         }
 
-        TypeName inputType = TypeName.get(method.getParameters().getFirst().asType());
+        TypeName inputType = boxIfPrimitive(TypeName.get(method.getParameters().getFirst().asType()));
         if (returnType instanceof DeclaredType declaredReturn && declaredReturn.getTypeArguments().size() == 1) {
             if (isDeclaredType(declaredReturn, "reactor.core.publisher.Mono")) {
                 return Optional.of(new SupportedServiceSignature(
                     ServiceApiKind.REACTIVE,
                     StreamingShape.UNARY_UNARY,
                     inputType,
-                    TypeName.get(declaredReturn.getTypeArguments().getFirst()),
+                    boxIfPrimitive(TypeName.get(declaredReturn.getTypeArguments().getFirst())),
                     ReactiveReturnKind.REACTOR_MONO,
                     null));
             }
@@ -1272,7 +1272,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                     ServiceApiKind.REACTIVE,
                     StreamingShape.UNARY_UNARY,
                     inputType,
-                    TypeName.get(declaredReturn.getTypeArguments().getFirst()),
+                    boxIfPrimitive(TypeName.get(declaredReturn.getTypeArguments().getFirst())),
                     ReactiveReturnKind.COMPLETION_STAGE,
                     null));
             }
@@ -1297,7 +1297,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             ServiceApiKind.BLOCKING,
             StreamingShape.UNARY_UNARY,
             inputType,
-            TypeName.get(returnType),
+            boxIfPrimitive(TypeName.get(returnType)),
             ReactiveReturnKind.MUTINY_UNI,
             null));
     }
@@ -1728,6 +1728,35 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             }
         }
         return null;
+    }
+
+    /**
+     * Boxes primitive TypeName values to their wrapper types.
+     * This ensures model types are always non-primitive, preventing invalid generic signatures.
+     */
+    private static TypeName boxIfPrimitive(TypeName typeName) {
+        if (typeName.isPrimitive()) {
+            if (typeName.equals(TypeName.INT)) {
+                return TypeName.get(Integer.class);
+            } else if (typeName.equals(TypeName.LONG)) {
+                return TypeName.get(Long.class);
+            } else if (typeName.equals(TypeName.BOOLEAN)) {
+                return TypeName.get(Boolean.class);
+            } else if (typeName.equals(TypeName.DOUBLE)) {
+                return TypeName.get(Double.class);
+            } else if (typeName.equals(TypeName.FLOAT)) {
+                return TypeName.get(Float.class);
+            } else if (typeName.equals(TypeName.SHORT)) {
+                return TypeName.get(Short.class);
+            } else if (typeName.equals(TypeName.BYTE)) {
+                return TypeName.get(Byte.class);
+            } else if (typeName.equals(TypeName.CHAR)) {
+                return TypeName.get(Character.class);
+            }
+        } else if (typeName.equals(TypeName.VOID)) {
+            return TypeName.get(Void.class);
+        }
+        return typeName;
     }
 
     private record ReactiveSignature(StreamingShape shape, TypeName inputType, TypeName outputType) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRenderer.java
@@ -108,28 +108,46 @@ public class SpringLocalClientStepRenderer implements PipelineRenderer<LocalBind
         return switch (model.reactiveReturnKind()) {
             case MUTINY_UNI -> "subscribeAsCompletionStage()";
             case REACTOR_MONO -> "toFuture()";
+            case COMPLETION_STAGE -> "";
         };
     }
 
     private String applyStatement(PipelineStepModel model) {
         if (model.serviceApiKind() == ServiceApiKind.BLOCKING) {
-            return "return $T.executeBlocking(() -> this.$N.processBlocking(input), $L)";
+            return "return $T.executeBlocking(() -> this.$N.$N(input), $L)";
         }
-        return "return this.$N.process(input).$L";
+        if (model.reactiveReturnKind() == ReactiveReturnKind.COMPLETION_STAGE) {
+            return "return this.$N.$N(input)";
+        }
+        return "return this.$N.$N(input).$L";
     }
 
     private Object[] applyStatementArgs(PipelineStepModel model, String serviceFieldName) {
+        String methodName = invocationMethodName(model);
         if (model.serviceApiKind() == ServiceApiKind.BLOCKING) {
             return new Object[] {
                 ClassName.get("org.pipelineframework.runtime.core", "RuntimeAdapters"),
                 serviceFieldName,
+                methodName,
                 model.executionMode() == ExecutionMode.VIRTUAL_THREADS
+            };
+        }
+        if (model.reactiveReturnKind() == ReactiveReturnKind.COMPLETION_STAGE) {
+            return new Object[] {
+                serviceFieldName,
+                methodName
             };
         }
         return new Object[] {
             serviceFieldName,
+            methodName,
             completionStageAdapter(model)
         };
+    }
+
+    private String invocationMethodName(PipelineStepModel model) {
+        return model.delegateMethodName()
+            .orElseGet(() -> model.serviceApiKind() == ServiceApiKind.BLOCKING ? "processBlocking" : "process");
     }
 
     private void validateSupported(PipelineStepModel model) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
@@ -356,6 +356,273 @@ class YamlDrivenStepGenerationTest {
     }
 
     @Test
+    void generatesSpringDelegatedStepFromNamedMonoOperatorMethod() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-mono.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            import reactor.core.publisher.Mono;
+
+            public class PaymentAuditService {
+                public Mono<PaymentStatus> audit(PaymentStatus input) {
+                    return Mono.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus, monoStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertTrue(result.success(), "Expected Spring named Mono operator compilation to succeed: " + result.errorSummary());
+    }
+
+    @Test
+    void generatesSpringDelegatedStepFromNamedCompletionStageOperatorMethod() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-stage.yaml",
+            "com.example.app.PaymentAuditService::auditAsync",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+
+            public class PaymentAuditService {
+                public CompletionStage<PaymentStatus> auditAsync(PaymentStatus input) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertTrue(result.success(), "Expected Spring named CompletionStage operator compilation to succeed: "
+            + result.errorSummary());
+    }
+
+    @Test
+    void generatesSpringDelegatedStepFromNamedBlockingOperatorMethod() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-blocking.yaml",
+            "com.example.app.PaymentAuditService::auditBlocking",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public PaymentStatus auditBlocking(PaymentStatus input) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertTrue(result.success(), "Expected Spring named blocking operator compilation to succeed: "
+            + result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWithoutSpringProfile() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-default-profile.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public PaymentStatus audit(PaymentStatus input) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(yamlFile, List.of(paymentAuditService, paymentStatus));
+        assertFalse(result.success(), "Expected default renderer profile to reject Class::method delegated operators");
+        assertTrue(result.errorSummary().contains("only by the Spring renderer profile"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenMissing() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-missing.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public PaymentStatus process(PaymentStatus input) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected missing named Spring operator method to fail");
+        assertTrue(result.errorSummary().contains("was not found"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenOverloaded() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-overloaded.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public PaymentStatus audit(PaymentStatus input) {
+                    return new PaymentStatus();
+                }
+
+                public PaymentStatus audit(AlternatePaymentStatus input) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+        Path alternatePaymentStatus = writeSource("AlternatePaymentStatus.java", """
+            package com.example.app;
+
+            public class AlternatePaymentStatus {
+            }
+            """);
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus, alternatePaymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected overloaded named Spring operator method to fail");
+        assertTrue(result.errorSummary().contains("is overloaded"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenWrongArity() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-wrong-arity.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public PaymentStatus audit(PaymentStatus input, String reason) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected wrong-arity named Spring operator method to fail");
+        assertTrue(result.errorSummary().contains("exactly one input parameter"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenVoid() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-void.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public void audit(PaymentStatus input) {
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected void named Spring operator method to fail");
+        assertTrue(result.errorSummary().contains("must return an output value"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenStaticOnly() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-static.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public static PaymentStatus audit(PaymentStatus input) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected static named Spring operator method to fail");
+        assertTrue(result.errorSummary().contains("must be instance bean methods"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenReturnTypeIsUnsupportedReactiveWrapper() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-flux.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "");
+        Path paymentAuditService = writePaymentAuditService("""
+            import reactor.core.publisher.Flux;
+
+            public class PaymentAuditService {
+                public Flux<PaymentStatus> audit(PaymentStatus input) {
+                    return Flux.just(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+        Path fluxStub = writeFluxStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus, fluxStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected unsupported reactive named Spring operator return type to fail");
+        assertTrue(result.errorSummary().contains("does not support return type"), result.errorSummary());
+    }
+
+    @Test
+    void failsNamedOperatorMethodWhenCardinalityIsNonUnary() throws IOException {
+        Path yamlFile = writeSpringNamedOperatorYaml(
+            "pipeline-delegated-named-non-unary.yaml",
+            "com.example.app.PaymentAuditService::audit",
+            "    cardinality: \"ONE_TO_MANY\"\n");
+        Path paymentAuditService = writePaymentAuditService("""
+            public class PaymentAuditService {
+                public PaymentStatus audit(PaymentStatus input) {
+                    return new PaymentStatus();
+                }
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentAuditService, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected non-unary named Spring operator compilation to fail");
+        assertTrue(result.errorSummary().contains("declares cardinality"), result.errorSummary());
+    }
+
+    @Test
     void failsYamlInternalStepFromPlainMonoProcessMethodWithoutSpringProfile() throws IOException {
         Path yamlFile = tempDir.resolve("pipeline-internal-plain-mono-quarkus.yaml");
         Files.writeString(yamlFile, """
@@ -1450,6 +1717,30 @@ class YamlDrivenStepGenerationTest {
             "Expected delegated step not to be skipped when mapper fallback is enabled: " + warnings);
     }
 
+    private Path writeSpringNamedOperatorYaml(String fileName, String operatorReference, String extraStepLines)
+        throws IOException {
+        Path yamlFile = tempDir.resolve(fileName);
+        Files.writeString(yamlFile,
+            "appName: \"Test App\"\n"
+                + "basePackage: \"com.example\"\n"
+                + "transport: \"LOCAL\"\n"
+                + "steps:\n"
+                + "  - name: \"audit\"\n"
+                + "    operator: \"" + operatorReference + "\"\n"
+                + "    input: \"com.example.app.PaymentStatus\"\n"
+                + "    output: \"com.example.app.PaymentStatus\"\n"
+                + extraStepLines);
+        return yamlFile;
+    }
+
+    private Path writePaymentAuditService(String classBody) throws IOException {
+        return writeSource("PaymentAuditService.java", """
+            package com.example.app;
+
+            %s
+            """.formatted(classBody));
+    }
+
     private Path writeSource(String fileName, String content) throws IOException {
         Path baseDir = tempDir;
         Matcher matcher = PACKAGE_PATTERN.matcher(content);
@@ -1488,6 +1779,18 @@ class YamlDrivenStepGenerationTest {
             public class Mono<T> {
                 public static <U> Mono<U> just(U value) {
                     return new Mono<>();
+                }
+            }
+            """);
+    }
+
+    private Path writeFluxStub() throws IOException {
+        return writeSource("Flux.java", """
+            package reactor.core.publisher;
+
+            public class Flux<T> {
+                public static <U> Flux<U> just(U value) {
+                    return new Flux<>();
                 }
             }
             """);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -160,6 +160,59 @@ class StepDefinitionParserTest {
     }
 
     @Test
+    void preservesClassMethodSegmentForDelegatedOperatorStep() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "delegate-payment"
+                operator: "com.example.PaymentOperators::approve"
+                input: "com.example.PaymentRecord"
+                output: "com.example.PaymentStatus"
+            """, diagnostics);
+
+        assertEquals(1, steps.size(), diagnostics.toString());
+        StepDefinition step = steps.getFirst();
+        assertEquals(StepKind.DELEGATED, step.kind());
+        assertEquals(ClassName.get("com.example", "PaymentOperators"), step.executionClass());
+        assertEquals(java.util.Optional.of("approve"), step.delegatedMethodName());
+    }
+
+    @Test
+    void rejectsMalformedClassMethodOperatorReference() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "delegate-payment"
+                operator: "com.example.PaymentOperators::"
+                input: "com.example.PaymentRecord"
+                output: "com.example.PaymentStatus"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("Expected <class> or <class>::<method>")),
+            diagnostics.toString());
+
+        diagnostics.clear();
+        steps = parse("""
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "delegate-payment"
+                operator: "::approve"
+                input: "com.example.PaymentRecord"
+                output: "com.example.PaymentStatus"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("Expected <class> or <class>::<method>")),
+            diagnostics.toString());
+    }
+
+    @Test
     void parsesExplicitFalseRunOnVirtualThreadsForInternalStep() throws IOException {
         List<String> diagnostics = new ArrayList<>();
         List<StepDefinition> steps = parse("""

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
@@ -18,6 +18,7 @@ package org.pipelineframework.processor.renderer;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Set;
 
 import com.squareup.javapoet.ClassName;
@@ -113,6 +114,40 @@ class SpringLocalClientStepRendererTest {
     }
 
     @Test
+    void rendersDelegatedSpringBeanClassMethodLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(delegatedModel(
+                ServiceApiKind.REACTIVE,
+                ReactiveReturnKind.REACTOR_MONO,
+                "audit")),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/AuditLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("private final PaymentAuditBean paymentAuditBean;"));
+        assertTrue(source.contains("return this.paymentAuditBean.audit(input).toFuture();"));
+        assertFalse(source.contains(".process(input)"));
+    }
+
+    @Test
+    void rendersDelegatedSpringBeanCompletionStageClassMethodLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(delegatedModel(
+                ServiceApiKind.REACTIVE,
+                ReactiveReturnKind.COMPLETION_STAGE,
+                "auditAsync")),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/AuditLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("return this.paymentAuditBean.auditAsync(input);"));
+        assertFalse(source.contains(".toFuture();"));
+        assertFalse(source.contains("subscribeAsCompletionStage"));
+    }
+
+    @Test
     void rendersDelegatedBlockingSpringBeanLocalClientStep() throws Exception {
         SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
 
@@ -123,6 +158,20 @@ class SpringLocalClientStepRendererTest {
         String source = Files.readString(clientStep);
         assertTrue(source.contains("private final PaymentAuditBean paymentAuditBean;"));
         assertTrue(source.contains("return RuntimeAdapters.executeBlocking(() -> this.paymentAuditBean.processBlocking(input), false);"));
+    }
+
+    @Test
+    void rendersDelegatedBlockingSpringBeanClassMethodLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(delegatedModel(ServiceApiKind.BLOCKING, ReactiveReturnKind.MUTINY_UNI,
+                "auditBlocking")),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/AuditLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("return RuntimeAdapters.executeBlocking(() -> this.paymentAuditBean.auditBlocking(input), false);"));
+        assertFalse(source.contains(".processBlocking(input)"));
     }
 
     @Test
@@ -216,6 +265,22 @@ class SpringLocalClientStepRendererTest {
     }
 
     private PipelineStepModel delegatedModel(ServiceApiKind apiKind, ReactiveReturnKind reactiveReturnKind) {
+        return delegatedModel(apiKind, reactiveReturnKind, Optional.empty());
+    }
+
+    private PipelineStepModel delegatedModel(
+        ServiceApiKind apiKind,
+        ReactiveReturnKind reactiveReturnKind,
+        String delegateMethodName
+    ) {
+        return delegatedModel(apiKind, reactiveReturnKind, Optional.of(delegateMethodName));
+    }
+
+    private PipelineStepModel delegatedModel(
+        ServiceApiKind apiKind,
+        ReactiveReturnKind reactiveReturnKind,
+        Optional<String> delegateMethodName
+    ) {
         return new PipelineStepModel.Builder()
             .serviceName("AuditService")
             .generatedName("AuditService")
@@ -228,6 +293,7 @@ class SpringLocalClientStepRendererTest {
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
             .delegateService(ClassName.get("com.example.operator", "PaymentAuditBean"))
+            .delegateMethodName(delegateMethodName)
             .serviceApiKind(apiKind)
             .reactiveReturnKind(reactiveReturnKind)
             .build();

--- a/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentAuditService.java
+++ b/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentAuditService.java
@@ -6,7 +6,7 @@ import reactor.core.publisher.Mono;
 
 @Component
 public class PaymentAuditService {
-    public Mono<PaymentStatus> process(PaymentStatus input) {
+    public Mono<PaymentStatus> audit(PaymentStatus input) {
         if (input == null) {
             return Mono.error(new IllegalArgumentException("Payment status must not be null"));
         }

--- a/framework/spring-smoke-tests/src/main/resources/pipeline.yaml
+++ b/framework/spring-smoke-tests/src/main/resources/pipeline.yaml
@@ -10,6 +10,6 @@ steps:
     output: "com.example.smoke.domain.PaymentStatus"
     outboundMapper: "com.example.smoke.mapper.PaymentStatusMapper"
   - name: "audit"
-    operator: "com.example.smoke.service.PaymentAuditService"
+    operator: "com.example.smoke.service.PaymentAuditService::audit"
     input: "com.example.smoke.domain.PaymentStatus"
     output: "com.example.smoke.domain.PaymentStatus"


### PR DESCRIPTION
## Summary

Adds Spring-profile support for unary local `Class::method` operator beans, allowing YAML such as:

```yaml
operator: "com.example.PaymentAuditService::audit"
```

This keeps the slice Spring-only, local, unary, and `COMPUTE`-focused. Durable coordinator, queue-async, await, checkpoint, broker, gRPC, and function paths remain out of scope.

## Changes

- Preserves optional `Class::method` metadata through explicit `Optional<String>` method metadata.
- Resolves named Spring operator methods as public instance bean methods.
- Supports `Out method(In)`, `Mono<Out> method(In)`, and `CompletionStage<Out> method(In)`.
- Updates `SpringLocalClientStepRenderer` to inject the owner bean and invoke the resolved method name.
- Keeps PR #444 class-only delegate support unchanged.
- Extends Spring REST smoke to use `PaymentAuditService::audit`.
- Updates `/develop/spring-support` status and constraints.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime-core,runtime-spring,deployment,spring-smoke-tests,spring-blocking-smoke-tests -am -Dtest='SpringRendererProfileSupportTest,SpringLocalClientStepRendererTest,YamlDrivenStepGenerationTest,StepDefinitionParserTest,GeneratedSpringRestSmokeTest,GeneratedSpringBlockingRestSmokeTest,SpringSmokeDependencyGuardTest,SpringBlockingSmokeDependencyGuardTest' -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl deployment spotless:check`
- `npm --prefix docs run build`
- `git diff --check`

Note: `npm --prefix docs ci` was required first in the fresh worktree because docs dependencies were not installed locally; existing npm audit findings were not changed in this slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spring-based pipelines can now target a specific bean method using `Class::method` references (including YAML authoring guidance).
  * Local Spring step generation now supports completion-stage (`CompletionStage`) reactive boundaries.
* **Bug Fixes**
  * Improved parsing and validation for delegated method references, including clearer diagnostics for unsupported or incompatible method shapes.
  * Generated local Spring client steps now invoke the specified delegated method (no longer fall back to the default call path).
* **Documentation**
  * Updated Spring support matrix and authoring guidance for current delegated operator capabilities.
* **Tests**
  * Added and expanded Spring delegated-method YAML compilation and renderer coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->