### PR TITLE
Extract queue async segment pipeline

### DIFF
--- a/docs/evolve/await-unit-runtime/immutable-boundaries.md
+++ b/docs/evolve/await-unit-runtime/immutable-boundaries.md
@@ -90,6 +90,57 @@ These facts are immutable. A `ControlPlaneJournal` appends them conditionally by
 
 Duplicate completions and terminal publications are handled by fact keys. Retrying the same append is a no-op when the fact key already exists; retrying a different fact against a stale version fails with an append conflict.
 
+## Segment Execution And Commitment
+
+Queue-async segment execution is modeled as a small reactive flow over immutable decisions:
+
+1. `QueueAsyncSegmentPipeline` claims one due `ExecutionRecord` and wraps it as a `ClaimedSegment`.
+2. The claimed segment builds the transition command from its pinned pipeline, contract, release, step index, attempt, and input payload.
+3. The transition worker returns a `TransitionResultEnvelope`.
+4. `SegmentCommitPlan` converts that envelope into one immutable decision: `CompletedSegment`, `SuspendedSegment`, or `FailedSegment`.
+5. `SegmentCommitEffects` interprets that decision against the current projection stores and appends the matching control-plane facts.
+6. `TerminalPublicationBoundary` handles checkpoint and Object Publish side effects before success is committed.
+
+The split is deliberate. `SegmentCommitPlan` is pure: it validates result shape and describes what happened without calling stores, publishers, telemetry, or dispatchers. Effects are interpreted afterwards through narrow boundaries.
+
+```mermaid
+sequenceDiagram
+    participant Queue as "QueueAsyncCoordinator"
+    participant Pipeline as "QueueAsyncSegmentPipeline"
+    participant Segment as "ClaimedSegment"
+    participant Worker as "Transition worker"
+    participant Plan as "SegmentCommitPlan"
+    participant Effects as "SegmentCommitEffects"
+    participant Publish as "TerminalPublicationBoundary"
+    participant Store as "Projection stores"
+    participant Ledger as "SegmentBoundaryLedger"
+
+    Queue->>Pipeline: "process work item"
+    Pipeline->>Store: "claim due execution"
+    Store-->>Pipeline: "ExecutionRecord"
+    Pipeline->>Segment: "wrap as ClaimedSegment"
+    Pipeline->>Ledger: "append SegmentAttemptStarted"
+    Segment-->>Pipeline: "TransitionCommandEnvelope"
+    Pipeline->>Worker: "execute segment"
+    Worker-->>Pipeline: "TransitionResultEnvelope"
+    Pipeline->>Plan: "classify completed/suspended/failed"
+    Pipeline->>Effects: "interpret immutable plan"
+    alt completed segment
+      Effects->>Ledger: "append SegmentCompleted"
+      Effects->>Publish: "checkpoint + Object Publish"
+      Publish-->>Effects: "published or no-op"
+      Effects->>Store: "commit success projection"
+      Effects->>Ledger: "append RunSucceeded"
+    else suspended segment
+      Effects->>Store: "persist WAITING_EXTERNAL projection"
+      Effects->>Ledger: "append SegmentSuspended"
+      Effects->>Store: "release ready continuation work"
+    else failed segment
+      Effects->>Store: "retry or terminal failure projection"
+      Effects->>Ledger: "append RunFailed when terminal"
+    end
+```
+
 ## Boundary Admission
 
 Await completion and checkpoint handoff are the same architectural shape: a transport message admits a correlated payload into a TPF-owned boundary.
@@ -114,7 +165,9 @@ sequenceDiagram
 
 For await completions, `AwaitBoundaryAdmission` is the internal owner of that route. It normalizes the completion command, applies local control-plane admission, records the existing await completion projection, appends `BoundaryCompletionAdmitted`, and only then chooses between a local live-session handoff or durable continuation work.
 
-`AwaitContinuations` owns the "future beginning" after the boundary. It releases scalar awaits, records per-item continuation outputs, assembles ordered itemized parent output, and dispatches resumed segment work. `QueueAsyncCoordinator` remains the API and provider façade for now; it should not own completion-routing semantics directly.
+`AwaitContinuations` is now only the small façade for the "future beginning" after the boundary. The semantic decision is made by `AwaitContinuationPlanner`, which returns immutable continuation plans: hold the completion, release a scalar continuation, dispatch item continuations, record an item output, release the itemized parent, fail the parent, or no-op. `ScalarAwaitContinuationFlow` and `ItemizedAwaitContinuationFlow` interpret those plans through the existing projection stores and dispatcher. `ItemContinuationClaims` is process-local duplicate suppression only; it does not decide durable readiness.
+
+`QueueAsyncCoordinator` remains the API and provider façade; it delegates segment execution to `QueueAsyncSegmentPipeline` and await completion routing to `AwaitBoundaryAdmission`.
 
 ```mermaid
 sequenceDiagram
@@ -124,7 +177,10 @@ sequenceDiagram
     participant Ledger as "SegmentBoundaryLedger -> ControlPlaneJournal"
     participant Live as "LiveAwaitSession"
     participant Consumer as "Downstream live consumer"
-    participant Continue as "AwaitContinuations"
+    participant Continue as "AwaitContinuations facade"
+    participant Planner as "AwaitContinuationPlanner"
+    participant Scalar as "ScalarAwaitContinuationFlow"
+    participant Itemized as "ItemizedAwaitContinuationFlow"
     participant Work as "Work dispatcher"
 
     Broker->>Admission: "correlated completion"
@@ -136,7 +192,56 @@ sequenceDiagram
       Live-->>Consumer: "emit item by demand"
     else no local live session
       Admission->>Continue: "durable fallback"
-      Continue->>Work: "enqueue scalar or item continuation when gates allow"
+      Continue->>Planner: "plan future beginning"
+      alt scalar await
+        Continue->>Scalar: "release scalar continuation"
+        Scalar->>Work: "enqueue resumed segment"
+      else itemized await
+        Continue->>Itemized: "dispatch item continuations or release parent"
+        Itemized->>Work: "enqueue item/parent continuation when gates allow"
+      end
+    end
+```
+
+## Scalar And Itemized Continuation Flows
+
+Scalar and itemized awaits share the same admission path, but their future beginnings differ:
+
+- Scalar continuation has one completed interaction. The scalar flow persists the parent execution as queued at the next step, records `ContinuationSegmentCreated`, and enqueues the resumed segment.
+- Itemized continuation has one owning unit and one interaction per input item. The itemized flow waits for dispatch completion and parent `WAITING_EXTERNAL` when it must use the durable fallback path. It then dispatches ready item continuations, records each child segment output under a stable `ItemContinuationKey`, assembles child outputs in item-index order, records the parent continuation segment, and enqueues the parent once.
+- Local claims prevent duplicate process-local dispatch or parent release attempts while a worker is active. They are deliberately weaker than durable state; duplicate completions or retries must still be safe through the projection stores and ledger fact keys.
+
+```mermaid
+sequenceDiagram
+    participant Completion as "Admitted completion"
+    participant Planner as "AwaitContinuationPlanner"
+    participant Scalar as "ScalarAwaitContinuationFlow"
+    participant Itemized as "ItemizedAwaitContinuationFlow"
+    participant Claims as "ItemContinuationClaims"
+    participant Store as "Projection stores"
+    participant Ledger as "SegmentBoundaryLedger"
+    participant Work as "Work dispatcher"
+
+    Completion->>Planner: "classify future beginning"
+    alt scalar release
+      Planner-->>Scalar: "ReleaseScalar"
+      Scalar->>Store: "queue parent at next step"
+      Scalar->>Ledger: "append ContinuationSegmentCreated"
+      Scalar->>Work: "enqueue parent segment"
+    else item ready
+      Planner-->>Itemized: "DispatchItemContinuations"
+      Itemized->>Claims: "claim item dispatch"
+      Itemized->>Store: "recheck parent WAITING_EXTERNAL"
+      Itemized->>Work: "run child continuation"
+      Itemized->>Store: "record child output"
+      Itemized->>Ledger: "append child ContinuationSegmentCreated"
+      Itemized->>Planner: "all child outputs present?"
+      Planner-->>Itemized: "ReleaseItemizedParent"
+      Itemized->>Store: "queue parent with ordered output"
+      Itemized->>Ledger: "append parent ContinuationSegmentCreated"
+      Itemized->>Work: "enqueue parent segment"
+    else not ready
+      Planner-->>Completion: "HoldCompletion / NoOp"
     end
 ```
 

--- a/docs/evolve/await-unit-runtime/index.md
+++ b/docs/evolve/await-unit-runtime/index.md
@@ -64,10 +64,18 @@ classDiagram
     class PipelineExecutionService
     class PipelineRunner
     class QueueAsyncCoordinator
+    class QueueAsyncSegmentPipeline
+    class SegmentCommitPlan
+    class SegmentCommitEffects
+    class TerminalPublicationBoundary
     class AwaitBoundaryAdmission
     class AwaitLiveCompletionRegistry
     class LiveAwaitSession
     class AwaitContinuations
+    class AwaitContinuationPlanner
+    class ScalarAwaitContinuationFlow
+    class ItemizedAwaitContinuationFlow
+    class ItemContinuationClaims
     class AwaitStepSupport
     class AwaitCoordinator
     class AwaitUnitStore
@@ -81,13 +89,22 @@ classDiagram
     PipelineRunner --> AwaitStepSupport : execute generated await step
     AwaitStepSupport --> AwaitCoordinator : create / dispatch unit
     PipelineExecutionService --> QueueAsyncCoordinator : async execution lifecycle
+    QueueAsyncCoordinator --> QueueAsyncSegmentPipeline : process work item
+    QueueAsyncSegmentPipeline --> SegmentCommitPlan : plan completed/suspended/failed
+    QueueAsyncSegmentPipeline --> SegmentCommitEffects : interpret plan
+    SegmentCommitEffects --> TerminalPublicationBoundary : publish before success
     QueueAsyncCoordinator --> AwaitBoundaryAdmission : complete await
     AwaitBoundaryAdmission --> AwaitCoordinator : record completion
     AwaitBoundaryAdmission --> AwaitLiveCompletionRegistry : try live handoff
     AwaitLiveCompletionRegistry --> LiveAwaitSession : local admission
     LiveAwaitSession --> PipelineRunner : downstream demand
     AwaitBoundaryAdmission --> AwaitContinuations : durable fallback
-    AwaitContinuations --> ExecutionStateStore : continuation projection writes
+    AwaitContinuations --> AwaitContinuationPlanner : plan future beginning
+    AwaitContinuations --> ScalarAwaitContinuationFlow : scalar resume
+    AwaitContinuations --> ItemizedAwaitContinuationFlow : item continuations
+    ItemizedAwaitContinuationFlow --> ItemContinuationClaims : local duplicate suppression
+    ScalarAwaitContinuationFlow --> ExecutionStateStore : continuation projection writes
+    ItemizedAwaitContinuationFlow --> ExecutionStateStore : continuation projection writes
     AwaitCoordinator --> AwaitUnitStore
     AwaitCoordinator --> AwaitInteractionStore
     AwaitCoordinator --> AwaitTransportAdapter : dispatch
@@ -96,6 +113,8 @@ classDiagram
 `AwaitUnitRecord` is the current compatibility projection for completion of the authored await boundary. `AwaitInteractionRecord` is the transport-facing projection. The target queue-async model represents the same behavior as immutable `BoundaryUnit` and `BoundaryInteraction` projections derived from appended facts.
 
 In that model, `PipelineRunner` still runs synchronous step segments. An await step suspends one `ExecutionSegment` by appending a `SegmentSuspended` fact. Kafka, webhook, or interaction-api completion appends `BoundaryCompletionAdmitted`. If a live await session is present, the admitted completion can flow into the active downstream `Multi`; if not, the same durable facts create continuation segment work.
+
+That continuation is the future beginning of the suspended pipeline. `AwaitContinuationPlanner` decides whether a completion is still held, releases a scalar resume, dispatches item continuations, records item output, or releases an itemized parent. `ScalarAwaitContinuationFlow` and `ItemizedAwaitContinuationFlow` interpret those decisions through the existing projection stores and dispatcher. `ItemContinuationClaims` is only process-local duplicate suppression; durable truth remains in the stores and immutable ledger facts.
 
 ## CSV Payments Applied Model
 

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitContinuationPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitContinuationPlan.java
@@ -1,0 +1,125 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+
+sealed interface AwaitContinuationPlan
+    permits AwaitContinuationPlan.HoldCompletion,
+    AwaitContinuationPlan.ReleaseScalar,
+    AwaitContinuationPlan.DispatchItemContinuations,
+    AwaitContinuationPlan.RecordItemOutput,
+    AwaitContinuationPlan.ReleaseItemizedParent,
+    AwaitContinuationPlan.FailParent,
+    AwaitContinuationPlan.NoOp {
+
+  record HoldCompletion(AwaitInteractionRecord interaction, AwaitUnitRecord unit) implements AwaitContinuationPlan {
+    public HoldCompletion {
+      if (interaction == null) {
+        throw new IllegalArgumentException("Held await completion requires interaction");
+      }
+      if (unit == null) {
+        throw new IllegalArgumentException("Held await completion requires unit");
+      }
+    }
+  }
+
+  record ReleaseScalar(
+      AwaitInteractionRecord interaction,
+      AwaitUnitRecord unit,
+      int nextStepIndex) implements AwaitContinuationPlan {
+    public ReleaseScalar {
+      if (interaction == null) {
+        throw new IllegalArgumentException("Scalar await release requires interaction");
+      }
+      if (unit == null) {
+        throw new IllegalArgumentException("Scalar await release requires unit");
+      }
+      if (nextStepIndex < 0) {
+        throw new IllegalArgumentException("Scalar await release requires a non-negative nextStepIndex");
+      }
+    }
+  }
+
+  record DispatchItemContinuations(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int nextStepIndex) implements AwaitContinuationPlan {
+    public DispatchItemContinuations {
+      if (parent == null) {
+        throw new IllegalArgumentException("Itemized await dispatch requires parent execution");
+      }
+      if (unit == null) {
+        throw new IllegalArgumentException("Itemized await dispatch requires unit");
+      }
+      if (nextStepIndex < 0) {
+        throw new IllegalArgumentException("Itemized await dispatch requires a non-negative nextStepIndex");
+      }
+      if (!unit.unitId().equals(parent.awaitUnitId())) {
+        throw new IllegalArgumentException("Parent await unit does not match itemized dispatch unit");
+      }
+    }
+  }
+
+  record RecordItemOutput(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      AwaitInteractionRecord interaction,
+      ItemContinuationKey key,
+      int aggregateStepIndex,
+      ExecutionInputSnapshot continuationInput,
+      List<?> segmentOutputs) implements AwaitContinuationPlan {
+    public RecordItemOutput {
+      if (parent == null) {
+        throw new IllegalArgumentException("Itemized output capture requires parent execution");
+      }
+      if (unit == null) {
+        throw new IllegalArgumentException("Itemized output capture requires unit");
+      }
+      if (interaction == null) {
+        throw new IllegalArgumentException("Itemized output capture requires interaction");
+      }
+      if (key == null) {
+        throw new IllegalArgumentException("Itemized output capture requires key");
+      }
+      if (aggregateStepIndex < 0) {
+        throw new IllegalArgumentException("Aggregate step index must be non-negative: " + aggregateStepIndex);
+      }
+      if (continuationInput == null) {
+        throw new IllegalArgumentException("Itemized await continuation requires normalized continuation input");
+      }
+      segmentOutputs = segmentOutputs == null ? List.of() : List.copyOf(segmentOutputs);
+    }
+  }
+
+  record ReleaseItemizedParent(ItemizedParentRelease release) implements AwaitContinuationPlan {
+    public ReleaseItemizedParent {
+      if (release == null) {
+        throw new IllegalArgumentException("Itemized parent release plan requires release");
+      }
+    }
+  }
+
+  record FailParent(AwaitInteractionRecord interaction, Throwable failure, int attempt) implements AwaitContinuationPlan {
+    public FailParent {
+      if (interaction == null) {
+        throw new IllegalArgumentException("Parent failure plan requires interaction");
+      }
+      if (failure == null) {
+        throw new IllegalArgumentException("Parent failure plan requires failure");
+      }
+      if (attempt < 1) {
+        throw new IllegalArgumentException("Parent failure attempt must be positive");
+      }
+    }
+  }
+
+  record NoOp(String reason) implements AwaitContinuationPlan {
+    public NoOp {
+      reason = reason == null ? "" : reason;
+    }
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitContinuationPlanner.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitContinuationPlanner.java
@@ -1,0 +1,188 @@
+package org.pipelineframework;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+class AwaitContinuationPlanner {
+
+  static final String ONE_TO_ONE_CARDINALITY = "ONE_TO_ONE";
+
+  AwaitContinuationPlan afterRecordedCompletion(
+      AwaitInteractionRecord interaction,
+      AwaitUnitRecord unit,
+      Optional<ExecutionRecord<Object, Object>> parent) {
+    if (!usesItemContinuations(interaction, unit)) {
+      return unit != null && unit.status() == AwaitUnitStatus.COMPLETED
+          ? new AwaitContinuationPlan.ReleaseScalar(interaction, unit, interaction.stepIndex() + 1)
+          : new AwaitContinuationPlan.NoOp("scalar-await-unit-not-complete");
+    }
+    if (!itemContinuationReady(parent, unit)) {
+      return new AwaitContinuationPlan.HoldCompletion(interaction, unit);
+    }
+    return new AwaitContinuationPlan.DispatchItemContinuations(parent.orElseThrow(), unit, interaction.stepIndex() + 1);
+  }
+
+  AwaitContinuationPlan afterParentWaiting(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int suspendedStepIndex) {
+    if (unit == null) {
+      return new AwaitContinuationPlan.NoOp("await-unit-missing");
+    }
+    if (usesItemContinuations(unit)) {
+      if (!itemContinuationReady(Optional.ofNullable(parent), unit)) {
+        return new AwaitContinuationPlan.NoOp("itemized-parent-not-ready");
+      }
+      return new AwaitContinuationPlan.DispatchItemContinuations(parent, unit, suspendedStepIndex + 1);
+    }
+    if (unit.status() != AwaitUnitStatus.COMPLETED) {
+      return new AwaitContinuationPlan.NoOp("scalar-await-unit-not-complete");
+    }
+    return new AwaitContinuationPlan.ReleaseScalar(
+        scalarInteraction(parent, unit, suspendedStepIndex),
+        unit,
+        suspendedStepIndex + 1);
+  }
+
+  AwaitContinuationPlan recordItemOutput(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      AwaitInteractionRecord interaction,
+      int aggregateStepIndex,
+      ExecutionInputSnapshot continuationInput,
+      List<?> segmentOutputs) {
+    if (!usesItemContinuations(interaction, unit)) {
+      return new AwaitContinuationPlan.NoOp("not-itemized-await-continuation");
+    }
+    validateItemIndex(interaction, unit);
+    if (continuationInput == null) {
+      throw new IllegalArgumentException("Itemized await continuation requires normalized continuation input");
+    }
+    return new AwaitContinuationPlan.RecordItemOutput(
+        parent,
+        unit,
+        interaction,
+        ItemContinuationKey.from(parent, unit, interaction),
+        aggregateStepIndex,
+        copyInputSnapshot(continuationInput),
+        segmentOutputs);
+  }
+
+  AwaitContinuationPlan releaseItemizedParent(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int aggregateStepIndex,
+      List<Optional<ExecutionRecord<Object, Object>>> children) {
+    if (parent == null || unit == null || !usesItemContinuations(unit)
+        || !unit.dispatchComplete() || unit.expectedItemCount() == null) {
+      return new AwaitContinuationPlan.NoOp("itemized-parent-release-not-ready");
+    }
+    List<Object> orderedOutputs = new ArrayList<>();
+    for (Optional<ExecutionRecord<Object, Object>> child : children) {
+      if (child.isEmpty() || child.get().status() != ExecutionStatus.SUCCEEDED) {
+        return new AwaitContinuationPlan.NoOp("itemized-child-not-succeeded");
+      }
+      Object payload = child.get().resultPayload();
+      if (payload instanceof Iterable<?> iterable) {
+        iterable.forEach(orderedOutputs::add);
+      } else if (payload != null) {
+        orderedOutputs.add(payload);
+      }
+    }
+    return new AwaitContinuationPlan.ReleaseItemizedParent(new ItemizedParentRelease(
+        parent,
+        unit,
+        aggregateStepIndex,
+        new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(orderedOutputs))));
+  }
+
+  void validateItemIndex(AwaitInteractionRecord interaction, AwaitUnitRecord unit) {
+    if (interaction == null || interaction.itemIndex() == null) {
+      throw new IllegalArgumentException("Itemized await continuation requires itemIndex");
+    }
+    int itemIndex = interaction.itemIndex();
+    if (itemIndex < 0) {
+      throw new IllegalArgumentException(
+          "Itemized await continuation itemIndex must be non-negative: " + itemIndex);
+    }
+    Integer expectedItemCount = unit == null ? null : unit.expectedItemCount();
+    if (expectedItemCount != null && itemIndex >= expectedItemCount) {
+      throw new IllegalArgumentException(
+          "Itemized await continuation itemIndex " + itemIndex
+              + " is outside expected item count " + expectedItemCount);
+    }
+  }
+
+  boolean itemContinuationReady(
+      Optional<ExecutionRecord<Object, Object>> parent,
+      AwaitUnitRecord unit) {
+    return parent.isPresent()
+        && parent.get().status() == ExecutionStatus.WAITING_EXTERNAL
+        && unit != null
+        && unit.dispatchComplete()
+        && unit.unitId().equals(parent.get().awaitUnitId());
+  }
+
+  static boolean usesItemContinuations(
+      AwaitInteractionRecord interaction,
+      AwaitUnitRecord unit) {
+    return interaction != null
+        && interaction.itemInteraction()
+        && usesItemContinuations(unit);
+  }
+
+  static boolean usesItemContinuations(AwaitUnitRecord unit) {
+    return unit != null
+        && unit.primaryInteractionId() == null
+        && ONE_TO_ONE_CARDINALITY.equalsIgnoreCase(unit.cardinality());
+  }
+
+  private static AwaitInteractionRecord scalarInteraction(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int suspendedStepIndex) {
+    return new AwaitInteractionRecord(
+        parent == null ? unit.tenantId() : parent.tenantId(),
+        parent == null ? unit.executionId() : parent.executionId(),
+        unit.stepId(),
+        suspendedStepIndex,
+        Object.class.getCanonicalName(),
+        unit.primaryInteractionId() == null ? "scalar:" + unit.unitId() : unit.primaryInteractionId(),
+        "scalar:" + unit.unitId(),
+        "await-unit:" + unit.unitId(),
+        "scalar:" + unit.unitId(),
+        1L,
+        AwaitInteractionStatus.COMPLETED,
+        null,
+        null,
+        unit.unitId(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        java.util.Map.of(),
+        unit.ttlEpochS(),
+        parent == null ? unit.createdAtEpochMs() : parent.createdAtEpochMs(),
+        unit.updatedAtEpochMs(),
+        unit.ttlEpochS());
+  }
+
+  private static ExecutionInputSnapshot copyInputSnapshot(ExecutionInputSnapshot snapshot) {
+    Object payload = snapshot.payload();
+    if (payload instanceof List<?> list) {
+      payload = List.copyOf(list);
+    }
+    return new ExecutionInputSnapshot(snapshot.shape(), payload);
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitContinuations.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitContinuations.java
@@ -1,35 +1,20 @@
 package org.pipelineframework;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
-import org.jboss.logging.Logger;
-import org.pipelineframework.awaitable.AwaitCompletionMetrics;
 import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitCoordinator;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
-import org.pipelineframework.awaitable.AwaitInteractionStatus;
 import org.pipelineframework.awaitable.AwaitUnitRecord;
-import org.pipelineframework.awaitable.AwaitUnitStatus;
-import org.pipelineframework.orchestrator.ExecutionCreateCommand;
-import org.pipelineframework.orchestrator.ExecutionInputShape;
 import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRecord;
-import org.pipelineframework.orchestrator.ExecutionResultShape;
 import org.pipelineframework.orchestrator.ExecutionStateStore;
-import org.pipelineframework.orchestrator.ExecutionStatus;
-import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
 import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
 import org.pipelineframework.orchestrator.WorkDispatcher;
@@ -37,14 +22,9 @@ import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
 
 /**
- * Owns durable continuations that begin after an await boundary.
+ * Facade for durable continuations that create the future beginning after an await boundary.
  */
 class AwaitContinuations {
-
-  private static final Logger LOG = Logger.getLogger(AwaitContinuations.class);
-  private static final int AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS = 3;
-  private static final long AWAIT_ITEM_CONTINUATION_RETRY_BASE_MS = 100L;
-  private static final String ONE_TO_ONE_CARDINALITY = "ONE_TO_ONE";
 
   static final AwaitItemContinuationHandler NOOP_ITEM_CONTINUATION_HANDLER =
       new AwaitItemContinuationHandler() {
@@ -68,16 +48,10 @@ class AwaitContinuations {
         }
       };
 
-  private final ExecutionStateStore executionStateStore;
-  private final WorkDispatcher workDispatcher;
+  private final AwaitContinuationPlanner planner;
   private final AwaitCoordinator awaitCoordinator;
-  private final TransitionWorkerExecutor transitionWorkerExecutor;
-  private final ScheduledExecutorService queueSweepExecutor;
-  private final Supplier<Duration> saturatedDelay;
-  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
-  private final Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder;
-  private final Set<String> itemContinuationDispatchClaims = ConcurrentHashMap.newKeySet();
-  private final Map<String, Set<Integer>> completedItemContinuationIndexes = new ConcurrentHashMap<>();
+  private final ScalarAwaitContinuationFlow scalarFlow;
+  private final ItemizedAwaitContinuationFlow itemizedFlow;
 
   AwaitContinuations(
       ExecutionStateStore executionStateStore,
@@ -88,14 +62,25 @@ class AwaitContinuations {
       Supplier<Duration> saturatedDelay,
       Supplier<SegmentBoundaryLedger> segmentBoundaryLedger,
       Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder) {
-    this.executionStateStore = executionStateStore;
-    this.workDispatcher = workDispatcher;
+    this.planner = new AwaitContinuationPlanner();
     this.awaitCoordinator = awaitCoordinator;
-    this.transitionWorkerExecutor = transitionWorkerExecutor;
-    this.queueSweepExecutor = queueSweepExecutor;
-    this.saturatedDelay = saturatedDelay;
-    this.segmentBoundaryLedger = segmentBoundaryLedger;
-    this.lifecycleRecorder = lifecycleRecorder;
+    ItemContinuationClaims claims = new ItemContinuationClaims();
+    this.scalarFlow = new ScalarAwaitContinuationFlow(
+        executionStateStore,
+        workDispatcher,
+        segmentBoundaryLedger,
+        lifecycleRecorder);
+    this.itemizedFlow = new ItemizedAwaitContinuationFlow(
+        executionStateStore,
+        workDispatcher,
+        awaitCoordinator,
+        transitionWorkerExecutor,
+        queueSweepExecutor,
+        saturatedDelay,
+        segmentBoundaryLedger,
+        lifecycleRecorder,
+        planner,
+        claims);
   }
 
   Uni<AwaitCompletionResult> afterRecordedCompletion(
@@ -103,17 +88,20 @@ class AwaitContinuations {
       AwaitUnitRecord unit,
       AwaitItemContinuationHandler itemContinuationHandler,
       long nowEpochMs) {
-    if (usesItemContinuations(result.record(), unit)) {
-      return dispatchCompletedItemContinuationsIfReady(
-              result.record(),
+    AwaitInteractionRecord record = result.record();
+    if (AwaitContinuationPlanner.usesItemContinuations(record, unit)) {
+      return itemizedFlow.afterRecordedCompletion(
+              record,
               unit,
               itemContinuationHandler,
               nowEpochMs)
           .replaceWith(result);
     }
-    return unit.status() == AwaitUnitStatus.COMPLETED
-        ? releaseScalarResume(result.record(), unit.unitId(), nowEpochMs).replaceWith(result)
-        : Uni.createFrom().item(result);
+    AwaitContinuationPlan plan = planner.afterRecordedCompletion(record, unit, Optional.empty());
+    if (plan instanceof AwaitContinuationPlan.ReleaseScalar scalar) {
+      return scalarFlow.release(scalar, nowEpochMs).replaceWith(result);
+    }
+    return Uni.createFrom().item(result);
   }
 
   Uni<Void> afterParentWaiting(
@@ -123,29 +111,18 @@ class AwaitContinuations {
       AwaitItemContinuationHandler itemContinuationHandler) {
     return awaitCoordinator.getUnit(record.tenantId(), suspended.unitId())
         .onItem().transformToUni(unit -> {
-          if (unit == null || unit.status() != AwaitUnitStatus.COMPLETED) {
-            return unit != null && usesItemContinuations(unit)
-                ? dispatchCompletedItemContinuations(record, unit, itemContinuationHandler, nowEpochMs)
-                : Uni.createFrom().voidItem();
+          if (unit == null) {
+            return Uni.createFrom().voidItem();
           }
-          if (usesItemContinuations(unit)) {
-            return dispatchCompletedItemContinuations(record, unit, itemContinuationHandler, nowEpochMs)
-                .onItem().transformToUni(ignored -> itemContinuationHandler.releaseAwaitParentIfReady(
-                    record,
-                    unit,
-                    suspended.stepIndex() + 1,
-                    nowEpochMs));
+          AwaitContinuationPlan plan = planner.afterParentWaiting(record, unit, suspended.stepIndex());
+          if (plan instanceof AwaitContinuationPlan.ReleaseScalar scalar) {
+            return scalarFlow.release(scalar, nowEpochMs);
           }
-          return releaseScalarResume(
-              record.tenantId(),
-              record.executionId(),
-              unit.unitId(),
-              unit.stepId(),
+          return itemizedFlow.afterParentWaiting(
+              record,
+              unit,
               suspended.stepIndex(),
-              null,
-              null,
-              null,
-              null,
+              itemContinuationHandler,
               nowEpochMs);
         });
   }
@@ -157,126 +134,13 @@ class AwaitContinuations {
       ExecutionInputSnapshot continuationInput,
       List<?> segmentOutputs,
       long nowEpochMs) {
-    if (!usesItemContinuations(interaction, unit)) {
-      return Uni.createFrom().voidItem();
-    }
-    if (interaction.itemIndex() == null) {
-      return Uni.createFrom().failure(new IllegalArgumentException("Itemized await continuation requires itemIndex"));
-    }
-    Optional<IllegalArgumentException> invalidIndex = invalidItemIndex(interaction, unit);
-    if (invalidIndex.isPresent()) {
-      return Uni.createFrom().failure(invalidIndex.get());
-    }
-    if (continuationInput == null) {
-      return Uni.createFrom().failure(new IllegalArgumentException(
-          "Itemized await continuation requires normalized continuation input"));
-    }
-    ExecutionInputSnapshot normalizedInput = copyInputSnapshot(continuationInput);
-    return executionStateStore.getExecution(interaction.tenantId(), interaction.executionId())
-        .onItem().transformToUni(parent -> {
-          if (parent.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          ExecutionRecord<Object, Object> parentRecord = parent.get();
-          String childKey = itemContinuationKey(parentRecord, unit, interaction.itemIndex());
-          return executionStateStore.getExecutionByKey(interaction.tenantId(), childKey)
-              .onItem().transformToUni(existing -> {
-                if (existing.isPresent() && existing.get().status() == ExecutionStatus.SUCCEEDED) {
-                  return recordItemContinuationSegment(
-                          parentRecord,
-                          unit,
-                          interaction,
-                          aggregateStepIndex,
-                          normalizedInput,
-                          nowEpochMs)
-                      .chain(() -> releaseParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
-                }
-                long ttl = parentRecord.ttlEpochS();
-                ExecutionCreateCommand create = new ExecutionCreateCommand(
-                    interaction.tenantId(),
-                    childKey,
-                    parentRecord.pipelineId(),
-                    parentRecord.contractVersion(),
-                    parentRecord.releaseVersion(),
-                    normalizedInput,
-                    ExecutionResultShape.MATERIALIZED_MULTI,
-                    nowEpochMs,
-                    ttl);
-                return executionStateStore.createOrGetExecution(create)
-                    .onItem().transformToUni(created -> {
-                      ExecutionRecord<Object, Object> child = created.record();
-                      if (created.duplicate() && child.status() == ExecutionStatus.SUCCEEDED) {
-                        return recordItemContinuationSegment(
-                                parentRecord,
-                                unit,
-                                interaction,
-                                aggregateStepIndex,
-                                normalizedInput,
-                                nowEpochMs)
-                            .chain(() -> releaseParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
-                      }
-                      String transitionKey = "await-item-continuation:" + unit.unitId() + ":" + interaction.itemIndex();
-                      return executionStateStore.markSucceeded(
-                              child.tenantId(),
-                              child.executionId(),
-                              child.version(),
-                              transitionKey,
-                              List.copyOf(segmentOutputs == null ? List.of() : segmentOutputs),
-                              nowEpochMs)
-                          .onItem().transformToUni(updated -> handleChildSuccessUpdate(
-                              updated,
-                              parentRecord,
-                              unit,
-                              interaction,
-                              aggregateStepIndex,
-                              normalizedInput,
-                              childKey,
-                              nowEpochMs));
-                    });
-              });
-        });
-  }
-
-  private Uni<Void> handleChildSuccessUpdate(
-      Optional<ExecutionRecord<Object, Object>> updated,
-      ExecutionRecord<Object, Object> parentRecord,
-      AwaitUnitRecord unit,
-      AwaitInteractionRecord interaction,
-      int aggregateStepIndex,
-      ExecutionInputSnapshot normalizedInput,
-      String childKey,
-      long nowEpochMs) {
-    if (updated.isPresent()) {
-      return recordItemContinuationSegment(
-              parentRecord,
-              unit,
-              interaction,
-              aggregateStepIndex,
-              normalizedInput,
-              nowEpochMs)
-          .chain(() -> releaseParentWhenLocallyReady(
-              parentRecord,
-              unit,
-              interaction.itemIndex(),
-              aggregateStepIndex,
-              nowEpochMs));
-    }
-    return executionStateStore.getExecutionByKey(parentRecord.tenantId(), childKey)
-        .onItem().transformToUni(current -> {
-          if (current.isPresent() && current.get().status() == ExecutionStatus.SUCCEEDED) {
-            return recordItemContinuationSegment(
-                    parentRecord,
-                    unit,
-                    interaction,
-                    aggregateStepIndex,
-                    normalizedInput,
-                    nowEpochMs)
-                .chain(() -> releaseParentIfReady(parentRecord, unit, aggregateStepIndex, nowEpochMs));
-          }
-          return Uni.createFrom().failure(new IllegalStateException(
-              "Await item continuation child success was not admitted and child is not already SUCCEEDED: "
-                  + childKey));
-        });
+    return itemizedFlow.captureOutput(
+        interaction,
+        unit,
+        aggregateStepIndex,
+        continuationInput,
+        segmentOutputs,
+        nowEpochMs);
   }
 
   Uni<Void> releaseParentIfReady(
@@ -284,589 +148,6 @@ class AwaitContinuations {
       AwaitUnitRecord unit,
       int aggregateStepIndex,
       long nowEpochMs) {
-    if (parent == null || unit == null || !usesItemContinuations(unit)
-        || !unit.dispatchComplete() || unit.expectedItemCount() == null) {
-      return Uni.createFrom().voidItem();
-    }
-    List<Uni<Optional<ExecutionRecord<Object, Object>>>> lookups = new ArrayList<>();
-    for (int index = 0; index < unit.expectedItemCount(); index++) {
-      lookups.add(executionStateStore.getExecutionByKey(parent.tenantId(), itemContinuationKey(parent, unit, index)));
-    }
-    return Uni.join().all(lookups).andCollectFailures()
-        .onItem().transformToUni(children -> {
-          List<Object> orderedOutputs = new ArrayList<>();
-          for (Object childObject : children) {
-            @SuppressWarnings("unchecked")
-            Optional<ExecutionRecord<Object, Object>> child = (Optional<ExecutionRecord<Object, Object>>) childObject;
-            if (child.isEmpty() || child.get().status() != ExecutionStatus.SUCCEEDED) {
-              return Uni.createFrom().voidItem();
-            }
-            Object payload = child.get().resultPayload();
-            if (payload instanceof Iterable<?> iterable) {
-              iterable.forEach(orderedOutputs::add);
-            } else if (payload != null) {
-              orderedOutputs.add(payload);
-            }
-          }
-          Object resumePayload = new ExecutionInputSnapshot(ExecutionInputShape.MULTI, List.copyOf(orderedOutputs));
-          return executionStateStore.markAwaitItemContinuationsCompleted(
-                  parent.tenantId(),
-                  parent.executionId(),
-                  unit.unitId(),
-                  aggregateStepIndex,
-                  resumePayload,
-                  nowEpochMs)
-              .onItem().transformToUni(updated -> {
-                if (updated.isEmpty()) {
-                  return enqueueAlreadyReleasedParent(
-                      parent.tenantId(),
-                      parent.executionId(),
-                      unit,
-                      aggregateStepIndex,
-                      resumePayload,
-                      nowEpochMs);
-                }
-                return recordItemizedParentReleaseAndEnqueue(
-                    updated.get(),
-                    unit,
-                    aggregateStepIndex,
-                    resumePayload,
-                    nowEpochMs);
-              });
-        });
-  }
-
-  private Uni<Void> recordItemContinuationSegment(
-      ExecutionRecord<Object, Object> parentRecord,
-      AwaitUnitRecord unit,
-      AwaitInteractionRecord interaction,
-      int aggregateStepIndex,
-      ExecutionInputSnapshot normalizedInput,
-      long nowEpochMs) {
-    return segmentBoundaryLedger.get().recordContinuationSegmentCreated(
-        parentRecord,
-        unit,
-        SegmentBoundaryLedger.itemContinuationSegmentId(
-            parentRecord.executionId(),
-            unit.unitId(),
-            interaction.itemIndex()),
-        interaction.stepIndex() + 1,
-        aggregateStepIndex,
-        normalizedInput,
-        nowEpochMs);
-  }
-
-  private Uni<Void> releaseParentWhenLocallyReady(
-      ExecutionRecord<Object, Object> parent,
-      AwaitUnitRecord unit,
-      Integer itemIndex,
-      int aggregateStepIndex,
-      long nowEpochMs) {
-    if (itemIndex == null || unit == null || unit.expectedItemCount() == null) {
-      return Uni.createFrom().voidItem();
-    }
-    Set<Integer> completed = completedItemContinuationIndexes.computeIfAbsent(
-        itemContinuationCompletionKey(parent, unit),
-        ignored -> ConcurrentHashMap.newKeySet());
-    completed.add(itemIndex);
-    if (completed.size() < unit.expectedItemCount()) {
-      return Uni.createFrom().voidItem();
-    }
-    return releaseParentIfReady(parent, unit, aggregateStepIndex, nowEpochMs);
-  }
-
-  private Uni<Void> enqueueAlreadyReleasedParent(
-      String tenantId,
-      String executionId,
-      AwaitUnitRecord unit,
-      int aggregateStepIndex,
-      Object resumePayload,
-      long nowEpochMs) {
-    return executionStateStore.getExecution(tenantId, executionId)
-        .onItem().transformToUni(current -> {
-          if (current.isEmpty() || !releasedForStep(current.get(), aggregateStepIndex)) {
-            return Uni.createFrom().voidItem();
-          }
-          return recordItemizedParentReleaseAndEnqueue(
-              current.get(),
-              unit,
-              aggregateStepIndex,
-              resumePayload,
-              nowEpochMs);
-        });
-  }
-
-  private Uni<Void> recordItemizedParentReleaseAndEnqueue(
-      ExecutionRecord<Object, Object> released,
-      AwaitUnitRecord unit,
-      int aggregateStepIndex,
-      Object resumePayload,
-      long nowEpochMs) {
-    return segmentBoundaryLedger.get().recordContinuationSegmentCreated(
-            released,
-            unit,
-            SegmentBoundaryLedger.segmentId(released),
-            aggregateStepIndex,
-            -1,
-            resumePayload,
-            nowEpochMs)
-        .chain(() -> workDispatcher.enqueueNow(new ExecutionWorkItem(
-            released.tenantId(),
-            released.executionId())))
-        .invoke(() -> {
-          clearItemContinuationDispatchClaims(unit);
-          clearItemContinuationCompletionClaims(released, unit);
-          lifecycleRecorder.accept(new AwaitReplayLifecycleEvent(
-              AwaitReplayLifecycleEvent.RESUME_RELEASED,
-              released.executionId(),
-              unit.unitId(),
-              unit.stepId(),
-              unit.stepIndex(),
-              released.status().name(),
-              null,
-              null,
-              null,
-              null,
-              unit.expectedItemCount(),
-              unit.completedItemCount(),
-              unit.dispatchComplete()));
-          AwaitCompletionMetrics.recordResumeReleased(unit);
-        })
-        .replaceWithVoid();
-  }
-
-  private Uni<Boolean> itemContinuationReady(
-      AwaitInteractionRecord record,
-      AwaitUnitRecord unit) {
-    if (record == null || unit == null || !unit.dispatchComplete()) {
-      return Uni.createFrom().item(false);
-    }
-    Uni<Optional<ExecutionRecord<Object, Object>>> parentLookup =
-        executionStateStore.getExecution(record.tenantId(), record.executionId());
-    if (parentLookup == null) {
-      return Uni.createFrom().item(false);
-    }
-    return parentLookup.onItem().transform(parent -> itemContinuationReady(parent, unit));
-  }
-
-  private static boolean itemContinuationReady(
-      Optional<ExecutionRecord<Object, Object>> parent,
-      AwaitUnitRecord unit) {
-    return parent.isPresent()
-        && parent.get().status() == ExecutionStatus.WAITING_EXTERNAL
-        && unit.unitId().equals(parent.get().awaitUnitId());
-  }
-
-  private Uni<Void> dispatchCompletedItemContinuationsIfReady(
-      AwaitInteractionRecord record,
-      AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs) {
-    if (record == null || unit == null || !unit.dispatchComplete()) {
-      AwaitCompletionMetrics.recordEarlyCompletionHeld(record, unit);
-      return Uni.createFrom().voidItem();
-    }
-    Uni<Optional<ExecutionRecord<Object, Object>>> parentLookup =
-        executionStateStore.getExecution(record.tenantId(), record.executionId());
-    if (parentLookup == null) {
-      AwaitCompletionMetrics.recordEarlyCompletionHeld(record, unit);
-      return Uni.createFrom().voidItem();
-    }
-    return parentLookup.onItem().transformToUni(parent -> {
-      if (!itemContinuationReady(parent, unit)) {
-        AwaitCompletionMetrics.recordEarlyCompletionHeld(record, unit);
-        return Uni.createFrom().voidItem();
-      }
-      return dispatchCompletedItemContinuations(parent.get(), unit, itemContinuationHandler, nowEpochMs);
-    });
-  }
-
-  private Uni<Void> dispatchCompletedItemContinuations(
-      ExecutionRecord<Object, Object> parent,
-      AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs) {
-    if (parent == null || unit == null || !usesItemContinuations(unit) || !unit.dispatchComplete()
-        || itemContinuationHandler == NOOP_ITEM_CONTINUATION_HANDLER) {
-      return Uni.createFrom().voidItem();
-    }
-    return awaitCoordinator.findByUnit(parent.tenantId(), unit.unitId())
-        .onItem().invoke(records -> records.stream()
-            .filter(record -> record.itemInteraction()
-                && record.itemIndex() != null
-                && record.status() == AwaitInteractionStatus.COMPLETED)
-            .forEach(record -> dispatchItemContinuation(
-                record,
-                unit,
-                itemContinuationHandler,
-                nowEpochMs)))
-        .replaceWithVoid();
-  }
-
-  private void dispatchItemContinuation(
-      AwaitInteractionRecord record,
-      AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs) {
-    if (itemContinuationHandler == NOOP_ITEM_CONTINUATION_HANDLER) {
-      return;
-    }
-    Optional<IllegalArgumentException> invalidIndex = invalidItemIndex(record, unit);
-    if (invalidIndex.isPresent()) {
-      throw invalidIndex.get();
-    }
-    String claimKey = itemContinuationDispatchClaimKey(record);
-    if (!itemContinuationDispatchClaims.add(claimKey)) {
-      return;
-    }
-    dispatchItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, claimKey, 1);
-  }
-
-  private void dispatchItemContinuationAttempt(
-      AwaitInteractionRecord record,
-      AwaitUnitRecord unit,
-      AwaitItemContinuationHandler itemContinuationHandler,
-      long nowEpochMs,
-      String claimKey,
-      int attempt) {
-    Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
-    if (admission.isEmpty()) {
-      queueSweepExecutor.schedule(
-          () -> dispatchItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, claimKey, attempt),
-          saturatedDelay.get().toMillis(),
-          TimeUnit.MILLISECONDS);
-      return;
-    }
-    TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
-    try {
-      Infrastructure.getDefaultExecutor().execute(() ->
-          executionStateStore
-              .getExecution(record.tenantId(), record.executionId())
-              .onItem().transformToUni(parent -> {
-                if (!itemContinuationReady(parent, unit)) {
-                  return Uni.createFrom().item(false);
-                }
-                return itemContinuationHandler.continueAwaitItem(
-                    record,
-                    unit,
-                    record.stepIndex() + 1,
-                    parent,
-                    nowEpochMs)
-                    .replaceWith(true);
-              })
-              .subscribe().with(
-                  dispatched -> {
-                    permit.close();
-                    if (!Boolean.TRUE.equals(dispatched)) {
-                      itemContinuationDispatchClaims.remove(claimKey);
-                    }
-                  },
-                  failure -> {
-                    permit.close();
-                    if (attempt < AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS) {
-                      long retryDelayMs = itemContinuationRetryDelayMs(attempt);
-                      LOG.warnf(
-                          failure,
-                          "Retrying await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s attempt=%d delayMs=%d",
-                          record.tenantId(),
-                          record.executionId(),
-                          record.unitId(),
-                          record.interactionId(),
-                          record.itemIndex(),
-                          attempt + 1,
-                          retryDelayMs);
-                      queueSweepExecutor.schedule(
-                          () -> dispatchItemContinuationAttempt(
-                              record,
-                              unit,
-                              itemContinuationHandler,
-                              nowEpochMs,
-                              claimKey,
-                              attempt + 1),
-                          retryDelayMs,
-                          TimeUnit.MILLISECONDS);
-                      return;
-                    }
-                    failParentAfterContinuationError(record, failure, attempt);
-                  }));
-    } catch (RuntimeException failure) {
-      permit.close();
-      itemContinuationDispatchClaims.remove(claimKey);
-      throw failure;
-    }
-  }
-
-  private static long itemContinuationRetryDelayMs(int attempt) {
-    int boundedAttempt = Math.max(1, Math.min(attempt, AWAIT_ITEM_CONTINUATION_MAX_ATTEMPTS));
-    return AWAIT_ITEM_CONTINUATION_RETRY_BASE_MS << (boundedAttempt - 1);
-  }
-
-  private void failParentAfterContinuationError(
-      AwaitInteractionRecord record,
-      Throwable failure,
-      int attempt) {
-    long nowEpochMs = System.currentTimeMillis();
-    executionStateStore.getExecution(record.tenantId(), record.executionId())
-        .onItem().transformToUni(parent -> {
-          if (parent.isEmpty() || parent.get().status().terminal()) {
-            return Uni.createFrom().item(Optional.<ExecutionRecord<Object, Object>>empty());
-          }
-          ExecutionRecord<Object, Object> parentRecord = parent.get();
-          return executionStateStore.markTerminalFailure(
-              parentRecord.tenantId(),
-              parentRecord.executionId(),
-              parentRecord.version(),
-              ExecutionStatus.FAILED,
-              "await-item-continuation-failed:" + record.unitId() + ":" + record.itemIndex(),
-              "AWAIT_ITEM_CONTINUATION_FAILED",
-              "Await item continuation failed after " + attempt + " attempts: " + failure.getMessage(),
-              nowEpochMs);
-        })
-        .subscribe().with(
-            ignored -> LOG.errorf(
-                failure,
-                "Failed processing await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s after %d attempts; marked parent failed when still active",
-                record.tenantId(),
-                record.executionId(),
-                record.unitId(),
-                record.interactionId(),
-                record.itemIndex(),
-                attempt),
-              persistenceFailure -> LOG.errorf(
-                  persistenceFailure,
-                  "Failed marking parent execution failed after await item continuation failure tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s",
-                  record.tenantId(),
-                  record.executionId(),
-                  record.unitId(),
-                  record.interactionId(),
-                  record.itemIndex()));
-  }
-
-  private Optional<IllegalArgumentException> invalidItemIndex(
-      AwaitInteractionRecord interaction,
-      AwaitUnitRecord unit) {
-    if (interaction == null || interaction.itemIndex() == null) {
-      return Optional.of(new IllegalArgumentException("Itemized await continuation requires itemIndex"));
-    }
-    int itemIndex = interaction.itemIndex();
-    if (itemIndex < 0) {
-      return Optional.of(new IllegalArgumentException(
-          "Itemized await continuation itemIndex must be non-negative: " + itemIndex));
-    }
-    Integer expectedItemCount = unit == null ? null : unit.expectedItemCount();
-    if (expectedItemCount != null && itemIndex >= expectedItemCount) {
-      return Optional.of(new IllegalArgumentException(
-          "Itemized await continuation itemIndex " + itemIndex
-              + " is outside expected item count " + expectedItemCount));
-    }
-    return Optional.empty();
-  }
-
-  private String itemContinuationDispatchClaimKey(AwaitInteractionRecord record) {
-    return record.tenantId() + "::"
-        + record.executionId() + "::"
-        + record.unitId() + "::"
-        + record.itemIndex();
-  }
-
-  private void clearItemContinuationDispatchClaims(AwaitUnitRecord unit) {
-    if (unit == null) {
-      return;
-    }
-    String prefix = unit.tenantId() + "::"
-        + unit.executionId() + "::"
-        + unit.unitId() + "::";
-    itemContinuationDispatchClaims.removeIf(key -> key.startsWith(prefix));
-  }
-
-  private void clearItemContinuationCompletionClaims(
-      ExecutionRecord<Object, Object> parent,
-      AwaitUnitRecord unit) {
-    completedItemContinuationIndexes.remove(itemContinuationCompletionKey(parent, unit));
-  }
-
-  private static String itemContinuationCompletionKey(
-      ExecutionRecord<Object, Object> parent,
-      AwaitUnitRecord unit) {
-    return parent.tenantId() + "::" + parent.executionId() + "::" + unit.unitId();
-  }
-
-  private Uni<Void> releaseScalarResume(
-      AwaitInteractionRecord record,
-      String awaitUnitId,
-      long nowEpochMs) {
-    return releaseScalarResume(
-        record.tenantId(),
-        record.executionId(),
-        awaitUnitId,
-        record.stepId(),
-        record.stepIndex(),
-        record.interactionId(),
-        record.correlationId(),
-        record.transportType(),
-        record.itemIndex(),
-        nowEpochMs);
-  }
-
-  private Uni<Void> releaseScalarResume(
-      String tenantId,
-      String executionId,
-      String awaitUnitId,
-      String stepId,
-      int stepIndex,
-      String interactionId,
-      String correlationId,
-      String transportType,
-      Integer itemIndex,
-      long nowEpochMs) {
-    return executionStateStore.markAwaitCompleted(
-            tenantId,
-            executionId,
-            awaitUnitId,
-            stepIndex + 1,
-            nowEpochMs)
-        .onItem().transformToUni(updated -> {
-          if (updated.isPresent()) {
-            return recordScalarResumeAndEnqueue(
-                updated.get(),
-                awaitUnitId,
-                stepId,
-                stepIndex,
-                interactionId,
-                correlationId,
-                transportType,
-                itemIndex,
-                nowEpochMs);
-          }
-          LOG.debugf(
-              "Await resume release for execution %s awaitUnitId=%s at stepIndex=%d produced no state update; treating as idempotent no-op",
-              executionId,
-              awaitUnitId,
-              stepIndex);
-          return enqueueAlreadyReleasedScalarResume(
-              tenantId,
-              executionId,
-              awaitUnitId,
-              stepId,
-              stepIndex,
-              interactionId,
-              correlationId,
-              transportType,
-              itemIndex,
-              nowEpochMs);
-        });
-  }
-
-  private Uni<Void> enqueueAlreadyReleasedScalarResume(
-      String tenantId,
-      String executionId,
-      String awaitUnitId,
-      String stepId,
-      int stepIndex,
-      String interactionId,
-      String correlationId,
-      String transportType,
-      Integer itemIndex,
-      long nowEpochMs) {
-    return executionStateStore.getExecution(tenantId, executionId)
-        .onItem().transformToUni(current -> {
-          if (current.isEmpty() || !releasedForStep(current.get(), stepIndex + 1)) {
-            return Uni.createFrom().voidItem();
-          }
-          return recordScalarResumeAndEnqueue(
-              current.get(),
-              awaitUnitId,
-              stepId,
-              stepIndex,
-              interactionId,
-              correlationId,
-              transportType,
-              itemIndex,
-              nowEpochMs);
-        });
-  }
-
-  private Uni<Void> recordScalarResumeAndEnqueue(
-      ExecutionRecord<Object, Object> released,
-      String awaitUnitId,
-      String stepId,
-      int stepIndex,
-      String interactionId,
-      String correlationId,
-      String transportType,
-      Integer itemIndex,
-      long nowEpochMs) {
-    return segmentBoundaryLedger.get().recordContinuationSegmentCreated(
-            released,
-            awaitUnitId,
-            SegmentBoundaryLedger.segmentId(released),
-            stepIndex + 1,
-            -1,
-            released.inputPayload(),
-            nowEpochMs)
-        .chain(() -> workDispatcher.enqueueNow(new ExecutionWorkItem(
-            released.tenantId(),
-            released.executionId())))
-        .invoke(() -> {
-          LOG.infof(
-              "Resuming async execution %s from awaitUnitId=%s at nextStepIndex=%d",
-              released.executionId(),
-              awaitUnitId,
-              released.currentStepIndex());
-          AwaitReplayLifecycleEvent lifecycleEvent = new AwaitReplayLifecycleEvent(
-              AwaitReplayLifecycleEvent.RESUME_RELEASED,
-              released.executionId(),
-              awaitUnitId,
-              stepId,
-              stepIndex,
-              released.status().name(),
-              interactionId,
-              correlationId,
-              transportType,
-              itemIndex,
-              null,
-              null,
-              null);
-          lifecycleRecorder.accept(lifecycleEvent);
-          AwaitCompletionMetrics.recordResumeReleased(lifecycleEvent);
-        })
-        .replaceWithVoid();
-  }
-
-  private static boolean releasedForStep(
-      ExecutionRecord<Object, Object> record,
-      int stepIndex) {
-    return record != null
-        && record.status() == ExecutionStatus.QUEUED
-        && record.currentStepIndex() == stepIndex;
-  }
-
-  private static boolean usesItemContinuations(
-      AwaitInteractionRecord record,
-      AwaitUnitRecord unit) {
-    return record != null
-        && record.itemInteraction()
-        && usesItemContinuations(unit);
-  }
-
-  private static boolean usesItemContinuations(AwaitUnitRecord unit) {
-    return unit != null
-        && unit.primaryInteractionId() == null
-        && ONE_TO_ONE_CARDINALITY.equalsIgnoreCase(unit.cardinality());
-  }
-
-  private static String itemContinuationKey(
-      ExecutionRecord<Object, Object> parent,
-      AwaitUnitRecord unit,
-      int itemIndex) {
-    return parent.executionKey() + ":await-item:" + unit.unitId() + ":" + itemIndex;
-  }
-
-  private static ExecutionInputSnapshot copyInputSnapshot(ExecutionInputSnapshot snapshot) {
-    Object payload = snapshot.payload();
-    if (payload instanceof List<?> list) {
-      payload = List.copyOf(list);
-    }
-    return new ExecutionInputSnapshot(snapshot.shape(), payload);
+    return itemizedFlow.releaseParentIfReady(parent, unit, aggregateStepIndex, nowEpochMs);
   }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/ClaimedSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ClaimedSegment.java
@@ -1,0 +1,62 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.SerializedTransitionPayload;
+import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionWorkerCommand;
+
+/**
+ * Immutable view of one queue-async segment claimed by a worker.
+ */
+record ClaimedSegment(
+    ExecutionRecord<Object, Object> record,
+    String transitionKey) {
+
+  ClaimedSegment {
+    Objects.requireNonNull(record, "record must not be null");
+    if (transitionKey == null || transitionKey.isBlank()) {
+      throw new IllegalArgumentException("transitionKey must not be blank");
+    }
+  }
+
+  static ClaimedSegment from(ExecutionRecord<Object, Object> record) {
+    Objects.requireNonNull(record, "record must not be null");
+    return new ClaimedSegment(
+        record,
+        transitionKey(record.executionId(), record.currentStepIndex(), record.attempt()));
+  }
+
+  boolean resumesFromAwait() {
+    return record.currentStepIndex() > 0
+        && record.awaitUnitId() != null
+        && !record.awaitUnitId().isBlank();
+  }
+
+  TransitionCommandEnvelope transitionCommand(Object payload, TransitionPayloadCodec payloadCodec) {
+    Objects.requireNonNull(payloadCodec, "payloadCodec must not be null");
+    TransitionWorkerCommand command = new TransitionWorkerCommand(
+        record.tenantId(),
+        record.executionId(),
+        record.currentStepIndex(),
+        record.attempt(),
+        record.resultShape(),
+        record.version(),
+        transitionKey,
+        payload);
+    SerializedTransitionPayload encodedPayload = payloadCodec.encode(payload);
+    return TransitionCommandEnvelope.from(
+        command,
+        record.pipelineId(),
+        record.contractVersion(),
+        record.releaseVersion(),
+        transitionKey,
+        encodedPayload);
+  }
+
+  private static String transitionKey(String executionId, int stepIndex, int attempt) {
+    return executionId + ":" + stepIndex + ":" + attempt;
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/CompletedSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/CompletedSegment.java
@@ -1,0 +1,20 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+record CompletedSegment(
+    ClaimedSegment segment,
+    TransitionResultEnvelope result,
+    List<?> outputItems,
+    TerminalPublicationPlan terminalPublication) implements SegmentCommitPlan {
+
+  CompletedSegment {
+    Objects.requireNonNull(segment, "segment must not be null");
+    Objects.requireNonNull(result, "result must not be null");
+    outputItems = outputItems == null ? List.of() : List.copyOf(outputItems);
+    Objects.requireNonNull(terminalPublication, "terminalPublication must not be null");
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/FailedSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/FailedSegment.java
@@ -1,0 +1,13 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+record FailedSegment(
+    ClaimedSegment segment,
+    Throwable failure) implements SegmentCommitPlan {
+
+  FailedSegment {
+    Objects.requireNonNull(segment, "segment must not be null");
+    Objects.requireNonNull(failure, "failure must not be null");
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ItemContinuationClaims.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ItemContinuationClaims.java
@@ -1,0 +1,58 @@
+package org.pipelineframework;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+
+class ItemContinuationClaims {
+
+  private final Set<String> dispatchClaims = ConcurrentHashMap.newKeySet();
+  private final Map<String, Set<Integer>> completedIndexes = new ConcurrentHashMap<>();
+
+  boolean claimDispatch(ItemContinuationKey key) {
+    return dispatchClaims.add(key.dispatchClaimKey());
+  }
+
+  void releaseDispatch(ItemContinuationKey key) {
+    dispatchClaims.remove(key.dispatchClaimKey());
+  }
+
+  boolean recordCompleted(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int itemIndex) {
+    if (unit == null || unit.expectedItemCount() == null) {
+      return false;
+    }
+    Set<Integer> completed = completedIndexes.computeIfAbsent(
+        completionKey(parent, unit),
+        ignored -> ConcurrentHashMap.newKeySet());
+    completed.add(itemIndex);
+    return completed.size() >= unit.expectedItemCount();
+  }
+
+  void clearDispatches(AwaitUnitRecord unit) {
+    if (unit == null) {
+      return;
+    }
+    String prefix = unit.tenantId() + "::"
+        + unit.executionId() + "::"
+        + unit.unitId() + "::";
+    dispatchClaims.removeIf(key -> key.startsWith(prefix));
+  }
+
+  void clearCompletions(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit) {
+    completedIndexes.remove(completionKey(parent, unit));
+  }
+
+  private static String completionKey(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit) {
+    return parent.tenantId() + "::" + parent.executionId() + "::" + unit.unitId();
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ItemContinuationKey.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ItemContinuationKey.java
@@ -1,0 +1,71 @@
+package org.pipelineframework;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+
+record ItemContinuationKey(
+    String tenantId,
+    String parentExecutionId,
+    String parentExecutionKey,
+    String unitId,
+    int itemIndex) {
+
+  ItemContinuationKey {
+    if (tenantId == null || tenantId.isBlank()) {
+      throw new IllegalArgumentException("Item continuation key requires tenantId");
+    }
+    if (parentExecutionId == null || parentExecutionId.isBlank()) {
+      throw new IllegalArgumentException("Item continuation key requires parentExecutionId");
+    }
+    if (parentExecutionKey == null || parentExecutionKey.isBlank()) {
+      throw new IllegalArgumentException("Item continuation key requires parentExecutionKey");
+    }
+    if (unitId == null || unitId.isBlank()) {
+      throw new IllegalArgumentException("Item continuation key requires unitId");
+    }
+    if (itemIndex < 0) {
+      throw new IllegalArgumentException("Item continuation index must be non-negative: " + itemIndex);
+    }
+  }
+
+  static ItemContinuationKey from(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      AwaitInteractionRecord interaction) {
+    if (interaction == null || interaction.itemIndex() == null) {
+      throw new IllegalArgumentException("Itemized await continuation requires itemIndex");
+    }
+    return from(parent, unit, interaction.itemIndex());
+  }
+
+  static ItemContinuationKey from(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int itemIndex) {
+    if (parent == null) {
+      throw new IllegalArgumentException("Item continuation key requires parent execution");
+    }
+    if (unit == null) {
+      throw new IllegalArgumentException("Item continuation key requires await unit");
+    }
+    return new ItemContinuationKey(
+        parent.tenantId(),
+        parent.executionId(),
+        parent.executionKey(),
+        unit.unitId(),
+        itemIndex);
+  }
+
+  String childExecutionKey() {
+    return parentExecutionKey + ":await-item:" + unitId + ":" + itemIndex;
+  }
+
+  String dispatchClaimKey() {
+    return tenantId + "::" + parentExecutionId + "::" + unitId + "::" + itemIndex;
+  }
+
+  String segmentId() {
+    return parentExecutionId + ":segment:await-item:" + unitId + ":" + itemIndex;
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ItemizedAwaitContinuationFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ItemizedAwaitContinuationFlow.java
@@ -1,0 +1,513 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCompletionMetrics;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
+
+class ItemizedAwaitContinuationFlow {
+
+  private static final Logger LOG = Logger.getLogger(ItemizedAwaitContinuationFlow.class);
+  private static final int MAX_ATTEMPTS = 3;
+  private static final long RETRY_BASE_MS = 100L;
+
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final AwaitCoordinator awaitCoordinator;
+  private final TransitionWorkerExecutor transitionWorkerExecutor;
+  private final ScheduledExecutorService queueSweepExecutor;
+  private final Supplier<Duration> saturatedDelay;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+  private final Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder;
+  private final AwaitContinuationPlanner planner;
+  private final ItemContinuationClaims claims;
+
+  ItemizedAwaitContinuationFlow(
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      AwaitCoordinator awaitCoordinator,
+      TransitionWorkerExecutor transitionWorkerExecutor,
+      ScheduledExecutorService queueSweepExecutor,
+      Supplier<Duration> saturatedDelay,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger,
+      Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder,
+      AwaitContinuationPlanner planner,
+      ItemContinuationClaims claims) {
+    this.executionStateStore = executionStateStore;
+    this.workDispatcher = workDispatcher;
+    this.awaitCoordinator = awaitCoordinator;
+    this.transitionWorkerExecutor = transitionWorkerExecutor;
+    this.queueSweepExecutor = queueSweepExecutor;
+    this.saturatedDelay = saturatedDelay;
+    this.segmentBoundaryLedger = segmentBoundaryLedger;
+    this.lifecycleRecorder = lifecycleRecorder;
+    this.planner = planner;
+    this.claims = claims;
+  }
+
+  Uni<Void> afterRecordedCompletion(
+      AwaitInteractionRecord record,
+      AwaitUnitRecord unit,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    if (record == null || unit == null || !unit.dispatchComplete()) {
+      AwaitCompletionMetrics.recordEarlyCompletionHeld(record, unit);
+      return Uni.createFrom().voidItem();
+    }
+    Uni<Optional<ExecutionRecord<Object, Object>>> parentLookup =
+        executionStateStore.getExecution(record.tenantId(), record.executionId());
+    if (parentLookup == null) {
+      AwaitCompletionMetrics.recordEarlyCompletionHeld(record, unit);
+      return Uni.createFrom().voidItem();
+    }
+    return parentLookup
+        .onItem().transform(parent -> planner.afterRecordedCompletion(record, unit, parent))
+        .onItem().transformToUni(plan -> interpretAfterRecordedCompletion(plan, itemContinuationHandler, nowEpochMs));
+  }
+
+  Uni<Void> afterParentWaiting(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int suspendedStepIndex,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    AwaitContinuationPlan plan = planner.afterParentWaiting(parent, unit, suspendedStepIndex);
+    if (plan instanceof AwaitContinuationPlan.DispatchItemContinuations dispatch) {
+      Uni<Void> dispatched = dispatchCompletedItemContinuations(
+          dispatch.parent(),
+          dispatch.unit(),
+          itemContinuationHandler,
+          nowEpochMs);
+      return unit.status() == AwaitUnitStatus.COMPLETED
+          ? dispatched.chain(() -> itemContinuationHandler.releaseAwaitParentIfReady(
+              dispatch.parent(),
+              dispatch.unit(),
+              dispatch.nextStepIndex(),
+              nowEpochMs))
+          : dispatched;
+    }
+    return Uni.createFrom().voidItem();
+  }
+
+  Uni<Void> captureOutput(
+      AwaitInteractionRecord interaction,
+      AwaitUnitRecord unit,
+      int aggregateStepIndex,
+      ExecutionInputSnapshot continuationInput,
+      List<?> segmentOutputs,
+      long nowEpochMs) {
+    if (!AwaitContinuationPlanner.usesItemContinuations(interaction, unit)) {
+      return Uni.createFrom().voidItem();
+    }
+    return executionStateStore.getExecution(interaction.tenantId(), interaction.executionId())
+        .onItem().transformToUni(parent -> {
+          if (parent.isEmpty()) {
+            return Uni.createFrom().voidItem();
+          }
+          AwaitContinuationPlan.RecordItemOutput plan =
+              (AwaitContinuationPlan.RecordItemOutput) planner.recordItemOutput(
+                  parent.get(),
+                  unit,
+                  interaction,
+                  aggregateStepIndex,
+                  continuationInput,
+                  segmentOutputs);
+          return captureOutput(plan, nowEpochMs);
+        });
+  }
+
+  Uni<Void> releaseParentIfReady(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      int aggregateStepIndex,
+      long nowEpochMs) {
+    if (parent == null || unit == null || !AwaitContinuationPlanner.usesItemContinuations(unit)
+        || !unit.dispatchComplete() || unit.expectedItemCount() == null) {
+      return Uni.createFrom().voidItem();
+    }
+    return Multi.createFrom().range(0, unit.expectedItemCount())
+        .onItem().transformToUniAndConcatenate(index ->
+            executionStateStore.getExecutionByKey(
+                parent.tenantId(),
+                ItemContinuationKey.from(parent, unit, index).childExecutionKey()))
+        .collect().asList()
+        .onItem().transformToUni(children -> {
+          AwaitContinuationPlan plan = planner.releaseItemizedParent(parent, unit, aggregateStepIndex, children);
+          if (plan instanceof AwaitContinuationPlan.ReleaseItemizedParent release) {
+            return releaseParent(release.release(), nowEpochMs);
+          }
+          return Uni.createFrom().voidItem();
+        });
+  }
+
+  private Uni<Void> interpretAfterRecordedCompletion(
+      AwaitContinuationPlan plan,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    if (plan instanceof AwaitContinuationPlan.HoldCompletion held) {
+      AwaitCompletionMetrics.recordEarlyCompletionHeld(held.interaction(), held.unit());
+      return Uni.createFrom().voidItem();
+    }
+    if (plan instanceof AwaitContinuationPlan.DispatchItemContinuations dispatch) {
+      return dispatchCompletedItemContinuations(
+          dispatch.parent(),
+          dispatch.unit(),
+          itemContinuationHandler,
+          nowEpochMs);
+    }
+    return Uni.createFrom().voidItem();
+  }
+
+  private Uni<Void> dispatchCompletedItemContinuations(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    if (parent == null || unit == null || !AwaitContinuationPlanner.usesItemContinuations(unit) || !unit.dispatchComplete()
+        || itemContinuationHandler == AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER) {
+      return Uni.createFrom().voidItem();
+    }
+    return awaitCoordinator.findByUnit(parent.tenantId(), unit.unitId())
+        .onItem().invoke(records -> records.stream()
+            .filter(record -> record.itemInteraction()
+                && record.itemIndex() != null
+                && record.status() == AwaitInteractionStatus.COMPLETED)
+            .forEach(record -> dispatchItemContinuation(
+                record,
+                unit,
+                itemContinuationHandler,
+                nowEpochMs)))
+        .replaceWithVoid();
+  }
+
+  private void dispatchItemContinuation(
+      AwaitInteractionRecord record,
+      AwaitUnitRecord unit,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    planner.validateItemIndex(record, unit);
+    ItemContinuationKey key = new ItemContinuationKey(
+        record.tenantId(),
+        record.executionId(),
+        record.executionId(),
+        record.unitId(),
+        record.itemIndex());
+    if (!claims.claimDispatch(key)) {
+      return;
+    }
+    dispatchItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, key, 1);
+  }
+
+  private void dispatchItemContinuationAttempt(
+      AwaitInteractionRecord record,
+      AwaitUnitRecord unit,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs,
+      ItemContinuationKey key,
+      int attempt) {
+    Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
+    if (admission.isEmpty()) {
+      queueSweepExecutor.schedule(
+          () -> dispatchItemContinuationAttempt(record, unit, itemContinuationHandler, nowEpochMs, key, attempt),
+          saturatedDelay.get().toMillis(),
+          TimeUnit.MILLISECONDS);
+      return;
+    }
+    TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
+    try {
+      Infrastructure.getDefaultExecutor().execute(() ->
+          executionStateStore
+              .getExecution(record.tenantId(), record.executionId())
+              .onItem().transformToUni(parent -> {
+                if (!planner.itemContinuationReady(parent, unit)) {
+                  return Uni.createFrom().item(false);
+                }
+                return itemContinuationHandler.continueAwaitItem(
+                    record,
+                    unit,
+                    record.stepIndex() + 1,
+                    parent,
+                    nowEpochMs)
+                    .replaceWith(true);
+              })
+              .subscribe().with(
+                  dispatched -> {
+                    permit.close();
+                    if (!Boolean.TRUE.equals(dispatched)) {
+                      claims.releaseDispatch(key);
+                    }
+                  },
+                  failure -> {
+                    permit.close();
+                    if (attempt < MAX_ATTEMPTS) {
+                      long retryDelayMs = retryDelayMs(attempt);
+                      LOG.warnf(
+                          failure,
+                          "Retrying await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s attempt=%d delayMs=%d",
+                          record.tenantId(),
+                          record.executionId(),
+                          record.unitId(),
+                          record.interactionId(),
+                          record.itemIndex(),
+                          attempt + 1,
+                          retryDelayMs);
+                      queueSweepExecutor.schedule(
+                          () -> dispatchItemContinuationAttempt(
+                              record,
+                              unit,
+                              itemContinuationHandler,
+                              nowEpochMs,
+                              key,
+                              attempt + 1),
+                          retryDelayMs,
+                          TimeUnit.MILLISECONDS);
+                      return;
+                    }
+                    failParentAfterContinuationError(
+                        new AwaitContinuationPlan.FailParent(record, failure, attempt));
+                  }));
+    } catch (RuntimeException failure) {
+      permit.close();
+      claims.releaseDispatch(key);
+      throw failure;
+    }
+  }
+
+  private Uni<Void> captureOutput(
+      AwaitContinuationPlan.RecordItemOutput plan,
+      long nowEpochMs) {
+    return executionStateStore.getExecutionByKey(plan.interaction().tenantId(), plan.key().childExecutionKey())
+        .onItem().transformToUni(existing -> {
+          if (existing.isPresent() && existing.get().status() == ExecutionStatus.SUCCEEDED) {
+            return recordItemContinuationSegment(plan, nowEpochMs)
+                .chain(() -> releaseParentIfReady(plan.parent(), plan.unit(), plan.aggregateStepIndex(), nowEpochMs));
+          }
+          long ttl = plan.parent().ttlEpochS();
+          ExecutionCreateCommand create = new ExecutionCreateCommand(
+              plan.interaction().tenantId(),
+              plan.key().childExecutionKey(),
+              plan.parent().pipelineId(),
+              plan.parent().contractVersion(),
+              plan.parent().releaseVersion(),
+              plan.continuationInput(),
+              ExecutionResultShape.MATERIALIZED_MULTI,
+              nowEpochMs,
+              ttl);
+          return executionStateStore.createOrGetExecution(create)
+              .onItem().transformToUni(created -> handleCreatedChild(plan, created, nowEpochMs));
+        });
+  }
+
+  private Uni<Void> handleCreatedChild(
+      AwaitContinuationPlan.RecordItemOutput plan,
+      CreateExecutionResult created,
+      long nowEpochMs) {
+    ExecutionRecord<Object, Object> child = created.record();
+    if (created.duplicate() && child.status() == ExecutionStatus.SUCCEEDED) {
+      return recordItemContinuationSegment(plan, nowEpochMs)
+          .chain(() -> releaseParentIfReady(plan.parent(), plan.unit(), plan.aggregateStepIndex(), nowEpochMs));
+    }
+    String transitionKey = "await-item-continuation:" + plan.unit().unitId() + ":" + plan.interaction().itemIndex();
+    return executionStateStore.markSucceeded(
+            child.tenantId(),
+            child.executionId(),
+            child.version(),
+            transitionKey,
+            plan.segmentOutputs(),
+            nowEpochMs)
+        .onItem().transformToUni(updated -> handleChildSuccessUpdate(plan, updated, child, nowEpochMs));
+  }
+
+  private Uni<Void> handleChildSuccessUpdate(
+      AwaitContinuationPlan.RecordItemOutput plan,
+      Optional<ExecutionRecord<Object, Object>> updated,
+      ExecutionRecord<Object, Object> child,
+      long nowEpochMs) {
+    if (updated.isPresent()) {
+      return recordItemContinuationSegment(plan, nowEpochMs)
+          .chain(() -> releaseParentWhenLocallyReady(
+              plan.parent(),
+              plan.unit(),
+              plan.interaction().itemIndex(),
+              plan.aggregateStepIndex(),
+              nowEpochMs));
+    }
+    return executionStateStore.getExecutionByKey(plan.parent().tenantId(), child.executionKey())
+        .onItem().transformToUni(current -> {
+          if (current.isPresent() && current.get().status() == ExecutionStatus.SUCCEEDED) {
+            return recordItemContinuationSegment(plan, nowEpochMs)
+                .chain(() -> releaseParentIfReady(plan.parent(), plan.unit(), plan.aggregateStepIndex(), nowEpochMs));
+          }
+          return Uni.createFrom().failure(new IllegalStateException(
+              "Await item continuation child success was not admitted and child is not already SUCCEEDED: "
+                  + child.executionKey()));
+        });
+  }
+
+  private Uni<Void> recordItemContinuationSegment(
+      AwaitContinuationPlan.RecordItemOutput plan,
+      long nowEpochMs) {
+    return segmentBoundaryLedger.get().recordContinuationSegmentCreated(
+        plan.parent(),
+        plan.unit(),
+        plan.key().segmentId(),
+        plan.interaction().stepIndex() + 1,
+        plan.aggregateStepIndex(),
+        plan.continuationInput(),
+        nowEpochMs);
+  }
+
+  private Uni<Void> releaseParentWhenLocallyReady(
+      ExecutionRecord<Object, Object> parent,
+      AwaitUnitRecord unit,
+      Integer itemIndex,
+      int aggregateStepIndex,
+      long nowEpochMs) {
+    if (itemIndex == null || !claims.recordCompleted(parent, unit, itemIndex)) {
+      return Uni.createFrom().voidItem();
+    }
+    return releaseParentIfReady(parent, unit, aggregateStepIndex, nowEpochMs);
+  }
+
+  private Uni<Void> releaseParent(
+      ItemizedParentRelease release,
+      long nowEpochMs) {
+    return executionStateStore.markAwaitItemContinuationsCompleted(
+            release.parent().tenantId(),
+            release.parent().executionId(),
+            release.unit().unitId(),
+            release.aggregateStepIndex(),
+            release.resumePayload(),
+            nowEpochMs)
+        .onItem().transformToUni(updated -> updated
+            .map(released -> recordReleaseAndEnqueue(released, release, nowEpochMs))
+            .orElseGet(() -> enqueueAlreadyReleasedParent(release, nowEpochMs)));
+  }
+
+  private Uni<Void> enqueueAlreadyReleasedParent(
+      ItemizedParentRelease release,
+      long nowEpochMs) {
+    return executionStateStore.getExecution(release.parent().tenantId(), release.parent().executionId())
+        .onItem().transformToUni(current -> {
+          if (current.isEmpty() || !releasedForStep(current.get(), release.aggregateStepIndex())) {
+            return Uni.createFrom().voidItem();
+          }
+          return recordReleaseAndEnqueue(current.get(), release, nowEpochMs);
+        });
+  }
+
+  private Uni<Void> recordReleaseAndEnqueue(
+      ExecutionRecord<Object, Object> released,
+      ItemizedParentRelease release,
+      long nowEpochMs) {
+    return segmentBoundaryLedger.get().recordContinuationSegmentCreated(
+            released,
+            release.unit(),
+            SegmentBoundaryLedger.segmentId(released),
+            release.aggregateStepIndex(),
+            -1,
+            release.resumePayload(),
+            nowEpochMs)
+        .chain(() -> workDispatcher.enqueueNow(new ExecutionWorkItem(
+            released.tenantId(),
+            released.executionId())))
+        .invoke(() -> {
+          claims.clearDispatches(release.unit());
+          claims.clearCompletions(released, release.unit());
+          lifecycleRecorder.accept(new AwaitReplayLifecycleEvent(
+              AwaitReplayLifecycleEvent.RESUME_RELEASED,
+              released.executionId(),
+              release.unit().unitId(),
+              release.unit().stepId(),
+              release.unit().stepIndex(),
+              released.status().name(),
+              null,
+              null,
+              null,
+              null,
+              release.unit().expectedItemCount(),
+              release.unit().completedItemCount(),
+              release.unit().dispatchComplete()));
+          AwaitCompletionMetrics.recordResumeReleased(release.unit());
+        })
+        .replaceWithVoid();
+  }
+
+  private void failParentAfterContinuationError(AwaitContinuationPlan.FailParent plan) {
+    AwaitInteractionRecord record = plan.interaction();
+    long nowEpochMs = System.currentTimeMillis();
+    executionStateStore.getExecution(record.tenantId(), record.executionId())
+        .onItem().transformToUni(parent -> {
+          if (parent.isEmpty() || parent.get().status().terminal()) {
+            return Uni.createFrom().item(Optional.<ExecutionRecord<Object, Object>>empty());
+          }
+          ExecutionRecord<Object, Object> parentRecord = parent.get();
+          return executionStateStore.markTerminalFailure(
+              parentRecord.tenantId(),
+              parentRecord.executionId(),
+              parentRecord.version(),
+              ExecutionStatus.FAILED,
+              "await-item-continuation-failed:" + record.unitId() + ":" + record.itemIndex(),
+              "AWAIT_ITEM_CONTINUATION_FAILED",
+              "Await item continuation failed after " + plan.attempt() + " attempts: " + plan.failure().getMessage(),
+              nowEpochMs);
+        })
+        .subscribe().with(
+            ignored -> LOG.errorf(
+                plan.failure(),
+                "Failed processing await item continuation tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s after %d attempts; marked parent failed when still active",
+                record.tenantId(),
+                record.executionId(),
+                record.unitId(),
+                record.interactionId(),
+                record.itemIndex(),
+                plan.attempt()),
+            persistenceFailure -> LOG.errorf(
+                persistenceFailure,
+                "Failed marking parent execution failed after await item continuation failure tenant=%s executionId=%s unitId=%s interactionId=%s itemIndex=%s",
+                record.tenantId(),
+                record.executionId(),
+                record.unitId(),
+                record.interactionId(),
+                record.itemIndex()));
+  }
+
+  private static long retryDelayMs(int attempt) {
+    int boundedAttempt = Math.max(1, Math.min(attempt, MAX_ATTEMPTS));
+    return RETRY_BASE_MS << (boundedAttempt - 1);
+  }
+
+  private static boolean releasedForStep(
+      ExecutionRecord<Object, Object> record,
+      int stepIndex) {
+    return record != null
+        && record.status() == ExecutionStatus.QUEUED
+        && record.currentStepIndex() == stepIndex;
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ItemizedParentRelease.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ItemizedParentRelease.java
@@ -1,0 +1,31 @@
+package org.pipelineframework;
+
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+
+record ItemizedParentRelease(
+    ExecutionRecord<Object, Object> parent,
+    AwaitUnitRecord unit,
+    int aggregateStepIndex,
+    ExecutionInputSnapshot resumePayload) {
+
+  ItemizedParentRelease {
+    if (parent == null) {
+      throw new IllegalArgumentException("Itemized parent release requires parent execution");
+    }
+    if (unit == null) {
+      throw new IllegalArgumentException("Itemized parent release requires await unit");
+    }
+    if (aggregateStepIndex < 0) {
+      throw new IllegalArgumentException("Aggregate step index must be non-negative: " + aggregateStepIndex);
+    }
+    if (resumePayload == null) {
+      throw new IllegalArgumentException("Itemized parent release requires resume payload");
+    }
+  }
+
+  String segmentId() {
+    return parent.executionId() + ":segment:" + aggregateStepIndex;
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -27,13 +27,11 @@ import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitCoordinator;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.awaitable.AwaitLiveCompletionRegistry;
-import org.pipelineframework.awaitable.AwaitThrowableSupport;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
-import org.pipelineframework.orchestrator.ControlPlaneTransitionAdmission;
 import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
 import org.pipelineframework.telemetry.PipelineTelemetry;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
@@ -53,14 +51,9 @@ import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.PipelineReleaseIdentityResolver;
 import org.pipelineframework.orchestrator.PipelineTransitionWorker;
 import org.pipelineframework.orchestrator.SerializedTransitionPayload;
-import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
-import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
 import org.pipelineframework.orchestrator.TransitionPayloadCodec;
 import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
-import org.pipelineframework.orchestrator.TransitionResultEnvelope;
 import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
-import org.pipelineframework.orchestrator.TransitionWorkerCommand;
-import org.pipelineframework.orchestrator.TransitionWorkerOutcome;
 import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
@@ -489,71 +482,7 @@ class QueueAsyncCoordinator {
     if (worker == null) {
       return Uni.createFrom().failure(new IllegalArgumentException("PipelineTransitionWorker must not be null"));
     }
-    Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
-    if (admission.isEmpty()) {
-      return workDispatcher.enqueueDelayed(workItem, saturatedDelay());
-    }
-    TransitionWorkerExecutor.TransitionAdmission permit = admission.get();
-    ControlPlaneTransitionAdmission tenantAdmission = admissionPolicy().admitTransition(admissionRequest(
-        workItem.tenantId(),
-        ControlPlaneAdmissionOperation.PROCESS_WORK_ITEM,
-        workItem.executionId(),
-        "worker-dispatch",
-        true));
-    if (!tenantAdmission.decision().allowed()) {
-      permit.close();
-      if (ControlPlaneAdmissionDecision.TENANT_TRANSITION_QUOTA_SATURATED.equals(tenantAdmission.decision().errorCode())) {
-        return workDispatcher.enqueueDelayed(workItem, saturatedDelay());
-      }
-      LOG.warnf(
-          "Skipping async execution work item tenant=%s executionId=%s: %s",
-          workItem.tenantId(),
-          workItem.executionId(),
-          tenantAdmission.decision().reason());
-      return Uni.createFrom().voidItem();
-    }
-    long now = System.currentTimeMillis();
-    return executionStateStore.claimLease(
-            workItem.tenantId(),
-            workItem.executionId(),
-            queueWorkerId,
-            now,
-            orchestratorConfig.leaseMs())
-        .onItem().transformToUni(claimed -> {
-          if (claimed.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          ExecutionRecord<Object, Object> record = claimed.get();
-          LOG.infof(
-              "Claimed async execution %s tenant=%s stepIndex=%d attempt=%d resultShape=%s awaitUnitId=%s",
-              record.executionId(),
-              record.tenantId(),
-              record.currentStepIndex(),
-              record.attempt(),
-              record.resultShape(),
-              record.awaitUnitId() == null ? "<none>" : record.awaitUnitId());
-          String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-          return segmentBoundaryLedger().recordSegmentAttemptStarted(record, transitionKey, now)
-              .chain(() -> prepareTransitionCommand(record, transitionKey))
-              .onItem().transformToUni(command -> transitionWorkerExecutor.execute(worker, command))
-              .onItem().transformToUni(result -> handleTransitionResult(record, transitionKey, result, itemContinuationHandler))
-              .onFailure(AwaitThrowableSupport::containsAwaitSuspension).recoverWithUni(failure ->
-                  awaitCoordinator.suspensionSnapshot(AwaitThrowableSupport.extractAwaitSuspension(failure))
-                      .onItem().transformToUni(suspension ->
-                          markWaitingExternal(record, suspension, transitionKey, itemContinuationHandler)))
-              .onFailure().recoverWithUni(
-                  failure -> executionFailureHandler.handleExecutionFailure(
-                      record,
-                      transitionKey,
-                      failure,
-                      executionStateStore,
-                      workDispatcher,
-                      deadLetterPublisher));
-        })
-        .onTermination().invoke(() -> {
-          permit.close();
-          tenantAdmission.permit().close();
-        });
+    return segmentPipeline().process(workItem, worker, itemContinuationHandler);
   }
 
   void sweepDueExecutions() {
@@ -616,138 +545,6 @@ class QueueAsyncCoordinator {
     return awaitCoordinator.queryPending(resolvedTenant, assignee, group, stepId, limit <= 0 ? 100 : limit);
   }
 
-  private Uni<Void> handleTransitionResult(
-      ExecutionRecord<Object, Object> record,
-      String transitionKey,
-      TransitionResultEnvelope result,
-      AwaitItemContinuationHandler itemContinuationHandler) {
-    if (result == null) {
-      return executionFailureHandler.handleExecutionFailure(
-          record,
-          transitionKey,
-          new IllegalStateException("PipelineTransitionWorker returned null result"),
-          executionStateStore,
-          workDispatcher,
-          deadLetterPublisher);
-    }
-    if (result.outcome() == TransitionWorkerOutcome.COMPLETED) {
-      return handleCompletedTransition(record, transitionKey, result);
-    }
-    if (result.outcome() == TransitionWorkerOutcome.WAITING_EXTERNAL) {
-      return markWaitingExternal(record, result.awaitSuspension(), transitionKey, itemContinuationHandler);
-    }
-    return executionFailureHandler.handleExecutionFailure(
-        record,
-        transitionKey,
-        result.failure().toException(),
-        executionStateStore,
-        workDispatcher,
-        deadLetterPublisher);
-  }
-
-  private Uni<Void> handleCompletedTransition(
-      ExecutionRecord<Object, Object> record,
-      String transitionKey,
-      TransitionResultEnvelope result) {
-    List<?> outputItems = result.coordinatorOutputItems();
-    if (record.resultShape() == ExecutionResultShape.SINGLE && outputItems.size() > 1) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue execution " + record.executionId()
-              + " produced " + outputItems.size()
-              + " terminal items for SINGLE result shape"));
-    }
-    long nowEpochMs = System.currentTimeMillis();
-    return segmentBoundaryLedger().recordSegmentCompleted(record, transitionKey, result, nowEpochMs)
-        .chain(() -> checkpointPublicationService.publishIfConfigured(record, singleResult(outputItems)))
-        .chain(() -> publishTerminalOutputsIfConfigured(record, transitionKey, result, nowEpochMs))
-        .replaceWith(outputItems)
-        .onItem().transformToUni(payload -> executionStateStore.markSucceeded(
-            record.tenantId(),
-            record.executionId(),
-            record.version(),
-            transitionKey,
-            payload,
-            nowEpochMs))
-        .onItem().transformToUni(updated -> updated
-            .map(succeeded -> segmentBoundaryLedger().recordRunSucceeded(succeeded, outputItems, nowEpochMs))
-            .orElseGet(() -> Uni.createFrom().voidItem()))
-        .replaceWithVoid();
-  }
-
-  private Uni<Void> publishTerminalOutputsIfConfigured(
-      ExecutionRecord<Object, Object> record,
-      String transitionKey,
-      TransitionResultEnvelope result,
-      long nowEpochMs) {
-    if (result.terminalOutputPublished()) {
-      return segmentBoundaryLedger().recordTerminalPublicationCompleted(record, transitionKey, nowEpochMs);
-    }
-    if (objectPublishCompletionService == null) {
-      return Uni.createFrom().voidItem();
-    }
-    return objectPublishCompletionService.publishIfConfigured(() -> result.decodeOutputItems(payloadCodec()))
-        .chain(() -> segmentBoundaryLedger().recordTerminalPublicationCompleted(record, transitionKey, nowEpochMs));
-  }
-
-  private Uni<Void> markWaitingExternal(
-      ExecutionRecord<Object, Object> record,
-      TransitionAwaitSuspension suspended,
-      String transitionKey,
-      AwaitItemContinuationHandler itemContinuationHandler) {
-    return awaitCoordinator.importSuspension(suspended)
-        .onItem().transformToUni(ignored -> {
-          long nowEpochMs = System.currentTimeMillis();
-          return executionStateStore.markWaitingExternal(
-            record.tenantId(),
-            record.executionId(),
-            record.version(),
-            transitionKey,
-            suspended.unitId(),
-            suspended.stepIndex(),
-            nowEpochMs)
-              .onItem().transformToUni(updated -> {
-                if (updated.isPresent()) {
-                  LOG.infof(
-                      "Execution %s persisted WAITING_EXTERNAL at stepIndex=%d awaitUnitId=%s awaitInteractions=%d",
-                      record.executionId(),
-                      suspended.stepIndex(),
-                      suspended.unitId(),
-                      suspended.interactions().size());
-                  recordAwaitLifecycle(new AwaitReplayLifecycleEvent(
-                      AwaitReplayLifecycleEvent.EXECUTION_WAITING,
-                      record.executionId(),
-                      suspended.unitId(),
-                      null,
-                      suspended.stepIndex(),
-                      ExecutionStatus.WAITING_EXTERNAL.name(),
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null));
-                  return segmentBoundaryLedger().recordSegmentSuspended(record, transitionKey, suspended, nowEpochMs)
-                      .chain(() -> releaseAlreadyCompletedAwaitUnit(
-                          updated.get(),
-                          suspended,
-                          nowEpochMs,
-                          itemContinuationHandler));
-                }
-                return Uni.createFrom().failure(new IllegalStateException(
-                    "Failed to persist WAITING_EXTERNAL state for execution "
-                        + record.executionId()
-                        + " at step "
-                        + suspended.stepIndex()
-                        + " (expectedVersion="
-                        + record.version()
-                        + ", awaitUnitId="
-                        + suspended.unitId()
-                        + ")"));
-              });
-        });
-  }
-
   private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
     return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
         .onItem().transformToUni(records -> {
@@ -793,57 +590,6 @@ class QueueAsyncCoordinator {
         });
   }
 
-  private Uni<List<?>> runAsyncExecution(
-      ExecutionRecord<Object, Object> record,
-      PipelineTransitionWorker worker) {
-    String transitionKey = transitionKey(record.executionId(), record.currentStepIndex(), record.attempt());
-    return prepareTransitionCommand(record, transitionKey)
-        .onItem().transformToUni(command -> transitionWorkerExecutor.execute(worker, command))
-        .onItem().transform(result -> {
-          if (result.outcome() != TransitionWorkerOutcome.COMPLETED) {
-            throw new IllegalStateException("Transition did not complete: " + result.outcome());
-          }
-          List<?> copied = result.coordinatorOutputItems();
-          if (record.resultShape() == ExecutionResultShape.SINGLE && copied.size() > 1) {
-            throw new IllegalStateException(
-                "Async queue execution " + record.executionId()
-                    + " produced " + copied.size()
-                    + " terminal items for SINGLE result shape");
-          }
-          return copied;
-        });
-  }
-
-  private Uni<TransitionCommandEnvelope> prepareTransitionCommand(
-      ExecutionRecord<Object, Object> record,
-      String transitionKey) {
-    Uni<Object> inputPayload = record.currentStepIndex() > 0 && hasAwaitUnitId(record)
-        ? loadAwaitResumePayload(record)
-        : Uni.createFrom().item(record.inputPayload());
-    return inputPayload.onItem().transform(payload -> {
-      TransitionWorkerCommand command = new TransitionWorkerCommand(
-          record.tenantId(),
-          record.executionId(),
-          record.currentStepIndex(),
-          record.attempt(),
-          record.resultShape(),
-          record.version(),
-          transitionKey,
-          payload);
-      return TransitionCommandEnvelope.from(
-          command,
-          record.pipelineId(),
-          record.contractVersion(),
-          record.releaseVersion(),
-          transitionKey,
-          payloadCodec().encode(payload));
-    });
-  }
-
-  private static boolean hasAwaitUnitId(ExecutionRecord<Object, Object> record) {
-    return record.awaitUnitId() != null && !record.awaitUnitId().isBlank();
-  }
-
   private static boolean redrivable(ExecutionStatus status, boolean allowFailed) {
     return status == ExecutionStatus.DLQ || (allowFailed && status == ExecutionStatus.FAILED);
   }
@@ -879,28 +625,12 @@ class QueueAsyncCoordinator {
     return value;
   }
 
-  private Uni<Object> loadAwaitResumePayload(ExecutionRecord<Object, Object> record) {
-    if (record.awaitUnitId() == null || record.awaitUnitId().isBlank()) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Execution " + record.executionId() + " is resuming from step "
-              + record.currentStepIndex() + " without awaitUnitId"));
-    }
-    return awaitCoordinator.loadResumePayload(record.tenantId(), record.awaitUnitId());
-  }
-
   private Duration saturatedDelay() {
     PipelineOrchestratorConfig.WorkerConfig workerConfig = orchestratorConfig.worker();
     if (workerConfig == null || workerConfig.saturatedDelay() == null) {
       return Duration.ofSeconds(1);
     }
     return workerConfig.saturatedDelay();
-  }
-
-  private Object singleResult(List<?> items) {
-    if (items == null || items.isEmpty()) {
-      return null;
-    }
-    return items.getFirst();
   }
 
   private Object coerceStoredResult(Object result, Class<?> outputType) {
@@ -1037,14 +767,6 @@ class QueueAsyncCoordinator {
     return tenantId != null && !tenantId.isBlank();
   }
 
-  private Uni<Void> releaseAlreadyCompletedAwaitUnit(
-      ExecutionRecord<Object, Object> record,
-      TransitionAwaitSuspension suspended,
-      long nowEpochMs,
-      AwaitItemContinuationHandler itemContinuationHandler) {
-    return awaitContinuations().afterParentWaiting(record, suspended, nowEpochMs, itemContinuationHandler);
-  }
-
   Uni<Void> recordAwaitItemContinuation(
       AwaitInteractionRecord interaction,
       org.pipelineframework.awaitable.AwaitUnitRecord unit,
@@ -1103,6 +825,34 @@ class QueueAsyncCoordinator {
       }
       return current;
     }
+  }
+
+  private QueueAsyncSegmentPipeline segmentPipeline() {
+    return new QueueAsyncSegmentPipeline(
+        orchestratorConfig,
+        executionStateStore,
+        workDispatcher,
+        awaitCoordinator,
+        transitionWorkerExecutor,
+        admissionPolicy(),
+        this::payloadCodec,
+        this::segmentBoundaryLedger,
+        this::saturatedDelay,
+        new SegmentCommitEffects(
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher,
+            awaitCoordinator,
+            executionFailureHandler,
+            this::segmentBoundaryLedger,
+            awaitContinuations(),
+            new TerminalPublicationBoundary(
+                checkpointPublicationService,
+                objectPublishCompletionService,
+                this::payloadCodec,
+                this::segmentBoundaryLedger),
+            this::recordAwaitLifecycle),
+        queueWorkerId);
   }
 
   private SegmentBoundaryLedger segmentBoundaryLedger() {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSegmentPipeline.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSegmentPipeline.java
@@ -1,0 +1,185 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitThrowableSupport;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
+import org.pipelineframework.orchestrator.ControlPlaneTransitionAdmission;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.PipelineTransitionWorker;
+import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+/**
+ * Reactive queue-async segment flow: claim, run, plan, and commit one synchronous segment.
+ */
+class QueueAsyncSegmentPipeline {
+
+  private static final Logger LOG = Logger.getLogger(QueueAsyncSegmentPipeline.class);
+
+  private final PipelineOrchestratorConfig orchestratorConfig;
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final AwaitCoordinator awaitCoordinator;
+  private final TransitionWorkerExecutor transitionWorkerExecutor;
+  private final ControlPlaneAdmissionPolicy admissionPolicy;
+  private final Supplier<TransitionPayloadCodec> payloadCodec;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+  private final Supplier<Duration> saturatedDelay;
+  private final SegmentCommitEffects segmentCommitEffects;
+  private final String queueWorkerId;
+
+  QueueAsyncSegmentPipeline(
+      PipelineOrchestratorConfig orchestratorConfig,
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      AwaitCoordinator awaitCoordinator,
+      TransitionWorkerExecutor transitionWorkerExecutor,
+      ControlPlaneAdmissionPolicy admissionPolicy,
+      Supplier<TransitionPayloadCodec> payloadCodec,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger,
+      Supplier<Duration> saturatedDelay,
+      SegmentCommitEffects segmentCommitEffects,
+      String queueWorkerId) {
+    this.orchestratorConfig = Objects.requireNonNull(orchestratorConfig, "orchestratorConfig must not be null");
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.workDispatcher = Objects.requireNonNull(workDispatcher, "workDispatcher must not be null");
+    this.awaitCoordinator = Objects.requireNonNull(awaitCoordinator, "awaitCoordinator must not be null");
+    this.transitionWorkerExecutor = Objects.requireNonNull(transitionWorkerExecutor, "transitionWorkerExecutor must not be null");
+    this.admissionPolicy = Objects.requireNonNull(admissionPolicy, "admissionPolicy must not be null");
+    this.payloadCodec = Objects.requireNonNull(payloadCodec, "payloadCodec must not be null");
+    this.segmentBoundaryLedger = Objects.requireNonNull(segmentBoundaryLedger, "segmentBoundaryLedger must not be null");
+    this.saturatedDelay = Objects.requireNonNull(saturatedDelay, "saturatedDelay must not be null");
+    this.segmentCommitEffects = Objects.requireNonNull(segmentCommitEffects, "segmentCommitEffects must not be null");
+    this.queueWorkerId = queueWorkerId == null || queueWorkerId.isBlank() ? "worker-local" : queueWorkerId;
+  }
+
+  Uni<Void> process(
+      ExecutionWorkItem workItem,
+      PipelineTransitionWorker worker,
+      AwaitItemContinuationHandler itemContinuationHandler) {
+    return Uni.createFrom().deferred(() -> {
+      Optional<TransitionWorkerExecutor.TransitionAdmission> admission = transitionWorkerExecutor.tryAdmit();
+      if (admission.isEmpty()) {
+        return workDispatcher.enqueueDelayed(workItem, saturatedDelay.get());
+      }
+      TransitionWorkerExecutor.TransitionAdmission transitionPermit = admission.get();
+      ControlPlaneTransitionAdmission tenantAdmission = admissionPolicy.admitTransition(admissionRequest(workItem));
+      if (!tenantAdmission.decision().allowed()) {
+        transitionPermit.close();
+        return handleDeniedAdmission(workItem, tenantAdmission);
+      }
+      return claimAndRun(workItem, worker, itemContinuationHandler)
+          .onTermination().invoke(() -> {
+            transitionPermit.close();
+            tenantAdmission.permit().close();
+          });
+    });
+  }
+
+  private Uni<Void> handleDeniedAdmission(
+      ExecutionWorkItem workItem,
+      ControlPlaneTransitionAdmission tenantAdmission) {
+    if (ControlPlaneAdmissionDecision.TENANT_TRANSITION_QUOTA_SATURATED
+        .equals(tenantAdmission.decision().errorCode())) {
+      return workDispatcher.enqueueDelayed(workItem, saturatedDelay.get());
+    }
+    LOG.warnf(
+        "Skipping async execution work item tenant=%s executionId=%s: %s",
+        workItem.tenantId(),
+        workItem.executionId(),
+        tenantAdmission.decision().reason());
+    return Uni.createFrom().voidItem();
+  }
+
+  private Uni<Void> claimAndRun(
+      ExecutionWorkItem workItem,
+      PipelineTransitionWorker worker,
+      AwaitItemContinuationHandler itemContinuationHandler) {
+    long now = System.currentTimeMillis();
+    return executionStateStore.claimLease(
+            workItem.tenantId(),
+            workItem.executionId(),
+            queueWorkerId,
+            now,
+            orchestratorConfig.leaseMs())
+        .onItem().transformToUni(claimed -> claimed
+            .map(record -> runClaimed(ClaimedSegment.from(record), worker, itemContinuationHandler, now))
+            .orElseGet(() -> Uni.createFrom().voidItem()));
+  }
+
+  private Uni<Void> runClaimed(
+      ClaimedSegment segment,
+      PipelineTransitionWorker worker,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long claimedAtEpochMs) {
+    ExecutionRecord<Object, Object> record = segment.record();
+    LOG.infof(
+        "Claimed async execution %s tenant=%s stepIndex=%d attempt=%d resultShape=%s awaitUnitId=%s",
+        record.executionId(),
+        record.tenantId(),
+        record.currentStepIndex(),
+        record.attempt(),
+        record.resultShape(),
+        record.awaitUnitId() == null ? "<none>" : record.awaitUnitId());
+    return segmentBoundaryLedger.get()
+        .recordSegmentAttemptStarted(record, segment.transitionKey(), claimedAtEpochMs)
+        .chain(() -> transitionCommand(segment))
+        .onItem().transformToUni(command -> transitionWorkerExecutor.execute(worker, command))
+        .onItem().transform(result -> SegmentCommitPlan.from(segment, result))
+        .onItem().transformToUni(plan -> segmentCommitEffects.commit(plan, itemContinuationHandler))
+        .onFailure(AwaitThrowableSupport::containsAwaitSuspension)
+        .recoverWithUni(failure -> suspendedPlan(segment, failure)
+            .onItem().transformToUni(plan -> segmentCommitEffects.commit(plan, itemContinuationHandler)))
+        .onFailure().recoverWithUni(failure -> segmentCommitEffects.fail(segment, failure));
+  }
+
+  private Uni<TransitionCommandEnvelope> transitionCommand(ClaimedSegment segment) {
+    return inputPayload(segment)
+        .onItem().transform(payload -> segment.transitionCommand(payload, payloadCodec.get()));
+  }
+
+  private Uni<Object> inputPayload(ClaimedSegment segment) {
+    if (!segment.resumesFromAwait()) {
+      return Uni.createFrom().item(segment.record().inputPayload());
+    }
+    String awaitUnitId = segment.record().awaitUnitId();
+    if (awaitUnitId == null || awaitUnitId.isBlank()) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Execution " + segment.record().executionId() + " is resuming from step "
+              + segment.record().currentStepIndex() + " without awaitUnitId"));
+    }
+    return awaitCoordinator.loadResumePayload(segment.record().tenantId(), awaitUnitId);
+  }
+
+  private Uni<SegmentCommitPlan> suspendedPlan(ClaimedSegment segment, Throwable failure) {
+    return awaitCoordinator.suspensionSnapshot(AwaitThrowableSupport.extractAwaitSuspension(failure))
+        .onItem().transform(suspension -> new SuspendedSegment(segment, suspension));
+  }
+
+  private ControlPlaneAdmissionRequest admissionRequest(ExecutionWorkItem workItem) {
+    return new ControlPlaneAdmissionRequest(
+        workItem.tenantId(),
+        ControlPlaneAdmissionOperation.PROCESS_WORK_ITEM,
+        null,
+        null,
+        workItem.executionId(),
+        "worker-dispatch",
+        true);
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ScalarAwaitContinuationFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ScalarAwaitContinuationFlow.java
@@ -1,0 +1,185 @@
+package org.pipelineframework;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCompletionMetrics;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
+
+class ScalarAwaitContinuationFlow {
+
+  private static final Logger LOG = Logger.getLogger(ScalarAwaitContinuationFlow.class);
+
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+  private final Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder;
+
+  ScalarAwaitContinuationFlow(
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger,
+      Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder) {
+    this.executionStateStore = executionStateStore;
+    this.workDispatcher = workDispatcher;
+    this.segmentBoundaryLedger = segmentBoundaryLedger;
+    this.lifecycleRecorder = lifecycleRecorder;
+  }
+
+  Uni<Void> release(AwaitContinuationPlan.ReleaseScalar plan, long nowEpochMs) {
+    AwaitInteractionRecord interaction = plan.interaction();
+    AwaitUnitRecord unit = plan.unit();
+    return release(
+        interaction.tenantId(),
+        interaction.executionId(),
+        unit.unitId(),
+        unit.stepId(),
+        interaction.stepIndex(),
+        interaction.interactionId(),
+        interaction.correlationId(),
+        interaction.transportType(),
+        interaction.itemIndex(),
+        nowEpochMs);
+  }
+
+  private Uni<Void> release(
+      String tenantId,
+      String executionId,
+      String awaitUnitId,
+      String stepId,
+      int stepIndex,
+      String interactionId,
+      String correlationId,
+      String transportType,
+      Integer itemIndex,
+      long nowEpochMs) {
+    return executionStateStore.markAwaitCompleted(
+            tenantId,
+            executionId,
+            awaitUnitId,
+            stepIndex + 1,
+            nowEpochMs)
+        .onItem().transformToUni(updated -> updated
+            .map(released -> recordAndEnqueue(
+                released,
+                awaitUnitId,
+                stepId,
+                stepIndex,
+                interactionId,
+                correlationId,
+                transportType,
+                itemIndex,
+                nowEpochMs))
+            .orElseGet(() -> enqueueAlreadyReleased(
+                tenantId,
+                executionId,
+                awaitUnitId,
+                stepId,
+                stepIndex,
+                interactionId,
+                correlationId,
+                transportType,
+                itemIndex,
+                nowEpochMs)));
+  }
+
+  private Uni<Void> enqueueAlreadyReleased(
+      String tenantId,
+      String executionId,
+      String awaitUnitId,
+      String stepId,
+      int stepIndex,
+      String interactionId,
+      String correlationId,
+      String transportType,
+      Integer itemIndex,
+      long nowEpochMs) {
+    LOG.debugf(
+        "Await resume release for execution %s awaitUnitId=%s at stepIndex=%d produced no state update; treating as idempotent no-op",
+        executionId,
+        awaitUnitId,
+        stepIndex);
+    return executionStateStore.getExecution(tenantId, executionId)
+        .onItem().transformToUni(current -> {
+          if (current.isEmpty() || !releasedForStep(current.get(), stepIndex + 1)) {
+            return Uni.createFrom().voidItem();
+          }
+          return recordAndEnqueue(
+              current.get(),
+              awaitUnitId,
+              stepId,
+              stepIndex,
+              interactionId,
+              correlationId,
+              transportType,
+              itemIndex,
+              nowEpochMs);
+        });
+  }
+
+  private Uni<Void> recordAndEnqueue(
+      ExecutionRecord<Object, Object> released,
+      String awaitUnitId,
+      String stepId,
+      int stepIndex,
+      String interactionId,
+      String correlationId,
+      String transportType,
+      Integer itemIndex,
+      long nowEpochMs) {
+    return segmentBoundaryLedger.get().recordContinuationSegmentCreated(
+            released,
+            awaitUnitId,
+            SegmentBoundaryLedger.segmentId(released),
+            stepIndex + 1,
+            -1,
+            released.inputPayload(),
+            nowEpochMs)
+        .chain(() -> workDispatcher.enqueueNow(new ExecutionWorkItem(
+            released.tenantId(),
+            released.executionId())))
+        .invoke(() -> {
+          LOG.infof(
+              "Resuming async execution %s from awaitUnitId=%s at nextStepIndex=%d",
+              released.executionId(),
+              awaitUnitId,
+              released.currentStepIndex());
+          AwaitReplayLifecycleEvent lifecycleEvent = new AwaitReplayLifecycleEvent(
+              AwaitReplayLifecycleEvent.RESUME_RELEASED,
+              released.executionId(),
+              awaitUnitId,
+              stepId,
+              stepIndex,
+              released.status().name(),
+              interactionId,
+              correlationId,
+              transportType,
+              itemIndex,
+              null,
+              null,
+              null);
+          lifecycleRecorder.accept(lifecycleEvent);
+          AwaitCompletionMetrics.recordResumeReleased(lifecycleEvent);
+        })
+        .replaceWithVoid();
+  }
+
+  private static boolean releasedForStep(
+      ExecutionRecord<Object, Object> record,
+      int stepIndex) {
+    return record != null
+        && record.status() == ExecutionStatus.QUEUED
+        && record.currentStepIndex() == stepIndex;
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/SegmentCommitEffects.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/SegmentCommitEffects.java
@@ -1,0 +1,180 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
+
+/**
+ * Interprets immutable segment commit plans against the existing projection stores.
+ */
+class SegmentCommitEffects {
+
+  private static final Logger LOG = Logger.getLogger(SegmentCommitEffects.class);
+
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final DeadLetterPublisher deadLetterPublisher;
+  private final AwaitCoordinator awaitCoordinator;
+  private final ExecutionFailureHandler executionFailureHandler;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+  private final AwaitContinuations awaitContinuations;
+  private final TerminalPublicationBoundary terminalPublicationBoundary;
+  private final Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder;
+
+  SegmentCommitEffects(
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      DeadLetterPublisher deadLetterPublisher,
+      AwaitCoordinator awaitCoordinator,
+      ExecutionFailureHandler executionFailureHandler,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger,
+      AwaitContinuations awaitContinuations,
+      TerminalPublicationBoundary terminalPublicationBoundary,
+      Consumer<AwaitReplayLifecycleEvent> lifecycleRecorder) {
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.workDispatcher = Objects.requireNonNull(workDispatcher, "workDispatcher must not be null");
+    this.deadLetterPublisher = Objects.requireNonNull(deadLetterPublisher, "deadLetterPublisher must not be null");
+    this.awaitCoordinator = Objects.requireNonNull(awaitCoordinator, "awaitCoordinator must not be null");
+    this.executionFailureHandler = Objects.requireNonNull(executionFailureHandler, "executionFailureHandler must not be null");
+    this.segmentBoundaryLedger = Objects.requireNonNull(segmentBoundaryLedger, "segmentBoundaryLedger must not be null");
+    this.awaitContinuations = Objects.requireNonNull(awaitContinuations, "awaitContinuations must not be null");
+    this.terminalPublicationBoundary = Objects.requireNonNull(
+        terminalPublicationBoundary,
+        "terminalPublicationBoundary must not be null");
+    this.lifecycleRecorder = Objects.requireNonNull(lifecycleRecorder, "lifecycleRecorder must not be null");
+  }
+
+  Uni<Void> commit(
+      SegmentCommitPlan plan,
+      AwaitItemContinuationHandler itemContinuationHandler) {
+    return switch (plan) {
+      case CompletedSegment completed -> commitCompleted(completed);
+      case SuspendedSegment suspended -> commitSuspended(suspended, itemContinuationHandler);
+      case FailedSegment failed -> fail(failed.segment(), failed.failure());
+    };
+  }
+
+  Uni<Void> fail(ClaimedSegment segment, Throwable failure) {
+    return executionFailureHandler.handleExecutionFailure(
+        segment.record(),
+        segment.transitionKey(),
+        failure,
+        executionStateStore,
+        workDispatcher,
+        deadLetterPublisher);
+  }
+
+  private Uni<Void> commitCompleted(CompletedSegment completed) {
+    ClaimedSegment segment = completed.segment();
+    long nowEpochMs = System.currentTimeMillis();
+    return segmentBoundaryLedger.get()
+        .recordSegmentCompleted(segment.record(), segment.transitionKey(), completed.result(), nowEpochMs)
+        .chain(() -> terminalPublicationBoundary.publishBeforeSuccess(completed, nowEpochMs))
+        .chain(() -> executionStateStore.markSucceeded(
+            segment.record().tenantId(),
+            segment.record().executionId(),
+            segment.record().version(),
+            segment.transitionKey(),
+            completed.outputItems(),
+            nowEpochMs))
+        .onItem().transformToUni(updated -> updated
+            .map(succeeded -> segmentBoundaryLedger.get().recordRunSucceeded(
+                succeeded,
+                completed.outputItems(),
+                nowEpochMs))
+            .orElseGet(() -> Uni.createFrom().failure(successCommitFailure(completed))))
+        .replaceWithVoid();
+  }
+
+  private Uni<Void> commitSuspended(
+      SuspendedSegment suspended,
+      AwaitItemContinuationHandler itemContinuationHandler) {
+    ClaimedSegment segment = suspended.segment();
+    long nowEpochMs = System.currentTimeMillis();
+    return executionStateStore.markWaitingExternal(
+            segment.record().tenantId(),
+            segment.record().executionId(),
+            segment.record().version(),
+            segment.transitionKey(),
+            suspended.suspension().unitId(),
+            suspended.suspension().stepIndex(),
+            nowEpochMs)
+        .onItem().transformToUni(updated -> {
+          if (updated.isEmpty()) {
+            return Uni.createFrom().failure(waitingExternalFailure(suspended));
+          }
+          return awaitCoordinator.importSuspension(suspended.suspension())
+              .chain(() -> afterWaitingExternal(suspended, updated.get(), itemContinuationHandler, nowEpochMs));
+        });
+  }
+
+  private Uni<Void> afterWaitingExternal(
+      SuspendedSegment suspended,
+      ExecutionRecord<Object, Object> waiting,
+      AwaitItemContinuationHandler itemContinuationHandler,
+      long nowEpochMs) {
+    ClaimedSegment segment = suspended.segment();
+    LOG.infof(
+        "Execution %s persisted WAITING_EXTERNAL at stepIndex=%d awaitUnitId=%s awaitInteractions=%d",
+        segment.record().executionId(),
+        suspended.suspension().stepIndex(),
+        suspended.suspension().unitId(),
+        suspended.suspension().interactions().size());
+    lifecycleRecorder.accept(new AwaitReplayLifecycleEvent(
+        AwaitReplayLifecycleEvent.EXECUTION_WAITING,
+        segment.record().executionId(),
+        suspended.suspension().unitId(),
+        null,
+        suspended.suspension().stepIndex(),
+        ExecutionStatus.WAITING_EXTERNAL.name(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null));
+    return segmentBoundaryLedger.get()
+        .recordSegmentSuspended(segment.record(), segment.transitionKey(), suspended.suspension(), nowEpochMs)
+        .chain(() -> awaitContinuations.afterParentWaiting(
+            waiting,
+            suspended.suspension(),
+            nowEpochMs,
+            itemContinuationHandler));
+  }
+
+  private IllegalStateException waitingExternalFailure(SuspendedSegment suspended) {
+    return new IllegalStateException(
+        "Failed to persist WAITING_EXTERNAL state for execution "
+            + suspended.segment().record().executionId()
+            + " at step "
+            + suspended.suspension().stepIndex()
+            + " (expectedVersion="
+            + suspended.segment().record().version()
+            + ", awaitUnitId="
+            + suspended.suspension().unitId()
+            + ")");
+  }
+
+  private IllegalStateException successCommitFailure(CompletedSegment completed) {
+    return new IllegalStateException(
+        "Failed to persist SUCCEEDED state for execution "
+            + completed.segment().record().executionId()
+            + " (expectedVersion="
+            + completed.segment().record().version()
+            + ", transitionKey="
+            + completed.segment().transitionKey()
+            + ")");
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/SegmentCommitPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/SegmentCommitPlan.java
@@ -1,0 +1,49 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.TransitionWorkerOutcome;
+
+/**
+ * Pure immutable decision for committing a worker transition result.
+ */
+sealed interface SegmentCommitPlan permits CompletedSegment, SuspendedSegment, FailedSegment {
+
+  ClaimedSegment segment();
+
+  static SegmentCommitPlan from(ClaimedSegment segment, TransitionResultEnvelope result) {
+    Objects.requireNonNull(segment, "segment must not be null");
+    if (result == null) {
+      return new FailedSegment(
+          segment,
+          new IllegalStateException("PipelineTransitionWorker returned null result"));
+    }
+    if (result.outcome() == TransitionWorkerOutcome.COMPLETED) {
+      return completed(segment, result);
+    }
+    if (result.outcome() == TransitionWorkerOutcome.WAITING_EXTERNAL) {
+      return new SuspendedSegment(segment, result.awaitSuspension());
+    }
+    return new FailedSegment(segment, result.failure().toException());
+  }
+
+  static CompletedSegment completed(ClaimedSegment segment, TransitionResultEnvelope result) {
+    Objects.requireNonNull(segment, "segment must not be null");
+    Objects.requireNonNull(result, "result must not be null");
+    List<?> outputItems = result.coordinatorOutputItems();
+    if (segment.record().resultShape() == ExecutionResultShape.SINGLE && outputItems.size() > 1) {
+      throw new IllegalStateException(
+          "Async queue execution " + segment.record().executionId()
+              + " produced " + outputItems.size()
+              + " terminal items for SINGLE result shape");
+    }
+    return new CompletedSegment(
+        segment,
+        result,
+        outputItems,
+        TerminalPublicationPlan.from(segment, result, outputItems));
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/SuspendedSegment.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/SuspendedSegment.java
@@ -1,0 +1,15 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+
+record SuspendedSegment(
+    ClaimedSegment segment,
+    TransitionAwaitSuspension suspension) implements SegmentCommitPlan {
+
+  SuspendedSegment {
+    Objects.requireNonNull(segment, "segment must not be null");
+    Objects.requireNonNull(suspension, "suspension must not be null");
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationBoundary.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationBoundary.java
@@ -1,0 +1,66 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+/**
+ * Interprets terminal publication plans before a segment can commit success.
+ */
+class TerminalPublicationBoundary {
+
+  private final CheckpointPublicationService checkpointPublicationService;
+  private final ObjectPublishCompletionService objectPublishCompletionService;
+  private final Supplier<TransitionPayloadCodec> payloadCodec;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+
+  TerminalPublicationBoundary(
+      CheckpointPublicationService checkpointPublicationService,
+      ObjectPublishCompletionService objectPublishCompletionService,
+      Supplier<TransitionPayloadCodec> payloadCodec,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger) {
+    this.checkpointPublicationService = checkpointPublicationService;
+    this.objectPublishCompletionService = objectPublishCompletionService;
+    this.payloadCodec = Objects.requireNonNull(payloadCodec, "payloadCodec must not be null");
+    this.segmentBoundaryLedger = Objects.requireNonNull(segmentBoundaryLedger, "segmentBoundaryLedger must not be null");
+  }
+
+  Uni<Void> publishBeforeSuccess(CompletedSegment completed, long nowEpochMs) {
+    Objects.requireNonNull(completed, "completed must not be null");
+    TerminalPublicationPlan plan = completed.terminalPublication();
+    return publishCheckpoint(completed, plan)
+        .chain(() -> publishObjectOutput(plan, nowEpochMs));
+  }
+
+  private Uni<Void> publishCheckpoint(CompletedSegment completed, TerminalPublicationPlan plan) {
+    if (checkpointPublicationService == null) {
+      return Uni.createFrom().voidItem();
+    }
+    return plan.checkpointPayload()
+        .map(payload -> checkpointPublicationService.publishIfConfigured(completed.segment().record(), payload))
+        .orElseGet(() -> Uni.createFrom().voidItem());
+  }
+
+  private Uni<Void> publishObjectOutput(TerminalPublicationPlan plan, long nowEpochMs) {
+    ClaimedSegment segment = plan.segment();
+    if (plan.alreadyPublished()) {
+      return segmentBoundaryLedger.get().recordTerminalPublicationCompleted(
+          segment.record(),
+          segment.transitionKey(),
+          nowEpochMs);
+    }
+    if (objectPublishCompletionService == null) {
+      return Uni.createFrom().voidItem();
+    }
+    return objectPublishCompletionService.publishIfConfigured(() -> plan.decodedOutputItems(payloadCodec.get()))
+        .chain(() -> segmentBoundaryLedger.get().recordTerminalPublicationCompleted(
+            segment.record(),
+            segment.transitionKey(),
+            nowEpochMs));
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationPlan.java
@@ -1,0 +1,44 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+/**
+ * Immutable plan for terminal publication side effects required before success.
+ */
+record TerminalPublicationPlan(
+    ClaimedSegment segment,
+    TransitionResultEnvelope result,
+    List<?> persistedOutputItems,
+    boolean alreadyPublished) {
+
+  TerminalPublicationPlan {
+    Objects.requireNonNull(segment, "segment must not be null");
+    Objects.requireNonNull(result, "result must not be null");
+    persistedOutputItems = persistedOutputItems == null ? List.of() : List.copyOf(persistedOutputItems);
+  }
+
+  static TerminalPublicationPlan from(
+      ClaimedSegment segment,
+      TransitionResultEnvelope result,
+      List<?> persistedOutputItems) {
+    return new TerminalPublicationPlan(segment, result, persistedOutputItems, result.terminalOutputPublished());
+  }
+
+  Optional<Object> checkpointPayload() {
+    return persistedOutputItems.isEmpty() ? Optional.empty() : Optional.ofNullable(persistedOutputItems.getFirst());
+  }
+
+  boolean objectPublishRequired() {
+    return !alreadyPublished;
+  }
+
+  List<?> decodedOutputItems(TransitionPayloadCodec payloadCodec) {
+    Objects.requireNonNull(payloadCodec, "payloadCodec must not be null");
+    return result.decodeOutputItems(payloadCodec);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/AwaitContinuationPlannerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/AwaitContinuationPlannerTest.java
@@ -1,0 +1,207 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AwaitContinuationPlannerTest {
+
+  private final AwaitContinuationPlanner planner = new AwaitContinuationPlanner();
+
+  @Test
+  void scalarCompletedUnitPlansReleaseScalar() {
+    AwaitInteractionRecord interaction = scalarRecord();
+    AwaitUnitRecord unit = unit(AwaitUnitStatus.COMPLETED, null, 0, false, "interaction-1");
+
+    AwaitContinuationPlan plan = planner.afterRecordedCompletion(interaction, unit, Optional.empty());
+
+    AwaitContinuationPlan.ReleaseScalar release = assertInstanceOf(AwaitContinuationPlan.ReleaseScalar.class, plan);
+    assertEquals(3, release.nextStepIndex());
+  }
+
+  @Test
+  void itemizedCompletionBeforeParentWaitingPlansHoldCompletion() {
+    AwaitInteractionRecord interaction = itemRecord(0);
+    AwaitUnitRecord unit = unit(AwaitUnitStatus.COMPLETED, 1, 1, true, null);
+    ExecutionRecord<Object, Object> parent = parent(ExecutionStatus.RUNNING);
+
+    AwaitContinuationPlan plan = planner.afterRecordedCompletion(interaction, unit, Optional.of(parent));
+
+    assertInstanceOf(AwaitContinuationPlan.HoldCompletion.class, plan);
+  }
+
+  @Test
+  void readyItemizedParentPlansDispatchItemContinuations() {
+    AwaitInteractionRecord interaction = itemRecord(0);
+    AwaitUnitRecord unit = unit(AwaitUnitStatus.COMPLETED, 1, 1, true, null);
+    ExecutionRecord<Object, Object> parent = parent(ExecutionStatus.WAITING_EXTERNAL);
+
+    AwaitContinuationPlan plan = planner.afterRecordedCompletion(interaction, unit, Optional.of(parent));
+
+    AwaitContinuationPlan.DispatchItemContinuations dispatch =
+        assertInstanceOf(AwaitContinuationPlan.DispatchItemContinuations.class, plan);
+    assertEquals(3, dispatch.nextStepIndex());
+  }
+
+  @Test
+  void invalidItemIndexFailsDuringPlanning() {
+    AwaitInteractionRecord interaction = itemRecord(3);
+    AwaitUnitRecord unit = unit(AwaitUnitStatus.COMPLETED, 2, 1, true, null);
+
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () ->
+        planner.recordItemOutput(
+            parent(ExecutionStatus.WAITING_EXTERNAL),
+            unit,
+            interaction,
+            4,
+            new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input"),
+            List.of("out")));
+
+    assertEquals("Itemized await continuation itemIndex 3 is outside expected item count 2", error.getMessage());
+  }
+
+  @Test
+  void allChildOutputsProduceOrderedParentRelease() {
+    AwaitUnitRecord unit = unit(AwaitUnitStatus.COMPLETED, 2, 2, true, null);
+    ExecutionRecord<Object, Object> parent = parent(ExecutionStatus.WAITING_EXTERNAL);
+    ExecutionRecord<Object, Object> first = child("child-0", List.of("out-0"));
+    ExecutionRecord<Object, Object> second = child("child-1", List.of("out-1"));
+
+    AwaitContinuationPlan plan = planner.releaseItemizedParent(
+        parent,
+        unit,
+        4,
+        List.of(Optional.of(first), Optional.of(second)));
+
+    AwaitContinuationPlan.ReleaseItemizedParent release =
+        assertInstanceOf(AwaitContinuationPlan.ReleaseItemizedParent.class, plan);
+    assertEquals(List.of("out-0", "out-1"), release.release().resumePayload().payload());
+  }
+
+  private static AwaitInteractionRecord scalarRecord() {
+    return record(null);
+  }
+
+  private static AwaitInteractionRecord itemRecord(int itemIndex) {
+    return record(itemIndex);
+  }
+
+  private static AwaitInteractionRecord record(Integer itemIndex) {
+    return new AwaitInteractionRecord(
+        "tenant-1",
+        "exec-1",
+        "AwaitPaymentProvider",
+        2,
+        String.class.getCanonicalName(),
+        "interaction-" + (itemIndex == null ? "scalar" : itemIndex),
+        "corr-" + (itemIndex == null ? "scalar" : itemIndex),
+        "cause-1",
+        "idem-" + (itemIndex == null ? "scalar" : itemIndex),
+        1L,
+        AwaitInteractionStatus.COMPLETED,
+        Map.of("value", "request"),
+        Map.of("value", "response"),
+        "unit-1",
+        itemIndex,
+        "user-1",
+        null,
+        null,
+        "kafka",
+        Map.of(),
+        10_000L,
+        1L,
+        2L,
+        999_999L);
+  }
+
+  private static AwaitUnitRecord unit(
+      AwaitUnitStatus status,
+      Integer expectedItemCount,
+      int completedItemCount,
+      boolean dispatchComplete,
+      String primaryInteractionId) {
+    return new AwaitUnitRecord(
+        "tenant-1",
+        "unit-1",
+        "exec-1",
+        "AwaitPaymentProvider",
+        2,
+        "ONE_TO_ONE",
+        1L,
+        status,
+        primaryInteractionId,
+        expectedItemCount,
+        completedItemCount,
+        completedItemCount == 0
+            ? Set.of()
+            : completedItemCount == 1 ? Set.of("item:0") : Set.of("item:0", "item:1"),
+        dispatchComplete,
+        1L,
+        2L,
+        999_999L);
+  }
+
+  private static ExecutionRecord<Object, Object> parent(ExecutionStatus status) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        ExecutionResultShape.MATERIALIZED_MULTI,
+        status,
+        7L,
+        2,
+        0,
+        null,
+        0L,
+        Long.MAX_VALUE,
+        "transition",
+        "input",
+        "unit-1",
+        null,
+        null,
+        null,
+        1L,
+        2L,
+        999_999L);
+  }
+
+  private static ExecutionRecord<Object, Object> child(String executionId, Object output) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        executionId,
+        "key-" + executionId,
+        ExecutionResultShape.MATERIALIZED_MULTI,
+        ExecutionStatus.SUCCEEDED,
+        8L,
+        4,
+        0,
+        null,
+        0L,
+        Long.MAX_VALUE,
+        "transition",
+        "input",
+        null,
+        output,
+        null,
+        null,
+        1L,
+        2L,
+        999_999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ItemizedAwaitContinuationFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ItemizedAwaitContinuationFlowTest.java
@@ -1,0 +1,294 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.invocation.PipelineInvocationRuntime;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.InMemoryExecutionStateStore;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.ControlPlaneProjection;
+import org.pipelineframework.orchestrator.controlplane.InMemoryControlPlaneJournal;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ItemizedAwaitContinuationFlowTest {
+
+  private InMemoryControlPlaneJournal journal;
+  private ScheduledExecutorService scheduler;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private WorkDispatcher workDispatcher;
+
+  @Mock
+  private AwaitCoordinator awaitCoordinator;
+
+  @BeforeEach
+  void setUp() {
+    journal = new InMemoryControlPlaneJournal();
+    scheduler = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @AfterEach
+  void tearDown() {
+    scheduler.shutdownNow();
+  }
+
+  @Test
+  void duplicateCompletedItemDoesNotDispatchTwice() {
+    AwaitInteractionRecord completed = itemAwaitRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "approved");
+    AwaitUnitRecord unit = awaitUnit("exec-1", AwaitUnitStatus.COMPLETED, 1, 1, true);
+    ExecutionRecord<Object, Object> parent = record("exec-1", "key-1", ExecutionStatus.WAITING_EXTERNAL, 7L);
+    AwaitItemContinuationHandler handler = org.mockito.Mockito.mock(AwaitItemContinuationHandler.class);
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(parent)));
+    when(awaitCoordinator.findByUnit("tenant-1", "unit-1"))
+        .thenReturn(Uni.createFrom().item(List.of(completed)));
+    when(handler.continueAwaitItem(eq(completed), eq(unit), eq(3), any(), any(Long.class)))
+        .thenReturn(Uni.createFrom().voidItem());
+    ItemizedAwaitContinuationFlow flow = flow(executionStateStore, workDispatcher, awaitCoordinator);
+
+    flow.afterRecordedCompletion(completed, unit, handler, 1234L).await().indefinitely();
+    verify(handler, timeout(1000).times(1)).continueAwaitItem(eq(completed), eq(unit), eq(3), any(), eq(1234L));
+
+    flow.afterRecordedCompletion(completed, unit, handler, 1235L).await().indefinitely();
+    verify(handler, after(300).times(1)).continueAwaitItem(eq(completed), eq(unit), eq(3), any(), any(Long.class));
+  }
+
+  @Test
+  void childOutputsReleaseParentOnceWithOrderedOutput() {
+    InMemoryExecutionStateStore store = new InMemoryExecutionStateStore();
+    when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+    ItemizedAwaitContinuationFlow flow = flow(store, workDispatcher, awaitCoordinator);
+    long now = 1234L;
+    CreateExecutionResult parent = store.createOrGetExecution(new ExecutionCreateCommand(
+            "tenant-1",
+            "parent-key",
+            new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input"),
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            now,
+            9_999_999_999L))
+        .await().indefinitely();
+    store.markWaitingExternal(
+            "tenant-1",
+            parent.record().executionId(),
+            parent.record().version(),
+            "transition",
+            "unit-1",
+            2,
+            now)
+        .await().indefinitely();
+    AwaitUnitRecord unit = awaitUnit(parent.record().executionId(), AwaitUnitStatus.COMPLETED, 2, 2, true);
+
+    flow.captureOutput(
+            itemAwaitRecord(parent.record().executionId(), 1, AwaitInteractionStatus.COMPLETED, "second"),
+            unit,
+            4,
+            new ExecutionInputSnapshot(ExecutionInputShape.UNI, "second-normalized"),
+            List.of("out-1"),
+            now)
+        .await().indefinitely();
+    verify(workDispatcher, never()).enqueueNow(any());
+
+    flow.captureOutput(
+            itemAwaitRecord(parent.record().executionId(), 0, AwaitInteractionStatus.COMPLETED, "first"),
+            unit,
+            4,
+            new ExecutionInputSnapshot(ExecutionInputShape.UNI, "first-normalized"),
+            List.of("out-0"),
+            now)
+        .await().indefinitely();
+
+    ExecutionRecord<Object, Object> resumed = store.getExecution("tenant-1", parent.record().executionId())
+        .await().indefinitely()
+        .orElseThrow();
+    assertEquals(ExecutionStatus.QUEUED, resumed.status());
+    assertEquals(4, resumed.currentStepIndex());
+    assertNull(resumed.awaitUnitId());
+    ExecutionInputSnapshot snapshot = assertInstanceOf(ExecutionInputSnapshot.class, resumed.inputPayload());
+    assertEquals(List.of("out-0", "out-1"), snapshot.payload());
+    verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", parent.record().executionId()));
+    ControlPlaneProjection projection = journal.projection("tenant-1", parent.record().executionId())
+        .await().indefinitely();
+    assertTrue(projection.factKeys().contains("continuation-segment-created:"
+        + parent.record().executionId() + ":segment:4"));
+  }
+
+  @Test
+  void readyCompletionDispatchesAllCompletedItemsForUnit() {
+    AwaitInteractionRecord first = itemAwaitRecord("exec-1", 0, AwaitInteractionStatus.COMPLETED, "first");
+    AwaitInteractionRecord second = itemAwaitRecord("exec-1", 1, AwaitInteractionStatus.COMPLETED, "second");
+    AwaitUnitRecord unit = awaitUnit("exec-1", AwaitUnitStatus.COMPLETED, 2, 2, true);
+    ExecutionRecord<Object, Object> parent = record("exec-1", "key-1", ExecutionStatus.WAITING_EXTERNAL, 7L);
+    AwaitItemContinuationHandler handler = org.mockito.Mockito.mock(AwaitItemContinuationHandler.class);
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(parent)));
+    when(awaitCoordinator.findByUnit("tenant-1", "unit-1"))
+        .thenReturn(Uni.createFrom().item(List.of(first, second)));
+    when(handler.continueAwaitItem(any(), eq(unit), eq(3), any(), any(Long.class)))
+        .thenReturn(Uni.createFrom().voidItem());
+    ItemizedAwaitContinuationFlow flow = flow(executionStateStore, workDispatcher, awaitCoordinator);
+
+    flow.afterRecordedCompletion(second, unit, handler, 1234L).await().indefinitely();
+
+    ArgumentCaptor<AwaitInteractionRecord> captor = ArgumentCaptor.forClass(AwaitInteractionRecord.class);
+    verify(handler, timeout(1000).times(2)).continueAwaitItem(
+        captor.capture(),
+        eq(unit),
+        eq(3),
+        any(),
+        eq(1234L));
+    assertEquals(Set.of(0, 1), new TreeSet<>(captor.getAllValues().stream()
+        .map(AwaitInteractionRecord::itemIndex)
+        .toList()));
+  }
+
+  private ItemizedAwaitContinuationFlow flow(
+      ExecutionStateStore stateStore,
+      WorkDispatcher dispatcher,
+      AwaitCoordinator coordinator) {
+    AwaitContinuationPlanner planner = new AwaitContinuationPlanner();
+    return new ItemizedAwaitContinuationFlow(
+        stateStore,
+        dispatcher,
+        coordinator,
+        new TransitionWorkerExecutor(null, new PipelineInvocationRuntime()),
+        scheduler,
+        () -> Duration.ofMillis(10),
+        () -> new SegmentBoundaryLedger(journal),
+        ignored -> {
+        },
+        planner,
+        new ItemContinuationClaims());
+  }
+
+  private static AwaitInteractionRecord itemAwaitRecord(
+      String executionId,
+      int itemIndex,
+      AwaitInteractionStatus status,
+      String response) {
+    return new AwaitInteractionRecord(
+        "tenant-1",
+        executionId,
+        "AwaitPaymentProvider",
+        2,
+        String.class.getCanonicalName(),
+        "interaction-" + itemIndex,
+        "corr-" + itemIndex,
+        "cause-1",
+        "idem-" + itemIndex,
+        1L,
+        status,
+        Map.of("value", "request-" + itemIndex),
+        Map.of("value", response),
+        "unit-1",
+        itemIndex,
+        "user-1",
+        null,
+        null,
+        "kafka",
+        Map.of(),
+        10_000L,
+        1L,
+        2L,
+        999_999L);
+  }
+
+  private static AwaitUnitRecord awaitUnit(
+      String executionId,
+      AwaitUnitStatus status,
+      Integer expectedItemCount,
+      int completedItemCount,
+      boolean dispatchComplete) {
+    return new AwaitUnitRecord(
+        "tenant-1",
+        "unit-1",
+        executionId,
+        "AwaitPaymentProvider",
+        2,
+        "ONE_TO_ONE",
+        1L,
+        status,
+        null,
+        expectedItemCount,
+        completedItemCount,
+        completedItemCount == 0
+            ? Set.of()
+            : completedItemCount == 1 ? Set.of("item:0") : Set.of("item:0", "item:1"),
+        dispatchComplete,
+        1L,
+        2L,
+        999_999L);
+  }
+
+  private static ExecutionRecord<Object, Object> record(
+      String executionId,
+      String executionKey,
+      ExecutionStatus status,
+      long version) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        executionId,
+        executionKey,
+        ExecutionResultShape.MATERIALIZED_MULTI,
+        status,
+        version,
+        2,
+        0,
+        null,
+        0L,
+        Long.MAX_VALUE,
+        "transition",
+        "input",
+        "unit-1",
+        null,
+        null,
+        null,
+        1L,
+        2L,
+        999_999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -1,12 +1,10 @@
 package org.pipelineframework;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -45,7 +43,6 @@ import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
 import org.pipelineframework.orchestrator.LocalControlPlaneAdmissionPolicy;
 import org.pipelineframework.orchestrator.SerializedTransitionPayload;
 import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
-import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
 import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
 import org.pipelineframework.orchestrator.TransitionWorkerExecutionMode;
 import org.pipelineframework.orchestrator.TransitionResultEnvelope;
@@ -964,21 +961,20 @@ class QueueAsyncCoordinatorTest {
 
     @Test
     void transitionCommandUsesExecutionPinnedReleaseIdentity() {
-        TransitionCommandEnvelope envelope = prepareTransitionCommand(
-            createRecord(
+        ClaimedSegment segment = ClaimedSegment.from(createRecord(
                 "tenant-1",
                 "exec-bundle",
                 "key-bundle",
                 "org.example.pinned",
                 "sha256:contract",
                 "sha256:release",
-                ExecutionResultShape.SINGLE),
-            "trace-1");
+                ExecutionResultShape.SINGLE));
+        var envelope = segment.transitionCommand("input", payloadCodec);
 
         assertEquals("org.example.pinned", envelope.pipelineId());
         assertEquals("sha256:contract", envelope.contractVersion());
         assertEquals("sha256:release", envelope.releaseVersion());
-        assertEquals("trace-1", envelope.traceId());
+        assertEquals("exec-bundle:0:0", envelope.traceId());
     }
 
     @Test
@@ -1060,22 +1056,24 @@ class QueueAsyncCoordinatorTest {
     }
 
     @Test
-    void runAsyncExecutionAllowsSingleShapeWithZeroOrOneItems() {
-        ExecutionRecord<Object, Object> single = createRecord("tenant-1", "exec-single", "key-single");
+    void segmentCommitPlanAllowsSingleShapeWithZeroOrOneItems() {
+        ClaimedSegment segment = ClaimedSegment.from(createRecord("tenant-1", "exec-single", "key-single"));
 
-        List<?> none = runAsyncExecution(single, record -> Multi.createFrom().empty());
-        List<?> one = runAsyncExecution(single, record -> Multi.createFrom().item("only"));
+        CompletedSegment none = assertInstanceOf(CompletedSegment.class,
+            SegmentCommitPlan.from(segment, TransitionResultEnvelope.completedInProcess(List.of())));
+        CompletedSegment one = assertInstanceOf(CompletedSegment.class,
+            SegmentCommitPlan.from(segment, TransitionResultEnvelope.completedInProcess(List.of("only"))));
 
-        assertTrue(none.isEmpty());
-        assertEquals(List.of("only"), one);
+        assertTrue(none.outputItems().isEmpty());
+        assertEquals(List.of("only"), one.outputItems());
     }
 
     @Test
-    void runAsyncExecutionRejectsMultipleItemsForSingleShape() {
-        ExecutionRecord<Object, Object> single = createRecord("tenant-1", "exec-single", "key-single");
+    void segmentCommitPlanRejectsMultipleItemsForSingleShape() {
+        ClaimedSegment segment = ClaimedSegment.from(createRecord("tenant-1", "exec-single", "key-single"));
 
         IllegalStateException error = assertThrows(IllegalStateException.class, () ->
-            runAsyncExecution(single, record -> Multi.createFrom().items("a", "b")));
+            SegmentCommitPlan.from(segment, TransitionResultEnvelope.completedInProcess(List.of("a", "b"))));
 
         assertTrue(error.getMessage().contains("SINGLE result shape"));
         assertTrue(error.getMessage().contains("exec-single"));
@@ -2147,66 +2145,6 @@ class QueueAsyncCoordinatorTest {
     }
 
     private record NonSerializableOutput(Object writer) {
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<?> runAsyncExecution(
-        ExecutionRecord<Object, Object> record,
-        Function<ExecutionRecord<Object, Object>, Multi<?>> executeStreaming) {
-        try {
-            Method method = QueueAsyncCoordinator.class.getDeclaredMethod(
-                "runAsyncExecution",
-                ExecutionRecord.class,
-                org.pipelineframework.orchestrator.PipelineTransitionWorker.class);
-            method.setAccessible(true);
-            return ((Uni<List<?>>) method.invoke(
-                coordinator,
-                record,
-                (org.pipelineframework.orchestrator.PipelineTransitionWorker) command ->
-                    executeStreaming.apply(new ExecutionRecord<>(
-                            command.tenantId(),
-                            command.executionId(),
-                            "key-" + command.executionId(),
-                            command.resultShape(),
-                            ExecutionStatus.RUNNING,
-                            command.executionVersion(),
-                            command.currentStepIndex(),
-                            command.attempt(),
-                            null,
-                            0L,
-                            0L,
-                            null,
-                            command.toCommand(payloadCodec).inputPayload(),
-                            null,
-                            null,
-                            null,
-                            null,
-                            1L,
-                            1L,
-                            99999999L))
-                        .collect().asList()
-                        .onItem().transform(TransitionResultEnvelope::completedInProcess)))
-                .await().indefinitely();
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("Failed invoking runAsyncExecution", e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private TransitionCommandEnvelope prepareTransitionCommand(
-        ExecutionRecord<Object, Object> record,
-        String transitionKey) {
-        try {
-            Method method = QueueAsyncCoordinator.class.getDeclaredMethod(
-                "prepareTransitionCommand",
-                ExecutionRecord.class,
-                String.class);
-            method.setAccessible(true);
-            return ((Uni<TransitionCommandEnvelope>) method.invoke(coordinator, record, transitionKey))
-                .await().indefinitely();
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("Failed invoking prepareTransitionCommand", e);
-        }
     }
 
     private AwaitInteractionRecord awaitRecord() {

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSegmentPipelineTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSegmentPipelineTest.java
@@ -1,0 +1,433 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.invocation.PipelineInvocationRuntime;
+import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ControlPlaneTransitionAdmission;
+import org.pipelineframework.orchestrator.ControlPlaneTransitionPermit;
+import org.pipelineframework.orchestrator.DeadLetterPublisher;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionCommandEnvelope;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
+import org.pipelineframework.orchestrator.TransitionWorkerExecutionMode;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAsyncSegmentPipelineTest {
+
+  @Mock
+  private PipelineOrchestratorConfig orchestratorConfig;
+
+  @Mock
+  private PipelineOrchestratorConfig.WorkerConfig workerConfig;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private WorkDispatcher workDispatcher;
+
+  @Mock
+  private DeadLetterPublisher deadLetterPublisher;
+
+  @Mock
+  private AwaitCoordinator awaitCoordinator;
+
+  @Mock
+  private ExecutionFailureHandler executionFailureHandler;
+
+  @Mock
+  private ControlPlaneAdmissionPolicy admissionPolicy;
+
+  @Mock
+  private SegmentBoundaryLedger segmentBoundaryLedger;
+
+  @Mock
+  private CheckpointPublicationService checkpointPublicationService;
+
+  @Mock
+  private ObjectPublishCompletionService objectPublishCompletionService;
+
+  @Mock
+  private AwaitContinuations awaitContinuations;
+
+  private JsonTransitionPayloadCodec payloadCodec;
+  private TransitionWorkerExecutor transitionWorkerExecutor;
+
+  @BeforeEach
+  void setUp() {
+    payloadCodec = new JsonTransitionPayloadCodec();
+    transitionWorkerExecutor = new TransitionWorkerExecutor(orchestratorConfig, new PipelineInvocationRuntime());
+    lenient().when(orchestratorConfig.worker()).thenReturn(workerConfig);
+    lenient().when(orchestratorConfig.leaseMs()).thenReturn(1000L);
+    lenient().when(workerConfig.executionMode()).thenReturn(TransitionWorkerExecutionMode.SAME_THREAD);
+    lenient().when(workerConfig.maxInFlight()).thenReturn(64);
+    lenient().when(workerConfig.saturatedDelay()).thenReturn(Duration.ofMillis(25));
+    lenient().when(admissionPolicy.admitTransition(any()))
+        .thenReturn(ControlPlaneTransitionAdmission.admitted(ControlPlaneTransitionPermit.noop()));
+    lenient().when(segmentBoundaryLedger.recordSegmentAttemptStarted(any(), any(), anyLong()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(segmentBoundaryLedger.recordSegmentCompleted(any(), any(), any(), anyLong()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(segmentBoundaryLedger.recordSegmentSuspended(any(), any(), any(), anyLong()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(segmentBoundaryLedger.recordTerminalPublicationCompleted(any(), any(), anyLong()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(segmentBoundaryLedger.recordRunSucceeded(any(), any(), anyLong()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(checkpointPublicationService.publishIfConfigured(any(), any()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(objectPublishCompletionService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(executionFailureHandler.handleExecutionFailure(any(), any(), any(), any(), any(), any()))
+        .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(awaitCoordinator.importSuspension(any())).thenReturn(Uni.createFrom().voidItem());
+    lenient().when(awaitContinuations.afterParentWaiting(any(), any(), anyLong(), any()))
+        .thenReturn(Uni.createFrom().voidItem());
+  }
+
+  @Test
+  void segmentPipelineClaimsRunsPublishesAndCommitsSuccessInOrder() {
+    ExecutionRecord<Object, Object> claimed = record("exec-success", ExecutionResultShape.MATERIALIZED_MULTI);
+    ExecutionRecord<Object, Object> succeeded = withStatus(claimed, ExecutionStatus.SUCCEEDED, 1L);
+    AtomicReference<TransitionCommandEnvelope> commandRef = new AtomicReference<>();
+    when(executionStateStore.claimLease(eq("tenant-1"), eq("exec-success"), any(), anyLong(), eq(1000L)))
+        .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+    when(executionStateStore.markSucceeded(
+            eq("tenant-1"),
+            eq("exec-success"),
+            eq(0L),
+            eq("exec-success:0:0"),
+            eq(List.of("out-1", "out-2")),
+            anyLong()))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded)));
+
+    pipeline().process(
+            new ExecutionWorkItem("tenant-1", "exec-success"),
+            command -> {
+              commandRef.set(command);
+              return Uni.createFrom().item(TransitionResultEnvelope.completedInProcess(List.of("out-1", "out-2")));
+            },
+            AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+        .await().indefinitely();
+
+    assertEquals("exec-success:0:0", commandRef.get().transitionKey());
+    assertEquals("input-exec-success", commandRef.get().toCommand(payloadCodec).inputPayload());
+    InOrder order = inOrder(
+        executionStateStore,
+        segmentBoundaryLedger,
+        checkpointPublicationService,
+        objectPublishCompletionService);
+    order.verify(executionStateStore).claimLease(eq("tenant-1"), eq("exec-success"), any(), anyLong(), eq(1000L));
+    order.verify(segmentBoundaryLedger).recordSegmentAttemptStarted(same(claimed), eq("exec-success:0:0"), anyLong());
+    order.verify(segmentBoundaryLedger).recordSegmentCompleted(same(claimed), eq("exec-success:0:0"), any(), anyLong());
+    order.verify(checkpointPublicationService).publishIfConfigured(same(claimed), eq("out-1"));
+    order.verify(objectPublishCompletionService).publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any());
+    order.verify(segmentBoundaryLedger).recordTerminalPublicationCompleted(same(claimed), eq("exec-success:0:0"), anyLong());
+    order.verify(executionStateStore).markSucceeded(
+        eq("tenant-1"),
+        eq("exec-success"),
+        eq(0L),
+        eq("exec-success:0:0"),
+        eq(List.of("out-1", "out-2")),
+        anyLong());
+    order.verify(segmentBoundaryLedger).recordRunSucceeded(same(succeeded), eq(List.of("out-1", "out-2")), anyLong());
+  }
+
+  @Test
+  void terminalPublicationFailurePreventsSuccessCommit() {
+    ExecutionRecord<Object, Object> claimed = record("exec-publish-fails", ExecutionResultShape.MATERIALIZED_MULTI);
+    when(executionStateStore.claimLease(eq("tenant-1"), eq("exec-publish-fails"), any(), anyLong(), eq(1000L)))
+        .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+    when(objectPublishCompletionService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
+        .thenReturn(Uni.createFrom().failure(new IllegalStateException("publish failed")));
+
+    pipeline().process(
+            new ExecutionWorkItem("tenant-1", "exec-publish-fails"),
+            command -> Uni.createFrom().item(TransitionResultEnvelope.completedInProcess(List.of("out"))),
+            AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+        .await().indefinitely();
+
+    verify(executionStateStore, never()).markSucceeded(any(), any(), anyLong(), any(), any(), anyLong());
+    ArgumentCaptor<Throwable> failureCaptor = ArgumentCaptor.forClass(Throwable.class);
+    verify(executionFailureHandler).handleExecutionFailure(
+        same(claimed),
+        eq("exec-publish-fails:0:0"),
+        failureCaptor.capture(),
+        same(executionStateStore),
+        same(workDispatcher),
+        same(deadLetterPublisher));
+    assertEquals("publish failed", failureCaptor.getValue().getMessage());
+  }
+
+  @Test
+  void awaitSuspensionImportsMarksWaitingAndReleasesCompletedWork() {
+    ExecutionRecord<Object, Object> claimed = record("exec-await", ExecutionResultShape.MATERIALIZED_MULTI);
+    ExecutionRecord<Object, Object> waiting = withStatus(claimed, ExecutionStatus.WAITING_EXTERNAL, 1L);
+    TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-await", "unit-1", 2);
+    when(executionStateStore.claimLease(eq("tenant-1"), eq("exec-await"), any(), anyLong(), eq(1000L)))
+        .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+    when(executionStateStore.markWaitingExternal(
+            eq("tenant-1"),
+            eq("exec-await"),
+            eq(0L),
+            eq("exec-await:0:0"),
+            eq("unit-1"),
+            eq(2),
+            anyLong()))
+        .thenReturn(Uni.createFrom().item(Optional.of(waiting)));
+
+    pipeline().process(
+            new ExecutionWorkItem("tenant-1", "exec-await"),
+            command -> Uni.createFrom().item(TransitionResultEnvelope.waiting(suspension)),
+            AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+        .await().indefinitely();
+
+    InOrder order = inOrder(executionStateStore, awaitCoordinator, segmentBoundaryLedger, awaitContinuations);
+    order.verify(executionStateStore).markWaitingExternal(
+        eq("tenant-1"),
+        eq("exec-await"),
+        eq(0L),
+        eq("exec-await:0:0"),
+        eq("unit-1"),
+        eq(2),
+        anyLong());
+    order.verify(awaitCoordinator).importSuspension(same(suspension));
+    order.verify(segmentBoundaryLedger).recordSegmentSuspended(same(claimed), eq("exec-await:0:0"), same(suspension), anyLong());
+    order.verify(awaitContinuations).afterParentWaiting(
+        same(waiting),
+        same(suspension),
+        anyLong(),
+        same(AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER));
+  }
+
+  @Test
+  void missedSuccessCasFailsCommitAndSkipsRunSucceededFact() {
+    ExecutionRecord<Object, Object> claimed = record("exec-success-cas-miss", ExecutionResultShape.MATERIALIZED_MULTI);
+    when(executionStateStore.claimLease(eq("tenant-1"), eq("exec-success-cas-miss"), any(), anyLong(), eq(1000L)))
+        .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+    when(executionStateStore.markSucceeded(
+            eq("tenant-1"),
+            eq("exec-success-cas-miss"),
+            eq(0L),
+            eq("exec-success-cas-miss:0:0"),
+            eq(List.of("out")),
+            anyLong()))
+        .thenReturn(Uni.createFrom().item(Optional.empty()));
+
+    pipeline().process(
+            new ExecutionWorkItem("tenant-1", "exec-success-cas-miss"),
+            command -> Uni.createFrom().item(TransitionResultEnvelope.completedInProcess(List.of("out"))),
+            AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+        .await().indefinitely();
+
+    ArgumentCaptor<Throwable> failureCaptor = ArgumentCaptor.forClass(Throwable.class);
+    verify(executionFailureHandler).handleExecutionFailure(
+        same(claimed),
+        eq("exec-success-cas-miss:0:0"),
+        failureCaptor.capture(),
+        same(executionStateStore),
+        same(workDispatcher),
+        same(deadLetterPublisher));
+    assertTrue(failureCaptor.getValue().getMessage().contains("Failed to persist SUCCEEDED state"));
+    verify(segmentBoundaryLedger, never()).recordRunSucceeded(any(), any(), anyLong());
+  }
+
+  @Test
+  void workerFailureDelegatesToFailureHandler() {
+    ExecutionRecord<Object, Object> claimed = record("exec-failed", ExecutionResultShape.SINGLE);
+    when(executionStateStore.claimLease(eq("tenant-1"), eq("exec-failed"), any(), anyLong(), eq(1000L)))
+        .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
+
+    pipeline().process(
+            new ExecutionWorkItem("tenant-1", "exec-failed"),
+            command -> Uni.createFrom().item(TransitionResultEnvelope.failed(new IllegalArgumentException("bad item"))),
+            AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+        .await().indefinitely();
+
+    ArgumentCaptor<Throwable> failureCaptor = ArgumentCaptor.forClass(Throwable.class);
+    verify(executionFailureHandler).handleExecutionFailure(
+        same(claimed),
+        eq("exec-failed:0:0"),
+        failureCaptor.capture(),
+        same(executionStateStore),
+        same(workDispatcher),
+        same(deadLetterPublisher));
+    assertTrue(failureCaptor.getValue().getMessage().contains("bad item"));
+  }
+
+  @Test
+  void workerAdmissionSaturationRequeuesWithoutClaiming() {
+    TransitionWorkerExecutor saturatedExecutor = new TransitionWorkerExecutor(orchestratorConfig, new PipelineInvocationRuntime());
+    when(workerConfig.maxInFlight()).thenReturn(1);
+    when(workDispatcher.enqueueDelayed(any(), eq(Duration.ofMillis(25))))
+        .thenReturn(Uni.createFrom().voidItem());
+    TransitionWorkerExecutor.TransitionAdmission held = saturatedExecutor.tryAdmit().orElseThrow();
+    try {
+      pipeline(saturatedExecutor, objectPublishCompletionService).process(
+              new ExecutionWorkItem("tenant-1", "exec-saturated"),
+              command -> Uni.createFrom().item(TransitionResultEnvelope.completedInProcess(List.of())),
+              AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+          .await().indefinitely();
+    } finally {
+      held.close();
+    }
+
+    verify(executionStateStore, never()).claimLease(any(), any(), any(), anyLong(), anyLong());
+    verify(workDispatcher).enqueueDelayed(
+        eq(new ExecutionWorkItem("tenant-1", "exec-saturated")),
+        eq(Duration.ofMillis(25)));
+  }
+
+  @Test
+  void tenantAdmissionSaturationClosesWorkerPermitAndRequeuesWithoutClaiming() {
+    when(workDispatcher.enqueueDelayed(any(), eq(Duration.ofMillis(25))))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(admissionPolicy.admitTransition(any()))
+        .thenReturn(ControlPlaneTransitionAdmission.denied(ControlPlaneAdmissionDecision.deny(
+            ControlPlaneAdmissionDecision.TENANT_TRANSITION_QUOTA_SATURATED,
+            "tenant saturated")));
+
+    pipeline().process(
+            new ExecutionWorkItem("tenant-1", "exec-tenant-saturated"),
+            command -> Uni.createFrom().item(TransitionResultEnvelope.completedInProcess(List.of())),
+            AwaitContinuations.NOOP_ITEM_CONTINUATION_HANDLER)
+        .await().indefinitely();
+
+    verify(executionStateStore, never()).claimLease(any(), any(), any(), anyLong(), anyLong());
+    verify(workDispatcher).enqueueDelayed(
+        eq(new ExecutionWorkItem("tenant-1", "exec-tenant-saturated")),
+        eq(Duration.ofMillis(25)));
+    assertEquals(0, transitionWorkerExecutor.activePermits());
+  }
+
+  private QueueAsyncSegmentPipeline pipeline() {
+    return pipeline(transitionWorkerExecutor, objectPublishCompletionService);
+  }
+
+  private QueueAsyncSegmentPipeline pipeline(
+      TransitionWorkerExecutor executor,
+      ObjectPublishCompletionService publishCompletionService) {
+    return new QueueAsyncSegmentPipeline(
+        orchestratorConfig,
+        executionStateStore,
+        workDispatcher,
+        awaitCoordinator,
+        executor,
+        admissionPolicy,
+        () -> payloadCodec,
+        () -> segmentBoundaryLedger,
+        () -> Duration.ofMillis(25),
+        new SegmentCommitEffects(
+            executionStateStore,
+            workDispatcher,
+            deadLetterPublisher,
+            awaitCoordinator,
+            executionFailureHandler,
+            () -> segmentBoundaryLedger,
+            awaitContinuations,
+            new TerminalPublicationBoundary(
+                checkpointPublicationService,
+                publishCompletionService,
+                () -> payloadCodec,
+                () -> segmentBoundaryLedger),
+            ignored -> {
+            }),
+        "worker-test");
+  }
+
+  private static ExecutionRecord<Object, Object> record(String executionId, ExecutionResultShape resultShape) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        executionId,
+        "key-" + executionId,
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        resultShape,
+        ExecutionStatus.QUEUED,
+        0L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        "input-" + executionId,
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+
+  private static ExecutionRecord<Object, Object> withStatus(
+      ExecutionRecord<Object, Object> source,
+      ExecutionStatus status,
+      long version) {
+    return new ExecutionRecord<>(
+        source.tenantId(),
+        source.executionId(),
+        source.executionKey(),
+        source.pipelineId(),
+        source.contractVersion(),
+        source.releaseVersion(),
+        source.resultShape(),
+        status,
+        version,
+        source.currentStepIndex(),
+        source.attempt(),
+        source.leaseOwner(),
+        source.leaseExpiresEpochMs(),
+        source.nextDueEpochMs(),
+        source.lastTransitionKey(),
+        source.inputPayload(),
+        source.awaitUnitId(),
+        source.resultPayload(),
+        source.errorCode(),
+        source.errorMessage(),
+        source.createdAtEpochMs(),
+        source.updatedAtEpochMs(),
+        source.ttlEpochS());
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ScalarAwaitContinuationFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ScalarAwaitContinuationFlowTest.java
@@ -1,0 +1,127 @@
+package org.pipelineframework;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.InMemoryExecutionStateStore;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.ControlPlaneProjection;
+import org.pipelineframework.orchestrator.controlplane.InMemoryControlPlaneJournal;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ScalarAwaitContinuationFlowTest {
+
+  @Test
+  void scalarResumeRecordsContinuationFactBeforeEnqueue() {
+    InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+    ExecutionStateStore store = new InMemoryExecutionStateStore();
+    WorkDispatcher dispatcher = Mockito.mock(WorkDispatcher.class);
+    long now = 1234L;
+    CreateExecutionResult created = store.createOrGetExecution(new ExecutionCreateCommand(
+            "tenant-1",
+            "key-1",
+            new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input"),
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            now,
+            9_999_999_999L))
+        .await().indefinitely();
+    store.markWaitingExternal(
+            "tenant-1",
+            created.record().executionId(),
+            created.record().version(),
+            "transition",
+            "unit-1",
+            2,
+            now)
+        .await().indefinitely();
+    when(dispatcher.enqueueNow(any())).thenAnswer(invocation -> {
+      ControlPlaneProjection projection = journal.projection("tenant-1", created.record().executionId())
+          .await().indefinitely();
+      assertTrue(projection.factKeys().contains("continuation-segment-created:"
+          + created.record().executionId() + ":segment:3"));
+      return Uni.createFrom().voidItem();
+    });
+    ScalarAwaitContinuationFlow flow = new ScalarAwaitContinuationFlow(
+        store,
+        dispatcher,
+        () -> new SegmentBoundaryLedger(journal),
+        ignored -> {
+        });
+
+    flow.release(new AwaitContinuationPlan.ReleaseScalar(
+            scalarRecord(created.record().executionId()),
+            scalarUnit(created.record().executionId()),
+            3),
+            now)
+        .await().indefinitely();
+
+    verify(dispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", created.record().executionId()));
+  }
+
+  private static AwaitInteractionRecord scalarRecord(String executionId) {
+    return new AwaitInteractionRecord(
+        "tenant-1",
+        executionId,
+        "AwaitPaymentProvider",
+        2,
+        String.class.getCanonicalName(),
+        "interaction-1",
+        "corr-1",
+        "cause-1",
+        "idem-1",
+        1L,
+        AwaitInteractionStatus.COMPLETED,
+        Map.of("value", "request"),
+        Map.of("value", "response"),
+        "unit-1",
+        null,
+        "user-1",
+        null,
+        null,
+        "kafka",
+        Map.of(),
+        10_000L,
+        1L,
+        2L,
+        999_999L);
+  }
+
+  private static AwaitUnitRecord scalarUnit(String executionId) {
+    return new AwaitUnitRecord(
+        "tenant-1",
+        "unit-1",
+        executionId,
+        "AwaitPaymentProvider",
+        2,
+        "ONE_TO_ONE",
+        1L,
+        AwaitUnitStatus.COMPLETED,
+        "interaction-1",
+        null,
+        1,
+        Set.of(),
+        false,
+        1L,
+        2L,
+        999_999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/SegmentCommitPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/SegmentCommitPlanTest.java
@@ -1,0 +1,98 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SegmentCommitPlanTest {
+
+  @Test
+  void completedResultShapeValidationRejectsMultipleSingleItems() {
+    ClaimedSegment segment = ClaimedSegment.from(record("exec-single", ExecutionResultShape.SINGLE));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        SegmentCommitPlan.from(segment, TransitionResultEnvelope.completedInProcess(List.of("a", "b"))));
+
+    assertTrue(error.getMessage().contains("SINGLE result shape"));
+    assertTrue(error.getMessage().contains("exec-single"));
+  }
+
+  @Test
+  void completedPlanKeepsOutputItemsAndTerminalPlan() {
+    ClaimedSegment segment = ClaimedSegment.from(record("exec-multi", ExecutionResultShape.MATERIALIZED_MULTI));
+
+    CompletedSegment completed = assertInstanceOf(CompletedSegment.class,
+        SegmentCommitPlan.from(segment, TransitionResultEnvelope.completedInProcess(List.of("a", "b"))));
+
+    assertEquals(List.of("a", "b"), completed.outputItems());
+    assertEquals("a", completed.terminalPublication().checkpointPayload().orElseThrow());
+  }
+
+  @Test
+  void nullWorkerResultBecomesFailedPlan() {
+    ClaimedSegment segment = ClaimedSegment.from(record("exec-null", ExecutionResultShape.SINGLE));
+
+    FailedSegment failed = assertInstanceOf(FailedSegment.class, SegmentCommitPlan.from(segment, null));
+
+    assertTrue(failed.failure().getMessage().contains("PipelineTransitionWorker returned null result"));
+  }
+
+  @Test
+  void awaitSuspensionBecomesSuspendedPlan() {
+    ClaimedSegment segment = ClaimedSegment.from(record("exec-await", ExecutionResultShape.SINGLE));
+    TransitionAwaitSuspension suspension = new TransitionAwaitSuspension("tenant-1", "exec-await", "unit-1", 2);
+
+    SuspendedSegment suspended = assertInstanceOf(SuspendedSegment.class,
+        SegmentCommitPlan.from(segment, TransitionResultEnvelope.waiting(suspension)));
+
+    assertEquals("unit-1", suspended.suspension().unitId());
+  }
+
+  @Test
+  void failureResultPreservesFailureMetadata() {
+    ClaimedSegment segment = ClaimedSegment.from(record("exec-failed", ExecutionResultShape.SINGLE));
+
+    FailedSegment failed = assertInstanceOf(FailedSegment.class,
+        SegmentCommitPlan.from(segment, TransitionResultEnvelope.failed(new IllegalArgumentException("boom"))));
+
+    assertTrue(failed.failure().getMessage().contains(IllegalArgumentException.class.getName()));
+    assertTrue(failed.failure().getMessage().contains("boom"));
+  }
+
+  private static ExecutionRecord<Object, Object> record(String executionId, ExecutionResultShape resultShape) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        executionId,
+        "key-" + executionId,
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        resultShape,
+        ExecutionStatus.QUEUED,
+        0L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationPlanTest.java
@@ -1,0 +1,76 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TerminalPublicationPlanTest {
+
+  @Test
+  void terminalPublicationPlanSkipsObjectPublishWhenEnvelopeAlreadyPublished() {
+    ClaimedSegment segment = ClaimedSegment.from(record());
+    TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out"), true);
+
+    TerminalPublicationPlan plan = TerminalPublicationPlan.from(segment, result, result.coordinatorOutputItems());
+
+    assertFalse(plan.objectPublishRequired());
+    assertTrue(plan.alreadyPublished());
+  }
+
+  @Test
+  void terminalPublicationPlanExposesCheckpointPayload() {
+    ClaimedSegment segment = ClaimedSegment.from(record());
+    TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("first", "second"));
+
+    TerminalPublicationPlan plan = TerminalPublicationPlan.from(segment, result, result.coordinatorOutputItems());
+
+    assertEquals("first", plan.checkpointPayload().orElseThrow());
+  }
+
+  @Test
+  void terminalPublicationPlanDecodesPortableOutputLazily() {
+    ClaimedSegment segment = ClaimedSegment.from(record());
+    JsonTransitionPayloadCodec codec = new JsonTransitionPayloadCodec();
+    TransitionResultEnvelope result = TransitionResultEnvelope.completed(codec, List.of("remote-output"));
+
+    TerminalPublicationPlan plan = TerminalPublicationPlan.from(segment, result, result.coordinatorOutputItems());
+
+    assertEquals(List.of("remote-output"), plan.decodedOutputItems(codec));
+  }
+
+  private static ExecutionRecord<Object, Object> record() {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        ExecutionResultShape.MATERIALIZED_MULTI,
+        ExecutionStatus.QUEUED,
+        0L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce immutable segment commitment records for queue-async transition outcomes
- route claimed execution work through a Mutiny `QueueAsyncSegmentPipeline` instead of branching inside `QueueAsyncCoordinator`
- isolate success/suspend/failure effects and terminal publication behind narrow internal boundaries
- introduce immutable await-continuation decisions for scalar and itemized future beginnings
- shrink `AwaitContinuations` into a façade over `AwaitContinuationPlanner`, `ScalarAwaitContinuationFlow`, `ItemizedAwaitContinuationFlow`, and `ItemContinuationClaims`
- refresh internal await-unit runtime docs to show the segment pipeline, continuation model, and future-beginning flows

## Out of scope
- terminal publication outbox/idempotency storage
- provider admission control from issue #436
- replay JSON or homepage media regeneration
- YAML, connector SPI, telemetry schema, or public API changes
- submission, redrive, and timeout sweeper extraction

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true -Dtest=AwaitContinuationPlannerTest,ScalarAwaitContinuationFlowTest,ItemizedAwaitContinuationFlowTest,AwaitBoundaryAdmissionTest,AwaitContinuationsTest,QueueAsyncCoordinatorTest,QueueAsyncSegmentPipelineTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="$PWD/.m2/repository"`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true test -Dmaven.repo.local="$PWD/.m2/repository"` (`1636` tests, `0` failures, `0` errors, `1` skipped)
- `npm --prefix docs test`
- `npm --prefix docs run build`
- `git diff --check`

## Review notes
- Local CodeRabbit was attempted once before the continuation-flow extension, against `main` in normal and `--light --type committed` modes, but both failed before producing findings with `payload_too_large`. Per follow-up direction, no second local CR pass was run.
- Fresh docs worktree required `npm --prefix docs ci` before docs build because VitePress was not installed locally; no audit fix was run.
