### PR TITLE
[codex] Support Spring CompletionStage service beans

### DIFF
--- a/docs/develop/spring-support.md
+++ b/docs/develop/spring-support.md
@@ -12,7 +12,7 @@ Current Spring work proves a narrow generated application path:
 - constrained `REST + COMPUTE` unary smoke coverage,
 - generated Spring `@Component` local step beans,
 - Spring WebFlux `@RestController` resources for the supported smoke path,
-- `Mono<Out>` authored service methods for YAML-declared Spring-profile unary services,
+- `Mono<Out>` and `CompletionStage<Out>` authored service methods for YAML-declared Spring-profile unary services,
 - unary delegated Spring bean steps for local pipeline execution,
 - unary `Class::method` Spring operator beans for local pipeline execution,
 - shared runner-core sequencing through the neutral runtime seam.
@@ -38,6 +38,8 @@ Unsupported combinations should fail at build time instead of silently falling b
 Use Quarkus for production TPF applications today.
 
 Use the Spring path only when you are validating the emerging renderer/runtime seam or contributing to portability work. Keep business contracts neutral: typed inputs, typed outputs, mappers, and YAML declarations should not rely on Quarkus-only application code unless the application is explicitly Quarkus-targeted.
+
+Spring-profile service steps are supported only for unary local steps declared from YAML. Normal `service:` beans can use `process(In): Mono<Out>`, `process(In): CompletionStage<Out>`, or `processBlocking(In): Out`.
 
 Delegated Spring beans are supported only for unary local steps declared from YAML with either a Spring bean class or an explicit `Class::method` operator reference. Class-only delegates use supported TPF-style service shapes such as `process(In): Mono<Out>` or `processBlocking(In): Out`. `Class::method` delegates support narrow unary Spring bean methods: `Out method(In)`, `Mono<Out> method(In)`, or `CompletionStage<Out> method(In)`.
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/ModelExtractionPhase.java
@@ -433,13 +433,14 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             ctx,
             serviceClass,
             ctx.getProcessingEnv().getTypeUtils(),
-            ctx.getProcessingEnv().getMessager());
+            ctx.getProcessingEnv().getMessager(),
+            true);
         if (serviceSignature == null) {
             ctx.getProcessingEnv().getMessager().printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal step service '" + stepDef.executionClass().canonicalName()
                     + "' must implement exactly one supported service interface or declare exactly one public process(In): Uni<Out>"
-                    + springPlainMethodHint(ctx) + " method for step '"
+                    + springPlainMethodHint(ctx, true) + " method for step '"
                     + stepDef.name() + "'");
             return null;
         }
@@ -1182,7 +1183,7 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return Optional.empty();
         }
         if (isSpringRendererProfile(ctx)) {
-            return Optional.ofNullable(resolveSupportedInternalSignature(ctx, delegateElement, typeUtils, messager));
+            return Optional.ofNullable(resolveSupportedInternalSignature(ctx, delegateElement, typeUtils, messager, false));
         }
         ReactiveSignature reactiveSignature = resolveReactiveSignature(delegateElement, typeUtils, messager);
         if (reactiveSignature == null) {
@@ -1306,7 +1307,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             PipelineCompilationContext ctx,
             TypeElement serviceElement,
             Types typeUtils,
-            javax.annotation.processing.Messager messager) {
+            javax.annotation.processing.Messager messager,
+            boolean allowSpringCompletionStageProcess) {
         List<SupportedServiceSignature> blockingMatches = new ArrayList<>();
         List<String> blockingMatchNames = new ArrayList<>();
 
@@ -1379,7 +1381,8 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             return null;
         }
         if (combinedMatches.isEmpty()) {
-            return resolvePlainUnaryProcessSignature(ctx, serviceElement, messager).orElse(null);
+            return resolvePlainUnaryProcessSignature(ctx, serviceElement, messager, allowSpringCompletionStageProcess)
+                .orElse(null);
         }
         SupportedServiceSignature match = combinedMatches.get(0);
         if (match.materializingWarning() != null) {
@@ -1394,20 +1397,33 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
     private Optional<SupportedServiceSignature> resolvePlainUnaryProcessSignature(
             PipelineCompilationContext ctx,
             TypeElement serviceElement,
-            javax.annotation.processing.Messager messager) {
+            javax.annotation.processing.Messager messager,
+            boolean allowSpringCompletionStageProcess) {
         List<SupportedServiceSignature> matches = new ArrayList<>();
+        List<String> invalidProcessReasons = new ArrayList<>();
         boolean springProfile = isSpringRendererProfile(ctx);
         for (Element enclosed : serviceElement.getEnclosedElements()) {
             if (!(enclosed instanceof ExecutableElement method)) {
                 continue;
             }
             if (!method.getModifiers().contains(Modifier.PUBLIC)
-                || method.getModifiers().contains(Modifier.STATIC)
-                || method.getParameters().size() != 1) {
+                || method.getModifiers().contains(Modifier.STATIC)) {
                 continue;
             }
             String methodName = method.getSimpleName().toString();
             TypeMirror returnType = method.getReturnType();
+            if ("process".equals(methodName) && method.getParameters().size() != 1) {
+                invalidProcessReasons.add("process method must accept exactly one input parameter");
+                continue;
+            }
+            if ("process".equals(methodName) && returnType.getKind() == TypeKind.VOID) {
+                invalidProcessReasons.add("process method must return a typed output");
+                continue;
+            }
+            if ("processBlocking".equals(methodName) && method.getParameters().size() != 1) {
+                invalidProcessReasons.add("processBlocking method must accept exactly one input parameter");
+                continue;
+            }
             if ("processBlocking".equals(methodName) && springProfile && returnType.getKind() != TypeKind.VOID) {
                 matches.add(new SupportedServiceSignature(
                     ServiceApiKind.BLOCKING,
@@ -1430,6 +1446,10 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
                 reactiveReturnKind = ReactiveReturnKind.MUTINY_UNI;
             } else if (springProfile && isDeclaredType(declaredReturn, "reactor.core.publisher.Mono")) {
                 reactiveReturnKind = ReactiveReturnKind.REACTOR_MONO;
+            } else if (springProfile
+                && allowSpringCompletionStageProcess
+                && isDeclaredType(declaredReturn, "java.util.concurrent.CompletionStage")) {
+                reactiveReturnKind = ReactiveReturnKind.COMPLETION_STAGE;
             } else {
                 continue;
             }
@@ -1446,9 +1466,17 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
             messager.printMessage(
                 javax.tools.Diagnostic.Kind.ERROR,
                 "Internal service '" + serviceElement.getQualifiedName()
-                    + "' declares multiple public process(In): Uni<Out>" + springPlainMethodHint(ctx)
+                    + "' declares multiple public process(In): Uni<Out>"
+                    + springPlainMethodHint(ctx, allowSpringCompletionStageProcess)
                     + " methods. Please declare exactly one.");
             return Optional.empty();
+        }
+        if (matches.isEmpty() && !invalidProcessReasons.isEmpty()) {
+            messager.printMessage(
+                javax.tools.Diagnostic.Kind.ERROR,
+                "Internal service '" + serviceElement.getQualifiedName()
+                    + "' has unsupported process method shape: "
+                    + invalidProcessReasons.stream().distinct().collect(Collectors.joining("; ")));
         }
         return matches.isEmpty() ? Optional.empty() : Optional.of(matches.getFirst());
     }
@@ -1482,8 +1510,12 @@ public class ModelExtractionPhase implements PipelineCompilationPhase {
         return ctx != null && "spring".equalsIgnoreCase(ctx.getRendererProfile());
     }
 
-    private String springPlainMethodHint(PipelineCompilationContext ctx) {
-        return isSpringRendererProfile(ctx) ? " or process(In): Mono<Out> or processBlocking(In): Out" : "";
+    private String springPlainMethodHint(PipelineCompilationContext ctx, boolean includeCompletionStage) {
+        if (!isSpringRendererProfile(ctx)) {
+            return "";
+        }
+        String completionStageShape = includeCompletionStage ? " or process(In): CompletionStage<Out>" : "";
+        return " or process(In): Mono<Out>" + completionStageShape + " or processBlocking(In): Out";
     }
 
     private boolean isDeclaredType(DeclaredType declaredType, String qualifiedName) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhase.java
@@ -6,6 +6,7 @@ import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -69,11 +70,12 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
     public void execute(PipelineCompilationContext ctx) throws Exception {
         PipelineTransport mode = ctx.getTransportMode();
         PipelineTransport transportMode = Objects.requireNonNullElse(mode, PipelineTransport.GRPC);
+        Optional<PipelineStepModel> springRestEntrypoint = springRestEntrypoint(ctx, transportMode);
 
         // Apply transport targets and resolve client/server roles for each step model
         List<PipelineStepModel> updatedModels = new ArrayList<>();
         for (PipelineStepModel model : ctx.getStepModels()) {
-            Set<GenerationTarget> targets = resolveTargetsForModel(ctx, model, transportMode);
+            Set<GenerationTarget> targets = resolveTargetsForModel(ctx, model, transportMode, springRestEntrypoint);
             PipelineStepModel updatedModel = model.toBuilder()
                 .enabledTargets(targets)
                 .build();
@@ -118,7 +120,8 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
     private Set<GenerationTarget> resolveTargetsForModel(
             PipelineCompilationContext ctx,
             PipelineStepModel model,
-            PipelineTransport transportMode) {
+            PipelineTransport transportMode,
+            Optional<PipelineStepModel> springRestEntrypoint) {
         if (model.serviceClassName() != null
             && AWAIT_STEP_DESCRIPTOR_CLASS.equals(model.serviceClassName().canonicalName())) {
             return Set.of(GenerationTarget.AWAIT_CLIENT_STEP);
@@ -142,6 +145,12 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             // External adapter generation is bound later in PipelineBindingConstructionPhase.
             return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
+        if (SpringRendererProfileSupport.isSpringProfile(ctx)
+            && transportMode == PipelineTransport.REST
+            && model.sideEffect()
+            && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
+            return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
+        }
         if (transportMode == PipelineTransport.LOCAL
             && model.sideEffect()
             && model.deploymentRole() == DeploymentRole.PLUGIN_SERVER) {
@@ -157,7 +166,10 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             && transportMode == PipelineTransport.REST
             && !model.sideEffect()
             && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
-            return Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP);
+            if (springRestEntrypoint.filter(entrypoint -> entrypoint == model).isPresent()) {
+                return Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP);
+            }
+            return Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         }
         LinkedHashSet<GenerationTarget> targets = new LinkedHashSet<>(resolveTargetsForRole(model.deploymentRole(), transportMode));
         if (model.serviceApiKind() != ServiceApiKind.REACTIVE
@@ -166,5 +178,21 @@ public class PipelineTargetResolutionPhase implements PipelineCompilationPhase {
             targets.add(GenerationTarget.BLOCKING_REACTIVE_BRIDGE);
         }
         return Collections.unmodifiableSet(targets);
+    }
+
+    private Optional<PipelineStepModel> springRestEntrypoint(PipelineCompilationContext ctx, PipelineTransport transportMode) {
+        if (!SpringRendererProfileSupport.isSpringProfile(ctx) || transportMode != PipelineTransport.REST) {
+            return Optional.empty();
+        }
+        for (PipelineStepModel model : ctx.getStepModels()) {
+            boolean remote = model.remoteExecution() != null && model.remoteExecution().isRemote();
+            if (!model.sideEffect()
+                && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER
+                && model.delegateService() == null
+                && !remote) {
+                return Optional.of(model);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/YamlDrivenStepGenerationTest.java
@@ -321,6 +321,43 @@ class YamlDrivenStepGenerationTest {
     }
 
     @Test
+    void generatesYamlInternalStepFromPlainCompletionStageProcessMethodWithSpringProfile() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-plain-stage.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+
+            public class PaymentService {
+                public CompletionStage<PaymentStatus> process(PaymentRecord input) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertTrue(result.success(), "Expected plain CompletionStage process method compilation to succeed: "
+            + result.errorSummary());
+    }
+
+    @Test
     void generatesYamlDelegatedStepFromPlainMonoProcessMethodWithSpringProfile() throws IOException {
         Path yamlFile = tempDir.resolve("pipeline-delegated-plain-mono.yaml");
         Files.writeString(yamlFile, """
@@ -669,6 +706,42 @@ class YamlDrivenStepGenerationTest {
     }
 
     @Test
+    void failsYamlInternalStepFromPlainCompletionStageProcessMethodWithoutSpringProfile() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-plain-stage-quarkus.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+
+            public class PaymentService {
+                public CompletionStage<PaymentStatus> process(PaymentRecord input) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(yamlFile, List.of(paymentService, paymentRecord, paymentStatus));
+        assertFalse(result.success(), "Expected default renderer profile to reject plain CompletionStage process methods");
+        assertTrue(
+            result.errorSummary().contains("must implement exactly one supported service interface or declare exactly one public process(In): Uni<Out> method"),
+            result.errorSummary());
+    }
+
+    @Test
     void failsYamlInternalStepWhenPlainMonoProcessMethodIsRaw() throws IOException {
         Path yamlFile = tempDir.resolve("pipeline-internal-raw-plain-mono.yaml");
         Files.writeString(yamlFile, """
@@ -716,6 +789,117 @@ class YamlDrivenStepGenerationTest {
         assertTrue(
             result.errorSummary().contains("process(In): Mono<Out>"),
             result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenPlainCompletionStageProcessMethodIsRaw() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-raw-plain-stage.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+
+            public class PaymentService {
+                @SuppressWarnings("rawtypes")
+                public CompletionStage process(PaymentRecord input) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected raw CompletionStage process method compilation to fail");
+        assertTrue(result.errorSummary().contains("process(In): CompletionStage<Out>"), result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenPlainCompletionStageProcessMethodHasWrongArity() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-wrong-arity-plain-stage.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+
+            public class PaymentService {
+                public CompletionStage<PaymentStatus> process(PaymentRecord input, String unused) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected wrong-arity CompletionStage process method compilation to fail");
+        assertTrue(result.errorSummary().contains("process method must accept exactly one input parameter"),
+            result.errorSummary());
+        assertTrue(result.errorSummary().contains("process(In): CompletionStage<Out>"), result.errorSummary());
+    }
+
+    @Test
+    void failsYamlInternalStepWhenPlainCompletionStageProcessMethodReturnsVoid() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-void-plain-stage.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            public class PaymentService {
+                public void process(PaymentRecord input) {
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected void process method compilation to fail");
+        assertTrue(result.errorSummary().contains("process method must return a typed output"), result.errorSummary());
+        assertTrue(result.errorSummary().contains("process(In): CompletionStage<Out>"), result.errorSummary());
     }
 
     @Test
@@ -777,6 +961,95 @@ class YamlDrivenStepGenerationTest {
         assertAll(
             () -> assertTrue(result.errorSummary().contains("multiple public"), result.errorSummary()),
             () -> assertTrue(result.errorSummary().contains("processBlocking(In): Out"), result.errorSummary()));
+    }
+
+    @Test
+    void failsYamlInternalStepWhenMultiplePlainSpringProcessMethodsExist() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-multiple-plain-spring.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+            import reactor.core.publisher.Mono;
+
+            public class PaymentService {
+                public Mono<PaymentStatus> process(PaymentRecord input) {
+                    return Mono.just(new PaymentStatus());
+                }
+
+                public CompletionStage<PaymentStatus> process(AlternatePaymentRecord input) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path alternatePaymentRecord = writeSource("AlternatePaymentRecord.java", """
+            package com.example.app;
+
+            public class AlternatePaymentRecord {
+            }
+            """);
+        Path paymentStatus = writePaymentStatus();
+        Path monoStub = writeMonoStub();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, alternatePaymentRecord, paymentStatus, monoStub),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected multiple plain Spring process methods to fail");
+        assertAll(
+            () -> assertTrue(result.errorSummary().contains("multiple public"), result.errorSummary()),
+            () -> assertTrue(result.errorSummary().contains("CompletionStage<Out>"), result.errorSummary()));
+    }
+
+    @Test
+    void failsYamlInternalStepWhenCompletionStageCardinalityIsNonUnary() throws IOException {
+        Path yamlFile = tempDir.resolve("pipeline-internal-stage-non-unary.yaml");
+        Files.writeString(yamlFile, """
+            appName: "Test App"
+            basePackage: "com.example"
+            transport: "LOCAL"
+            steps:
+              - name: "pay"
+                service: "com.example.app.PaymentService"
+                cardinality: "ONE_TO_MANY"
+                input: "com.example.app.PaymentRecord"
+                output: "com.example.app.PaymentStatus"
+            """);
+
+        Path paymentService = writeSource("PaymentService.java", """
+            package com.example.app;
+
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
+
+            public class PaymentService {
+                public CompletionStage<PaymentStatus> process(PaymentRecord input) {
+                    return CompletableFuture.completedFuture(new PaymentStatus());
+                }
+            }
+            """);
+        Path paymentRecord = writePaymentRecord();
+        Path paymentStatus = writePaymentStatus();
+
+        CompilationResult result = compile(
+            yamlFile,
+            List.of(paymentService, paymentRecord, paymentStatus),
+            List.of("-Apipeline.codegen.rendererProfile=spring"));
+        assertFalse(result.success(), "Expected non-unary CompletionStage process method compilation to fail");
+        assertTrue(result.errorSummary().contains("declares cardinality"), result.errorSummary());
     }
 
     @Test

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/PipelineTargetResolutionPhaseTest.java
@@ -107,6 +107,43 @@ class PipelineTargetResolutionPhaseTest {
     }
 
     @Test
+    void springProfileResolvesOnlyFirstRestServerStepToRestResource() throws Exception {
+        PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
+        PipelineCompilationContext context = new PipelineCompilationContext(null, null);
+        context.setRendererProfile("spring");
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(
+            step("SideEffectSpringServer", DeploymentRole.PIPELINE_SERVER)
+                .toBuilder()
+                .sideEffect(true)
+                .build(),
+            step("DelegatedSpringServer", DeploymentRole.PIPELINE_SERVER)
+                .toBuilder()
+                .delegateService(ClassName.get("com.example.delegate", "DelegatedSpringService"))
+                .build(),
+            step("SpringRestEntrypoint", DeploymentRole.PIPELINE_SERVER),
+            step("SpringLocalContinuation", DeploymentRole.PIPELINE_SERVER)));
+
+        phase.execute(context);
+
+        assertEquals(
+            Set.of(GenerationTarget.LOCAL_CLIENT_STEP),
+            context.getStepModels().get(0).enabledTargets());
+        assertEquals(
+            Set.of(GenerationTarget.LOCAL_CLIENT_STEP),
+            context.getStepModels().get(1).enabledTargets());
+        assertEquals(
+            Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP),
+            context.getStepModels().get(2).enabledTargets());
+        assertEquals(
+            Set.of(GenerationTarget.LOCAL_CLIENT_STEP),
+            context.getStepModels().get(3).enabledTargets());
+        assertEquals(
+            Set.of(GenerationTarget.REST_RESOURCE, GenerationTarget.LOCAL_CLIENT_STEP),
+            context.getResolvedTargets());
+    }
+
+    @Test
     void defaultsToGrpcWhenTransportModeIsNull() throws Exception {
         PipelineTargetResolutionPhase phase = new PipelineTargetResolutionPhase();
         PipelineCompilationContext context = new PipelineCompilationContext(null, null);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringLocalClientStepRendererTest.java
@@ -94,6 +94,27 @@ class SpringLocalClientStepRendererTest {
     }
 
     @Test
+    void rendersCompletionStageUnaryLocalClientStep() throws Exception {
+        SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
+
+        renderer.render(new LocalBinding(model(
+                StreamingShape.UNARY_UNARY,
+                ServiceApiKind.REACTIVE,
+                ReactiveReturnKind.COMPLETION_STAGE)),
+            new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null,
+                null, null, 1));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/PaymentLocalClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("return this.paymentService.process(input);"));
+        assertFalse(source.contains(".toFuture();"));
+        assertFalse(source.contains("subscribeAsCompletionStage"));
+        assertFalse(source.contains("RuntimeAdapters.executeBlocking"));
+        assertFalse(source.contains("reactor.core.publisher"));
+        assertFalse(source.contains("io.smallrye.mutiny"));
+    }
+
+    @Test
     void rendersDelegatedSpringBeanLocalClientStep() throws Exception {
         SpringLocalClientStepRenderer renderer = new SpringLocalClientStepRenderer();
 

--- a/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentReceiptService.java
+++ b/framework/spring-smoke-tests/src/main/java/com/example/smoke/service/PaymentReceiptService.java
@@ -1,0 +1,16 @@
+package com.example.smoke.service;
+
+import com.example.smoke.domain.PaymentStatus;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentReceiptService {
+    public CompletionStage<PaymentStatus> process(PaymentStatus input) {
+        if (input == null) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Payment status must not be null"));
+        }
+        return CompletableFuture.completedFuture(new PaymentStatus(input.paymentId(), input.status() + ":STAGE"));
+    }
+}

--- a/framework/spring-smoke-tests/src/main/resources/pipeline.yaml
+++ b/framework/spring-smoke-tests/src/main/resources/pipeline.yaml
@@ -13,3 +13,7 @@ steps:
     operator: "com.example.smoke.service.PaymentAuditService::audit"
     input: "com.example.smoke.domain.PaymentStatus"
     output: "com.example.smoke.domain.PaymentStatus"
+  - name: "receipt"
+    service: "com.example.smoke.service.PaymentReceiptService"
+    input: "com.example.smoke.domain.PaymentStatus"
+    output: "com.example.smoke.domain.PaymentStatus"

--- a/framework/spring-smoke-tests/src/test/java/com/example/smoke/GeneratedSpringRestSmokeTest.java
+++ b/framework/spring-smoke-tests/src/test/java/com/example/smoke/GeneratedSpringRestSmokeTest.java
@@ -22,7 +22,7 @@ class GeneratedSpringRestSmokeTest {
 
     @Test
     void generatedRestEndpointRunsThroughSpringPipelineRunner() {
-        assertEquals(2, pipelineRunner.stepCount());
+        assertEquals(3, pipelineRunner.stepCount());
 
         WebTestClient.bindToServer()
             .baseUrl("http://localhost:" + port)
@@ -36,7 +36,7 @@ class GeneratedSpringRestSmokeTest {
             .expectBody(PaymentStatusDto.class)
             .value(response -> {
                 assertEquals("pay-123", response.paymentId());
-                assertEquals("APPROVED:42:DELEGATED", response.status());
+                assertEquals("APPROVED:42:DELEGATED:STAGE", response.status());
             });
     }
 }


### PR DESCRIPTION
## Summary

Adds the next Spring adoption slice for normal YAML `service:` beans:

- accepts unary Spring-profile internal services shaped as `process(In): CompletionStage<Out>`
- keeps support scoped to Spring renderer profile, COMPUTE, LOCAL/REST, unary local service steps
- preserves existing Mono service smoke coverage and adds a separate CompletionStage receipt step
- keeps delegated beans and `Class::method` operator behavior from PR #446 unchanged
- keeps queue-async, coordinator, await, checkpoint, broker, gRPC, function, side effects, and streaming out of scope

## Notes

The Spring REST target policy now exposes only the first eligible internal server step as a REST resource. Later internal service steps remain local client steps, which avoids duplicate WebFlux mappings when a REST pipeline has multiple local service beans.

Local CodeRabbit was run against `origin/main`. Fixed the valid target-resolution and test-specificity items. One remote-target suggestion was rejected as out of scope because Spring remote execution remains intentionally unsupported and is rejected by `SpringRendererProfileSupport` before generation.

## Validation

- `./mvnw -f framework/pom.xml -pl deployment -Dtest='PipelineTargetResolutionPhaseTest,YamlDrivenStepGenerationTest,SpringLocalClientStepRendererTest' test`
- `./mvnw -f framework/pom.xml -pl runtime-core,runtime-spring,deployment,spring-smoke-tests,spring-blocking-smoke-tests -am -Dtest='SpringRendererProfileSupportTest,SpringLocalClientStepRendererTest,YamlDrivenStepGenerationTest,GeneratedSpringRestSmokeTest,GeneratedSpringBlockingRestSmokeTest,SpringSmokeDependencyGuardTest,SpringBlockingSmokeDependencyGuardTest' -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl deployment spotless:check`
- `npm --prefix docs run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spring-based services can now use `CompletionStage` for unary processing in supported YAML-defined local steps.
  * Spring REST pipelines now resolve the first eligible server step as the REST entrypoint, while other steps remain local clients.
  * Smoke tests now include a `CompletionStage`-backed processing step in the sample pipeline.

* **Bug Fixes**
  * Improved validation and diagnostics for unsupported or invalid service method shapes.
  * Updated generated output expectations to reflect the new step routing and returned status format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->