### PR TITLE
Add queue async architecture fitness tests

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionReadModel.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionReadModel.java
@@ -1,0 +1,99 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.NotFoundException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+
+class ExecutionReadModel {
+
+  private final PipelineOrchestratorConfig orchestratorConfig;
+  private final ExecutionInputPolicy executionInputPolicy;
+  private final ExecutionStateStore executionStateStore;
+  private final ControlPlaneAdmissionPolicy admissionPolicy;
+  private final Supplier<String> pipelineId;
+  private final Supplier<String> releaseVersion;
+  private final Supplier<TransitionPayloadCodec> payloadCodec;
+
+  ExecutionReadModel(
+      PipelineOrchestratorConfig orchestratorConfig,
+      ExecutionInputPolicy executionInputPolicy,
+      ExecutionStateStore executionStateStore,
+      ControlPlaneAdmissionPolicy admissionPolicy,
+      Supplier<String> pipelineId,
+      Supplier<String> releaseVersion,
+      Supplier<TransitionPayloadCodec> payloadCodec) {
+    this.orchestratorConfig = Objects.requireNonNull(orchestratorConfig, "orchestratorConfig must not be null");
+    this.executionInputPolicy = Objects.requireNonNull(executionInputPolicy, "executionInputPolicy must not be null");
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.admissionPolicy = Objects.requireNonNull(admissionPolicy, "admissionPolicy must not be null");
+    this.pipelineId = Objects.requireNonNull(pipelineId, "pipelineId must not be null");
+    this.releaseVersion = Objects.requireNonNull(releaseVersion, "releaseVersion must not be null");
+    this.payloadCodec = Objects.requireNonNull(payloadCodec, "payloadCodec must not be null");
+  }
+
+  Uni<ExecutionStatusDto> getExecutionStatus(String tenantId, String executionId) {
+    return readExecution(tenantId, executionId, ControlPlaneAdmissionOperation.GET_EXECUTION_STATUS)
+        .onItem().transform(record -> new ExecutionResultView(record).statusDto());
+  }
+
+  @SuppressWarnings("unchecked")
+  <T> Uni<T> getExecutionResult(String tenantId, String executionId, Class<?> outputType, boolean outputStreaming) {
+    return readExecution(tenantId, executionId, ControlPlaneAdmissionOperation.GET_EXECUTION_RESULT)
+        .onItem().transform(record ->
+            (T) new ExecutionResultView(record).typedResult(outputType, outputStreaming, payloadCodec));
+  }
+
+  Uni<Object> getExecutionResultPayload(String tenantId, String executionId) {
+    return readExecution(tenantId, executionId, ControlPlaneAdmissionOperation.GET_EXECUTION_RESULT)
+        .onItem().transform(record -> new ExecutionResultView(record).rawPayload());
+  }
+
+  private Uni<ExecutionRecord<Object, Object>> readExecution(
+      String tenantId,
+      String executionId,
+      ControlPlaneAdmissionOperation operation) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return Uni.createFrom().failure(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    }
+    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+    RuntimeException admissionFailure = admissionFailure(new ControlPlaneAdmissionRequest(
+        resolvedTenant,
+        operation,
+        pipelineId.get(),
+        releaseVersion.get(),
+        executionId,
+        "api",
+        tenantId != null && !tenantId.isBlank()));
+    if (admissionFailure != null) {
+      return Uni.createFrom().failure(admissionFailure);
+    }
+    return executionStateStore.getExecution(resolvedTenant, executionId)
+        .onItem().transform(optional -> requireExecution(optional, executionId));
+  }
+
+  private RuntimeException admissionFailure(ControlPlaneAdmissionRequest request) {
+    ControlPlaneAdmissionDecision decision = admissionPolicy.admit(request);
+    return decision.allowed() ? null : new ControlPlaneAdmissionException(decision);
+  }
+
+  private ExecutionRecord<Object, Object> requireExecution(
+      Optional<ExecutionRecord<Object, Object>> record,
+      String executionId) {
+    return record.orElseThrow(() -> new NotFoundException("Execution not found: " + executionId));
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionReadModel.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionReadModel.java
@@ -71,7 +71,7 @@ class ExecutionReadModel {
           "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
     }
     String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
-    RuntimeException admissionFailure = admissionFailure(new ControlPlaneAdmissionRequest(
+    Optional<RuntimeException> admissionFailure = admissionFailure(new ControlPlaneAdmissionRequest(
         resolvedTenant,
         operation,
         pipelineId.get(),
@@ -79,16 +79,18 @@ class ExecutionReadModel {
         executionId,
         "api",
         tenantId != null && !tenantId.isBlank()));
-    if (admissionFailure != null) {
-      return Uni.createFrom().failure(admissionFailure);
+    if (admissionFailure.isPresent()) {
+      return Uni.createFrom().failure(admissionFailure.get());
     }
     return executionStateStore.getExecution(resolvedTenant, executionId)
         .onItem().transform(optional -> requireExecution(optional, executionId));
   }
 
-  private RuntimeException admissionFailure(ControlPlaneAdmissionRequest request) {
+  private Optional<RuntimeException> admissionFailure(ControlPlaneAdmissionRequest request) {
     ControlPlaneAdmissionDecision decision = admissionPolicy.admit(request);
-    return decision.allowed() ? null : new ControlPlaneAdmissionException(decision);
+    return decision.allowed()
+        ? Optional.empty()
+        : Optional.of(new ControlPlaneAdmissionException(decision));
   }
 
   private ExecutionRecord<Object, Object> requireExecution(

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionResultView.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionResultView.java
@@ -1,0 +1,122 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.pipelineframework.config.pipeline.PipelineJson;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.SerializedTransitionPayload;
+import org.pipelineframework.orchestrator.TransitionPayloadCodec;
+import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+
+record ExecutionResultView(ExecutionRecord<Object, Object> record) {
+
+  ExecutionResultView {
+    if (record == null) {
+      throw new IllegalArgumentException("ExecutionResultView requires record");
+    }
+  }
+
+  ExecutionStatusDto statusDto() {
+    return new ExecutionStatusDto(
+        record.executionId(),
+        record.status(),
+        record.currentStepIndex(),
+        record.attempt(),
+        record.version(),
+        record.nextDueEpochMs(),
+        record.updatedAtEpochMs(),
+        record.errorCode(),
+        record.errorMessage());
+  }
+
+  Object typedResult(Class<?> outputType, boolean outputStreaming, Supplier<TransitionPayloadCodec> payloadCodec) {
+    List<?> items = successfulItems();
+    if (record.resultShape() == ExecutionResultShape.SINGLE) {
+      validateSingleShape(items);
+      if (outputStreaming) {
+        return List.copyOf(items);
+      }
+      return items.isEmpty() ? null : coerceStoredResult(items.getFirst(), outputType, payloadCodec);
+    }
+    if (!outputStreaming) {
+      throw new IllegalStateException(
+          "Execution " + record.executionId()
+              + " produced a materialized multi result. Request list retrieval instead.");
+    }
+    return coerceStoredResults(items, outputType, payloadCodec);
+  }
+
+  Object rawPayload() {
+    List<?> items = successfulItems();
+    if (record.resultShape() == ExecutionResultShape.SINGLE) {
+      validateSingleShape(items);
+      return items.isEmpty() ? null : items.getFirst();
+    }
+    return List.copyOf(items);
+  }
+
+  Optional<Object> typedOptionalResult(
+      Class<?> outputType,
+      boolean outputStreaming,
+      Supplier<TransitionPayloadCodec> payloadCodec) {
+    return Optional.ofNullable(typedResult(outputType, outputStreaming, payloadCodec));
+  }
+
+  private List<?> successfulItems() {
+    if (record.status() == ExecutionStatus.SUCCEEDED) {
+      if (record.resultPayload() == null) {
+        return List.of();
+      }
+      return (List<?>) record.resultPayload();
+    }
+    if (record.status().terminal()) {
+      throw new IllegalStateException("Execution finished without a successful result: " + record.status());
+    }
+    throw new IllegalStateException("Execution is not complete yet: " + record.status());
+  }
+
+  private void validateSingleShape(List<?> items) {
+    if (items.size() > 1) {
+      throw new IllegalStateException(
+          "Execution " + record.executionId() + " stored multiple terminal items for SINGLE result shape");
+    }
+  }
+
+  private Object coerceStoredResult(
+      Object result,
+      Class<?> outputType,
+      Supplier<TransitionPayloadCodec> payloadCodec) {
+    if (result instanceof SerializedTransitionPayload serialized) {
+      return coerceStoredResult(payloadCodec.get().decode(serialized), outputType, payloadCodec);
+    }
+    if (result == null || outputType == null || outputType.isInstance(result)) {
+      return result;
+    }
+    try {
+      return PipelineJson.mapper().convertValue(result, outputType);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException(
+          "Failed to coerce stored result from "
+              + result.getClass().getName()
+              + " to "
+              + outputType.getName(),
+          e);
+    }
+  }
+
+  private List<?> coerceStoredResults(
+      List<?> results,
+      Class<?> outputType,
+      Supplier<TransitionPayloadCodec> payloadCodec) {
+    if (outputType == null) {
+      return List.copyOf(results);
+    }
+    return results.stream()
+        .map(result -> coerceStoredResult(result, outputType, payloadCodec))
+        .toList();
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionResultView.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionResultView.java
@@ -40,7 +40,11 @@ record ExecutionResultView(ExecutionRecord<Object, Object> record) {
       if (outputStreaming) {
         return List.copyOf(items);
       }
-      return items.isEmpty() ? null : coerceStoredResult(items.getFirst(), outputType, payloadCodec);
+      if (items.isEmpty()) {
+        return Optional.empty();
+      }
+      Object result = coerceStoredResult(items.getFirst(), outputType, payloadCodec);
+      return result == null ? Optional.empty() : result;
     }
     if (!outputStreaming) {
       throw new IllegalStateException(
@@ -54,7 +58,7 @@ record ExecutionResultView(ExecutionRecord<Object, Object> record) {
     List<?> items = successfulItems();
     if (record.resultShape() == ExecutionResultShape.SINGLE) {
       validateSingleShape(items);
-      return items.isEmpty() ? null : items.getFirst();
+      return items.isEmpty() ? Optional.empty() : items.getFirst();
     }
     return List.copyOf(items);
   }
@@ -63,7 +67,11 @@ record ExecutionResultView(ExecutionRecord<Object, Object> record) {
       Class<?> outputType,
       boolean outputStreaming,
       Supplier<TransitionPayloadCodec> payloadCodec) {
-    return Optional.ofNullable(typedResult(outputType, outputStreaming, payloadCodec));
+    Object result = typedResult(outputType, outputStreaming, payloadCodec);
+    if (result instanceof Optional<?> optional && optional.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(result);
   }
 
   private List<?> successfulItems() {

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunSubmission.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunSubmission.java
@@ -1,0 +1,25 @@
+package org.pipelineframework;
+
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
+
+record PipelineRunSubmission(
+    String tenantId,
+    boolean explicitTenant,
+    String pipelineId,
+    String contractVersion,
+    String releaseVersion,
+    String idempotencyKey,
+    boolean outputStreaming) {
+
+  ControlPlaneAdmissionRequest admissionRequest() {
+    return new ControlPlaneAdmissionRequest(
+        tenantId,
+        ControlPlaneAdmissionOperation.SUBMIT_EXECUTION,
+        pipelineId,
+        releaseVersion,
+        null,
+        "api",
+        explicitTenant);
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/PipelineRunSubmissionPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/PipelineRunSubmissionPlan.java
@@ -1,0 +1,58 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+record PipelineRunSubmissionPlan(
+    PipelineRunSubmission submission,
+    ExecutionInputSnapshot snapshot,
+    String executionKey,
+    ExecutionResultShape resultShape,
+    long nowEpochMs,
+    long ttlEpochS) {
+
+  PipelineRunSubmissionPlan {
+    Objects.requireNonNull(submission, "submission must not be null");
+    Objects.requireNonNull(snapshot, "snapshot must not be null");
+    Objects.requireNonNull(resultShape, "resultShape must not be null");
+    executionKey = scopedRootExecutionKey(
+        submission.pipelineId(),
+        submission.releaseVersion(),
+        executionKey);
+  }
+
+  ExecutionCreateCommand createCommand() {
+    return new ExecutionCreateCommand(
+        submission.tenantId(),
+        executionKey,
+        submission.pipelineId(),
+        submission.contractVersion(),
+        submission.releaseVersion(),
+        snapshot,
+        resultShape,
+        nowEpochMs,
+        ttlEpochS);
+  }
+
+  private static String scopedRootExecutionKey(String pipelineId, String releaseVersion, String executionKey) {
+    return compositeScopedKey("pipelineId", pipelineId, "releaseVersion", releaseVersion)
+        + ":executionKey:"
+        + requireScopedValue("executionKey", executionKey);
+  }
+
+  private static String compositeScopedKey(String leftName, String left, String rightName, String right) {
+    String safeLeft = requireScopedValue(leftName, left);
+    String safeRight = requireScopedValue(rightName, right);
+    return safeLeft.length() + ":" + safeLeft + ":" + safeRight.length() + ":" + safeRight;
+  }
+
+  private static String requireScopedValue(String name, String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value;
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -2,7 +2,6 @@ package org.pipelineframework;
 
 import org.pipelineframework.orchestrator.release.PipelineContractDescriptor;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +14,6 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 
 import io.smallrye.mutiny.Uni;
@@ -33,9 +31,7 @@ import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
 import org.pipelineframework.telemetry.AwaitReplayLifecycleEvent;
 import org.pipelineframework.telemetry.PipelineTelemetry;
-import org.pipelineframework.orchestrator.CreateExecutionResult;
 import org.pipelineframework.orchestrator.DeadLetterPublisher;
-import org.pipelineframework.orchestrator.ExecutionCreateCommand;
 import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRedriveResult;
 import org.pipelineframework.orchestrator.ExecutionRecord;
@@ -120,6 +116,7 @@ class QueueAsyncCoordinator {
   private volatile ControlPlaneAdmissionPolicy fallbackAdmissionPolicy;
   private volatile AwaitContinuations awaitContinuations;
   private volatile ExecutionReadModel executionReadModel;
+  private volatile QueueAsyncSubmissionFlow submissionFlow;
 
   @Inject
   PipelineTelemetry telemetry;
@@ -201,14 +198,7 @@ class QueueAsyncCoordinator {
       String tenantId,
       String idempotencyKey,
       boolean outputStreaming) {
-    return executePipelineAsync(
-        input,
-        tenantId,
-        idempotencyKey,
-        outputStreaming,
-        pipelineId(),
-        contractVersion(),
-        releaseVersion());
+    return submissionFlow().submit(input, tenantId, idempotencyKey, outputStreaming);
   }
 
   Uni<RunAsyncAcceptedDto> executePipelineAsync(
@@ -219,72 +209,14 @@ class QueueAsyncCoordinator {
       String pipelineId,
       String contractVersion,
       String releaseVersion) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    if (outputStreaming) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode does not support streaming pipeline outputs yet."));
-    }
-    Object executionInput = executionInputPolicy.normalizeExecutionInput(input);
-    RuntimeException inputFailure = executionInputPolicy.validateInputShape(executionInput);
-    if (inputFailure != null) {
-      return Uni.createFrom().failure(inputFailure);
-    }
-    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
-    RuntimeException admissionFailure = admissionFailure(admissionRequest(
-        resolvedTenant,
-        ControlPlaneAdmissionOperation.SUBMIT_EXECUTION,
+    return submissionFlow().submit(
+        input,
+        tenantId,
+        idempotencyKey,
+        outputStreaming,
         pipelineId,
-        releaseVersion,
-        null,
-        "api",
-        explicitTenant(tenantId)));
-    if (admissionFailure != null) {
-      return Uni.createFrom().failure(admissionFailure);
-    }
-    long now = System.currentTimeMillis();
-    long ttlEpochS = Instant.ofEpochMilli(now)
-        .plus(Duration.ofDays(Math.max(1, orchestratorConfig.executionTtlDays())))
-        .getEpochSecond();
-
-    return executionInputPolicy.resolveExecutionInputPayload(executionInput)
-        .onItem().transformToUni(snapshot -> {
-              String executionKey;
-              try {
-                executionKey = scopedRootExecutionKey(
-                    pipelineId,
-                    releaseVersion,
-                    executionInputPolicy.resolveExecutionKey(resolvedTenant, snapshot.payload(), idempotencyKey));
-              } catch (IllegalArgumentException e) {
-                return Uni.createFrom().failure(new BadRequestException(e.getMessage()));
-              }
-          ExecutionCreateCommand command = new ExecutionCreateCommand(
-              resolvedTenant,
-              executionKey,
-              pipelineId,
-              contractVersion,
-              releaseVersion,
-              snapshot,
-              executionResultShapeResolver.resolve(),
-              now,
-              ttlEpochS);
-          return executionStateStore.createOrGetExecution(command)
-              .onItem().transformToUni(created -> {
-                Uni<Void> recordSubmitted = created.duplicate()
-                    ? Uni.createFrom().voidItem()
-                    : segmentBoundaryLedger().recordRunSubmitted(created, command, now);
-                Uni<Void> enqueue = created.duplicate()
-                    ? Uni.createFrom().voidItem()
-                    : workDispatcher.enqueueNow(new ExecutionWorkItem(
-                        created.record().tenantId(),
-                        created.record().executionId()));
-                return recordSubmitted
-                    .chain(() -> enqueue)
-                    .onItem().transform(ignored -> toRunAccepted(created, now));
-              });
-        });
+        contractVersion,
+        releaseVersion);
   }
 
   Uni<ExecutionStatusDto> getExecutionStatus(String tenantId, String executionId) {
@@ -504,25 +436,6 @@ class QueueAsyncCoordinator {
     return trimmed.length() <= 80 ? trimmed : trimmed.substring(0, 80);
   }
 
-  private static String scopedRootExecutionKey(String pipelineId, String releaseVersion, String executionKey) {
-    return compositeScopedKey("pipelineId", pipelineId, "releaseVersion", releaseVersion)
-        + ":executionKey:"
-        + requireScopedValue("executionKey", executionKey);
-  }
-
-  private static String compositeScopedKey(String leftName, String left, String rightName, String right) {
-    String safeLeft = requireScopedValue(leftName, left);
-    String safeRight = requireScopedValue(rightName, right);
-    return safeLeft.length() + ":" + safeLeft + ":" + safeRight.length() + ":" + safeRight;
-  }
-
-  private static String requireScopedValue(String name, String value) {
-    if (value == null || value.isBlank()) {
-      throw new IllegalArgumentException(name + " must not be blank");
-    }
-    return value;
-  }
-
   private Duration saturatedDelay() {
     PipelineOrchestratorConfig.WorkerConfig workerConfig = orchestratorConfig.worker();
     if (workerConfig == null || workerConfig.saturatedDelay() == null) {
@@ -696,6 +609,31 @@ class QueueAsyncCoordinator {
     }
   }
 
+  private QueueAsyncSubmissionFlow submissionFlow() {
+    QueueAsyncSubmissionFlow current = submissionFlow;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      current = submissionFlow;
+      if (current == null) {
+        current = new QueueAsyncSubmissionFlow(
+            orchestratorConfig,
+            executionInputPolicy,
+            executionResultShapeResolver,
+            executionStateStore,
+            workDispatcher,
+            admissionPolicy(),
+            this::pipelineId,
+            this::contractVersion,
+            this::releaseVersion,
+            this::segmentBoundaryLedger);
+        submissionFlow = current;
+      }
+      return current;
+    }
+  }
+
   private AwaitContinuations awaitContinuations() {
     AwaitContinuations current = awaitContinuations;
     if (current != null) {
@@ -794,15 +732,6 @@ class QueueAsyncCoordinator {
       return true;
     }
     return configuredName.equalsIgnoreCase(availableName);
-  }
-
-  private static RunAsyncAcceptedDto toRunAccepted(CreateExecutionResult created, long nowEpochMs) {
-    String executionId = created.record().executionId();
-    return new RunAsyncAcceptedDto(
-        executionId,
-        created.duplicate(),
-        "/pipeline/executions/" + executionId,
-        nowEpochMs);
   }
 
   private static String transitionKey(String executionId, int stepIndex, int attempt) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -21,7 +21,6 @@ import jakarta.ws.rs.NotFoundException;
 import io.smallrye.mutiny.Uni;
 import org.jboss.logging.Logger;
 import org.pipelineframework.checkpoint.CheckpointPublicationService;
-import org.pipelineframework.config.pipeline.PipelineJson;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
 import org.pipelineframework.awaitable.AwaitCompletionResult;
 import org.pipelineframework.awaitable.AwaitCoordinator;
@@ -40,7 +39,6 @@ import org.pipelineframework.orchestrator.ExecutionCreateCommand;
 import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRedriveResult;
 import org.pipelineframework.orchestrator.ExecutionRecord;
-import org.pipelineframework.orchestrator.ExecutionResultShape;
 import org.pipelineframework.orchestrator.ExecutionResultShapeResolver;
 import org.pipelineframework.orchestrator.ExecutionStateStore;
 import org.pipelineframework.orchestrator.ExecutionStatus;
@@ -50,7 +48,6 @@ import org.pipelineframework.orchestrator.OrchestratorMode;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.PipelineReleaseIdentityResolver;
 import org.pipelineframework.orchestrator.PipelineTransitionWorker;
-import org.pipelineframework.orchestrator.SerializedTransitionPayload;
 import org.pipelineframework.orchestrator.TransitionPayloadCodec;
 import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
 import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
@@ -122,6 +119,7 @@ class QueueAsyncCoordinator {
   private volatile PipelineReleaseIdentityResolver fallbackReleaseIdentityResolver;
   private volatile ControlPlaneAdmissionPolicy fallbackAdmissionPolicy;
   private volatile AwaitContinuations awaitContinuations;
+  private volatile ExecutionReadModel executionReadModel;
 
   @Inject
   PipelineTelemetry telemetry;
@@ -290,75 +288,11 @@ class QueueAsyncCoordinator {
   }
 
   Uni<ExecutionStatusDto> getExecutionStatus(String tenantId, String executionId) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
-    RuntimeException admissionFailure = admissionFailure(admissionRequest(
-        resolvedTenant,
-        ControlPlaneAdmissionOperation.GET_EXECUTION_STATUS,
-        executionId,
-        "api",
-        explicitTenant(tenantId)));
-    if (admissionFailure != null) {
-      return Uni.createFrom().failure(admissionFailure);
-    }
-    return executionStateStore.getExecution(resolvedTenant, executionId)
-        .onItem().transform(optional -> optional
-            .map(QueueAsyncCoordinator::toStatusDto)
-            .orElseThrow(() -> new NotFoundException("Execution not found: " + executionId)));
+    return executionReadModel().getExecutionStatus(tenantId, executionId);
   }
 
-  @SuppressWarnings("unchecked")
   <T> Uni<T> getExecutionResult(String tenantId, String executionId, Class<?> outputType, boolean outputStreaming) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
-    RuntimeException admissionFailure = admissionFailure(admissionRequest(
-        resolvedTenant,
-        ControlPlaneAdmissionOperation.GET_EXECUTION_RESULT,
-        executionId,
-        "api",
-        explicitTenant(tenantId)));
-    if (admissionFailure != null) {
-      return Uni.createFrom().failure(admissionFailure);
-    }
-    return executionStateStore.getExecution(resolvedTenant, executionId)
-        .onItem().transform(optional -> optional.orElseThrow(
-            () -> new NotFoundException("Execution not found: " + executionId)))
-        .onItem().transform(record -> {
-          if (record.status() == ExecutionStatus.SUCCEEDED) {
-            if (record.resultPayload() == null) {
-              return null;
-            }
-            List<?> items = (List<?>) record.resultPayload();
-            if (record.resultShape() == ExecutionResultShape.SINGLE) {
-              if (items.size() > 1) {
-                throw new IllegalStateException(
-                    "Execution " + executionId + " stored multiple terminal items for SINGLE result shape");
-              }
-              if (outputStreaming) {
-                return (T) List.copyOf(items);
-              }
-              if (items.isEmpty()) {
-                return null;
-              }
-              return (T) coerceStoredResult(items.getFirst(), outputType);
-            }
-            if (!outputStreaming) {
-              throw new IllegalStateException(
-                  "Execution " + executionId + " produced a materialized multi result. Request list retrieval instead.");
-            }
-            return (T) coerceStoredResults(items, outputType);
-          }
-          if (record.status().terminal()) {
-            throw new IllegalStateException("Execution finished without a successful result: " + record.status());
-          }
-          throw new IllegalStateException("Execution is not complete yet: " + record.status());
-        });
+    return executionReadModel().getExecutionResult(tenantId, executionId, outputType, outputStreaming);
   }
 
   Uni<ExecutionRedriveResult> redriveExecution(
@@ -429,43 +363,7 @@ class QueueAsyncCoordinator {
   }
 
   Uni<Object> getExecutionResultPayload(String tenantId, String executionId) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
-    }
-    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
-    RuntimeException admissionFailure = admissionFailure(admissionRequest(
-        resolvedTenant,
-        ControlPlaneAdmissionOperation.GET_EXECUTION_RESULT,
-        executionId,
-        "api",
-        explicitTenant(tenantId)));
-    if (admissionFailure != null) {
-      return Uni.createFrom().failure(admissionFailure);
-    }
-    return executionStateStore.getExecution(resolvedTenant, executionId)
-        .onItem().transform(optional -> optional.orElseThrow(
-            () -> new NotFoundException("Execution not found: " + executionId)))
-        .onItem().transform(record -> {
-          if (record.status() == ExecutionStatus.SUCCEEDED) {
-            if (record.resultPayload() == null) {
-              return null;
-            }
-            List<?> items = (List<?>) record.resultPayload();
-            if (record.resultShape() == ExecutionResultShape.SINGLE) {
-              if (items.size() > 1) {
-                throw new IllegalStateException(
-                    "Execution " + executionId + " stored multiple terminal items for SINGLE result shape");
-              }
-              return items.isEmpty() ? null : items.getFirst();
-            }
-            return List.copyOf(items);
-          }
-          if (record.status().terminal()) {
-            throw new IllegalStateException("Execution finished without a successful result: " + record.status());
-          }
-          throw new IllegalStateException("Execution is not complete yet: " + record.status());
-        });
+    return executionReadModel().getExecutionResultPayload(tenantId, executionId);
   }
 
   Uni<Void> processExecutionWorkItem(ExecutionWorkItem workItem, PipelineTransitionWorker worker) {
@@ -633,34 +531,6 @@ class QueueAsyncCoordinator {
     return workerConfig.saturatedDelay();
   }
 
-  private Object coerceStoredResult(Object result, Class<?> outputType) {
-    if (result instanceof SerializedTransitionPayload serialized) {
-      return coerceStoredResult(payloadCodec().decode(serialized), outputType);
-    }
-    if (result == null || outputType == null || outputType.isInstance(result)) {
-      return result;
-    }
-    try {
-      return PipelineJson.mapper().convertValue(result, outputType);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalStateException(
-          "Failed to coerce stored result from "
-              + result.getClass().getName()
-              + " to "
-              + outputType.getName(),
-          e);
-    }
-  }
-
-  private List<?> coerceStoredResults(List<?> results, Class<?> outputType) {
-    if (outputType == null) {
-      return List.copyOf(results);
-    }
-    return results.stream()
-        .map(result -> coerceStoredResult(result, outputType))
-        .toList();
-  }
-
   private TransitionPayloadCodec payloadCodec() {
     if (transitionPayloadCodec != null) {
       return transitionPayloadCodec;
@@ -804,6 +674,28 @@ class QueueAsyncCoordinator {
         awaitContinuations());
   }
 
+  private ExecutionReadModel executionReadModel() {
+    ExecutionReadModel current = executionReadModel;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      current = executionReadModel;
+      if (current == null) {
+        current = new ExecutionReadModel(
+            orchestratorConfig,
+            executionInputPolicy,
+            executionStateStore,
+            admissionPolicy(),
+            this::pipelineId,
+            this::releaseVersion,
+            this::payloadCodec);
+        executionReadModel = current;
+      }
+      return current;
+    }
+  }
+
   private AwaitContinuations awaitContinuations() {
     AwaitContinuations current = awaitContinuations;
     if (current != null) {
@@ -911,19 +803,6 @@ class QueueAsyncCoordinator {
         created.duplicate(),
         "/pipeline/executions/" + executionId,
         nowEpochMs);
-  }
-
-  private static ExecutionStatusDto toStatusDto(ExecutionRecord<Object, Object> record) {
-    return new ExecutionStatusDto(
-        record.executionId(),
-        record.status(),
-        record.currentStepIndex(),
-        record.attempt(),
-        record.version(),
-        record.nextDueEpochMs(),
-        record.updatedAtEpochMs(),
-        record.errorCode(),
-        record.errorMessage());
   }
 
   private static String transitionKey(String executionId, int stepIndex, int attempt) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -146,6 +146,8 @@ class QueueAsyncCoordinator {
     executionStateStore = selectExecutionStateStore(orchestratorConfig.stateProvider());
     workDispatcher = selectWorkDispatcher(orchestratorConfig.dispatcherProvider());
     deadLetterPublisher = selectDeadLetterPublisher(orchestratorConfig.dlqProvider());
+    executionReadModel = null;
+    submissionFlow = null;
 
     List<String> providerReadinessErrors = new ArrayList<>();
     executionStateStore.startupValidationError(orchestratorConfig)
@@ -198,6 +200,9 @@ class QueueAsyncCoordinator {
       String tenantId,
       String idempotencyKey,
       boolean outputStreaming) {
+    if (!ensureQueueModeReady()) {
+      return Uni.createFrom().failure(queueModeDisabledException());
+    }
     return submissionFlow().submit(input, tenantId, idempotencyKey, outputStreaming);
   }
 
@@ -209,6 +214,9 @@ class QueueAsyncCoordinator {
       String pipelineId,
       String contractVersion,
       String releaseVersion) {
+    if (!ensureQueueModeReady()) {
+      return Uni.createFrom().failure(queueModeDisabledException());
+    }
     return submissionFlow().submit(
         input,
         tenantId,
@@ -220,10 +228,16 @@ class QueueAsyncCoordinator {
   }
 
   Uni<ExecutionStatusDto> getExecutionStatus(String tenantId, String executionId) {
+    if (!ensureQueueModeReady()) {
+      return Uni.createFrom().failure(queueModeDisabledException());
+    }
     return executionReadModel().getExecutionStatus(tenantId, executionId);
   }
 
   <T> Uni<T> getExecutionResult(String tenantId, String executionId, Class<?> outputType, boolean outputStreaming) {
+    if (!ensureQueueModeReady()) {
+      return Uni.createFrom().failure(queueModeDisabledException());
+    }
     return executionReadModel().getExecutionResult(tenantId, executionId, outputType, outputStreaming);
   }
 
@@ -295,6 +309,9 @@ class QueueAsyncCoordinator {
   }
 
   Uni<Object> getExecutionResultPayload(String tenantId, String executionId) {
+    if (!ensureQueueModeReady()) {
+      return Uni.createFrom().failure(queueModeDisabledException());
+    }
     return executionReadModel().getExecutionResultPayload(tenantId, executionId);
   }
 
@@ -550,6 +567,25 @@ class QueueAsyncCoordinator {
     return tenantId != null && !tenantId.isBlank();
   }
 
+  private boolean ensureQueueModeReady() {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return false;
+    }
+    if (!queueModeInitialized && missingQueueProviders()) {
+      initializeQueueMode();
+    }
+    return true;
+  }
+
+  private boolean missingQueueProviders() {
+    return executionStateStore == null || workDispatcher == null || deadLetterPublisher == null;
+  }
+
+  private static IllegalStateException queueModeDisabledException() {
+    return new IllegalStateException(
+        "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC.");
+  }
+
   Uni<Void> recordAwaitItemContinuation(
       AwaitInteractionRecord interaction,
       org.pipelineframework.awaitable.AwaitUnitRecord unit,
@@ -588,6 +624,9 @@ class QueueAsyncCoordinator {
   }
 
   private ExecutionReadModel executionReadModel() {
+    if (!ensureQueueModeReady()) {
+      throw queueModeDisabledException();
+    }
     ExecutionReadModel current = executionReadModel;
     if (current != null) {
       return current;
@@ -610,6 +649,9 @@ class QueueAsyncCoordinator {
   }
 
   private QueueAsyncSubmissionFlow submissionFlow() {
+    if (!ensureQueueModeReady()) {
+      throw queueModeDisabledException();
+    }
     QueueAsyncSubmissionFlow current = submissionFlow;
     if (current != null) {
       return current;

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSubmissionFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSubmissionFlow.java
@@ -3,6 +3,7 @@ package org.pipelineframework;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Uni;
@@ -85,9 +86,9 @@ class QueueAsyncSubmissionFlow {
       String contractVersion,
       String releaseVersion) {
     return Uni.createFrom().deferred(() -> {
-      RuntimeException guardFailure = guardSubmission(outputStreaming);
-      if (guardFailure != null) {
-        return Uni.createFrom().failure(guardFailure);
+      Optional<RuntimeException> guardFailure = guardSubmission(outputStreaming);
+      if (guardFailure.isPresent()) {
+        return Uni.createFrom().failure(guardFailure.get());
       }
       Object executionInput = executionInputPolicy.normalizeExecutionInput(input);
       RuntimeException inputFailure = executionInputPolicy.validateInputShape(executionInput);
@@ -102,9 +103,9 @@ class QueueAsyncSubmissionFlow {
           releaseVersion,
           idempotencyKey,
           outputStreaming);
-      RuntimeException admissionFailure = admissionFailure(submission);
-      if (admissionFailure != null) {
-        return Uni.createFrom().failure(admissionFailure);
+      Optional<RuntimeException> admissionFailure = admissionFailure(submission);
+      if (admissionFailure.isPresent()) {
+        return Uni.createFrom().failure(admissionFailure.get());
       }
       long now = System.currentTimeMillis();
       long ttlEpochS = ttlEpochS(now);
@@ -116,16 +117,16 @@ class QueueAsyncSubmissionFlow {
     });
   }
 
-  private RuntimeException guardSubmission(boolean outputStreaming) {
+  private Optional<RuntimeException> guardSubmission(boolean outputStreaming) {
     if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC.");
+      return Optional.of(new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
     }
     if (outputStreaming) {
-      return new IllegalStateException(
-          "Async queue mode does not support streaming pipeline outputs yet.");
+      return Optional.of(new IllegalStateException(
+          "Async queue mode does not support streaming pipeline outputs yet."));
     }
-    return null;
+    return Optional.empty();
   }
 
   private Uni<PipelineRunSubmissionPlan> createPlan(
@@ -173,9 +174,11 @@ class QueueAsyncSubmissionFlow {
         .onItem().transform(ignored -> new RunAcceptance(created, now).toDto());
   }
 
-  private RuntimeException admissionFailure(PipelineRunSubmission submission) {
+  private Optional<RuntimeException> admissionFailure(PipelineRunSubmission submission) {
     ControlPlaneAdmissionDecision decision = admissionPolicy.admit(submission.admissionRequest());
-    return decision.allowed() ? null : new ControlPlaneAdmissionException(decision);
+    return decision.allowed()
+        ? Optional.empty()
+        : Optional.of(new ControlPlaneAdmissionException(decision));
   }
 
   private long ttlEpochS(long nowEpochMs) {

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSubmissionFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSubmissionFlow.java
@@ -1,0 +1,186 @@
+package org.pipelineframework;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.BadRequestException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionResultShapeResolver;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+
+class QueueAsyncSubmissionFlow {
+
+  private final PipelineOrchestratorConfig orchestratorConfig;
+  private final ExecutionInputPolicy executionInputPolicy;
+  private final ExecutionResultShapeResolver executionResultShapeResolver;
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final ControlPlaneAdmissionPolicy admissionPolicy;
+  private final Supplier<String> pipelineId;
+  private final Supplier<String> contractVersion;
+  private final Supplier<String> releaseVersion;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+
+  QueueAsyncSubmissionFlow(
+      PipelineOrchestratorConfig orchestratorConfig,
+      ExecutionInputPolicy executionInputPolicy,
+      ExecutionResultShapeResolver executionResultShapeResolver,
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      ControlPlaneAdmissionPolicy admissionPolicy,
+      Supplier<String> pipelineId,
+      Supplier<String> contractVersion,
+      Supplier<String> releaseVersion,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger) {
+    this.orchestratorConfig = Objects.requireNonNull(orchestratorConfig, "orchestratorConfig must not be null");
+    this.executionInputPolicy = Objects.requireNonNull(executionInputPolicy, "executionInputPolicy must not be null");
+    this.executionResultShapeResolver =
+        Objects.requireNonNull(executionResultShapeResolver, "executionResultShapeResolver must not be null");
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.workDispatcher = Objects.requireNonNull(workDispatcher, "workDispatcher must not be null");
+    this.admissionPolicy = Objects.requireNonNull(admissionPolicy, "admissionPolicy must not be null");
+    this.pipelineId = Objects.requireNonNull(pipelineId, "pipelineId must not be null");
+    this.contractVersion = Objects.requireNonNull(contractVersion, "contractVersion must not be null");
+    this.releaseVersion = Objects.requireNonNull(releaseVersion, "releaseVersion must not be null");
+    this.segmentBoundaryLedger =
+        Objects.requireNonNull(segmentBoundaryLedger, "segmentBoundaryLedger must not be null");
+  }
+
+  Uni<RunAsyncAcceptedDto> submit(
+      Object input,
+      String tenantId,
+      String idempotencyKey,
+      boolean outputStreaming) {
+    return submit(
+        input,
+        tenantId,
+        idempotencyKey,
+        outputStreaming,
+        pipelineId.get(),
+        contractVersion.get(),
+        releaseVersion.get());
+  }
+
+  Uni<RunAsyncAcceptedDto> submit(
+      Object input,
+      String tenantId,
+      String idempotencyKey,
+      boolean outputStreaming,
+      String pipelineId,
+      String contractVersion,
+      String releaseVersion) {
+    return Uni.createFrom().deferred(() -> {
+      RuntimeException guardFailure = guardSubmission(outputStreaming);
+      if (guardFailure != null) {
+        return Uni.createFrom().failure(guardFailure);
+      }
+      Object executionInput = executionInputPolicy.normalizeExecutionInput(input);
+      RuntimeException inputFailure = executionInputPolicy.validateInputShape(executionInput);
+      if (inputFailure != null) {
+        return Uni.createFrom().failure(inputFailure);
+      }
+      PipelineRunSubmission submission = new PipelineRunSubmission(
+          executionInputPolicy.normalizeTenant(tenantId),
+          tenantId != null && !tenantId.isBlank(),
+          pipelineId,
+          contractVersion,
+          releaseVersion,
+          idempotencyKey,
+          outputStreaming);
+      RuntimeException admissionFailure = admissionFailure(submission);
+      if (admissionFailure != null) {
+        return Uni.createFrom().failure(admissionFailure);
+      }
+      long now = System.currentTimeMillis();
+      long ttlEpochS = ttlEpochS(now);
+      return executionInputPolicy.resolveExecutionInputPayload(executionInput)
+          .onItem().transformToUni(snapshot -> createPlan(submission, snapshot, now, ttlEpochS))
+          .onItem().transform(PipelineRunSubmissionPlan::createCommand)
+          .onItem().transformToUni(command -> executionStateStore.createOrGetExecution(command)
+              .onItem().transformToUni(created -> accept(created, command, now)));
+    });
+  }
+
+  private RuntimeException guardSubmission(boolean outputStreaming) {
+    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+      return new IllegalStateException(
+          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC.");
+    }
+    if (outputStreaming) {
+      return new IllegalStateException(
+          "Async queue mode does not support streaming pipeline outputs yet.");
+    }
+    return null;
+  }
+
+  private Uni<PipelineRunSubmissionPlan> createPlan(
+      PipelineRunSubmission submission,
+      ExecutionInputSnapshot snapshot,
+      long now,
+      long ttlEpochS) {
+    String executionKey;
+    try {
+      executionKey = executionInputPolicy.resolveExecutionKey(
+          submission.tenantId(),
+          snapshot.payload(),
+          submission.idempotencyKey());
+    } catch (IllegalArgumentException e) {
+      return Uni.createFrom().failure(new BadRequestException(e.getMessage()));
+    }
+    ExecutionResultShape resultShape = executionResultShapeResolver.resolve();
+    try {
+      return Uni.createFrom().item(new PipelineRunSubmissionPlan(
+          submission,
+          snapshot,
+          executionKey,
+          resultShape,
+          now,
+          ttlEpochS));
+    } catch (IllegalArgumentException e) {
+      return Uni.createFrom().failure(new BadRequestException(e.getMessage()));
+    }
+  }
+
+  private Uni<RunAsyncAcceptedDto> accept(
+      CreateExecutionResult created,
+      ExecutionCreateCommand command,
+      long now) {
+    Uni<Void> recordSubmitted = created.duplicate()
+        ? Uni.createFrom().voidItem()
+        : segmentBoundaryLedger.get().recordRunSubmitted(created, command, now);
+    Uni<Void> enqueue = created.duplicate()
+        ? Uni.createFrom().voidItem()
+        : workDispatcher.enqueueNow(new ExecutionWorkItem(
+            created.record().tenantId(),
+            created.record().executionId()));
+    return recordSubmitted
+        .chain(() -> enqueue)
+        .onItem().transform(ignored -> new RunAcceptance(created, now).toDto());
+  }
+
+  private RuntimeException admissionFailure(PipelineRunSubmission submission) {
+    ControlPlaneAdmissionDecision decision = admissionPolicy.admit(submission.admissionRequest());
+    return decision.allowed() ? null : new ControlPlaneAdmissionException(decision);
+  }
+
+  private long ttlEpochS(long nowEpochMs) {
+    return Instant.ofEpochMilli(nowEpochMs)
+        .plus(Duration.ofDays(Math.max(1, orchestratorConfig.executionTtlDays())))
+        .getEpochSecond();
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/RunAcceptance.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/RunAcceptance.java
@@ -1,0 +1,22 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+
+record RunAcceptance(CreateExecutionResult created, long acceptedAtEpochMs) {
+
+  RunAcceptance {
+    Objects.requireNonNull(created, "created must not be null");
+  }
+
+  RunAsyncAcceptedDto toDto() {
+    String executionId = created.record().executionId();
+    return new RunAsyncAcceptedDto(
+        executionId,
+        created.duplicate(),
+        "/pipeline/executions/" + executionId,
+        acceptedAtEpochMs);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ExecutionReadModelTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ExecutionReadModelTest.java
@@ -28,7 +28,6 @@ import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -119,7 +118,7 @@ class ExecutionReadModelTest {
   }
 
   @Test
-  void succeededSingleEmptyResultReturnsNull() {
+  void succeededSingleEmptyResultReturnsEmptyOptional() {
     when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
     when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
     when(executionStateStore.getExecution("tenant-1", "exec-empty"))
@@ -132,7 +131,7 @@ class ExecutionReadModelTest {
     Object result = readModel.getExecutionResult("tenant-1", "exec-empty", String.class, false)
         .await().indefinitely();
 
-    assertNull(result);
+    assertEquals(Optional.empty(), result);
   }
 
   @Test
@@ -146,6 +145,23 @@ class ExecutionReadModelTest {
     Optional<Object> result = view.typedOptionalResult(String.class, false, () -> payloadCodec);
 
     assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void succeededSingleEmptyRawPayloadReturnsEmptyOptional() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-empty"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-empty",
+            ExecutionResultShape.SINGLE,
+            List.of()))));
+
+    Object result = readModel.getExecutionResultPayload("tenant-1", "exec-empty")
+        .await().indefinitely();
+
+    assertEquals(Optional.empty(), result);
   }
 
   @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/ExecutionReadModelTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ExecutionReadModelTest.java
@@ -1,0 +1,371 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.SerializedTransitionPayload;
+import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutionReadModelTest {
+
+  @Mock
+  private PipelineOrchestratorConfig orchestratorConfig;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private ControlPlaneAdmissionPolicy admissionPolicy;
+
+  private ExecutionInputPolicy executionInputPolicy;
+  private JsonTransitionPayloadCodec payloadCodec;
+  private ExecutionReadModel readModel;
+
+  @BeforeEach
+  void setUp() {
+    executionInputPolicy = new ExecutionInputPolicy();
+    executionInputPolicy.orchestratorConfig = orchestratorConfig;
+    payloadCodec = new JsonTransitionPayloadCodec();
+    readModel = new ExecutionReadModel(
+        orchestratorConfig,
+        executionInputPolicy,
+        executionStateStore,
+        admissionPolicy,
+        () -> "pipeline-a",
+        () -> "release-a",
+        () -> payloadCodec);
+  }
+
+  @Test
+  void statusReturnsExecutionStatusDto() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(record("tenant-1", "exec-1", ExecutionStatus.RUNNING))));
+
+    ExecutionStatusDto dto = readModel.getExecutionStatus("tenant-1", "exec-1").await().indefinitely();
+
+    assertEquals("exec-1", dto.executionId());
+    assertEquals(ExecutionStatus.RUNNING, dto.status());
+    assertEquals(1L, dto.version());
+  }
+
+  @Test
+  void queueModeDisabledFailsBeforeStoreLookup() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        readModel.getExecutionStatus("tenant-1", "exec-1").await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Async queue mode is disabled"));
+    verify(executionStateStore, never()).getExecution(any(), any());
+  }
+
+  @Test
+  void admissionDeniedFailsBeforeStoreLookup() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any()))
+        .thenReturn(ControlPlaneAdmissionDecision.deny("read-denied", "no reads"));
+
+    ControlPlaneAdmissionException error = assertThrows(ControlPlaneAdmissionException.class, () ->
+        readModel.getExecutionStatus("tenant-1", "exec-1").await().indefinitely());
+
+    assertTrue(error.getMessage().contains("read-denied"));
+    verify(executionStateStore, never()).getExecution(any(), any());
+  }
+
+  @Test
+  void missingExecutionThrowsNotFound() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "missing"))
+        .thenReturn(Uni.createFrom().item(Optional.empty()));
+
+    NotFoundException error = assertThrows(NotFoundException.class, () ->
+        readModel.getExecutionResult("tenant-1", "missing", String.class, false).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Execution not found: missing"));
+  }
+
+  @Test
+  void succeededSingleEmptyResultReturnsNull() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-empty"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-empty",
+            ExecutionResultShape.SINGLE,
+            List.of()))));
+
+    Object result = readModel.getExecutionResult("tenant-1", "exec-empty", String.class, false)
+        .await().indefinitely();
+
+    assertNull(result);
+  }
+
+  @Test
+  void succeededSingleEmptyResultProducesEmptyOptionalView() {
+    ExecutionResultView view = new ExecutionResultView(succeeded(
+        "tenant-1",
+        "exec-empty",
+        ExecutionResultShape.SINGLE,
+        List.of()));
+
+    Optional<Object> result = view.typedOptionalResult(String.class, false, () -> payloadCodec);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void succeededSingleOneItemReturnsTypedItem() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-one"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-one",
+            ExecutionResultShape.SINGLE,
+            List.of(Map.of("value", "ok"))))));
+
+    TestResult result = (TestResult) readModel.getExecutionResult("tenant-1", "exec-one", TestResult.class, false)
+        .await().indefinitely();
+
+    assertEquals("ok", result.value());
+  }
+
+  @Test
+  void corruptSingleMultipleItemsFails() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-corrupt"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-corrupt",
+            ExecutionResultShape.SINGLE,
+            List.of("a", "b")))));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        readModel.getExecutionResult("tenant-1", "exec-corrupt", String.class, false).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("multiple terminal items"));
+  }
+
+  @Test
+  void succeededMaterializedMultiReturnsListForStreamingRetrieval() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-multi"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-multi",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            List.of("a", "b")))));
+
+    Object result = readModel.getExecutionResult("tenant-1", "exec-multi", String.class, true)
+        .await().indefinitely();
+
+    assertEquals(List.of("a", "b"), result);
+  }
+
+  @Test
+  void nonStreamingRetrievalOfMaterializedMultiFails() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-multi"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-multi",
+            ExecutionResultShape.MATERIALIZED_MULTI,
+            List.of("a", "b")))));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        readModel.getExecutionResult("tenant-1", "exec-multi", String.class, false).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("materialized multi result"));
+  }
+
+  @Test
+  void runningExecutionSaysNotComplete() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-running"))
+        .thenReturn(Uni.createFrom().item(Optional.of(record("tenant-1", "exec-running", ExecutionStatus.RUNNING))));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        readModel.getExecutionResult("tenant-1", "exec-running", String.class, false).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Execution is not complete yet: RUNNING"));
+  }
+
+  @Test
+  void failedExecutionSaysFinishedWithoutSuccessfulResult() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-failed"))
+        .thenReturn(Uni.createFrom().item(Optional.of(record("tenant-1", "exec-failed", ExecutionStatus.FAILED))));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        readModel.getExecutionResult("tenant-1", "exec-failed", String.class, false).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Execution finished without a successful result: FAILED"));
+  }
+
+  @Test
+  void dlqExecutionSaysFinishedWithoutSuccessfulResult() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("tenant-1", "exec-dlq"))
+        .thenReturn(Uni.createFrom().item(Optional.of(record("tenant-1", "exec-dlq", ExecutionStatus.DLQ))));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        readModel.getExecutionResult("tenant-1", "exec-dlq", String.class, false).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Execution finished without a successful result: DLQ"));
+  }
+
+  @Test
+  void typedRetrievalDecodesSerializedTransitionPayload() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    SerializedTransitionPayload serialized = payloadCodec.encode(Map.of("value", "decoded"));
+    when(executionStateStore.getExecution("tenant-1", "exec-serialized"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-serialized",
+            ExecutionResultShape.SINGLE,
+            List.of(serialized)))));
+
+    TestResult result = (TestResult) readModel.getExecutionResult(
+            "tenant-1",
+            "exec-serialized",
+            TestResult.class,
+            false)
+        .await().indefinitely();
+
+    assertEquals("decoded", result.value());
+  }
+
+  @Test
+  void rawPayloadRetrievalReturnsStoredPayloadWithoutTypedCoercion() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    SerializedTransitionPayload serialized = payloadCodec.encode(Map.of("value", "raw"));
+    when(executionStateStore.getExecution("tenant-1", "exec-raw"))
+        .thenReturn(Uni.createFrom().item(Optional.of(succeeded(
+            "tenant-1",
+            "exec-raw",
+            ExecutionResultShape.SINGLE,
+            List.of(serialized)))));
+
+    Object result = readModel.getExecutionResultPayload("tenant-1", "exec-raw").await().indefinitely();
+
+    assertInstanceOf(SerializedTransitionPayload.class, result);
+    assertEquals(serialized, result);
+  }
+
+  @Test
+  void admissionRequestUsesNormalizedTenantAndReleaseIdentity() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    when(orchestratorConfig.defaultTenant()).thenReturn("default-tenant");
+    when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    when(executionStateStore.getExecution("default-tenant", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(record("default-tenant", "exec-1", ExecutionStatus.RUNNING))));
+
+    readModel.getExecutionStatus(null, "exec-1").await().indefinitely();
+
+    org.mockito.ArgumentCaptor<ControlPlaneAdmissionRequest> request =
+        org.mockito.ArgumentCaptor.forClass(ControlPlaneAdmissionRequest.class);
+    verify(admissionPolicy).admit(request.capture());
+    assertEquals("default-tenant", request.getValue().tenantId());
+    assertEquals("pipeline-a", request.getValue().pipelineId());
+    assertEquals("release-a", request.getValue().releaseVersion());
+    assertFalse(request.getValue().explicitTenant());
+  }
+
+  private ExecutionRecord<Object, Object> record(String tenantId, String executionId, ExecutionStatus status) {
+    return new ExecutionRecord<>(
+        tenantId,
+        executionId,
+        "key-" + executionId,
+        ExecutionResultShape.SINGLE,
+        status,
+        1L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        1L,
+        2L,
+        99999999L);
+  }
+
+  private ExecutionRecord<Object, Object> succeeded(
+      String tenantId,
+      String executionId,
+      ExecutionResultShape resultShape,
+      List<?> resultPayload) {
+    return new ExecutionRecord<>(
+        tenantId,
+        executionId,
+        "key-" + executionId,
+        resultShape,
+        ExecutionStatus.SUCCEEDED,
+        1L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        null,
+        null,
+        resultPayload,
+        null,
+        null,
+        1L,
+        2L,
+        99999999L);
+  }
+
+  record TestResult(String value) {
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineRunSubmissionPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineRunSubmissionPlanTest.java
@@ -1,0 +1,85 @@
+package org.pipelineframework;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PipelineRunSubmissionPlanTest {
+
+  @Test
+  void scopesIdempotencyKeyByPipelineIdAndReleaseVersion() {
+    PipelineRunSubmissionPlan left = plan("pipeline-a", "release-1", "client-key");
+    PipelineRunSubmissionPlan right = plan("pipeline-b", "release-1", "client-key");
+
+    assertEquals("10:pipeline-a:9:release-1:executionKey:client-key", left.executionKey());
+    assertEquals("10:pipeline-b:9:release-1:executionKey:client-key", right.executionKey());
+  }
+
+  @Test
+  void rejectsBlankScopedValues() {
+    IllegalArgumentException pipeline = assertThrows(IllegalArgumentException.class,
+        () -> plan(" ", "release-1", "client-key"));
+    IllegalArgumentException release = assertThrows(IllegalArgumentException.class,
+        () -> plan("pipeline-a", "", "client-key"));
+    IllegalArgumentException executionKey = assertThrows(IllegalArgumentException.class,
+        () -> plan("pipeline-a", "release-1", null));
+
+    assertEquals("pipelineId must not be blank", pipeline.getMessage());
+    assertEquals("releaseVersion must not be blank", release.getMessage());
+    assertEquals("executionKey must not be blank", executionKey.getMessage());
+  }
+
+  @Test
+  void buildsExecutionCreateCommandWithIdentityTtlSnapshotAndResultShape() {
+    ExecutionInputSnapshot snapshot = new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input");
+    PipelineRunSubmission submission = new PipelineRunSubmission(
+        "tenant-1",
+        true,
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        "client-key",
+        false);
+    PipelineRunSubmissionPlan plan = new PipelineRunSubmissionPlan(
+        submission,
+        snapshot,
+        "resolved-key",
+        ExecutionResultShape.MATERIALIZED_MULTI,
+        100L,
+        200L);
+
+    ExecutionCreateCommand command = plan.createCommand();
+
+    assertEquals("tenant-1", command.tenantId());
+    assertEquals("10:pipeline-a:9:release-a:executionKey:resolved-key", command.executionKey());
+    assertEquals("pipeline-a", command.pipelineId());
+    assertEquals("contract-a", command.contractVersion());
+    assertEquals("release-a", command.releaseVersion());
+    assertEquals(snapshot, command.inputPayload());
+    assertEquals(ExecutionResultShape.MATERIALIZED_MULTI, command.resultShape());
+    assertEquals(100L, command.nowEpochMs());
+    assertEquals(200L, command.ttlEpochS());
+  }
+
+  private PipelineRunSubmissionPlan plan(String pipelineId, String releaseVersion, String executionKey) {
+    return new PipelineRunSubmissionPlan(
+        new PipelineRunSubmission(
+            "tenant-1",
+            true,
+            pipelineId,
+            "contract-a",
+            releaseVersion,
+            "client-key",
+            false),
+        new ExecutionInputSnapshot(ExecutionInputShape.UNI, "input"),
+        executionKey,
+        ExecutionResultShape.SINGLE,
+        10L,
+        20L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncArchitectureFitnessTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncArchitectureFitnessTest.java
@@ -129,11 +129,12 @@ class QueueAsyncArchitectureFitnessTest {
 
   private static void assertOnlyFileCalls(String invocation, String allowedType) throws IOException {
     Path packageRoot = sourceRoot().resolve("org/pipelineframework");
-    try (var files = Files.list(packageRoot)) {
+    try (var files = Files.walk(packageRoot)) {
       List<Path> offenders = files
+          .filter(Files::isRegularFile)
           .filter(path -> path.getFileName().toString().endsWith(".java"))
           .filter(path -> !path.getFileName().toString().equals(allowedType + ".java"))
-          .filter(path -> contains(path, invocation + "("))
+          .filter(path -> contains(path, "." + invocation + "("))
           .toList();
       assertTrue(offenders.isEmpty(), () -> invocation + " may only be called by " + allowedType + ": " + offenders);
     }

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncArchitectureFitnessTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncArchitectureFitnessTest.java
@@ -1,0 +1,189 @@
+package org.pipelineframework;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueueAsyncArchitectureFitnessTest {
+
+  private static final List<String> PURE_MODEL_FILES = List.of(
+      "ClaimedSegment",
+      "SegmentCommitPlan",
+      "CompletedSegment",
+      "SuspendedSegment",
+      "FailedSegment",
+      "TerminalPublicationPlan",
+      "AwaitContinuationPlan",
+      "AwaitContinuationPlanner",
+      "ItemContinuationKey",
+      "ItemizedParentRelease");
+
+  private static final Pattern FORBIDDEN_PURE_IMPORT = Pattern.compile(
+      "^import\\s+.*("
+          + "Store|Dispatcher|Publisher|CheckpointPublicationService|ObjectPublishCompletionService|"
+          + "AwaitCoordinator|SegmentBoundaryLedger|jakarta\\.|javax\\.|Logger|"
+          + "io\\.smallrye\\.mutiny\\.|\\.Uni|\\.Multi"
+          + ").*;",
+      Pattern.MULTILINE);
+
+  private static final Pattern FORBIDDEN_PURE_INVOCATION = Pattern.compile(
+      "\\.\\s*(mark\\w*|enqueue\\w*|publish\\w*|dispatch(?!Complete\\(|ClaimKey\\()\\w*|subscribe)\\s*\\(");
+
+  @Test
+  void pureQueueAsyncModelsDoNotImportOrInvokeImperativeShells() throws IOException {
+    for (String type : PURE_MODEL_FILES) {
+      Path source = source(type);
+      if (!Files.exists(source)) {
+        continue;
+      }
+      String code = stripComments(Files.readString(source));
+
+      Matcher importMatcher = FORBIDDEN_PURE_IMPORT.matcher(code);
+      assertFalse(
+          importMatcher.find(),
+          () -> type + " must stay pure; forbidden import: " + importMatcher.group());
+
+      Matcher invocationMatcher = FORBIDDEN_PURE_INVOCATION.matcher(code);
+      assertFalse(
+          invocationMatcher.find(),
+          () -> type + " must not perform shell effects; forbidden invocation: " + invocationMatcher.group());
+    }
+  }
+
+  @Test
+  void coordinatorStaysFacadeForSegmentAndAwaitCompletionPaths() throws IOException {
+    String coordinator = Files.readString(source("QueueAsyncCoordinator"));
+
+    assertFalse(coordinator.contains("TransitionWorkerOutcome"),
+        "QueueAsyncCoordinator must not branch on worker outcomes");
+    assertFalse(coordinator.contains("TransitionResultEnvelope"),
+        "QueueAsyncCoordinator must not branch on transition result envelopes");
+    assertAbsent(coordinator, "handleCompletedTransition");
+    assertAbsent(coordinator, "prepareTransitionCommand");
+    assertAbsent(coordinator, "runAsyncExecution");
+    assertAbsent(coordinator, "markWaitingExternal");
+    assertAbsent(coordinator, "publishTerminalOutputsIfConfigured");
+
+    assertTrue(
+        coordinator.contains("return segmentPipeline().process(workItem, worker, itemContinuationHandler);"),
+        "processExecutionWorkItem must delegate to QueueAsyncSegmentPipeline");
+    assertTrue(
+        coordinator.contains("return awaitBoundaryAdmission().complete(command, itemContinuationHandler);"),
+        "completeAwait must delegate to AwaitBoundaryAdmission");
+  }
+
+  @Test
+  void effectCallsStayBehindExplicitBoundaries() throws IOException {
+    assertOnlyFileCalls("publishIfConfigured", "TerminalPublicationBoundary");
+
+    String segmentEffects = Files.readString(source("SegmentCommitEffects"));
+    assertTrue(segmentEffects.contains(".markSucceeded("),
+        "SegmentCommitEffects owns transition success projection writes");
+    assertTrue(segmentEffects.contains(".markWaitingExternal("),
+        "SegmentCommitEffects owns transition suspend projection writes");
+
+    for (String type : PURE_MODEL_FILES) {
+      Path source = source(type);
+      if (!Files.exists(source)) {
+        continue;
+      }
+      String code = stripComments(Files.readString(source));
+      assertFalse(code.contains(".markSucceeded("), type + " must not mark transition success");
+      assertFalse(code.contains(".markWaitingExternal("), type + " must not mark transition suspension");
+      assertFalse(code.contains(".markTerminalFailure("), type + " must not mark transition failure");
+    }
+  }
+
+  @Test
+  void segmentPipelineHasSingleSubscriptionBoundaryAndNoManualSubscribe() throws IOException {
+    String pipeline = Files.readString(source("QueueAsyncSegmentPipeline"));
+
+    assertEquals(
+        1,
+        occurrences(pipeline, "Uni.createFrom().deferred("),
+        "QueueAsyncSegmentPipeline should have exactly one per-subscription deferred boundary");
+    assertFalse(pipeline.contains(".subscribe("), "QueueAsyncSegmentPipeline must not subscribe manually");
+  }
+
+  @Test
+  void queueAsyncClassesStayBelowGodClassGuardrails() throws IOException {
+    assertLineCountAtMost("QueueAsyncCoordinator", 1050);
+    assertLineCountAtMost("AwaitContinuations", 900);
+    assertLineCountAtMost("QueueAsyncSegmentPipeline", 275);
+    assertLineCountAtMost("SegmentCommitEffects", 250);
+    assertLineCountAtMost("TerminalPublicationBoundary", 175);
+  }
+
+  private static void assertAbsent(String code, String token) {
+    assertFalse(code.contains(token), () -> token + " should not be reintroduced in QueueAsyncCoordinator");
+  }
+
+  private static void assertOnlyFileCalls(String invocation, String allowedType) throws IOException {
+    Path packageRoot = sourceRoot().resolve("org/pipelineframework");
+    try (var files = Files.list(packageRoot)) {
+      List<Path> offenders = files
+          .filter(path -> path.getFileName().toString().endsWith(".java"))
+          .filter(path -> !path.getFileName().toString().equals(allowedType + ".java"))
+          .filter(path -> contains(path, invocation + "("))
+          .toList();
+      assertTrue(offenders.isEmpty(), () -> invocation + " may only be called by " + allowedType + ": " + offenders);
+    }
+  }
+
+  private static boolean contains(Path path, String token) {
+    try {
+      return stripComments(Files.readString(path)).contains(token);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed reading " + path, e);
+    }
+  }
+
+  private static int occurrences(String code, String token) {
+    int count = 0;
+    int index = 0;
+    while ((index = code.indexOf(token, index)) >= 0) {
+      count++;
+      index += token.length();
+    }
+    return count;
+  }
+
+  private static void assertLineCountAtMost(String type, int maxLines) throws IOException {
+    long lines;
+    try (var sourceLines = Files.lines(source(type))) {
+      lines = sourceLines.count();
+    }
+    assertTrue(lines <= maxLines, () -> type + ".java has " + lines + " lines; limit is " + maxLines);
+  }
+
+  private static Path source(String type) {
+    return sourceRoot().resolve("org/pipelineframework/" + type + ".java");
+  }
+
+  private static Path sourceRoot() {
+    Path fromRepoRoot = Path.of("framework/runtime/src/main/java");
+    if (Files.exists(fromRepoRoot)) {
+      return fromRepoRoot;
+    }
+    Path fromModuleRoot = Path.of("src/main/java");
+    if (Files.exists(fromModuleRoot)) {
+      return fromModuleRoot;
+    }
+    throw new IllegalStateException("Cannot locate runtime source root from " + Path.of("").toAbsolutePath());
+  }
+
+  private static String stripComments(String code) {
+    return code
+        .replaceAll("(?s)/\\*.*?\\*/", "")
+        .replaceAll("(?m)//.*$", "");
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -70,6 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -199,6 +200,32 @@ class QueueAsyncCoordinatorTest {
 
         IllegalStateException error = assertThrows(IllegalStateException.class, coordinator::initializeQueueMode);
         assertTrue(error.getMessage().contains("ExecutionStateStore(dynamo)"));
+    }
+
+    @Test
+    void getExecutionStatusInitializesQueueProvidersBeforeCachingReadModel() {
+        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+        coordinator.executionStateStore = null;
+        coordinator.workDispatcher = null;
+        coordinator.deadLetterPublisher = null;
+        when(executionStateStore.providerName()).thenReturn("memory");
+        when(workDispatcher.providerName()).thenReturn("memory");
+        when(deadLetterPublisher.providerName()).thenReturn("log");
+        when(executionStateStore.startupValidationError(orchestratorConfig)).thenReturn(Optional.empty());
+        when(workDispatcher.startupValidationError(orchestratorConfig)).thenReturn(Optional.empty());
+        when(deadLetterPublisher.startupValidationError(orchestratorConfig)).thenReturn(Optional.empty());
+        when(executionStateStores.stream()).thenReturn(Stream.of(executionStateStore));
+        when(workDispatchers.stream()).thenReturn(Stream.of(workDispatcher));
+        when(deadLetterPublishers.stream()).thenReturn(Stream.of(deadLetterPublisher));
+        ExecutionRecord<Object, Object> record = createRecord("tenant-1", "exec-1", "key-1");
+        when(executionStateStore.getExecution("tenant-1", "exec-1"))
+            .thenReturn(Uni.createFrom().item(Optional.of(record)));
+
+        ExecutionStatusDto dto = coordinator.getExecutionStatus("tenant-1", "exec-1").await().indefinitely();
+
+        assertEquals("exec-1", dto.executionId());
+        assertSame(executionStateStore, coordinator.executionStateStore);
+        assertSame(workDispatcher, coordinator.workDispatcher);
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -1080,54 +1080,39 @@ class QueueAsyncCoordinatorTest {
     }
 
     @Test
-    void getExecutionResultReturnsStoredListForMaterializedMulti() {
+    void getExecutionResultDelegatesToReadModel() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        when(executionStateStore.getExecution("tenant-1", "exec-multi"))
+        when(executionStateStore.getExecution("tenant-1", "exec-single"))
             .thenReturn(Uni.createFrom().item(Optional.of(succeededRecord(
                 "tenant-1",
-                "exec-multi",
-                "key-multi",
-                ExecutionResultShape.MATERIALIZED_MULTI,
-                List.of("a", "b")))));
+                "exec-single",
+                "key-single",
+                ExecutionResultShape.SINGLE,
+                List.of("value")))));
 
-        Object result = coordinator.getExecutionResult("tenant-1", "exec-multi", String.class, true)
+        Object result = coordinator.getExecutionResult("tenant-1", "exec-single", String.class, false)
             .await().indefinitely();
 
-        assertEquals(List.of("a", "b"), result);
+        assertEquals("value", result);
+        verify(executionStateStore).getExecution("tenant-1", "exec-single");
     }
 
     @Test
-    void getExecutionResultRejectsUnaryRetrievalForMaterializedMulti() {
+    void getExecutionResultPayloadDelegatesToReadModel() {
         when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        when(executionStateStore.getExecution("tenant-1", "exec-multi"))
+        when(executionStateStore.getExecution("tenant-1", "exec-payload"))
             .thenReturn(Uni.createFrom().item(Optional.of(succeededRecord(
                 "tenant-1",
-                "exec-multi",
-                "key-multi",
-                ExecutionResultShape.MATERIALIZED_MULTI,
-                List.of("a", "b")))));
-
-        IllegalStateException error = assertThrows(IllegalStateException.class, () ->
-            coordinator.getExecutionResult("tenant-1", "exec-multi", String.class, false).await().indefinitely());
-
-        assertTrue(error.getMessage().contains("materialized multi result"));
-    }
-
-    @Test
-    void getExecutionResultRejectsCorruptSingleResultList() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        when(executionStateStore.getExecution("tenant-1", "exec-corrupt"))
-            .thenReturn(Uni.createFrom().item(Optional.of(succeededRecord(
-                "tenant-1",
-                "exec-corrupt",
-                "key-corrupt",
+                "exec-payload",
+                "key-payload",
                 ExecutionResultShape.SINGLE,
-                List.of("a", "b")))));
+                List.of("raw")))));
 
-        IllegalStateException error = assertThrows(IllegalStateException.class, () ->
-            coordinator.getExecutionResult("tenant-1", "exec-corrupt", String.class, false).await().indefinitely());
+        Object result = coordinator.getExecutionResultPayload("tenant-1", "exec-payload")
+            .await().indefinitely();
 
-        assertTrue(error.getMessage().contains("multiple terminal items"));
+        assertEquals("raw", result);
+        verify(executionStateStore).getExecution("tenant-1", "exec-payload");
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
 import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
 import org.pipelineframework.orchestrator.ControlPlaneTransitionAdmission;
@@ -37,7 +35,6 @@ import org.pipelineframework.orchestrator.InMemoryExecutionStateStore;
 import org.pipelineframework.orchestrator.LoggingDeadLetterPublisher;
 import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
 import org.pipelineframework.orchestrator.OrchestratorMode;
-import org.pipelineframework.orchestrator.PipelineReleaseIdentityResolver;
 import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
 import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
 import org.pipelineframework.orchestrator.LocalControlPlaneAdmissionPolicy;
@@ -52,7 +49,6 @@ import org.pipelineframework.orchestrator.DynamoExecutionStateStore;
 import org.pipelineframework.orchestrator.controlplane.BoundaryUnitStatus;
 import org.pipelineframework.orchestrator.controlplane.ControlPlaneProjection;
 import org.pipelineframework.orchestrator.controlplane.InMemoryControlPlaneJournal;
-import org.pipelineframework.orchestrator.controlplane.PipelineRunStatus;
 import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
 import org.pipelineframework.orchestrator.dto.ExecutionStatusDto;
 import org.pipelineframework.awaitable.AwaitCompletionCommand;
@@ -74,7 +70,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -172,22 +167,22 @@ class QueueAsyncCoordinatorTest {
     }
 
     @Test
-    void executePipelineAsyncRequiresQueueMode() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+    void executePipelineAsyncDelegatesToSubmissionFlow() {
+        configureQueueModeDefaults();
+        when(executionStateStore.createOrGetExecution(any()))
+            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
+                createRecord("tenant-1", "exec-submit", "key-submit"),
+                true)));
 
-        Uni<?> result = coordinator.executePipelineAsync("input", "tenant-1", "idem-1", false);
+        coordinator.executePipelineAsync("input", "tenant-1", "client-key", false)
+            .await().indefinitely();
 
-        assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
-    }
-
-    @Test
-    void executePipelineAsyncRejectsStreamingOutputFlagInQueueMode() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-
-        Uni<?> result = coordinator.executePipelineAsync("input", "tenant-1", "idem-1", true);
-
-        IllegalStateException error = assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
-        assertTrue(error.getMessage().contains("does not support streaming pipeline outputs"));
+        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
+            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
+        verify(executionStateStore).createOrGetExecution(captor.capture());
+        assertEquals("local-pipeline", captor.getValue().pipelineId());
+        assertEquals("local-contract", captor.getValue().contractVersion());
+        assertEquals("local-contract", captor.getValue().releaseVersion());
     }
 
     @Test
@@ -337,125 +332,29 @@ class QueueAsyncCoordinatorTest {
     }
 
     @Test
-    void executePipelineAsyncPersistsUniInputShapeForPlainArrayPayload() {
+    void executePipelineAsyncExplicitIdentityOverloadDelegatesToSubmissionFlow() {
         configureQueueModeDefaults();
         when(executionStateStore.createOrGetExecution(any()))
             .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
-                createRecord("tenant-1", "exec-uni", "key-uni"),
+                createRecord("tenant-1", "exec-explicit", "key-explicit"),
                 true)));
 
-        coordinator.executePipelineAsync(java.util.List.of("a", "b"), "tenant-1", null, false)
+        coordinator.executePipelineAsync(
+                "input",
+                "tenant-1",
+                "client-key",
+                false,
+                "pipeline-explicit",
+                "contract-explicit",
+                "release-explicit")
             .await().indefinitely();
 
         ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
             ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
         verify(executionStateStore).createOrGetExecution(captor.capture());
-        Object persisted = captor.getValue().inputPayload();
-        assertTrue(persisted instanceof ExecutionInputSnapshot);
-        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) persisted;
-        assertEquals(ExecutionInputShape.UNI, snapshot.shape());
-        assertEquals(java.util.List.of("a", "b"), snapshot.payload());
-        assertEquals(ExecutionResultShape.SINGLE, captor.getValue().resultShape());
-    }
-
-    @Test
-    void executePipelineAsyncAppendsRunSubmittedForNewExecution() {
-        configureQueueModeDefaults();
-        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
-        coordinator.segmentBoundaryLedger = new SegmentBoundaryLedger(journal);
-        ExecutionRecord<Object, Object> record = createRecord("tenant-1", "exec-ledger", "key-ledger");
-        when(executionStateStore.createOrGetExecution(any()))
-            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record, false)));
-        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
-
-        coordinator.executePipelineAsync("input", "tenant-1", null, false).await().indefinitely();
-
-        ControlPlaneProjection projection = journal.projection("tenant-1", "exec-ledger").await().indefinitely();
-        assertEquals(PipelineRunStatus.ACCEPTED, projection.status());
-        assertTrue(projection.factKeys().contains("run-submitted:tenant-1:exec-ledger"));
-    }
-
-    @Test
-    void executePipelineAsyncRejectsDeniedTenantBeforeStoreAccess() {
-        when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
-        PipelineOrchestratorConfig.TenancyConfig tenancy = mock(PipelineOrchestratorConfig.TenancyConfig.class);
-        when(orchestratorConfig.tenancy()).thenReturn(tenancy);
-        when(tenancy.allowedTenants()).thenReturn(List.of("tenant-allowed"));
-        when(tenancy.requireExplicitTenant()).thenReturn(false);
-        coordinator.controlPlaneAdmissionPolicy = new LocalControlPlaneAdmissionPolicy(orchestratorConfig);
-
-        Uni<?> result = coordinator.executePipelineAsync("input", "tenant-denied", null, false);
-
-        ControlPlaneAdmissionException error = assertThrows(
-            ControlPlaneAdmissionException.class,
-            () -> result.await().indefinitely());
-        assertTrue(error.getMessage().contains("TENANT_NOT_ALLOWED"));
-        verify(executionStateStore, never()).createOrGetExecution(any());
-    }
-
-    @Test
-    void executePipelineAsyncPersistsMultiInputShapeForStreamingPayload() {
-        configureQueueModeDefaults();
-        when(executionStateStore.createOrGetExecution(any()))
-            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
-                createRecord("tenant-1", "exec-multi", "key-multi", ExecutionResultShape.MATERIALIZED_MULTI),
-                true)));
-
-        coordinator.executePipelineAsync(Multi.createFrom().items("x", "y"), "tenant-1", null, false)
-            .await().indefinitely();
-
-        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
-            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
-        verify(executionStateStore).createOrGetExecution(captor.capture());
-        Object persisted = captor.getValue().inputPayload();
-        assertTrue(persisted instanceof ExecutionInputSnapshot);
-        ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) persisted;
-        assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
-        assertEquals(java.util.List.of("x", "y"), snapshot.payload());
-    }
-
-    @Test
-    void executePipelineAsyncPersistsResolvedMaterializedMultiResultShape() {
-        configureQueueModeDefaults();
-        when(executionResultShapeResolver.resolve()).thenReturn(ExecutionResultShape.MATERIALIZED_MULTI);
-        when(executionStateStore.createOrGetExecution(any()))
-            .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
-                createRecord("tenant-1", "exec-resolved", "key-resolved", ExecutionResultShape.MATERIALIZED_MULTI),
-                true)));
-
-        coordinator.executePipelineAsync("input", "tenant-1", null, false)
-            .await().indefinitely();
-
-        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
-            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
-        verify(executionStateStore).createOrGetExecution(captor.capture());
-        assertEquals(ExecutionResultShape.MATERIALIZED_MULTI, captor.getValue().resultShape());
-    }
-
-    @Test
-    void executePipelineAsyncScopesIdempotencyKeyByPipelineAndRelease() {
-        configureQueueModeDefaults();
-        PipelineReleaseIdentityResolver identityResolver = mock(PipelineReleaseIdentityResolver.class);
-        coordinator.releaseIdentityResolver = identityResolver;
-        when(identityResolver.pipelineId(orchestratorConfig)).thenReturn("pipeline-a", "pipeline-b");
-        when(identityResolver.contractVersion()).thenReturn("contract-1", "contract-1");
-        when(identityResolver.releaseVersion(orchestratorConfig)).thenReturn("release-1", "release-1");
-        when(executionStateStore.createOrGetExecution(any()))
-            .thenReturn(
-                Uni.createFrom().item(new CreateExecutionResult(createRecord("tenant-1", "exec-a", "key-a"), false)),
-                Uni.createFrom().item(new CreateExecutionResult(createRecord("tenant-1", "exec-b", "key-b"), false)));
-        when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
-
-        coordinator.executePipelineAsync("input", "tenant-1", "client-key", false).await().indefinitely();
-        coordinator.executePipelineAsync("input", "tenant-1", "client-key", false).await().indefinitely();
-
-        ArgumentCaptor<org.pipelineframework.orchestrator.ExecutionCreateCommand> captor =
-            ArgumentCaptor.forClass(org.pipelineframework.orchestrator.ExecutionCreateCommand.class);
-        verify(executionStateStore, org.mockito.Mockito.times(2)).createOrGetExecution(captor.capture());
-        List<org.pipelineframework.orchestrator.ExecutionCreateCommand> commands = captor.getAllValues();
-        assertEquals("pipeline-a", commands.get(0).pipelineId());
-        assertEquals("pipeline-b", commands.get(1).pipelineId());
-        assertNotEquals(commands.get(0).executionKey(), commands.get(1).executionKey());
+        assertEquals("pipeline-explicit", captor.getValue().pipelineId());
+        assertEquals("contract-explicit", captor.getValue().contractVersion());
+        assertEquals("release-explicit", captor.getValue().releaseVersion());
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSubmissionFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSubmissionFlowTest.java
@@ -1,0 +1,287 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionInputShape;
+import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionResultShapeResolver;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.orchestrator.dto.RunAsyncAcceptedDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAsyncSubmissionFlowTest {
+
+  private ExecutionInputPolicy inputPolicy;
+  private QueueAsyncSubmissionFlow flow;
+
+  @Mock
+  private PipelineOrchestratorConfig orchestratorConfig;
+
+  @Mock
+  private ExecutionResultShapeResolver resultShapeResolver;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private WorkDispatcher workDispatcher;
+
+  @Mock
+  private ControlPlaneAdmissionPolicy admissionPolicy;
+
+  @Mock
+  private SegmentBoundaryLedger segmentBoundaryLedger;
+
+  @BeforeEach
+  void setUp() {
+    inputPolicy = new ExecutionInputPolicy();
+    inputPolicy.orchestratorConfig = orchestratorConfig;
+    lenient().when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    lenient().when(orchestratorConfig.defaultTenant()).thenReturn("default");
+    lenient().when(orchestratorConfig.idempotencyPolicy()).thenReturn(OrchestratorIdempotencyPolicy.OPTIONAL_CLIENT_KEY);
+    lenient().when(orchestratorConfig.executionTtlDays()).thenReturn(1);
+    lenient().when(resultShapeResolver.resolve()).thenReturn(ExecutionResultShape.SINGLE);
+    lenient().when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    lenient().when(segmentBoundaryLedger.recordRunSubmitted(any(), any(), org.mockito.ArgumentMatchers.anyLong()))
+        .thenReturn(Uni.createFrom().voidItem());
+    flow = newFlow(inputPolicy, () -> segmentBoundaryLedger);
+  }
+
+  @Test
+  void queueModeDisabledFailsBeforeStoreAccess() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+
+    Uni<?> result = flow.submit("input", "tenant-1", "idem-1", false);
+
+    assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
+    verify(executionStateStore, never()).createOrGetExecution(any());
+    verify(admissionPolicy, never()).admit(any());
+  }
+
+  @Test
+  void streamingOutputFlagIsRejected() {
+    Uni<?> result = flow.submit("input", "tenant-1", "idem-1", true);
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () -> result.await().indefinitely());
+
+    assertTrue(error.getMessage().contains("does not support streaming pipeline outputs"));
+    verify(executionStateStore, never()).createOrGetExecution(any());
+  }
+
+  @Test
+  void invalidInputShapeFailsBeforeAdmissionAndStoreAccess() {
+    ExecutionInputPolicy rejectingPolicy = mock(ExecutionInputPolicy.class);
+    when(rejectingPolicy.normalizeExecutionInput("input")).thenReturn("bad-shape");
+    when(rejectingPolicy.validateInputShape("bad-shape")).thenReturn(new IllegalArgumentException("bad input"));
+    QueueAsyncSubmissionFlow rejectingFlow = newFlow(rejectingPolicy, () -> segmentBoundaryLedger);
+
+    Uni<?> result = rejectingFlow.submit("input", "tenant-1", "idem-1", false);
+
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () -> result.await().indefinitely());
+    assertEquals("bad input", error.getMessage());
+    verify(admissionPolicy, never()).admit(any());
+    verify(executionStateStore, never()).createOrGetExecution(any());
+  }
+
+  @Test
+  void deniedTenantFailsBeforeSnapshotAndStoreAccess() {
+    ExecutionInputPolicy policy = mock(ExecutionInputPolicy.class);
+    Object normalized = Uni.createFrom().item("input");
+    when(policy.normalizeExecutionInput("input")).thenReturn(normalized);
+    when(policy.validateInputShape(normalized)).thenReturn(null);
+    when(policy.normalizeTenant("tenant-denied")).thenReturn("tenant-denied");
+    when(admissionPolicy.admit(any()))
+        .thenReturn(ControlPlaneAdmissionDecision.deny("TENANT_NOT_ALLOWED", "tenant denied"));
+    QueueAsyncSubmissionFlow deniedFlow = newFlow(policy, () -> segmentBoundaryLedger);
+
+    Uni<?> result = deniedFlow.submit("input", "tenant-denied", "idem-1", false);
+
+    ControlPlaneAdmissionException error = assertThrows(
+        ControlPlaneAdmissionException.class,
+        () -> result.await().indefinitely());
+    assertTrue(error.getMessage().contains("TENANT_NOT_ALLOWED"));
+    verify(policy, never()).resolveExecutionInputPayload(any());
+    verify(executionStateStore, never()).createOrGetExecution(any());
+  }
+
+  @Test
+  void uniListPayloadIsPreservedAsSingleInputItem() {
+    when(executionStateStore.createOrGetExecution(any()))
+        .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record("exec-1", "key-1"), true)));
+
+    flow.submit(List.of("a", "b"), "tenant-1", null, false).await().indefinitely();
+
+    ArgumentCaptor<ExecutionCreateCommand> captor = ArgumentCaptor.forClass(ExecutionCreateCommand.class);
+    verify(executionStateStore).createOrGetExecution(captor.capture());
+    assertInstanceOf(ExecutionInputSnapshot.class, captor.getValue().inputPayload());
+    ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) captor.getValue().inputPayload();
+    assertEquals(ExecutionInputShape.UNI, snapshot.shape());
+    assertEquals(List.of("a", "b"), snapshot.payload());
+  }
+
+  @Test
+  void multiInputMaterializesToMultiSnapshot() {
+    when(executionStateStore.createOrGetExecution(any()))
+        .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record("exec-1", "key-1"), true)));
+
+    flow.submit(Multi.createFrom().items("x", "y"), "tenant-1", null, false).await().indefinitely();
+
+    ArgumentCaptor<ExecutionCreateCommand> captor = ArgumentCaptor.forClass(ExecutionCreateCommand.class);
+    verify(executionStateStore).createOrGetExecution(captor.capture());
+    ExecutionInputSnapshot snapshot = (ExecutionInputSnapshot) captor.getValue().inputPayload();
+    assertEquals(ExecutionInputShape.MULTI, snapshot.shape());
+    assertEquals(List.of("x", "y"), snapshot.payload());
+  }
+
+  @Test
+  void resolvedResultShapeIsPersisted() {
+    when(resultShapeResolver.resolve()).thenReturn(ExecutionResultShape.MATERIALIZED_MULTI);
+    when(executionStateStore.createOrGetExecution(any()))
+        .thenReturn(Uni.createFrom().item(new CreateExecutionResult(
+            record("exec-1", "key-1", ExecutionResultShape.MATERIALIZED_MULTI),
+            true)));
+
+    flow.submit("input", "tenant-1", null, false).await().indefinitely();
+
+    ArgumentCaptor<ExecutionCreateCommand> captor = ArgumentCaptor.forClass(ExecutionCreateCommand.class);
+    verify(executionStateStore).createOrGetExecution(captor.capture());
+    assertEquals(ExecutionResultShape.MATERIALIZED_MULTI, captor.getValue().resultShape());
+  }
+
+  @Test
+  void duplicateExecutionSkipsLedgerAndEnqueue() {
+    when(executionStateStore.createOrGetExecution(any()))
+        .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record("exec-1", "key-1"), true)));
+
+    RunAsyncAcceptedDto dto = flow.submit("input", "tenant-1", "idem-1", false).await().indefinitely();
+
+    assertEquals("exec-1", dto.executionId());
+    assertTrue(dto.duplicate());
+    verify(segmentBoundaryLedger, never()).recordRunSubmitted(any(), any(), org.mockito.ArgumentMatchers.anyLong());
+    verify(workDispatcher, never()).enqueueNow(any());
+  }
+
+  @Test
+  void newExecutionAppendsRunSubmittedThenEnqueuesInitialWorkThenReturnsAcceptedDto() {
+    ExecutionRecord<Object, Object> record = record("exec-1", "key-1");
+    when(executionStateStore.createOrGetExecution(any()))
+        .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record, false)));
+    when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+    RunAsyncAcceptedDto dto = flow.submit("input", "tenant-1", "idem-1", false).await().indefinitely();
+
+    assertEquals("exec-1", dto.executionId());
+    assertFalse(dto.duplicate());
+    assertEquals("/pipeline/executions/exec-1", dto.statusUrl());
+    InOrder order = inOrder(segmentBoundaryLedger, workDispatcher);
+    order.verify(segmentBoundaryLedger).recordRunSubmitted(
+        any(),
+        any(),
+        org.mockito.ArgumentMatchers.anyLong());
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+  }
+
+  @Test
+  void admissionRequestUsesNormalizedIdentity() {
+    when(executionStateStore.createOrGetExecution(any()))
+        .thenReturn(Uni.createFrom().item(new CreateExecutionResult(record("exec-1", "key-1"), true)));
+
+    flow.submit("input", "  ", "idem-1", false).await().indefinitely();
+
+    ArgumentCaptor<ControlPlaneAdmissionRequest> captor = ArgumentCaptor.forClass(ControlPlaneAdmissionRequest.class);
+    verify(admissionPolicy).admit(captor.capture());
+    ControlPlaneAdmissionRequest request = captor.getValue();
+    assertEquals("default", request.tenantId());
+    assertEquals("pipeline-a", request.pipelineId());
+    assertEquals("release-a", request.releaseVersion());
+    assertFalse(request.explicitTenant());
+  }
+
+  private QueueAsyncSubmissionFlow newFlow(
+      ExecutionInputPolicy policy,
+      Supplier<SegmentBoundaryLedger> ledger) {
+    return new QueueAsyncSubmissionFlow(
+        orchestratorConfig,
+        policy,
+        resultShapeResolver,
+        executionStateStore,
+        workDispatcher,
+        admissionPolicy,
+        () -> "pipeline-a",
+        () -> "contract-a",
+        () -> "release-a",
+        ledger);
+  }
+
+  private ExecutionRecord<Object, Object> record(String executionId, String executionKey) {
+    return record(executionId, executionKey, ExecutionResultShape.SINGLE);
+  }
+
+  private ExecutionRecord<Object, Object> record(
+      String executionId,
+      String executionKey,
+      ExecutionResultShape resultShape) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        executionId,
+        executionKey,
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        resultShape,
+        ExecutionStatus.QUEUED,
+        0L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}


### PR DESCRIPTION
- Added QueueAsyncSubmissionFlow for executePipelineAsync submission/admission.
- Added immutable helpers: PipelineRunSubmission, PipelineRunSubmissionPlan, and RunAcceptance.
- QueueAsyncCoordinator now delegates both submit overloads and no longer owns scoped key construction, accepted DTO mapping, admission/store/enqueue branching for submissions.
- Moved detailed submit behavior tests into PipelineRunSubmissionPlanTest and QueueAsyncSubmissionFlowTest; coordinator tests are now façade-level for submit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added faster queue-based pipeline submission and execution result retrieval.
  - Improved support for viewing execution status, typed results, and raw payloads.
  - Added clearer acceptance responses for async runs, including execution links and duplicate-run handling.

- **Bug Fixes**
  - Tightened validation for invalid input, unsupported streaming requests, and non-queue execution modes.
  - Improved error handling for missing executions and denied submissions.
  - Made execution identifiers more consistent across submissions and lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->