### PR TITLE
Add terminal publication barrier facts

### DIFF
--- a/docs/evolve/await-unit-runtime/immutable-boundaries.md
+++ b/docs/evolve/await-unit-runtime/immutable-boundaries.md
@@ -82,6 +82,7 @@ The control-plane model uses facts such as:
 - `BoundaryCompletionAdmitted`
 - `InteractionTimedOut`
 - `ContinuationSegmentCreated`
+- `TerminalPublicationPrepared`
 - `TerminalPublicationCompleted`
 - `RunSucceeded`
 - `RunFailed`
@@ -102,6 +103,8 @@ Queue-async segment execution is modeled as a small reactive flow over immutable
 6. `TerminalPublicationBoundary` handles checkpoint and Object Publish side effects before success is committed.
 
 The split is deliberate. `SegmentCommitPlan` is pure: it validates result shape and describes what happened without calling stores, publishers, telemetry, or dispatchers. Effects are interpreted afterwards through narrow boundaries.
+
+Terminal publication is a prepare/complete barrier before run success. When a control-plane journal is available, `TerminalPublicationBoundary` appends `TerminalPublicationPrepared` before checkpoint or Object Publish side effects run, then appends `TerminalPublicationCompleted` after the side effect succeeds. A retry that sees a completed publication skips the external effect. A retry that sees only a prepared publication may run the effect again with the same deterministic idempotency key, so the checkpoint target or object provider still needs idempotent writes. The future Dynamo append-only journal work in issue #396 is the durable storage implementation for this same model.
 
 ```mermaid
 sequenceDiagram

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationBoundary.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationBoundary.java
@@ -33,34 +33,34 @@ class TerminalPublicationBoundary {
   Uni<Void> publishBeforeSuccess(CompletedSegment completed, long nowEpochMs) {
     Objects.requireNonNull(completed, "completed must not be null");
     TerminalPublicationPlan plan = completed.terminalPublication();
-    return publishCheckpoint(completed, plan)
+    return publishCheckpoint(completed, plan, nowEpochMs)
         .chain(() -> publishObjectOutput(plan, nowEpochMs));
   }
 
-  private Uni<Void> publishCheckpoint(CompletedSegment completed, TerminalPublicationPlan plan) {
-    if (checkpointPublicationService == null) {
+  private Uni<Void> publishCheckpoint(CompletedSegment completed, TerminalPublicationPlan plan, long nowEpochMs) {
+    var checkpointPayload = plan.checkpointPayload();
+    if (checkpointPublicationService == null || !checkpointPublicationService.enabled() || checkpointPayload.isEmpty()) {
       return Uni.createFrom().voidItem();
     }
-    return plan.checkpointPayload()
-        .map(payload -> checkpointPublicationService.publishIfConfigured(completed.segment().record(), payload))
-        .orElseGet(() -> Uni.createFrom().voidItem());
+    return new TerminalPublicationIntent(
+        TerminalPublicationIntent.CHECKPOINT,
+        completed.segment(),
+        () -> checkpointPublicationService.publishIfConfigured(completed.segment().record(), checkpointPayload.get()))
+        .run(segmentBoundaryLedger.get(), nowEpochMs);
   }
 
   private Uni<Void> publishObjectOutput(TerminalPublicationPlan plan, long nowEpochMs) {
     ClaimedSegment segment = plan.segment();
-    if (plan.alreadyPublished()) {
-      return segmentBoundaryLedger.get().recordTerminalPublicationCompleted(
-          segment.record(),
-          segment.transitionKey(),
-          nowEpochMs);
-    }
-    if (objectPublishCompletionService == null) {
+    if (!plan.alreadyPublished()
+        && (objectPublishCompletionService == null || !objectPublishCompletionService.enabled())) {
       return Uni.createFrom().voidItem();
     }
-    return objectPublishCompletionService.publishIfConfigured(() -> plan.decodedOutputItems(payloadCodec.get()))
-        .chain(() -> segmentBoundaryLedger.get().recordTerminalPublicationCompleted(
-            segment.record(),
-            segment.transitionKey(),
-            nowEpochMs));
+    return new TerminalPublicationIntent(
+        TerminalPublicationIntent.OBJECT_PUBLISH,
+        segment,
+        () -> plan.alreadyPublished()
+            ? Uni.createFrom().voidItem()
+            : objectPublishCompletionService.publishIfConfigured(() -> plan.decodedOutputItems(payloadCodec.get())))
+        .run(segmentBoundaryLedger.get(), nowEpochMs);
   }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationIntent.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TerminalPublicationIntent.java
@@ -1,0 +1,55 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.orchestrator.controlplane.TerminalPublicationClaim;
+
+/**
+ * Immutable intent for one terminal publication side effect.
+ */
+record TerminalPublicationIntent(
+    String kind,
+    ClaimedSegment segment,
+    Supplier<Uni<Void>> effect
+) {
+
+  static final String CHECKPOINT = "checkpoint";
+  static final String OBJECT_PUBLISH = "object-publish";
+
+  TerminalPublicationIntent {
+    if (kind == null || kind.isBlank()) {
+      throw new IllegalArgumentException("kind must not be blank");
+    }
+    kind = kind.trim();
+    Objects.requireNonNull(segment, "segment must not be null");
+    Objects.requireNonNull(effect, "effect must not be null");
+  }
+
+  Uni<Void> run(SegmentBoundaryLedger ledger, long nowEpochMs) {
+    Objects.requireNonNull(ledger, "ledger must not be null");
+    ExecutionRecord<Object, Object> record = segment.record();
+    return ledger.claimTerminalPublication(record, segment.transitionKey(), kind, nowEpochMs)
+        .onItem().transformToUni(claim -> {
+          if (!claim.shouldPublish()) {
+            return Uni.createFrom().voidItem();
+          }
+          return effect.get()
+              .chain(() -> completeIfTracked(ledger, claim, record, nowEpochMs));
+        });
+  }
+
+  private Uni<Void> completeIfTracked(
+      SegmentBoundaryLedger ledger,
+      TerminalPublicationClaim claim,
+      ExecutionRecord<Object, Object> record,
+      long nowEpochMs) {
+    if (claim.status() == TerminalPublicationClaim.Status.UNTRACKED) {
+      return Uni.createFrom().voidItem();
+    }
+    return ledger.completeTerminalPublication(record, segment.transitionKey(), kind, nowEpochMs);
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/CheckpointPublicationService.java
@@ -64,6 +64,10 @@ public class CheckpointPublicationService {
         }
     }
 
+    public boolean enabled() {
+        return descriptor != null;
+    }
+
     public Uni<Void> publishIfConfigured(ExecutionRecord<Object, Object> record, Object resultPayload) {
         if (descriptor == null) {
             return Uni.createFrom().voidItem();

--- a/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishCompletionService.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/objectpublish/ObjectPublishCompletionService.java
@@ -33,6 +33,10 @@ public class ObjectPublishCompletionService {
         return active.publishItems(outputItems == null ? List.of() : outputItems);
     }
 
+    public boolean enabled() {
+        return runner().enabled();
+    }
+
     private ObjectPublishRunner runner() {
         ObjectPublishRunner active = runner;
         if (active != null) {

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneFact.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneFact.java
@@ -14,6 +14,7 @@ public sealed interface ControlPlaneFact permits
     ControlPlaneFact.BoundaryCompletionAdmitted,
     ControlPlaneFact.InteractionTimedOut,
     ControlPlaneFact.ContinuationSegmentCreated,
+    ControlPlaneFact.TerminalPublicationPrepared,
     ControlPlaneFact.TerminalPublicationCompleted,
     ControlPlaneFact.RunSucceeded,
     ControlPlaneFact.RunFailed {
@@ -278,6 +279,27 @@ public sealed interface ControlPlaneFact permits
         @Override
         public String factKey() {
             return "terminal-publication-completed:" + publicationId + ":" + idempotencyKey;
+        }
+    }
+
+    record TerminalPublicationPrepared(
+        String tenantId,
+        String runId,
+        String segmentId,
+        String publicationId,
+        String idempotencyKey
+    ) implements ControlPlaneFact {
+        public TerminalPublicationPrepared {
+            tenantId = ControlPlaneChecks.requireText(tenantId, "tenantId");
+            runId = ControlPlaneChecks.requireText(runId, "runId");
+            segmentId = ControlPlaneChecks.requireText(segmentId, "segmentId");
+            publicationId = ControlPlaneChecks.requireText(publicationId, "publicationId");
+            idempotencyKey = ControlPlaneChecks.requireText(idempotencyKey, "idempotencyKey");
+        }
+
+        @Override
+        public String factKey() {
+            return "terminal-publication-prepared:" + publicationId + ":" + idempotencyKey;
         }
     }
 

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneProjection.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneProjection.java
@@ -13,6 +13,7 @@ public record ControlPlaneProjection(
     Map<String, SegmentAttempt> attempts,
     Map<String, BoundaryUnit> boundaries,
     Map<String, BoundaryInteraction> interactions,
+    Set<String> terminalPublicationPreparedKeys,
     Set<String> terminalPublicationKeys,
     Set<String> factKeys
 ) {
@@ -25,6 +26,7 @@ public record ControlPlaneProjection(
         attempts = ControlPlaneChecks.copyMap(attempts);
         boundaries = ControlPlaneChecks.copyMap(boundaries);
         interactions = ControlPlaneChecks.copyMap(interactions);
+        terminalPublicationPreparedKeys = ControlPlaneChecks.copySet(terminalPublicationPreparedKeys);
         terminalPublicationKeys = ControlPlaneChecks.copySet(terminalPublicationKeys);
         factKeys = ControlPlaneChecks.copySet(factKeys);
     }
@@ -39,6 +41,7 @@ public record ControlPlaneProjection(
             Map.of(),
             Map.of(),
             Map.of(),
+            Set.of(),
             Set.of(),
             Set.of());
     }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducer.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducer.java
@@ -31,6 +31,7 @@ public final class ControlPlaneReducer {
         private final Map<String, SegmentAttempt> attempts = new HashMap<>();
         private final Map<String, BoundaryUnit> boundaries = new HashMap<>();
         private final Map<String, BoundaryInteraction> interactions = new HashMap<>();
+        private final Set<String> terminalPublicationPreparedKeys = new HashSet<>();
         private final Set<String> terminalPublicationKeys = new HashSet<>();
         private final Set<String> factKeys = new HashSet<>();
 
@@ -55,6 +56,7 @@ public final class ControlPlaneReducer {
                 case ControlPlaneFact.BoundaryCompletionAdmitted fact -> applyBoundaryCompletionAdmitted(event, fact);
                 case ControlPlaneFact.InteractionTimedOut fact -> applyInteractionTimedOut(event, fact);
                 case ControlPlaneFact.ContinuationSegmentCreated fact -> applyContinuationSegmentCreated(event, fact);
+                case ControlPlaneFact.TerminalPublicationPrepared fact -> terminalPublicationPreparedKeys.add(fact.factKey());
                 case ControlPlaneFact.TerminalPublicationCompleted fact -> terminalPublicationKeys.add(fact.factKey());
                 case ControlPlaneFact.RunSucceeded fact -> applyRunSucceeded(event, fact);
                 case ControlPlaneFact.RunFailed fact -> applyRunFailed(event, fact);
@@ -273,6 +275,7 @@ public final class ControlPlaneReducer {
                 new HashMap<>(attempts),
                 new HashMap<>(boundaries),
                 new HashMap<>(interactions),
+                new HashSet<>(terminalPublicationPreparedKeys),
                 new HashSet<>(terminalPublicationKeys),
                 new HashSet<>(factKeys));
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
@@ -272,20 +272,49 @@ public class SegmentBoundaryLedger {
         String transitionKey,
         long nowEpochMs
     ) {
+        return completeTerminalPublication(record, transitionKey, "object-publish", nowEpochMs);
+    }
+
+    public Uni<TerminalPublicationClaim> claimTerminalPublication(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        String publicationKind,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().item(TerminalPublicationClaim.untracked(null, null));
+        }
+        String kind = publicationKind(publicationKind);
+        TerminalPublicationFacts facts = terminalPublicationFacts(record, transitionKey, kind);
+        Optional<ControlPlaneJournal> journal = journal();
+        if (journal.isEmpty()) {
+            return Uni.createFrom().item(TerminalPublicationClaim.untracked(facts.publicationId(), facts.idempotencyKey()));
+        }
+        return claimTerminalPublication(journal.get(), record, facts, nowEpochMs, 1);
+    }
+
+    public Uni<Void> completeTerminalPublication(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        String publicationKind,
+        long nowEpochMs
+    ) {
         if (record == null) {
             return Uni.createFrom().voidItem();
         }
-        String idempotencyKey = attemptId(record, transitionKey) + ":terminal-publication";
-        return appendBuilt(
+        Optional<ControlPlaneJournal> journal = journal();
+        if (journal.isEmpty()) {
+            return Uni.createFrom().voidItem();
+        }
+        TerminalPublicationFacts facts = terminalPublicationFacts(record, transitionKey, publicationKind(publicationKind));
+        return appendWithRetry(
+            journal.get(),
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.TerminalPublicationCompleted(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                record.executionId() + ":terminal-output",
-                idempotencyKey)),
-            nowEpochMs);
+            List.of(facts.completed()),
+            nowEpochMs,
+            1)
+            .replaceWithVoid();
     }
 
     public Uni<Void> recordRunSucceeded(
@@ -415,6 +444,41 @@ public class SegmentBoundaryLedger {
             });
     }
 
+    private Uni<TerminalPublicationClaim> claimTerminalPublication(
+        ControlPlaneJournal journal,
+        ExecutionRecord<Object, Object> record,
+        TerminalPublicationFacts facts,
+        long nowEpochMs,
+        int attempt
+    ) {
+        return journal.projection(record.tenantId(), record.executionId())
+            .onItem().transformToUni(projection -> {
+                if (projection.terminalPublicationKeys().contains(facts.completed().factKey())) {
+                    return Uni.createFrom().item(toClaim(
+                        TerminalPublicationClaim.Status.ALREADY_COMPLETED,
+                        facts));
+                }
+                if (projection.terminalPublicationPreparedKeys().contains(facts.prepared().factKey())) {
+                    return Uni.createFrom().item(toClaim(
+                        TerminalPublicationClaim.Status.PREPARED_RETRY,
+                        facts));
+                }
+                return journal.append(
+                        record.tenantId(),
+                        record.executionId(),
+                        projection.version(),
+                        List.of(facts.prepared()),
+                        nowEpochMs)
+                    .onItem().transform(ignored -> toClaim(TerminalPublicationClaim.Status.CLAIMED, facts));
+            })
+            .onFailure(ControlPlaneAppendConflictException.class).recoverWithUni(failure -> {
+                if (attempt >= MAX_APPEND_ATTEMPTS) {
+                    return Uni.createFrom().failure(failure);
+                }
+                return claimTerminalPublication(journal, record, facts, nowEpochMs, attempt + 1);
+            });
+    }
+
     private Optional<ControlPlaneJournal> journal() {
         if (explicitJournal != null) {
             return Optional.of(explicitJournal);
@@ -455,5 +519,56 @@ public class SegmentBoundaryLedger {
             return transitionKey;
         }
         return record.executionId() + ":" + record.currentStepIndex() + ":" + record.attempt();
+    }
+
+    private static TerminalPublicationClaim toClaim(
+        TerminalPublicationClaim.Status status,
+        TerminalPublicationFacts facts
+    ) {
+        return new TerminalPublicationClaim(
+            status,
+            facts.publicationId(),
+            facts.idempotencyKey(),
+            facts.prepared().factKey(),
+            facts.completed().factKey());
+    }
+
+    private static TerminalPublicationFacts terminalPublicationFacts(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        String publicationKind
+    ) {
+        String publicationId = record.executionId() + ":terminal-output:" + publicationKind;
+        String idempotencyKey = publicationId + ":terminal-publication";
+        return new TerminalPublicationFacts(
+            publicationId,
+            idempotencyKey,
+            new ControlPlaneFact.TerminalPublicationPrepared(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                publicationId,
+                idempotencyKey),
+            new ControlPlaneFact.TerminalPublicationCompleted(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                publicationId,
+                idempotencyKey));
+    }
+
+    private static String publicationKind(String publicationKind) {
+        if (publicationKind == null || publicationKind.isBlank()) {
+            throw new IllegalArgumentException("publicationKind must not be blank");
+        }
+        return publicationKind.trim();
+    }
+
+    private record TerminalPublicationFacts(
+        String publicationId,
+        String idempotencyKey,
+        ControlPlaneFact.TerminalPublicationPrepared prepared,
+        ControlPlaneFact.TerminalPublicationCompleted completed
+    ) {
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/TerminalPublicationClaim.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/TerminalPublicationClaim.java
@@ -1,0 +1,47 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.Objects;
+
+public record TerminalPublicationClaim(
+    Status status,
+    String publicationId,
+    String idempotencyKey,
+    String preparedFactKey,
+    String completedFactKey
+) {
+
+    public enum Status {
+        UNTRACKED,
+        CLAIMED,
+        PREPARED_RETRY,
+        ALREADY_COMPLETED
+    }
+
+    public TerminalPublicationClaim {
+        Objects.requireNonNull(status, "status must not be null");
+        publicationId = requireText(publicationId, "publicationId");
+        idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        if (status == Status.UNTRACKED) {
+            preparedFactKey = null;
+            completedFactKey = null;
+        } else {
+            preparedFactKey = requireText(preparedFactKey, "preparedFactKey");
+            completedFactKey = requireText(completedFactKey, "completedFactKey");
+        }
+    }
+
+    public static TerminalPublicationClaim untracked(String publicationId, String idempotencyKey) {
+        return new TerminalPublicationClaim(Status.UNTRACKED, publicationId, idempotencyKey, null, null);
+    }
+
+    public boolean shouldPublish() {
+        return status != Status.ALREADY_COMPLETED;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncCoordinatorTest.java
@@ -735,8 +735,6 @@ class QueueAsyncCoordinatorTest {
             99999999L);
         when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
-        when(checkpointPublicationService.publishIfConfigured(org.mockito.ArgumentMatchers.eq(claimed), org.mockito.ArgumentMatchers.eq("out-1")))
-            .thenReturn(Uni.createFrom().voidItem());
         when(executionStateStore.markSucceeded(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-stream"),
@@ -794,8 +792,6 @@ class QueueAsyncCoordinatorTest {
             99999999L);
         when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
-        when(checkpointPublicationService.publishIfConfigured(org.mockito.ArgumentMatchers.eq(claimed), org.mockito.ArgumentMatchers.eq("output-file")))
-            .thenReturn(Uni.createFrom().voidItem());
         when(executionStateStore.markSucceeded(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-aggregate"),
@@ -833,8 +829,6 @@ class QueueAsyncCoordinatorTest {
         NonSerializableOutput output = new NonSerializableOutput(new Object());
         when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
-        when(checkpointPublicationService.publishIfConfigured(org.mockito.ArgumentMatchers.eq(claimed), org.mockito.ArgumentMatchers.same(output)))
-            .thenReturn(Uni.createFrom().voidItem());
         when(executionStateStore.markSucceeded(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-local"),
@@ -872,8 +866,6 @@ class QueueAsyncCoordinatorTest {
             "{\"value\":\"remote\"}");
         when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
-        when(checkpointPublicationService.publishIfConfigured(org.mockito.ArgumentMatchers.eq(claimed), org.mockito.ArgumentMatchers.eq(serialized)))
-            .thenReturn(Uni.createFrom().voidItem());
         when(executionStateStore.markSucceeded(
                 org.mockito.ArgumentMatchers.eq("tenant-1"),
                 org.mockito.ArgumentMatchers.eq("exec-remote"),
@@ -917,8 +909,7 @@ class QueueAsyncCoordinatorTest {
         coordinator.objectPublishCompletionService = publishService;
         when(executionStateStore.claimLease(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong()))
             .thenReturn(Uni.createFrom().item(Optional.of(claimed)));
-        when(checkpointPublicationService.publishIfConfigured(org.mockito.ArgumentMatchers.eq(claimed), org.mockito.ArgumentMatchers.eq(serialized)))
-            .thenReturn(Uni.createFrom().voidItem());
+        when(publishService.enabled()).thenReturn(true);
         when(publishService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
             .thenAnswer(invocation -> {
                 Supplier<List<?>> supplier = invocation.getArgument(0);
@@ -956,7 +947,7 @@ class QueueAsyncCoordinatorTest {
         assertEquals(serialized, persisted.getFirst());
         ControlPlaneProjection projection = journal.projection("tenant-1", "exec-publish").await().indefinitely();
         assertTrue(projection.terminalPublicationKeys()
-            .contains("terminal-publication-completed:exec-publish:terminal-output:exec-publish:0:0:terminal-publication"));
+            .contains("terminal-publication-completed:exec-publish:terminal-output:object-publish:exec-publish:terminal-output:object-publish:terminal-publication"));
     }
 
     @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSegmentPipelineTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSegmentPipelineTest.java
@@ -37,6 +37,7 @@ import org.pipelineframework.orchestrator.TransitionWorkerExecutor;
 import org.pipelineframework.orchestrator.TransitionWorkerExecutionMode;
 import org.pipelineframework.orchestrator.WorkDispatcher;
 import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.orchestrator.controlplane.TerminalPublicationClaim;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -109,10 +110,22 @@ class QueueAsyncSegmentPipelineTest {
         .thenReturn(Uni.createFrom().voidItem());
     lenient().when(segmentBoundaryLedger.recordSegmentSuspended(any(), any(), any(), anyLong()))
         .thenReturn(Uni.createFrom().voidItem());
-    lenient().when(segmentBoundaryLedger.recordTerminalPublicationCompleted(any(), any(), anyLong()))
+    lenient().when(segmentBoundaryLedger.claimTerminalPublication(
+            any(),
+            any(),
+            org.mockito.ArgumentMatchers.anyString(),
+            anyLong()))
+        .thenAnswer(invocation -> Uni.createFrom().item(claim(TerminalPublicationClaim.Status.CLAIMED, invocation.getArgument(2))));
+    lenient().when(segmentBoundaryLedger.completeTerminalPublication(
+            any(),
+            any(),
+            org.mockito.ArgumentMatchers.anyString(),
+            anyLong()))
         .thenReturn(Uni.createFrom().voidItem());
     lenient().when(segmentBoundaryLedger.recordRunSucceeded(any(), any(), anyLong()))
         .thenReturn(Uni.createFrom().voidItem());
+    lenient().when(checkpointPublicationService.enabled()).thenReturn(true);
+    lenient().when(objectPublishCompletionService.enabled()).thenReturn(true);
     lenient().when(checkpointPublicationService.publishIfConfigured(any(), any()))
         .thenReturn(Uni.createFrom().voidItem());
     lenient().when(objectPublishCompletionService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
@@ -159,9 +172,28 @@ class QueueAsyncSegmentPipelineTest {
     order.verify(executionStateStore).claimLease(eq("tenant-1"), eq("exec-success"), any(), anyLong(), eq(1000L));
     order.verify(segmentBoundaryLedger).recordSegmentAttemptStarted(same(claimed), eq("exec-success:0:0"), anyLong());
     order.verify(segmentBoundaryLedger).recordSegmentCompleted(same(claimed), eq("exec-success:0:0"), any(), anyLong());
+    order.verify(segmentBoundaryLedger).claimTerminalPublication(
+        same(claimed),
+        eq("exec-success:0:0"),
+        eq(TerminalPublicationIntent.CHECKPOINT),
+        anyLong());
     order.verify(checkpointPublicationService).publishIfConfigured(same(claimed), eq("out-1"));
+    order.verify(segmentBoundaryLedger).completeTerminalPublication(
+        same(claimed),
+        eq("exec-success:0:0"),
+        eq(TerminalPublicationIntent.CHECKPOINT),
+        anyLong());
+    order.verify(segmentBoundaryLedger).claimTerminalPublication(
+        same(claimed),
+        eq("exec-success:0:0"),
+        eq(TerminalPublicationIntent.OBJECT_PUBLISH),
+        anyLong());
     order.verify(objectPublishCompletionService).publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any());
-    order.verify(segmentBoundaryLedger).recordTerminalPublicationCompleted(same(claimed), eq("exec-success:0:0"), anyLong());
+    order.verify(segmentBoundaryLedger).completeTerminalPublication(
+        same(claimed),
+        eq("exec-success:0:0"),
+        eq(TerminalPublicationIntent.OBJECT_PUBLISH),
+        anyLong());
     order.verify(executionStateStore).markSucceeded(
         eq("tenant-1"),
         eq("exec-success"),
@@ -429,5 +461,14 @@ class QueueAsyncSegmentPipelineTest {
         source.createdAtEpochMs(),
         source.updatedAtEpochMs(),
         source.ttlEpochS());
+  }
+
+  private static TerminalPublicationClaim claim(TerminalPublicationClaim.Status status, String kind) {
+    return new TerminalPublicationClaim(
+        status,
+        "publication-" + kind,
+        "idempotency-" + kind,
+        "terminal-publication-prepared:publication-" + kind + ":idempotency-" + kind,
+        "terminal-publication-completed:publication-" + kind + ":idempotency-" + kind);
   }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationBoundaryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TerminalPublicationBoundaryTest.java
@@ -1,0 +1,231 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.checkpoint.CheckpointPublicationService;
+import org.pipelineframework.objectpublish.ObjectPublishCompletionService;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.JsonTransitionPayloadCodec;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+import org.pipelineframework.orchestrator.controlplane.TerminalPublicationClaim;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TerminalPublicationBoundaryTest {
+
+  @Mock
+  private CheckpointPublicationService checkpointPublicationService;
+
+  @Mock
+  private ObjectPublishCompletionService objectPublishCompletionService;
+
+  @Mock
+  private SegmentBoundaryLedger segmentBoundaryLedger;
+
+  private JsonTransitionPayloadCodec payloadCodec;
+  private ClaimedSegment segment;
+  private CompletedSegment completed;
+  private ExecutionRecord<Object, Object> record;
+
+  @BeforeEach
+  void setUp() {
+    payloadCodec = new JsonTransitionPayloadCodec();
+    record = record();
+    segment = ClaimedSegment.from(record);
+    TransitionResultEnvelope result = TransitionResultEnvelope.completedInProcess(List.of("out-1", "out-2"));
+    completed = (CompletedSegment) SegmentCommitPlan.from(segment, result);
+    org.mockito.Mockito.lenient().when(checkpointPublicationService.enabled()).thenReturn(true);
+    org.mockito.Mockito.lenient().when(objectPublishCompletionService.enabled()).thenReturn(true);
+  }
+
+  @Test
+  void publicationClaimsBeforeEffectsAndCompletesAfterEffects() {
+    long now = 100L;
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.CHECKPOINT, now))
+        .thenReturn(Uni.createFrom().item(claim(TerminalPublicationClaim.Status.CLAIMED, TerminalPublicationIntent.CHECKPOINT)));
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.OBJECT_PUBLISH, now))
+        .thenReturn(Uni.createFrom().item(claim(TerminalPublicationClaim.Status.CLAIMED, TerminalPublicationIntent.OBJECT_PUBLISH)));
+    when(segmentBoundaryLedger.completeTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.CHECKPOINT, now))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(segmentBoundaryLedger.completeTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.OBJECT_PUBLISH, now))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(checkpointPublicationService.publishIfConfigured(record, "out-1")).thenReturn(Uni.createFrom().voidItem());
+    when(objectPublishCompletionService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
+        .thenReturn(Uni.createFrom().voidItem());
+
+    boundary().publishBeforeSuccess(completed, now).await().indefinitely();
+
+    InOrder order = inOrder(segmentBoundaryLedger, checkpointPublicationService, objectPublishCompletionService);
+    order.verify(segmentBoundaryLedger).claimTerminalPublication(
+        record,
+        segment.transitionKey(),
+        TerminalPublicationIntent.CHECKPOINT,
+        now);
+    order.verify(checkpointPublicationService).publishIfConfigured(record, "out-1");
+    order.verify(segmentBoundaryLedger).completeTerminalPublication(
+        record,
+        segment.transitionKey(),
+        TerminalPublicationIntent.CHECKPOINT,
+        now);
+    order.verify(segmentBoundaryLedger).claimTerminalPublication(
+        record,
+        segment.transitionKey(),
+        TerminalPublicationIntent.OBJECT_PUBLISH,
+        now);
+    order.verify(objectPublishCompletionService).publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any());
+    order.verify(segmentBoundaryLedger).completeTerminalPublication(
+        record,
+        segment.transitionKey(),
+        TerminalPublicationIntent.OBJECT_PUBLISH,
+        now);
+  }
+
+  @Test
+  void alreadyCompletedPublicationSkipsExternalEffects() {
+    long now = 101L;
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.CHECKPOINT, now))
+        .thenReturn(Uni.createFrom().item(claim(
+            TerminalPublicationClaim.Status.ALREADY_COMPLETED,
+            TerminalPublicationIntent.CHECKPOINT)));
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.OBJECT_PUBLISH, now))
+        .thenReturn(Uni.createFrom().item(claim(
+            TerminalPublicationClaim.Status.ALREADY_COMPLETED,
+            TerminalPublicationIntent.OBJECT_PUBLISH)));
+
+    boundary().publishBeforeSuccess(completed, now).await().indefinitely();
+
+    verify(checkpointPublicationService, never()).publishIfConfigured(same(record), eq("out-1"));
+    verify(objectPublishCompletionService, never())
+        .publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any());
+    verify(segmentBoundaryLedger, never()).completeTerminalPublication(anyRecord(), eq(segment.transitionKey()), eq(TerminalPublicationIntent.CHECKPOINT), anyLong());
+    verify(segmentBoundaryLedger, never()).completeTerminalPublication(anyRecord(), eq(segment.transitionKey()), eq(TerminalPublicationIntent.OBJECT_PUBLISH), anyLong());
+  }
+
+  @Test
+  void preparedRetryRunsEffectAndCompletesPublication() {
+    long now = 102L;
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.CHECKPOINT, now))
+        .thenReturn(Uni.createFrom().item(claim(
+            TerminalPublicationClaim.Status.ALREADY_COMPLETED,
+            TerminalPublicationIntent.CHECKPOINT)));
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.OBJECT_PUBLISH, now))
+        .thenReturn(Uni.createFrom().item(claim(
+            TerminalPublicationClaim.Status.PREPARED_RETRY,
+            TerminalPublicationIntent.OBJECT_PUBLISH)));
+    when(segmentBoundaryLedger.completeTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.OBJECT_PUBLISH, now))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(objectPublishCompletionService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
+        .thenReturn(Uni.createFrom().voidItem());
+
+    boundary().publishBeforeSuccess(completed, now).await().indefinitely();
+
+    verify(objectPublishCompletionService).publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any());
+    verify(segmentBoundaryLedger).completeTerminalPublication(
+        record,
+        segment.transitionKey(),
+        TerminalPublicationIntent.OBJECT_PUBLISH,
+        now);
+  }
+
+  @Test
+  void claimFailurePreventsPublication() {
+    long now = 103L;
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.CHECKPOINT, now))
+        .thenReturn(Uni.createFrom().failure(new IllegalStateException("claim failed")));
+
+    assertThrows(IllegalStateException.class, () -> boundary().publishBeforeSuccess(completed, now).await().indefinitely());
+
+    verify(checkpointPublicationService, never()).publishIfConfigured(same(record), eq("out-1"));
+    verify(objectPublishCompletionService, never())
+        .publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any());
+  }
+
+  @Test
+  void publicationFailureDoesNotCompletePublication() {
+    long now = 104L;
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.CHECKPOINT, now))
+        .thenReturn(Uni.createFrom().item(claim(
+            TerminalPublicationClaim.Status.ALREADY_COMPLETED,
+            TerminalPublicationIntent.CHECKPOINT)));
+    when(segmentBoundaryLedger.claimTerminalPublication(record, segment.transitionKey(), TerminalPublicationIntent.OBJECT_PUBLISH, now))
+        .thenReturn(Uni.createFrom().item(claim(TerminalPublicationClaim.Status.CLAIMED, TerminalPublicationIntent.OBJECT_PUBLISH)));
+    when(objectPublishCompletionService.publishIfConfigured(org.mockito.ArgumentMatchers.<Supplier<List<?>>>any()))
+        .thenReturn(Uni.createFrom().failure(new IllegalStateException("publish failed")));
+
+    assertThrows(IllegalStateException.class, () -> boundary().publishBeforeSuccess(completed, now).await().indefinitely());
+
+    verify(segmentBoundaryLedger, never()).completeTerminalPublication(
+        record,
+        segment.transitionKey(),
+        TerminalPublicationIntent.OBJECT_PUBLISH,
+        now);
+  }
+
+  private TerminalPublicationBoundary boundary() {
+    return new TerminalPublicationBoundary(
+        checkpointPublicationService,
+        objectPublishCompletionService,
+        () -> payloadCodec,
+        () -> segmentBoundaryLedger);
+  }
+
+  private static TerminalPublicationClaim claim(TerminalPublicationClaim.Status status, String kind) {
+    return new TerminalPublicationClaim(
+        status,
+        "exec-1:terminal-output:" + kind,
+        "exec-1:terminal-output:" + kind + ":terminal-publication",
+        "terminal-publication-prepared:exec-1:terminal-output:" + kind + ":exec-1:terminal-output:" + kind + ":terminal-publication",
+        "terminal-publication-completed:exec-1:terminal-output:" + kind + ":exec-1:terminal-output:" + kind + ":terminal-publication");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ExecutionRecord<Object, Object> anyRecord() {
+    return org.mockito.ArgumentMatchers.any(ExecutionRecord.class);
+  }
+
+  private static ExecutionRecord<Object, Object> record() {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        ExecutionResultShape.MATERIALIZED_MULTI,
+        ExecutionStatus.QUEUED,
+        0L,
+        0,
+        0,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/ControlPlaneReducerTest.java
@@ -22,18 +22,25 @@ class ControlPlaneReducerTest {
                 "attempt-0",
                 List.of("out-1", "out-2"),
                 true)),
-            event(4, new ControlPlaneFact.TerminalPublicationCompleted(
+            event(4, new ControlPlaneFact.TerminalPublicationPrepared(
                 "tenant",
                 "run-1",
                 "segment-0",
                 "object-publish",
                 "run-1:publish")),
-            event(5, new ControlPlaneFact.RunSucceeded("tenant", "run-1", "segment-0", List.of("out-1", "out-2")))));
+            event(5, new ControlPlaneFact.TerminalPublicationCompleted(
+                "tenant",
+                "run-1",
+                "segment-0",
+                "object-publish",
+                "run-1:publish")),
+            event(6, new ControlPlaneFact.RunSucceeded("tenant", "run-1", "segment-0", List.of("out-1", "out-2")))));
 
-        assertEquals(5, projection.version());
+        assertEquals(6, projection.version());
         assertEquals(PipelineRunStatus.SUCCEEDED, projection.run().orElseThrow().status());
         assertEquals(SegmentStatus.COMPLETED, projection.segments().get("segment-0").status());
         assertEquals(SegmentAttemptStatus.COMPLETED, projection.attempts().get("attempt-0").status());
+        assertTrue(projection.terminalPublicationPreparedKeys().contains("terminal-publication-prepared:object-publish:run-1:publish"));
         assertTrue(projection.terminalPublicationKeys().contains("terminal-publication-completed:object-publish:run-1:publish"));
     }
 

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedgerTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedgerTest.java
@@ -80,6 +80,112 @@ class SegmentBoundaryLedgerTest {
     }
 
     @Test
+    void terminalPublicationClaimIsPreparedThenCompletedByFactKey() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(journal);
+        ExecutionRecord<Object, Object> record = record("run-terminal");
+
+        TerminalPublicationClaim claim = ledger.claimTerminalPublication(
+                record,
+                "run-terminal:0:0",
+                "object-publish",
+                50L)
+            .await().indefinitely();
+        ledger.completeTerminalPublication(record, "run-terminal:0:0", "object-publish", 51L)
+            .await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant", "run-terminal").await().indefinitely();
+        assertEquals(TerminalPublicationClaim.Status.CLAIMED, claim.status());
+        assertTrue(projection.terminalPublicationPreparedKeys().contains(claim.preparedFactKey()));
+        assertTrue(projection.terminalPublicationKeys().contains(claim.completedFactKey()));
+    }
+
+    @Test
+    void duplicateTerminalPublicationClaimReturnsPreparedRetryBeforeCompletion() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(journal);
+        ExecutionRecord<Object, Object> record = record("run-terminal-retry");
+
+        TerminalPublicationClaim first = ledger.claimTerminalPublication(
+                record,
+                "run-terminal-retry:0:0",
+                "object-publish",
+                60L)
+            .await().indefinitely();
+        TerminalPublicationClaim second = ledger.claimTerminalPublication(
+                record,
+                "run-terminal-retry:0:0",
+                "object-publish",
+                61L)
+            .await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant", "run-terminal-retry").await().indefinitely();
+        assertEquals(TerminalPublicationClaim.Status.CLAIMED, first.status());
+        assertEquals(TerminalPublicationClaim.Status.PREPARED_RETRY, second.status());
+        assertEquals(first.idempotencyKey(), second.idempotencyKey());
+        assertEquals(1L, projection.version());
+    }
+
+    @Test
+    void untrackedTerminalPublicationClaimStillCarriesStableIdentifiers() {
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger((ControlPlaneJournal) null);
+        ExecutionRecord<Object, Object> record = record("run-terminal-untracked");
+
+        TerminalPublicationClaim claim = ledger.claimTerminalPublication(
+                record,
+                "run-terminal-untracked:0:0",
+                "object-publish",
+                65L)
+            .await().indefinitely();
+
+        assertEquals(TerminalPublicationClaim.Status.UNTRACKED, claim.status());
+        assertEquals("run-terminal-untracked:terminal-output:object-publish", claim.publicationId());
+        assertEquals("run-terminal-untracked:terminal-output:object-publish:terminal-publication",
+            claim.idempotencyKey());
+    }
+
+    @Test
+    void terminalPublicationClaimSkipsAlreadyCompletedPublication() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(journal);
+        ExecutionRecord<Object, Object> record = record("run-terminal-completed");
+
+        ledger.claimTerminalPublication(record, "run-terminal-completed:0:0", "object-publish", 70L)
+            .await().indefinitely();
+        ledger.completeTerminalPublication(record, "run-terminal-completed:0:0", "object-publish", 71L)
+            .await().indefinitely();
+
+        TerminalPublicationClaim duplicate = ledger.claimTerminalPublication(
+                record,
+                "run-terminal-completed:0:0",
+                "object-publish",
+                72L)
+            .await().indefinitely();
+
+        assertEquals(TerminalPublicationClaim.Status.ALREADY_COMPLETED, duplicate.status());
+    }
+
+    @Test
+    void terminalPublicationClaimRetriesBoundedOccConflict() {
+        InMemoryControlPlaneJournal delegate = new InMemoryControlPlaneJournal();
+        SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(new ConflictOnceJournal(delegate));
+        ExecutionRecord<Object, Object> record = record("run-terminal-conflict");
+
+        TerminalPublicationClaim claim = ledger.claimTerminalPublication(
+                record,
+                "run-terminal-conflict:0:0",
+                "object-publish",
+                80L)
+            .await().indefinitely();
+
+        assertEquals(TerminalPublicationClaim.Status.CLAIMED, claim.status());
+        assertTrue(delegate.projection("tenant", "run-terminal-conflict")
+            .await().indefinitely()
+            .terminalPublicationPreparedKeys()
+            .contains(claim.preparedFactKey()));
+    }
+
+    @Test
     void requiredBoundaryInteractionFactsFailFastWhenPayloadCannotBeFrozen() {
         SegmentBoundaryLedger ledger = new SegmentBoundaryLedger(new InMemoryControlPlaneJournal());
         ExecutionRecord<Object, Object> record = record("run-5");


### PR DESCRIPTION
## Summary

Adds a queue-async terminal publication prepare/complete barrier over the control-plane ledger:

- appends `TerminalPublicationPrepared` before checkpoint/Object Publish terminal side effects;
- appends `TerminalPublicationCompleted` only after the side effect succeeds;
- skips already completed terminal publications on retry;
- uses a stable publication-based idempotency key across transition attempts;
- keeps checkpoint/Object Publish details behind `TerminalPublicationBoundary` / `TerminalPublicationIntent`.

## Scope

In scope:

- internal runtime/control-plane facts and projection state;
- terminal publication claim/complete behavior;
- focused unit coverage for claim, prepared retry, completed skip, failure, and segment commit ordering;
- internal `/evolve/await-unit-runtime` docs.

Out of scope:

- public YAML, connector SPI, telemetry schema, replay JSON, homepage media;
- Dynamo append-only implementation;
- full owner/lease semantics for prepared-but-not-completed terminal publication claims.

## Review Notes

Local CodeRabbit first pass found four items:

- fixed: `TerminalPublicationClaim` now validates and preserves publication/idempotency ids for `UNTRACKED` claims;
- fixed: terminal publication idempotency keys no longer depend on transition attempt id;
- fixed: docs now use prepare/complete barrier terminology;
- deferred: prepared-but-not-completed owner/lease semantics tracked in #450 because it widens this slice into durable outbox/lease design and should align with #396.

A follow-up local CodeRabbit run was attempted after fixes, but the CLI hit the org rate limit.

## Validation

- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true -Dtest=TerminalPublicationBoundaryTest,TerminalPublicationPlanTest,QueueAsyncSegmentPipelineTest,SegmentBoundaryLedgerTest,ControlPlaneReducerTest,QueueAsyncCoordinatorTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="$PWD/.m2/repository"`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true test -Dmaven.repo.local="$PWD/.m2/repository"`
  - `1647` tests, `0` failures, `0` errors, `1` skipped
- `npm --prefix docs test`
- `npm --prefix docs run build`
- `git diff --check`
- conflict-marker scan
