### PR TITLE
Add Spring REST client-step boundaries

### DIFF
--- a/docs/develop/spring-support.md
+++ b/docs/develop/spring-support.md
@@ -43,7 +43,7 @@ Spring-profile service steps are supported only for unary local steps declared f
 
 Delegated Spring beans are supported only for unary local steps declared from YAML with either a Spring bean class or an explicit `Class::method` operator reference. Class-only delegates use supported TPF-style service shapes such as `process(In): Mono<Out>` or `processBlocking(In): Out`. `Class::method` delegates support narrow unary Spring bean methods: `Out method(In)`, `Mono<Out> method(In)`, or `CompletionStage<Out> method(In)`.
 
-Spring REST client-step boundaries are supported only for unary `REST + COMPUTE` client-role steps. Configure each generated Spring REST client with `tpf.rest-client.<client-name>.url`; v1 does not forward TPF control, cache, or replay headers.
+Spring REST client-step boundaries are supported only for unary `REST + COMPUTE` client-role steps. Configure each generated Spring REST client with `tpf.rest-client.<client-name>.url`; Spring REST client steps do not forward TPF control, cache, or replay headers.
 
 This support does not imply gRPC, function, await/checkpoint, broker, durable coordinator, streaming/non-unary, or production parity with the Quarkus runtime.
 

--- a/docs/develop/spring-support.md
+++ b/docs/develop/spring-support.md
@@ -15,6 +15,7 @@ Current Spring work proves a narrow generated application path:
 - `Mono<Out>` and `CompletionStage<Out>` authored service methods for YAML-declared Spring-profile unary services,
 - unary delegated Spring bean steps for local pipeline execution,
 - unary `Class::method` Spring operator beans for local pipeline execution,
+- unary REST client-step boundaries for Spring WebFlux pipelines,
 - shared runner-core sequencing through the neutral runtime seam.
 
 ## Not Yet Supported
@@ -27,7 +28,6 @@ Spring does not yet have parity for:
 - persistence providers,
 - non-local delegated/operator paths,
 - side effects and plugins,
-- REST client-step remote boundaries,
 - streaming or non-unary shapes,
 - production Spring observability and deployment guidance.
 
@@ -42,6 +42,8 @@ Use the Spring path only when you are validating the emerging renderer/runtime s
 Spring-profile service steps are supported only for unary local steps declared from YAML. Normal `service:` beans can use `process(In): Mono<Out>`, `process(In): CompletionStage<Out>`, or `processBlocking(In): Out`.
 
 Delegated Spring beans are supported only for unary local steps declared from YAML with either a Spring bean class or an explicit `Class::method` operator reference. Class-only delegates use supported TPF-style service shapes such as `process(In): Mono<Out>` or `processBlocking(In): Out`. `Class::method` delegates support narrow unary Spring bean methods: `Out method(In)`, `Mono<Out> method(In)`, or `CompletionStage<Out> method(In)`.
+
+Spring REST client-step boundaries are supported only for unary `REST + COMPUTE` client-role steps. Configure each generated Spring REST client with `tpf.rest-client.<client-name>.url`; v1 does not forward TPF control, cache, or replay headers.
 
 This support does not imply gRPC, function, await/checkpoint, broker, durable coordinator, streaming/non-unary, or production parity with the Quarkus runtime.
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -89,7 +89,9 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
         PipelineRenderer<LocalBinding> localClientRenderer = springProfile
             ? new SpringLocalClientStepRenderer()
             : new org.pipelineframework.processor.renderer.LocalClientStepRenderer();
-        RestClientStepRenderer restClientRenderer = new RestClientStepRenderer();
+        PipelineRenderer<RestBinding> restClientRenderer = springProfile
+            ? new SpringRestClientStepRenderer()
+            : new RestClientStepRenderer();
         PipelineRenderer<RestBinding> restRenderer = springProfile
             ? new SpringRestResourceRenderer()
             : new RestResourceRenderer();
@@ -710,7 +712,7 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             GrpcServiceAdapterRenderer grpcRenderer,
             org.pipelineframework.processor.renderer.ClientStepRenderer clientRenderer,
             PipelineRenderer<LocalBinding> localClientRenderer,
-            RestClientStepRenderer restClientRenderer,
+            PipelineRenderer<RestBinding> restClientRenderer,
             PipelineRenderer<RestBinding> restRenderer,
             RestFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
@@ -24,6 +24,7 @@ import javax.tools.Diagnostic;
 
 import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.DeploymentRole;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.ServiceApiKind;
@@ -74,7 +75,7 @@ final class SpringRendererProfileSupport {
 
     private static void validateModel(PipelineStepModel model, PipelineTransport transportMode, List<String> errors) {
         Set<GenerationTarget> supportedTargets = transportMode == PipelineTransport.REST
-            ? Set.of(GenerationTarget.LOCAL_CLIENT_STEP, GenerationTarget.REST_RESOURCE)
+            ? Set.of(GenerationTarget.LOCAL_CLIENT_STEP, GenerationTarget.REST_RESOURCE, GenerationTarget.REST_CLIENT_STEP)
             : Set.of(GenerationTarget.LOCAL_CLIENT_STEP);
         if (!supportedTargets.containsAll(model.enabledTargets())) {
             errors.add("Spring renderer profile currently supports only " + supportedTargets + " generation; step '"
@@ -83,6 +84,11 @@ final class SpringRendererProfileSupport {
         if (model.delegateService() != null && !model.enabledTargets().equals(Set.of(GenerationTarget.LOCAL_CLIENT_STEP))) {
             errors.add("Spring renderer profile supports delegated Spring beans only as unary local client steps; step '"
                 + model.serviceName() + "' resolved targets " + model.enabledTargets() + ".");
+        }
+        if (model.enabledTargets().contains(GenerationTarget.REST_CLIENT_STEP)
+            && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
+            errors.add("Spring renderer profile supports REST client steps only for client-role boundaries; step '"
+                + model.serviceName() + "' resolved role " + model.deploymentRole() + ".");
         }
         if (model.streamingShape() != StreamingShape.UNARY_UNARY) {
             errors.add("Spring renderer profile currently supports only unary-unary steps; step '"

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/SpringRendererProfileSupport.java
@@ -86,7 +86,7 @@ final class SpringRendererProfileSupport {
                 + model.serviceName() + "' resolved targets " + model.enabledTargets() + ".");
         }
         if (model.enabledTargets().contains(GenerationTarget.REST_CLIENT_STEP)
-            && model.deploymentRole() == DeploymentRole.PIPELINE_SERVER) {
+            && isServerRole(model.deploymentRole())) {
             errors.add("Spring renderer profile supports REST client steps only for client-role boundaries; step '"
                 + model.serviceName() + "' resolved role " + model.deploymentRole() + ".");
         }
@@ -107,5 +107,11 @@ final class SpringRendererProfileSupport {
             errors.add("Spring renderer profile does not support remote execution; step '"
                 + model.serviceName() + "'.");
         }
+    }
+
+    private static boolean isServerRole(DeploymentRole role) {
+        return role == DeploymentRole.PIPELINE_SERVER
+            || role == DeploymentRole.REST_SERVER
+            || role == DeploymentRole.PLUGIN_SERVER;
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/StepArtifactGenerationService.java
@@ -21,7 +21,6 @@ import org.pipelineframework.processor.renderer.GenerationContext;
 import org.pipelineframework.processor.renderer.GrpcServiceAdapterRenderer;
 import org.pipelineframework.processor.renderer.PipelineRenderer;
 import org.pipelineframework.processor.renderer.RemoteOperatorAdapterRenderer;
-import org.pipelineframework.processor.renderer.RestClientStepRenderer;
 import org.pipelineframework.processor.renderer.AbstractFunctionHandlerRenderer;
 import org.pipelineframework.processor.renderer.AwaitClientStepRenderer;
 import org.pipelineframework.processor.renderer.CommandClientStepRenderer;
@@ -91,7 +90,7 @@ class StepArtifactGenerationService {
             GrpcServiceAdapterRenderer grpcRenderer,
             ClientStepRenderer clientRenderer,
             PipelineRenderer<LocalBinding> localClientRenderer,
-            RestClientStepRenderer restClientRenderer,
+            PipelineRenderer<RestBinding> restClientRenderer,
             PipelineRenderer<RestBinding> restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,
@@ -405,7 +404,7 @@ class StepArtifactGenerationService {
             GrpcServiceAdapterRenderer grpcRenderer,
             ClientStepRenderer clientRenderer,
             PipelineRenderer<LocalBinding> localClientRenderer,
-            RestClientStepRenderer restClientRenderer,
+            PipelineRenderer<RestBinding> restClientRenderer,
             PipelineRenderer<RestBinding> restRenderer,
             AbstractFunctionHandlerRenderer restFunctionHandlerRenderer,
             BlockingReactiveBridgeRenderer blockingReactiveBridgeRenderer,

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestClientStepRenderer.java
@@ -70,8 +70,7 @@ public class SpringRestClientStepRenderer implements PipelineRenderer<RestBindin
             ClassName.get("org.pipelineframework.runtime.core", "PipelineUnaryStep"),
             inputDomainType,
             outputDomainType);
-        String servicePath = resolveServicePath(binding, ctx);
-        String operationPath = RestPathResolver.resolveOperationPath(ctx.processingEnv());
+        String endpointPath = endpointPath(binding, ctx);
         String configKey = "tpf.rest-client." + restClientName(model.serviceName()) + ".url";
 
         return TypeSpec.classBuilder(clientStepClassName(model))
@@ -104,7 +103,7 @@ public class SpringRestClientStepRenderer implements PipelineRenderer<RestBindin
                 .build())
             .addMethod(constructor(inputDomainType, inputDtoType, outputDomainType, outputDtoType))
             .addMethod(applyMethod(inputDomainType, outputDomainType, inputDtoType, outputDtoType))
-            .addMethod(resolveEndpointUrlMethod(configKey, servicePath, operationPath))
+            .addMethod(resolveEndpointUrlMethod(configKey, endpointPath))
             .addMethod(normalizeBaseUrlMethod())
             .build();
     }
@@ -155,19 +154,50 @@ public class SpringRestClientStepRenderer implements PipelineRenderer<RestBindin
             .build();
     }
 
+    private String endpointPath(RestBinding binding, GenerationContext ctx) {
+        return joinPaths(resolveServicePath(binding, ctx),
+            normalizePath(RestPathResolver.resolveOperationPath(ctx.processingEnv()), "operation", binding.model()));
+    }
+
     private String resolveServicePath(RestBinding binding, GenerationContext ctx) {
         String servicePath = binding.restPathOverride() != null
             ? binding.restPathOverride()
             : RestPathResolver.resolveResourcePath(binding.model(), ctx.processingEnv());
-        if (servicePath == null || servicePath.isBlank()) {
-            throw new IllegalArgumentException(
-                "REST client step requires a non-blank resource path; step '"
-                    + binding.model().serviceName() + "'");
-        }
-        return servicePath;
+        return normalizePath(servicePath, "resource", binding.model());
     }
 
-    private MethodSpec resolveEndpointUrlMethod(String configKey, String servicePath, String operationPath) {
+    private String joinPaths(String servicePath, String operationPath) {
+        if ("/".equals(servicePath)) {
+            return operationPath;
+        }
+        if ("/".equals(operationPath)) {
+            return servicePath + "/";
+        }
+        return servicePath + operationPath;
+    }
+
+    private String normalizePath(String path, String label, PipelineStepModel model) {
+        if (path == null || path.isBlank()) {
+            throw new IllegalArgumentException(
+                "REST client step requires a non-blank " + label + " path; step '"
+                    + model.serviceName() + "'");
+        }
+        String normalized = path.strip();
+        if (normalized.contains("://") || normalized.contains("?") || normalized.contains("#")) {
+            throw new IllegalArgumentException(
+                "REST client step " + label + " path must be a path, not a full URL or query/fragment target; step '"
+                    + model.serviceName() + "'");
+        }
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        while (normalized.length() > 1 && normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private MethodSpec resolveEndpointUrlMethod(String configKey, String endpointPath) {
         return MethodSpec.methodBuilder("resolveEndpointUrl")
             .addModifiers(Modifier.PRIVATE)
             .returns(String.class)
@@ -178,7 +208,7 @@ public class SpringRestClientStepRenderer implements PipelineRenderer<RestBindin
                 IllegalStateException.class,
                 "Missing required Spring REST client URL property '" + configKey + "'")
             .endControlFlow()
-            .addStatement("return normalizeBaseUrl(baseUrl) + $S", servicePath + operationPath)
+            .addStatement("return normalizeBaseUrl(baseUrl) + $S", endpointPath)
             .build();
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestClientStepRenderer.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/renderer/SpringRestClientStepRenderer.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.renderer;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.CompletionStage;
+import javax.lang.model.element.Modifier;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import org.pipelineframework.processor.PipelineStepProcessor;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.RestBinding;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.util.DtoTypeUtils;
+import org.pipelineframework.processor.util.ResourceNameUtils;
+import org.pipelineframework.processor.util.RestPathResolver;
+
+/**
+ * Spring WebFlux renderer for unary REST client steps.
+ */
+public class SpringRestClientStepRenderer implements PipelineRenderer<RestBinding> {
+
+    @Override
+    public GenerationTarget target() {
+        return GenerationTarget.REST_CLIENT_STEP;
+    }
+
+    @Override
+    public void render(RestBinding binding, GenerationContext ctx) throws IOException {
+        PipelineStepModel model = binding.model();
+        validateSupported(model);
+
+        TypeSpec clientStepClass = buildClientStepClass(binding, ctx);
+        JavaFile.builder(model.servicePackage() + PipelineStepProcessor.PIPELINE_PACKAGE_SUFFIX, clientStepClass)
+            .build()
+            .writeTo(ctx.outputDir());
+    }
+
+    private TypeSpec buildClientStepClass(RestBinding binding, GenerationContext ctx) {
+        PipelineStepModel model = binding.model();
+        TypeName inputDomainType = model.inboundDomainType();
+        TypeName outputDomainType = model.outboundDomainType();
+        TypeName inputDtoType = DtoTypeUtils.toDtoType(inputDomainType);
+        TypeName outputDtoType = DtoTypeUtils.toDtoType(outputDomainType);
+        TypeName stepInterface = ParameterizedTypeName.get(
+            ClassName.get("org.pipelineframework.runtime.core", "PipelineUnaryStep"),
+            inputDomainType,
+            outputDomainType);
+        String servicePath = resolveServicePath(binding, ctx);
+        String operationPath = RestPathResolver.resolveOperationPath(ctx.processingEnv());
+        String configKey = "tpf.rest-client." + restClientName(model.serviceName()) + ".url";
+
+        return TypeSpec.classBuilder(clientStepClassName(model))
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.stereotype", "Component")).build())
+            .addSuperinterface(stepInterface)
+            .addField(FieldSpec.builder(
+                    ClassName.get("org.springframework.web.reactive.function.client", "WebClient"),
+                    "webClient",
+                    Modifier.PRIVATE,
+                    Modifier.FINAL)
+                .build())
+            .addField(FieldSpec.builder(
+                    String.class,
+                    "endpointUrl",
+                    Modifier.PRIVATE,
+                    Modifier.FINAL)
+                .build())
+            .addField(FieldSpec.builder(
+                    mapperType(inputDomainType, inputDtoType),
+                    "inboundMapper",
+                    Modifier.PRIVATE,
+                    Modifier.FINAL)
+                .build())
+            .addField(FieldSpec.builder(
+                    mapperType(outputDomainType, outputDtoType),
+                    "outboundMapper",
+                    Modifier.PRIVATE,
+                    Modifier.FINAL)
+                .build())
+            .addMethod(constructor(inputDomainType, inputDtoType, outputDomainType, outputDtoType))
+            .addMethod(applyMethod(inputDomainType, outputDomainType, inputDtoType, outputDtoType))
+            .addMethod(resolveEndpointUrlMethod(configKey, servicePath, operationPath))
+            .addMethod(normalizeBaseUrlMethod())
+            .build();
+    }
+
+    private MethodSpec constructor(
+            TypeName inputDomainType,
+            TypeName inputDtoType,
+            TypeName outputDomainType,
+            TypeName outputDtoType) {
+        return MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(ClassName.get("org.springframework.web.reactive.function.client", "WebClient", "Builder"),
+                "webClientBuilder")
+            .addParameter(ClassName.get("org.springframework.core.env", "Environment"), "environment")
+            .addParameter(mapperType(inputDomainType, inputDtoType), "inboundMapper")
+            .addParameter(mapperType(outputDomainType, outputDtoType), "outboundMapper")
+            .addStatement("this.webClient = webClientBuilder.build()")
+            .addStatement("this.endpointUrl = resolveEndpointUrl(environment)")
+            .addStatement("this.inboundMapper = inboundMapper")
+            .addStatement("this.outboundMapper = outboundMapper")
+            .build();
+    }
+
+    private MethodSpec applyMethod(
+            TypeName inputDomainType,
+            TypeName outputDomainType,
+            TypeName inputDtoType,
+            TypeName outputDtoType) {
+        TypeName completionStage = ParameterizedTypeName.get(ClassName.get(CompletionStage.class), outputDomainType);
+        return MethodSpec.methodBuilder("apply")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(completionStage)
+            .addParameter(inputDomainType, "input")
+            .addStatement("$T inputDto = this.inboundMapper.toExternal(input)", inputDtoType)
+            .addStatement("return this.webClient.post()\n"
+                    + ".uri(this.endpointUrl)\n"
+                    + ".bodyValue(inputDto)\n"
+                    + ".retrieve()\n"
+                    + ".bodyToMono($T.class)\n"
+                    + ".switchIfEmpty($T.error(new $T($S)))\n"
+                    + ".map(this.outboundMapper::fromExternal)\n"
+                    + ".toFuture()",
+                outputDtoType,
+                ClassName.get("reactor.core.publisher", "Mono"),
+                IllegalStateException.class,
+                "REST client step received an empty response body")
+            .build();
+    }
+
+    private String resolveServicePath(RestBinding binding, GenerationContext ctx) {
+        String servicePath = binding.restPathOverride() != null
+            ? binding.restPathOverride()
+            : RestPathResolver.resolveResourcePath(binding.model(), ctx.processingEnv());
+        if (servicePath == null || servicePath.isBlank()) {
+            throw new IllegalArgumentException(
+                "REST client step requires a non-blank resource path; step '"
+                    + binding.model().serviceName() + "'");
+        }
+        return servicePath;
+    }
+
+    private MethodSpec resolveEndpointUrlMethod(String configKey, String servicePath, String operationPath) {
+        return MethodSpec.methodBuilder("resolveEndpointUrl")
+            .addModifiers(Modifier.PRIVATE)
+            .returns(String.class)
+            .addParameter(ClassName.get("org.springframework.core.env", "Environment"), "environment")
+            .addStatement("String baseUrl = environment.getProperty($S)", configKey)
+            .beginControlFlow("if (baseUrl == null || baseUrl.isBlank())")
+            .addStatement("throw new $T($S)",
+                IllegalStateException.class,
+                "Missing required Spring REST client URL property '" + configKey + "'")
+            .endControlFlow()
+            .addStatement("return normalizeBaseUrl(baseUrl) + $S", servicePath + operationPath)
+            .build();
+    }
+
+    private MethodSpec normalizeBaseUrlMethod() {
+        return MethodSpec.methodBuilder("normalizeBaseUrl")
+            .addModifiers(Modifier.PRIVATE)
+            .returns(String.class)
+            .addParameter(String.class, "baseUrl")
+            .addStatement("String normalized = baseUrl.strip()")
+            .beginControlFlow("while (normalized.endsWith($S))", "/")
+            .addStatement("normalized = normalized.substring(0, normalized.length() - 1)")
+            .endControlFlow()
+            .addStatement("return normalized")
+            .build();
+    }
+
+    private TypeName mapperType(TypeName domainType, TypeName dtoType) {
+        return ParameterizedTypeName.get(ClassName.get("org.pipelineframework.mapper", "Mapper"), domainType, dtoType);
+    }
+
+    private void validateSupported(PipelineStepModel model) {
+        if (model.streamingShape() != StreamingShape.UNARY_UNARY) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only unary-unary REST client steps; step '"
+                    + model.serviceName() + "' has shape " + model.streamingShape());
+        }
+        if (model.inboundDomainType() == null || model.outboundDomainType() == null) {
+            throw new IllegalArgumentException(
+                "Unary-unary REST client steps require non-null input and output domain types; step '"
+                    + model.serviceName() + "'");
+        }
+        if (model.serviceApiKind() != ServiceApiKind.REACTIVE
+            && model.serviceApiKind() != ServiceApiKind.BLOCKING) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only reactive or blocking unary services; step '"
+                    + model.serviceName() + "' has API kind " + model.serviceApiKind());
+        }
+        if (model.sideEffect()) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile does not yet support side-effect REST client steps; step '"
+                    + model.serviceName() + "'");
+        }
+        if (model.remoteExecution() != null || model.delegateService() != null) {
+            throw new IllegalArgumentException(
+                "Spring renderer profile currently supports only internal REST client steps; step '"
+                    + model.serviceName() + "'");
+        }
+    }
+
+    private String clientStepClassName(PipelineStepModel model) {
+        return ResourceNameUtils.normalizeBaseName(model.generatedName()) + PipelineStepProcessor.REST_CLIENT_STEP_SUFFIX;
+    }
+
+    private static String restClientName(String serviceName) {
+        if (serviceName == null || serviceName.isBlank()) {
+            throw new IllegalArgumentException("Spring REST client step requires a non-blank service name");
+        }
+        String baseName = serviceName.replaceFirst("Service$", "");
+        String withBoundaryHyphens = baseName
+            .replaceAll("([A-Z]+)([A-Z][a-z])", "$1-$2")
+            .replaceAll("([a-z0-9])([A-Z])", "$1-$2");
+        return withBoundaryHyphens.toLowerCase(Locale.ROOT);
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
@@ -132,6 +132,32 @@ class SpringRendererProfileSupportTest {
     }
 
     @Test
+    void rejectsRestClientStepForRestServerRole() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(step(Set.of(GenerationTarget.REST_CLIENT_STEP), StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE, DeploymentRole.REST_SERVER)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+        assertTrue(error.getMessage().contains("REST client steps only for client-role boundaries"),
+            error.getMessage());
+    }
+
+    @Test
+    void rejectsRestClientStepForPluginServerRole() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(step(Set.of(GenerationTarget.REST_CLIENT_STEP), StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE, DeploymentRole.PLUGIN_SERVER)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+        assertTrue(error.getMessage().contains("REST client steps only for client-role boundaries"),
+            error.getMessage());
+    }
+
+    @Test
     void rejectsBlockingIteratorStep() {
         PipelineCompilationContext context = context();
         context.setStepModels(List.of(step(Set.of(GenerationTarget.LOCAL_CLIENT_STEP), StreamingShape.UNARY_UNARY,

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/phase/SpringRendererProfileSupportTest.java
@@ -58,6 +58,19 @@ class SpringRendererProfileSupportTest {
     }
 
     @Test
+    void acceptsUnaryRestClientStep() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(step(
+            Set.of(GenerationTarget.REST_CLIENT_STEP),
+            StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE,
+            DeploymentRole.ORCHESTRATOR_CLIENT)));
+
+        assertDoesNotThrow(() -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
     void acceptsBlockingUnaryStep() {
         PipelineCompilationContext context = context();
         context.setStepModels(List.of(step(Set.of(GenerationTarget.LOCAL_CLIENT_STEP), StreamingShape.UNARY_UNARY,
@@ -103,6 +116,19 @@ class SpringRendererProfileSupportTest {
 
         assertThrows(IllegalStateException.class,
             () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+    }
+
+    @Test
+    void rejectsRestClientStepForPipelineServerRole() {
+        PipelineCompilationContext context = context();
+        context.setTransportMode(PipelineTransport.REST);
+        context.setStepModels(List.of(step(Set.of(GenerationTarget.REST_CLIENT_STEP), StreamingShape.UNARY_UNARY,
+            ServiceApiKind.REACTIVE, DeploymentRole.PIPELINE_SERVER)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> SpringRendererProfileSupport.validateGenerationSupported(context));
+        assertTrue(error.getMessage().contains("REST client steps only for client-role boundaries"),
+            error.getMessage());
     }
 
     @Test
@@ -170,6 +196,17 @@ class SpringRendererProfileSupportTest {
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.PIPELINE_SERVER)
             .serviceApiKind(apiKind)
+            .build();
+    }
+
+    private PipelineStepModel step(
+        Set<GenerationTarget> targets,
+        StreamingShape shape,
+        ServiceApiKind apiKind,
+        DeploymentRole role
+    ) {
+        return step(targets, shape, apiKind).toBuilder()
+            .deploymentRole(role)
             .build();
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestClientStepRendererTest.java
@@ -133,6 +133,43 @@ class SpringRestClientStepRendererTest {
         assertTrue(error.getMessage().contains("non-blank resource path"), error.getMessage());
     }
 
+    @Test
+    void rejectsFullUrlRestPathOverride() {
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, false),
+                    "https://payments.example.test/payments"),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+
+        assertTrue(error.getMessage().contains("must be a path"), error.getMessage());
+    }
+
+    @Test
+    void rejectsQueryRestPathOverride() {
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, false), "/payments?mode=test"),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+
+        assertTrue(error.getMessage().contains("query/fragment"), error.getMessage());
+    }
+
+    @Test
+    void normalizesRelativeRestPathOverride() throws Exception {
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(Map.of());
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, false), "payments/"),
+            new GenerationContext(processingEnv, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/PaymentRestClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("return normalizeBaseUrl(baseUrl) + \"/payments/\";"));
+    }
+
     private PipelineStepModel model(StreamingShape shape, boolean sideEffect) {
         return new PipelineStepModel.Builder()
             .serviceName("PaymentService")

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestClientStepRendererTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/renderer/SpringRestClientStepRendererTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2023-2026 Mariano Barcia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pipelineframework.processor.renderer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.RestBinding;
+import org.pipelineframework.processor.ir.ServiceApiKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SpringRestClientStepRendererTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rendersSpringWebClientUnaryRestClientStep() throws Exception {
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(Map.of());
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, false), "/payments"),
+            new GenerationContext(processingEnv, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null));
+
+        Path clientStep = tempDir.resolve("com/example/service/pipeline/PaymentRestClientStep.java");
+        String source = Files.readString(clientStep);
+        assertTrue(source.contains("import java.util.concurrent.CompletionStage;"));
+        assertTrue(source.contains("import org.pipelineframework.runtime.core.PipelineUnaryStep;"));
+        assertTrue(source.contains("import org.springframework.core.env.Environment;"));
+        assertTrue(source.contains("import org.springframework.stereotype.Component;"));
+        assertTrue(source.contains("import org.springframework.web.reactive.function.client.WebClient;"));
+        assertTrue(source.contains("@Component"));
+        assertTrue(source.contains("public class PaymentRestClientStep implements PipelineUnaryStep<PaymentRecord, PaymentStatus>"));
+        assertTrue(source.contains("private final WebClient webClient;"));
+        assertTrue(source.contains("private final String endpointUrl;"));
+        assertTrue(source.contains("Mapper<PaymentRecord, PaymentRecordDto> inboundMapper;"));
+        assertTrue(source.contains("Mapper<PaymentStatus, PaymentStatusDto> outboundMapper;"));
+        assertTrue(source.contains("public PaymentRestClientStep(WebClient.Builder webClientBuilder, Environment environment,"));
+        assertTrue(source.contains("Mapper<PaymentRecord, PaymentRecordDto> inboundMapper,"));
+        assertTrue(source.contains("Mapper<PaymentStatus, PaymentStatusDto> outboundMapper)"));
+        assertTrue(source.contains("this.webClient = webClientBuilder.build();"));
+        assertTrue(source.contains("PaymentRecordDto inputDto = this.inboundMapper.toExternal(input);"));
+        assertTrue(source.contains(".bodyToMono(PaymentStatusDto.class)"));
+        assertTrue(source.contains(".switchIfEmpty(Mono.error(new IllegalStateException(\"REST client step received an empty response body\")))"));
+        assertTrue(source.contains(".map(this.outboundMapper::fromExternal)"));
+        assertTrue(source.contains(".toFuture()"));
+        assertTrue(source.contains("this.endpointUrl = resolveEndpointUrl(environment);"));
+        assertTrue(source.contains(".uri(this.endpointUrl)"));
+        assertTrue(source.contains("environment.getProperty(\"tpf.rest-client.payment.url\")"));
+        assertTrue(source.contains("Missing required Spring REST client URL property 'tpf.rest-client.payment.url'"));
+        assertTrue(source.contains("return normalizeBaseUrl(baseUrl) + \"/payments/\";"));
+        assertFalse(source.contains("io.quarkus."));
+        assertFalse(source.contains("io.smallrye.mutiny"));
+        assertFalse(source.contains("jakarta.enterprise."));
+        assertFalse(source.contains("jakarta.inject."));
+        assertFalse(source.contains("org.eclipse.microprofile"));
+        assertFalse(source.contains("@RegisterRestClient"));
+        assertFalse(source.contains("@RestClient"));
+        assertFalse(source.contains("PipelineInvocationRuntime"));
+        assertFalse(source.contains("PipelineContextHolder"));
+        assertGeneratedSourcesCompile();
+    }
+
+    @Test
+    void rejectsNonUnaryRestClientStep() {
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_STREAMING, false), "/payments"),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+
+        assertTrue(error.getMessage().contains("only unary-unary REST client steps"), error.getMessage());
+    }
+
+    @Test
+    void rejectsSideEffectRestClientStep() {
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, true), "/payments"),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+
+        assertTrue(error.getMessage().contains("side-effect REST client steps"), error.getMessage());
+    }
+
+    @Test
+    void rejectsBlankRestPathOverride() {
+        SpringRestClientStepRenderer renderer = new SpringRestClientStepRenderer();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> renderer.render(new RestBinding(model(StreamingShape.UNARY_UNARY, false), " "),
+                new GenerationContext(null, tempDir, DeploymentRole.ORCHESTRATOR_CLIENT, Set.of(), null, null)));
+
+        assertTrue(error.getMessage().contains("non-blank resource path"), error.getMessage());
+    }
+
+    private PipelineStepModel model(StreamingShape shape, boolean sideEffect) {
+        return new PipelineStepModel.Builder()
+            .serviceName("PaymentService")
+            .generatedName("PaymentService")
+            .servicePackage("com.example.service")
+            .serviceClassName(ClassName.get("com.example.service", "PaymentService"))
+            .inputMapping(new TypeMapping(
+                ClassName.get("com.example.service", "PaymentRecord"),
+                ClassName.get("com.example.service", "PaymentRecordMapper"),
+                true))
+            .outputMapping(new TypeMapping(
+                ClassName.get("com.example.service", "PaymentStatus"),
+                ClassName.get("com.example.service", "PaymentStatusMapper"),
+                true))
+            .streamingShape(shape)
+            .enabledTargets(Set.of(GenerationTarget.REST_CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .serviceApiKind(ServiceApiKind.REACTIVE)
+            .sideEffect(sideEffect)
+            .build();
+    }
+
+    private void assertGeneratedSourcesCompile() throws Exception {
+        writeSource("org/springframework/stereotype/Component.java",
+            """
+            package org.springframework.stereotype;
+            public @interface Component {
+            }
+            """);
+        writeSource("org/springframework/core/env/Environment.java",
+            """
+            package org.springframework.core.env;
+            public interface Environment {
+                String getProperty(String key);
+            }
+            """);
+        writeSource("org/springframework/web/reactive/function/client/WebClient.java",
+            """
+            package org.springframework.web.reactive.function.client;
+            import reactor.core.publisher.Mono;
+            public class WebClient {
+                public interface Builder {
+                    WebClient build();
+                }
+                public RequestBodyUriSpec post() {
+                    throw new UnsupportedOperationException("stub");
+                }
+                public interface RequestBodyUriSpec {
+                    RequestBodySpec uri(String uri);
+                }
+                public interface RequestBodySpec {
+                    RequestHeadersSpec bodyValue(Object body);
+                }
+                public interface RequestHeadersSpec {
+                    ResponseSpec retrieve();
+                }
+                public interface ResponseSpec {
+                    <T> Mono<T> bodyToMono(Class<T> elementClass);
+                }
+            }
+            """);
+        writeSource("reactor/core/publisher/Mono.java",
+            """
+            package reactor.core.publisher;
+            import java.util.concurrent.CompletableFuture;
+            import java.util.function.Function;
+            public class Mono<T> {
+                public static <T> Mono<T> error(Throwable throwable) {
+                    throw new UnsupportedOperationException("stub");
+                }
+                public Mono<T> switchIfEmpty(Mono<T> alternate) {
+                    throw new UnsupportedOperationException("stub");
+                }
+                public <R> Mono<R> map(Function<? super T, ? extends R> mapper) {
+                    throw new UnsupportedOperationException("stub");
+                }
+                public CompletableFuture<T> toFuture() {
+                    throw new UnsupportedOperationException("stub");
+                }
+            }
+            """);
+        writeSource("com/example/service/PaymentRecord.java",
+            """
+            package com.example.service;
+            public record PaymentRecord(String value) {
+            }
+            """);
+        writeSource("com/example/dto/PaymentRecordDto.java",
+            """
+            package com.example.dto;
+            public record PaymentRecordDto(String value) {
+            }
+            """);
+        writeSource("com/example/service/PaymentStatus.java",
+            """
+            package com.example.service;
+            public record PaymentStatus(String value) {
+            }
+            """);
+        writeSource("com/example/dto/PaymentStatusDto.java",
+            """
+            package com.example.dto;
+            public record PaymentStatusDto(String value) {
+            }
+            """);
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, null)) {
+            List<Path> sources;
+            try (var stream = Files.walk(tempDir)) {
+                sources = stream
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .toList();
+            }
+            Iterable<? extends JavaFileObject> compilationUnits =
+                fileManager.getJavaFileObjectsFromPaths(sources);
+            Files.createDirectories(tempDir.resolve("classes"));
+            Boolean compiled = compiler.getTask(
+                null,
+                fileManager,
+                diagnostics,
+                List.of(
+                    "-proc:none",
+                    "-classpath", System.getProperty("java.class.path"),
+                    "-d", tempDir.resolve("classes").toString()),
+                null,
+                compilationUnits).call();
+            if (!Boolean.TRUE.equals(compiled)) {
+                String messages = diagnostics.getDiagnostics().stream()
+                    .map(this::formatDiagnostic)
+                    .toList()
+                    .toString();
+                throw new AssertionError("Generated Spring REST client source did not compile: " + messages);
+            }
+        }
+    }
+
+    private void writeSource(String relativePath, String source) throws Exception {
+        Path path = tempDir.resolve(relativePath);
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, source);
+    }
+
+    private String formatDiagnostic(Diagnostic<? extends JavaFileObject> diagnostic) {
+        return diagnostic.getKind() + " " + diagnostic.getSource() + ":" + diagnostic.getLineNumber()
+            + " " + diagnostic.getMessage(null);
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring-profile unary REST client-step rendering with WebClient and CompletionStage
- allow Spring REST client-step targets only for client-role unary REST+COMPUTE boundaries
- document partial Spring REST client-step support and `tpf.rest-client.<client-name>.url`

## Scope
- Spring renderer adoption slice only
- no queue-async/coordinator, await/checkpoint/broker, gRPC/function, side effects, streaming, or control-header propagation

## Validation
- `cr review --agent --base origin/main --config ./AGENTS.md`
- `./mvnw -f framework/pom.xml -pl runtime-core,runtime-spring,deployment,spring-smoke-tests,spring-blocking-smoke-tests -am -Dtest='SpringRendererProfileSupportTest,SpringRestClientStepRendererTest,SpringLocalClientStepRendererTest,YamlDrivenStepGenerationTest,GeneratedSpringRestSmokeTest,GeneratedSpringBlockingRestSmokeTest,SpringSmokeDependencyGuardTest,SpringBlockingSmokeDependencyGuardTest,RuntimeSpringDependencyGuardTest' -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f framework/pom.xml -pl deployment spotless:check`
- `npm --prefix docs run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spring WebFlux support for unary REST client steps with Spring-based code generation.
  * Improved endpoint resolution and request/response mapping for generated client steps.
* **Bug Fixes**
  * Tightened validation so unsupported step shapes and server-role REST client steps are rejected with clear errors.
  * Updated supported Spring guidance to reflect current REST client-step boundaries and configuration requirements.
* **Tests**
  * Added coverage for Spring profile validation and Spring REST client step generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->