### PR TITLE
Extract queue async operations flow

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitTimeoutFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitTimeoutFlow.java
@@ -29,10 +29,16 @@ class AwaitTimeoutFlow {
 
   Uni<Void> sweepTimedOut(long nowEpochMs, int limit) {
     return awaitCoordinator.findTimedOut(nowEpochMs, limit)
-        .onItem().transformToUni(records -> Multi.createFrom().iterable(records)
-            .onItem().transformToUniAndConcatenate(record -> admitTimeout(record, nowEpochMs))
-            .collect().asList()
-            .replaceWithVoid());
+        .onItem().transform(records -> TimedOutAwaitInteractionsPlan.from(records, limit))
+        .onItem().transformToUni(plan -> {
+          if (plan.empty()) {
+            return Uni.createFrom().voidItem();
+          }
+          return Multi.createFrom().iterable(plan.interactions())
+              .onItem().transformToUniAndConcatenate(record -> admitTimeout(record, nowEpochMs))
+              .collect().asList()
+              .replaceWithVoid();
+        });
   }
 
   private Uni<Void> admitTimeout(AwaitInteractionRecord interaction, long nowEpochMs) {

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitTimeoutFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitTimeoutFlow.java
@@ -1,0 +1,70 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+class AwaitTimeoutFlow {
+
+  private final AwaitCoordinator awaitCoordinator;
+  private final ExecutionStateStore executionStateStore;
+  private final Supplier<SegmentBoundaryLedger> segmentBoundaryLedger;
+
+  AwaitTimeoutFlow(
+      AwaitCoordinator awaitCoordinator,
+      ExecutionStateStore executionStateStore,
+      Supplier<SegmentBoundaryLedger> segmentBoundaryLedger) {
+    this.awaitCoordinator = Objects.requireNonNull(awaitCoordinator, "awaitCoordinator must not be null");
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.segmentBoundaryLedger =
+        Objects.requireNonNull(segmentBoundaryLedger, "segmentBoundaryLedger must not be null");
+  }
+
+  Uni<Void> sweepTimedOut(long nowEpochMs, int limit) {
+    return awaitCoordinator.findTimedOut(nowEpochMs, limit)
+        .onItem().transformToUni(records -> Multi.createFrom().iterable(records)
+            .onItem().transformToUniAndConcatenate(record -> admitTimeout(record, nowEpochMs))
+            .collect().asList()
+            .replaceWithVoid());
+  }
+
+  private Uni<Void> admitTimeout(AwaitInteractionRecord interaction, long nowEpochMs) {
+    return awaitCoordinator.markTimedOut(interaction, nowEpochMs)
+        .onItem().transformToUni(updated -> updated.map(record ->
+                segmentBoundaryLedger.get().recordInteractionTimedOut(record, nowEpochMs)
+                    .chain(() -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
+                    .onItem().transform(parent -> AwaitTimeoutPlan.from(record, parent))
+                    .onItem().transformToUni(plan -> plan.failParent()
+                        ? failParent(plan, nowEpochMs)
+                        : Uni.createFrom().voidItem()))
+            .orElseGet(() -> Uni.createFrom().voidItem()));
+  }
+
+  private Uni<Void> failParent(AwaitTimeoutPlan plan, long nowEpochMs) {
+    var parent = plan.parent().orElseThrow();
+    return executionStateStore.markTerminalFailure(
+            parent.tenantId(),
+            parent.executionId(),
+            parent.version(),
+            ExecutionStatus.FAILED,
+            plan.transitionKey().orElseThrow(),
+            plan.errorCode(),
+            plan.errorMessage(),
+            nowEpochMs)
+        .onItem().transformToUni(updated -> updated
+            .map(failed -> segmentBoundaryLedger.get().recordRunFailed(
+                failed,
+                plan.errorCode(),
+                plan.errorMessage(),
+                nowEpochMs))
+            .orElseGet(() -> Uni.createFrom().voidItem()))
+        .replaceWithVoid();
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/AwaitTimeoutPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/AwaitTimeoutPlan.java
@@ -1,0 +1,78 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+record AwaitTimeoutPlan(
+    AwaitInteractionRecord interaction,
+    Optional<ExecutionRecord<Object, Object>> parent,
+    boolean failParent,
+    Optional<String> transitionKey,
+    String errorCode,
+    String errorMessage) {
+
+  private static final String ERROR_CODE = "AWAIT_TIMEOUT";
+
+  AwaitTimeoutPlan {
+    Objects.requireNonNull(interaction, "interaction must not be null");
+    Objects.requireNonNull(parent, "parent must not be null");
+    Objects.requireNonNull(transitionKey, "transitionKey must not be null");
+    Objects.requireNonNull(errorCode, "errorCode must not be null");
+    Objects.requireNonNull(errorMessage, "errorMessage must not be null");
+    if (failParent && (parent.isEmpty() || transitionKey.isEmpty())) {
+      throw new IllegalArgumentException("parent failure plans require a parent record and transition key");
+    }
+    if (failParent) {
+      ExecutionRecord<Object, Object> execution = parent.orElseThrow();
+      if (execution.status() != ExecutionStatus.WAITING_EXTERNAL
+          || !Objects.equals(interaction.unitId(), execution.awaitUnitId())) {
+        throw new IllegalArgumentException(
+            "parent failure plans require a waiting parent bound to the timed-out interaction");
+      }
+    }
+  }
+
+  static AwaitTimeoutPlan from(
+      AwaitInteractionRecord interaction,
+      Optional<ExecutionRecord<Object, Object>> parent) {
+    Objects.requireNonNull(interaction, "interaction must not be null");
+    Objects.requireNonNull(parent, "parent must not be null");
+    String message = "Await interaction timed out: " + interaction.interactionId();
+    if (parent.isEmpty() || parent.get().status().terminal()) {
+      return recordOnly(interaction, parent, message);
+    }
+    ExecutionRecord<Object, Object> execution = parent.get();
+    if (execution.status() != ExecutionStatus.WAITING_EXTERNAL
+        || !Objects.equals(interaction.unitId(), execution.awaitUnitId())) {
+      return recordOnly(interaction, parent, message);
+    }
+    return new AwaitTimeoutPlan(
+        interaction,
+        parent,
+        true,
+        Optional.of(transitionKey(execution)),
+        ERROR_CODE,
+        message);
+  }
+
+  private static AwaitTimeoutPlan recordOnly(
+      AwaitInteractionRecord interaction,
+      Optional<ExecutionRecord<Object, Object>> parent,
+      String message) {
+    return new AwaitTimeoutPlan(
+        interaction,
+        parent,
+        false,
+        Optional.empty(),
+        ERROR_CODE,
+        message);
+  }
+
+  private static String transitionKey(ExecutionRecord<Object, Object> execution) {
+    return execution.executionId() + ":" + execution.currentStepIndex() + ":" + execution.attempt();
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/DueExecutionDispatchPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/DueExecutionDispatchPlan.java
@@ -1,0 +1,31 @@
+package org.pipelineframework;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+
+record DueExecutionDispatchPlan(List<ExecutionWorkItem> workItems) {
+
+  DueExecutionDispatchPlan {
+    Objects.requireNonNull(workItems, "workItems must not be null");
+    workItems = List.copyOf(workItems);
+  }
+
+  static DueExecutionDispatchPlan from(List<ExecutionRecord<Object, Object>> dueExecutions) {
+    Objects.requireNonNull(dueExecutions, "dueExecutions must not be null");
+    return new DueExecutionDispatchPlan(dueExecutions.stream()
+        .sorted(Comparator
+            .comparingLong(ExecutionRecord<Object, Object>::nextDueEpochMs)
+            .thenComparing(ExecutionRecord::tenantId)
+            .thenComparing(ExecutionRecord::executionId))
+        .map(record -> new ExecutionWorkItem(record.tenantId(), record.executionId()))
+        .toList());
+  }
+
+  boolean empty() {
+    return workItems.isEmpty();
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/ExecutionRedrivePlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/ExecutionRedrivePlan.java
@@ -1,0 +1,57 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+record ExecutionRedrivePlan(
+    ExecutionRecord<Object, Object> previous,
+    long expectedVersion,
+    boolean allowFailed,
+    String normalizedReason,
+    String transitionKey) {
+
+  ExecutionRedrivePlan {
+    Objects.requireNonNull(previous, "previous must not be null");
+    Objects.requireNonNull(normalizedReason, "normalizedReason must not be null");
+    Objects.requireNonNull(transitionKey, "transitionKey must not be null");
+    if (!redrivable(previous.status(), allowFailed)) {
+      throw new IllegalStateException(
+          "Execution " + previous.executionId() + " cannot be re-driven from status " + previous.status());
+    }
+    if (expectedVersion != previous.version()) {
+      throw new IllegalStateException(
+          "Execution " + previous.executionId() + " version mismatch: expected " + expectedVersion
+              + " but current version is " + previous.version());
+    }
+  }
+
+  static ExecutionRedrivePlan from(
+      ExecutionRecord<Object, Object> previous,
+      Long expectedVersion,
+      boolean allowFailed,
+      String reason) {
+    Objects.requireNonNull(previous, "previous must not be null");
+    long version = expectedVersion == null ? previous.version() : expectedVersion;
+    String normalizedReason = normalizeReason(reason);
+    return new ExecutionRedrivePlan(
+        previous,
+        version,
+        allowFailed,
+        normalizedReason,
+        "redrive:" + previous.executionId() + ":" + version);
+  }
+
+  private static boolean redrivable(ExecutionStatus status, boolean allowFailed) {
+    return status == ExecutionStatus.DLQ || (allowFailed && status == ExecutionStatus.FAILED);
+  }
+
+  private static String normalizeReason(String reason) {
+    if (reason == null || reason.isBlank()) {
+      return "operator";
+    }
+    String trimmed = reason.trim();
+    return trimmed.length() <= 80 ? trimmed : trimmed.substring(0, 80);
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncCoordinator.java
@@ -4,7 +4,6 @@ import org.pipelineframework.orchestrator.release.PipelineContractDescriptor;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -14,7 +13,6 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.NotFoundException;
 
 import io.smallrye.mutiny.Uni;
 import org.jboss.logging.Logger;
@@ -37,7 +35,6 @@ import org.pipelineframework.orchestrator.ExecutionRedriveResult;
 import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.ExecutionResultShapeResolver;
 import org.pipelineframework.orchestrator.ExecutionStateStore;
-import org.pipelineframework.orchestrator.ExecutionStatus;
 import org.pipelineframework.orchestrator.ExecutionWorkItem;
 import org.pipelineframework.orchestrator.OrchestratorIdempotencyPolicy;
 import org.pipelineframework.orchestrator.OrchestratorMode;
@@ -117,6 +114,8 @@ class QueueAsyncCoordinator {
   private volatile AwaitContinuations awaitContinuations;
   private volatile ExecutionReadModel executionReadModel;
   private volatile QueueAsyncSubmissionFlow submissionFlow;
+  private volatile QueueAsyncRedriveFlow redriveFlow;
+  private volatile QueueAsyncSweepFlow sweepFlow;
 
   @Inject
   PipelineTelemetry telemetry;
@@ -148,6 +147,8 @@ class QueueAsyncCoordinator {
     deadLetterPublisher = selectDeadLetterPublisher(orchestratorConfig.dlqProvider());
     executionReadModel = null;
     submissionFlow = null;
+    redriveFlow = null;
+    sweepFlow = null;
 
     List<String> providerReadinessErrors = new ArrayList<>();
     executionStateStore.startupValidationError(orchestratorConfig)
@@ -247,65 +248,10 @@ class QueueAsyncCoordinator {
       Long expectedVersion,
       boolean allowFailed,
       String reason) {
-    if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
-      return Uni.createFrom().failure(new IllegalStateException(
-          "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+    if (!ensureQueueModeReady()) {
+      return Uni.createFrom().failure(queueModeDisabledException());
     }
-    String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
-    RuntimeException admissionFailure = admissionFailure(admissionRequest(
-        resolvedTenant,
-        ControlPlaneAdmissionOperation.REDRIVE_EXECUTION,
-        executionId,
-        "api",
-        explicitTenant(tenantId)));
-    if (admissionFailure != null) {
-      return Uni.createFrom().failure(admissionFailure);
-    }
-    long now = System.currentTimeMillis();
-    return executionStateStore.getExecution(resolvedTenant, executionId)
-        .onItem().transformToUni(optional -> {
-          if (optional.isEmpty()) {
-            return Uni.createFrom().failure(new NotFoundException("Execution not found: " + executionId));
-          }
-          ExecutionRecord<Object, Object> previous = optional.get();
-          if (!redrivable(previous.status(), allowFailed)) {
-            return Uni.createFrom().failure(new IllegalStateException(
-                "Execution " + executionId + " cannot be re-driven from status " + previous.status()));
-          }
-          long version = expectedVersion == null ? previous.version() : expectedVersion;
-          if (version != previous.version()) {
-            return Uni.createFrom().failure(new IllegalStateException(
-                "Execution " + executionId + " version mismatch: expected " + version
-                    + " but current version is " + previous.version()));
-          }
-          String transitionKey = redriveTransitionKey(previous, reason);
-          return executionStateStore.redriveTerminalExecution(
-                  resolvedTenant,
-                  executionId,
-                  version,
-                  allowFailed,
-                  transitionKey,
-                  now)
-              .onItem().transformToUni(redriven -> {
-                if (redriven.isEmpty()) {
-                  return Uni.createFrom().failure(new IllegalStateException(
-                      "Execution " + executionId + " changed before re-drive could be admitted"));
-                }
-                ExecutionRecord<Object, Object> record = redriven.get();
-                return workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
-                    .onItem().transform(ignored -> {
-                      LOG.infof(
-                          "Re-drove execution tenant=%s executionId=%s previousStatus=%s stepIndex=%d attempt=%d reason=%s",
-                          record.tenantId(),
-                          record.executionId(),
-                          previous.status(),
-                          record.currentStepIndex(),
-                          record.attempt(),
-                          normalizeReason(reason));
-                      return ExecutionRedriveResult.from(previous, record);
-                    });
-              });
-        });
+    return redriveFlow().redrive(tenantId, executionId, expectedVersion, allowFailed, reason);
   }
 
   Uni<Object> getExecutionResultPayload(String tenantId, String executionId) {
@@ -336,27 +282,7 @@ class QueueAsyncCoordinator {
     if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC || executionStateStore == null || workDispatcher == null) {
       return;
     }
-    long now = System.currentTimeMillis();
-    sweepTimedOutAwaitInteractions(now)
-        .onItem().transformToUni(ignored -> executionStateStore.findDueExecutions(now, orchestratorConfig.sweepLimit()))
-        .onItem().transformToUni(due -> {
-          if (due.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          List<Uni<Void>> enqueueOperations = new ArrayList<>(due.size());
-          for (ExecutionRecord<Object, Object> record : due) {
-            enqueueOperations.add(workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
-                .onFailure().transform(failure -> new IllegalStateException(
-                    "Failed to re-dispatch due execution " + record.executionId(),
-                    failure)));
-          }
-          return Uni.join().all(enqueueOperations).andCollectFailures().replaceWithVoid();
-        })
-        .subscribe()
-        .with(
-            ignored -> {
-            },
-            failure -> LOG.errorf(failure, "Failed sweeping due async executions"));
+    sweepFlow().sweepDueExecutions();
   }
 
   Uni<AwaitCompletionResult> completeAwait(AwaitCompletionCommand command) {
@@ -390,67 +316,6 @@ class QueueAsyncCoordinator {
       return Uni.createFrom().failure(admissionFailure);
     }
     return awaitCoordinator.queryPending(resolvedTenant, assignee, group, stepId, limit <= 0 ? 100 : limit);
-  }
-
-  private Uni<Void> sweepTimedOutAwaitInteractions(long now) {
-    return awaitCoordinator.findTimedOut(now, orchestratorConfig.sweepLimit())
-        .onItem().transformToUni(records -> {
-          if (records.isEmpty()) {
-            return Uni.createFrom().voidItem();
-          }
-          List<Uni<Void>> operations = new ArrayList<>(records.size());
-          for (AwaitInteractionRecord record : records) {
-            operations.add(awaitCoordinator.markTimedOut(record, now)
-                .onItem().transformToUni(updated -> updated.isPresent()
-                    ? segmentBoundaryLedger().recordInteractionTimedOut(updated.get(), now)
-                    : Uni.createFrom().voidItem())
-                .onItem().transformToUni(ignored -> executionStateStore.getExecution(record.tenantId(), record.executionId()))
-                .onItem().transformToUni(execution -> {
-                  if (execution.isEmpty() || execution.get().status().terminal()) {
-                    return Uni.createFrom().voidItem();
-                  }
-                  ExecutionRecord<Object, Object> executionRecord = execution.get();
-                  if (executionRecord.status() != ExecutionStatus.WAITING_EXTERNAL
-                      || !record.unitId().equals(executionRecord.awaitUnitId())) {
-                    return Uni.createFrom().voidItem();
-                  }
-                  return executionStateStore.markTerminalFailure(
-                          executionRecord.tenantId(),
-                          executionRecord.executionId(),
-                          executionRecord.version(),
-                          ExecutionStatus.FAILED,
-                          transitionKey(executionRecord.executionId(), executionRecord.currentStepIndex(), executionRecord.attempt()),
-                          "AWAIT_TIMEOUT",
-                          "Await interaction timed out: " + record.interactionId(),
-                          now)
-                      .onItem().transformToUni(updated -> updated
-                          .map(failed -> segmentBoundaryLedger().recordRunFailed(
-                              failed,
-                              "AWAIT_TIMEOUT",
-                              "Await interaction timed out: " + record.interactionId(),
-                              now))
-                          .orElseGet(() -> Uni.createFrom().voidItem()))
-                      .replaceWithVoid();
-                }));
-          }
-          return Uni.join().all(operations).andCollectFailures().replaceWithVoid();
-        });
-  }
-
-  private static boolean redrivable(ExecutionStatus status, boolean allowFailed) {
-    return status == ExecutionStatus.DLQ || (allowFailed && status == ExecutionStatus.FAILED);
-  }
-
-  private static String redriveTransitionKey(ExecutionRecord<Object, Object> record, String reason) {
-    return "redrive:" + record.executionId() + ":" + record.version() + ":" + normalizeReason(reason);
-  }
-
-  private static String normalizeReason(String reason) {
-    if (reason == null || reason.isBlank()) {
-      return "operator";
-    }
-    String trimmed = reason.trim();
-    return trimmed.length() <= 80 ? trimmed : trimmed.substring(0, 80);
   }
 
   private Duration saturatedDelay() {
@@ -676,6 +541,50 @@ class QueueAsyncCoordinator {
     }
   }
 
+  private QueueAsyncRedriveFlow redriveFlow() {
+    if (!ensureQueueModeReady()) {
+      throw queueModeDisabledException();
+    }
+    QueueAsyncRedriveFlow current = redriveFlow;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      current = redriveFlow;
+      if (current == null) {
+        current = new QueueAsyncRedriveFlow(
+            orchestratorConfig,
+            executionInputPolicy,
+            executionStateStore,
+            workDispatcher,
+            admissionPolicy(),
+            this::pipelineId,
+            this::releaseVersion);
+        redriveFlow = current;
+      }
+      return current;
+    }
+  }
+
+  private QueueAsyncSweepFlow sweepFlow() {
+    QueueAsyncSweepFlow current = sweepFlow;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      current = sweepFlow;
+      if (current == null) {
+        current = new QueueAsyncSweepFlow(
+            orchestratorConfig,
+            executionStateStore,
+            workDispatcher,
+            new AwaitTimeoutFlow(awaitCoordinator, executionStateStore, this::segmentBoundaryLedger));
+        sweepFlow = current;
+      }
+      return current;
+    }
+  }
+
   private AwaitContinuations awaitContinuations() {
     AwaitContinuations current = awaitContinuations;
     if (current != null) {
@@ -774,10 +683,6 @@ class QueueAsyncCoordinator {
       return true;
     }
     return configuredName.equalsIgnoreCase(availableName);
-  }
-
-  private static String transitionKey(String executionId, int stepIndex, int attempt) {
-    return executionId + ":" + stepIndex + ":" + attempt;
   }
 
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncRedriveFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncRedriveFlow.java
@@ -1,0 +1,148 @@
+package org.pipelineframework;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.NotFoundException;
+import org.jboss.logging.Logger;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionOperation;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionRequest;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionRedriveResult;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+class QueueAsyncRedriveFlow {
+
+  private static final Logger LOG = Logger.getLogger(QueueAsyncRedriveFlow.class);
+
+  private final PipelineOrchestratorConfig orchestratorConfig;
+  private final ExecutionInputPolicy executionInputPolicy;
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final ControlPlaneAdmissionPolicy admissionPolicy;
+  private final Supplier<String> pipelineId;
+  private final Supplier<String> releaseVersion;
+
+  QueueAsyncRedriveFlow(
+      PipelineOrchestratorConfig orchestratorConfig,
+      ExecutionInputPolicy executionInputPolicy,
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      ControlPlaneAdmissionPolicy admissionPolicy,
+      Supplier<String> pipelineId,
+      Supplier<String> releaseVersion) {
+    this.orchestratorConfig = Objects.requireNonNull(orchestratorConfig, "orchestratorConfig must not be null");
+    this.executionInputPolicy = Objects.requireNonNull(executionInputPolicy, "executionInputPolicy must not be null");
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.workDispatcher = Objects.requireNonNull(workDispatcher, "workDispatcher must not be null");
+    this.admissionPolicy = Objects.requireNonNull(admissionPolicy, "admissionPolicy must not be null");
+    this.pipelineId = Objects.requireNonNull(pipelineId, "pipelineId must not be null");
+    this.releaseVersion = Objects.requireNonNull(releaseVersion, "releaseVersion must not be null");
+  }
+
+  Uni<ExecutionRedriveResult> redrive(
+      String tenantId,
+      String executionId,
+      Long expectedVersion,
+      boolean allowFailed,
+      String reason) {
+    return Uni.createFrom().deferred(() -> {
+      if (orchestratorConfig.mode() != OrchestratorMode.QUEUE_ASYNC) {
+        return Uni.createFrom().failure(new IllegalStateException(
+            "Async queue mode is disabled. Set pipeline.orchestrator.mode=QUEUE_ASYNC."));
+      }
+      String resolvedTenant = executionInputPolicy.normalizeTenant(tenantId);
+      Optional<RuntimeException> admissionFailure = admissionFailure(resolvedTenant, tenantId, executionId);
+      if (admissionFailure.isPresent()) {
+        return Uni.createFrom().failure(admissionFailure.get());
+      }
+      long now = System.currentTimeMillis();
+      return executionStateStore.getExecution(resolvedTenant, executionId)
+          .onItem().transformToUni(optional -> accept(
+              resolvedTenant,
+              executionId,
+              optional,
+              expectedVersion,
+              allowFailed,
+              reason,
+              now));
+    });
+  }
+
+  private Uni<ExecutionRedriveResult> accept(
+      String tenantId,
+      String executionId,
+      Optional<ExecutionRecord<Object, Object>> optional,
+      Long expectedVersion,
+      boolean allowFailed,
+      String reason,
+      long now) {
+    if (optional.isEmpty()) {
+      return Uni.createFrom().failure(new NotFoundException("Execution not found: " + executionId));
+    }
+    ExecutionRedrivePlan plan = ExecutionRedrivePlan.from(optional.get(), expectedVersion, allowFailed, reason);
+    return executionStateStore.redriveTerminalExecution(
+            tenantId,
+            executionId,
+            plan.expectedVersion(),
+            plan.allowFailed(),
+            plan.transitionKey(),
+            now)
+        .onItem().transformToUni(redriven -> redriven
+            .map(record -> enqueue(plan, record))
+            .orElseGet(() -> Uni.createFrom().failure(new IllegalStateException(
+                "Execution " + executionId + " changed before re-drive could be admitted"))));
+  }
+
+  private Uni<ExecutionRedriveResult> enqueue(
+      ExecutionRedrivePlan plan,
+      ExecutionRecord<Object, Object> record) {
+    return workDispatcher.enqueueNow(new ExecutionWorkItem(record.tenantId(), record.executionId()))
+        .onFailure().recoverWithUni(failure -> {
+          LOG.warnf(
+              failure,
+              "Re-drive admitted but immediate enqueue failed; due-work sweep will retry tenant=%s executionId=%s stepIndex=%d attempt=%d",
+              record.tenantId(),
+              record.executionId(),
+              record.currentStepIndex(),
+              record.attempt());
+          return Uni.createFrom().voidItem();
+        })
+        .onItem().transform(ignored -> {
+          LOG.infof(
+              "Re-drove execution tenant=%s executionId=%s previousStatus=%s stepIndex=%d attempt=%d",
+              record.tenantId(),
+              record.executionId(),
+              plan.previous().status(),
+              record.currentStepIndex(),
+              record.attempt());
+          return ExecutionRedriveResult.from(plan.previous(), record);
+        });
+  }
+
+  private Optional<RuntimeException> admissionFailure(
+      String resolvedTenant,
+      String originalTenant,
+      String executionId) {
+    ControlPlaneAdmissionDecision decision = admissionPolicy.admit(new ControlPlaneAdmissionRequest(
+        resolvedTenant,
+        ControlPlaneAdmissionOperation.REDRIVE_EXECUTION,
+        pipelineId.get(),
+        releaseVersion.get(),
+        executionId,
+        "api",
+        originalTenant != null && !originalTenant.isBlank()));
+    return decision.allowed()
+        ? Optional.empty()
+        : Optional.of(new ControlPlaneAdmissionException(decision));
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSweepFlow.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/QueueAsyncSweepFlow.java
@@ -1,0 +1,86 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+class QueueAsyncSweepFlow {
+
+  private static final Logger LOG = Logger.getLogger(QueueAsyncSweepFlow.class);
+
+  private final PipelineOrchestratorConfig orchestratorConfig;
+  private final ExecutionStateStore executionStateStore;
+  private final WorkDispatcher workDispatcher;
+  private final AwaitTimeoutFlow awaitTimeoutFlow;
+
+  QueueAsyncSweepFlow(
+      PipelineOrchestratorConfig orchestratorConfig,
+      ExecutionStateStore executionStateStore,
+      WorkDispatcher workDispatcher,
+      AwaitTimeoutFlow awaitTimeoutFlow) {
+    this.orchestratorConfig = Objects.requireNonNull(orchestratorConfig, "orchestratorConfig must not be null");
+    this.executionStateStore = Objects.requireNonNull(executionStateStore, "executionStateStore must not be null");
+    this.workDispatcher = Objects.requireNonNull(workDispatcher, "workDispatcher must not be null");
+    this.awaitTimeoutFlow = Objects.requireNonNull(awaitTimeoutFlow, "awaitTimeoutFlow must not be null");
+  }
+
+  void sweepDueExecutions() {
+    sweepOnce(System.currentTimeMillis())
+        .subscribe()
+        .with(
+            ignored -> {
+            },
+            failure -> LOG.errorf(failure, "Failed sweeping due async executions"));
+  }
+
+  Uni<Void> sweepOnce(long nowEpochMs) {
+    int limit = orchestratorConfig.sweepLimit();
+    return awaitTimeoutFlow.sweepTimedOut(nowEpochMs, limit)
+        .chain(() -> executionStateStore.findDueExecutions(nowEpochMs, limit))
+        .onItem().transform(DueExecutionDispatchPlan::from)
+        .onItem().transformToUni(this::dispatchDueExecutions);
+  }
+
+  private Uni<Void> dispatchDueExecutions(DueExecutionDispatchPlan plan) {
+    if (plan.empty()) {
+      return Uni.createFrom().voidItem();
+    }
+    return Multi.createFrom().iterable(plan.workItems())
+        .onItem().transformToUniAndConcatenate(this::enqueueDueExecution)
+        .collect().asList()
+        .onItem().transformToUni(this::failIfAnyDispatchFailed);
+  }
+
+  private Uni<Optional<Throwable>> enqueueDueExecution(ExecutionWorkItem item) {
+    return workDispatcher.enqueueNow(item)
+        .replaceWith(Optional.<Throwable>empty())
+        .onFailure().recoverWithItem(failure -> Optional.of(new IllegalStateException(
+            "Failed to re-dispatch due execution " + item.executionId(),
+            failure)));
+  }
+
+  private Uni<Void> failIfAnyDispatchFailed(List<Optional<Throwable>> results) {
+    List<Throwable> failures = results.stream()
+        .flatMap(Optional::stream)
+        .toList();
+    if (failures.isEmpty()) {
+      return Uni.createFrom().voidItem();
+    }
+    if (failures.size() == 1) {
+      return Uni.createFrom().failure(failures.get(0));
+    }
+    IllegalStateException combined = new IllegalStateException(
+        "Failed to re-dispatch " + failures.size() + " due executions",
+        failures.get(0));
+    failures.stream().skip(1).forEach(combined::addSuppressed);
+    return Uni.createFrom().failure(combined);
+  }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/TimedOutAwaitInteractionsPlan.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/TimedOutAwaitInteractionsPlan.java
@@ -1,0 +1,30 @@
+package org.pipelineframework;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+
+record TimedOutAwaitInteractionsPlan(List<AwaitInteractionRecord> interactions) {
+
+  TimedOutAwaitInteractionsPlan {
+    Objects.requireNonNull(interactions, "interactions must not be null");
+    interactions = List.copyOf(interactions);
+  }
+
+  static TimedOutAwaitInteractionsPlan from(List<AwaitInteractionRecord> interactions, int limit) {
+    Objects.requireNonNull(interactions, "interactions must not be null");
+    return new TimedOutAwaitInteractionsPlan(interactions.stream()
+        .sorted(Comparator
+            .comparingLong(AwaitInteractionRecord::deadlineEpochMs)
+            .thenComparing(AwaitInteractionRecord::tenantId)
+            .thenComparing(AwaitInteractionRecord::interactionId))
+        .limit(Math.max(0, limit))
+        .toList());
+  }
+
+  boolean empty() {
+    return interactions.isEmpty();
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/AwaitTimeoutFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/AwaitTimeoutFlowTest.java
@@ -1,0 +1,213 @@
+package org.pipelineframework;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.awaitable.AwaitCoordinator;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.controlplane.SegmentBoundaryLedger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AwaitTimeoutFlowTest {
+
+  private AwaitTimeoutFlow flow;
+
+  @Mock
+  private AwaitCoordinator awaitCoordinator;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private SegmentBoundaryLedger segmentBoundaryLedger;
+
+  @BeforeEach
+  void setUp() {
+    flow = new AwaitTimeoutFlow(awaitCoordinator, executionStateStore, () -> segmentBoundaryLedger);
+  }
+
+  @Test
+  void timeoutRecordsFactBeforeFailingWaitingParent() {
+    AwaitInteractionRecord interaction = interaction("unit-1");
+    ExecutionRecord<Object, Object> parent = parent(ExecutionStatus.WAITING_EXTERNAL, "unit-1");
+    ExecutionRecord<Object, Object> failed = parent(ExecutionStatus.FAILED, "unit-1");
+    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(interaction)));
+    when(awaitCoordinator.markTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
+    when(segmentBoundaryLedger.recordInteractionTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(parent)));
+    when(executionStateStore.markTerminalFailure(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(7L),
+            eq(ExecutionStatus.FAILED),
+            eq("exec-1:2:3"),
+            eq("AWAIT_TIMEOUT"),
+            eq("Await interaction timed out: interaction-1"),
+            anyLong()))
+        .thenReturn(Uni.createFrom().item(Optional.of(failed)));
+    when(segmentBoundaryLedger.recordRunFailed(
+            failed,
+            "AWAIT_TIMEOUT",
+            "Await interaction timed out: interaction-1",
+            1000L))
+        .thenReturn(Uni.createFrom().voidItem());
+
+    flow.sweepTimedOut(1000L, 100).await().indefinitely();
+
+    InOrder order = inOrder(awaitCoordinator, segmentBoundaryLedger, executionStateStore);
+    order.verify(awaitCoordinator).markTimedOut(interaction, 1000L);
+    order.verify(segmentBoundaryLedger).recordInteractionTimedOut(interaction, 1000L);
+    order.verify(executionStateStore).getExecution("tenant-1", "exec-1");
+    order.verify(executionStateStore).markTerminalFailure(
+        eq("tenant-1"),
+        eq("exec-1"),
+        eq(7L),
+        eq(ExecutionStatus.FAILED),
+        eq("exec-1:2:3"),
+        eq("AWAIT_TIMEOUT"),
+        eq("Await interaction timed out: interaction-1"),
+        anyLong());
+    order.verify(segmentBoundaryLedger).recordRunFailed(
+        failed,
+        "AWAIT_TIMEOUT",
+        "Await interaction timed out: interaction-1",
+        1000L);
+  }
+
+  @Test
+  void missingParentDoesNotFailExecution() {
+    AwaitInteractionRecord interaction = interaction("unit-1");
+    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(interaction)));
+    when(awaitCoordinator.markTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
+    when(segmentBoundaryLedger.recordInteractionTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.empty()));
+
+    flow.sweepTimedOut(1000L, 100).await().indefinitely();
+
+    verify(executionStateStore).getExecution("tenant-1", "exec-1");
+    verify(segmentBoundaryLedger).recordInteractionTimedOut(interaction, 1000L);
+    verify(executionStateStore, never()).markTerminalFailure(
+        any(), any(), anyLong(), any(), any(), any(), any(), anyLong());
+    verify(segmentBoundaryLedger, never()).recordRunFailed(any(), any(), any(), anyLong());
+  }
+
+  @Test
+  void nonMatchingParentDoesNotFailExecution() {
+    AwaitInteractionRecord interaction = interaction("unit-1");
+    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(interaction)));
+    when(awaitCoordinator.markTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
+    when(segmentBoundaryLedger.recordInteractionTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(parent(ExecutionStatus.WAITING_EXTERNAL, "other-unit"))));
+
+    flow.sweepTimedOut(1000L, 100).await().indefinitely();
+
+    verify(executionStateStore).getExecution("tenant-1", "exec-1");
+    verify(segmentBoundaryLedger).recordInteractionTimedOut(interaction, 1000L);
+    verify(executionStateStore, never()).markTerminalFailure(
+        any(), any(), anyLong(), any(), any(), any(), any(), anyLong());
+  }
+
+  @Test
+  void lostTimeoutAdmissionDoesNotLoadParent() {
+    AwaitInteractionRecord interaction = interaction("unit-1");
+    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(interaction)));
+    when(awaitCoordinator.markTimedOut(interaction, 1000L))
+        .thenReturn(Uni.createFrom().item(Optional.empty()));
+
+    flow.sweepTimedOut(1000L, 100).await().indefinitely();
+
+    verify(executionStateStore, never()).getExecution(any(), any());
+    verify(segmentBoundaryLedger, never()).recordInteractionTimedOut(any(), anyLong());
+  }
+
+  @Test
+  void emptyTimeoutBatchIsNoOp() {
+    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of()));
+
+    flow.sweepTimedOut(1000L, 100).await().indefinitely();
+
+    verify(awaitCoordinator, never()).markTimedOut(any(), anyLong());
+    verify(executionStateStore, never()).getExecution(any(), any());
+  }
+
+  private static AwaitInteractionRecord interaction(String unitId) {
+    return new AwaitInteractionRecord(
+        "tenant-1",
+        "exec-1",
+        "AwaitStep",
+        2,
+        String.class.getName(),
+        "interaction-1",
+        "corr-1",
+        "cause-1",
+        "idem-1",
+        1L,
+        AwaitInteractionStatus.DISPATCHED,
+        "request",
+        null,
+        unitId,
+        null,
+        "user-1",
+        null,
+        null,
+        "kafka",
+        java.util.Map.of(),
+        1000L,
+        1L,
+        1L,
+        99999999L);
+  }
+
+  private static ExecutionRecord<Object, Object> parent(ExecutionStatus status, String awaitUnitId) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        ExecutionResultShape.SINGLE,
+        status,
+        7L,
+        2,
+        3,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        awaitUnitId,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/AwaitTimeoutFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/AwaitTimeoutFlowTest.java
@@ -48,16 +48,23 @@ class AwaitTimeoutFlowTest {
 
   @Test
   void timeoutRecordsFactBeforeFailingWaitingParent() {
-    AwaitInteractionRecord interaction = interaction("unit-1");
+    AwaitInteractionRecord earlier = interaction("unit-1", "interaction-a", "corr-a", 900L);
+    AwaitInteractionRecord later = interaction("unit-1", "interaction-b", "corr-b", 950L);
     ExecutionRecord<Object, Object> parent = parent(ExecutionStatus.WAITING_EXTERNAL, "unit-1");
     ExecutionRecord<Object, Object> failed = parent(ExecutionStatus.FAILED, "unit-1");
-    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(interaction)));
-    when(awaitCoordinator.markTimedOut(interaction, 1000L))
-        .thenReturn(Uni.createFrom().item(Optional.of(interaction)));
-    when(segmentBoundaryLedger.recordInteractionTimedOut(interaction, 1000L))
+    when(awaitCoordinator.findTimedOut(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(later, earlier)));
+    when(awaitCoordinator.markTimedOut(earlier, 1000L))
+        .thenReturn(Uni.createFrom().item(Optional.of(earlier)));
+    when(awaitCoordinator.markTimedOut(later, 1000L))
+        .thenReturn(Uni.createFrom().item(Optional.of(later)));
+    when(segmentBoundaryLedger.recordInteractionTimedOut(earlier, 1000L))
+        .thenReturn(Uni.createFrom().voidItem());
+    when(segmentBoundaryLedger.recordInteractionTimedOut(later, 1000L))
         .thenReturn(Uni.createFrom().voidItem());
     when(executionStateStore.getExecution("tenant-1", "exec-1"))
-        .thenReturn(Uni.createFrom().item(Optional.of(parent)));
+        .thenReturn(
+            Uni.createFrom().item(Optional.of(parent)),
+            Uni.createFrom().item(Optional.of(failed)));
     when(executionStateStore.markTerminalFailure(
             eq("tenant-1"),
             eq("exec-1"),
@@ -65,21 +72,21 @@ class AwaitTimeoutFlowTest {
             eq(ExecutionStatus.FAILED),
             eq("exec-1:2:3"),
             eq("AWAIT_TIMEOUT"),
-            eq("Await interaction timed out: interaction-1"),
+            eq("Await interaction timed out: interaction-a"),
             anyLong()))
         .thenReturn(Uni.createFrom().item(Optional.of(failed)));
     when(segmentBoundaryLedger.recordRunFailed(
             failed,
             "AWAIT_TIMEOUT",
-            "Await interaction timed out: interaction-1",
+            "Await interaction timed out: interaction-a",
             1000L))
         .thenReturn(Uni.createFrom().voidItem());
 
     flow.sweepTimedOut(1000L, 100).await().indefinitely();
 
     InOrder order = inOrder(awaitCoordinator, segmentBoundaryLedger, executionStateStore);
-    order.verify(awaitCoordinator).markTimedOut(interaction, 1000L);
-    order.verify(segmentBoundaryLedger).recordInteractionTimedOut(interaction, 1000L);
+    order.verify(awaitCoordinator).markTimedOut(earlier, 1000L);
+    order.verify(segmentBoundaryLedger).recordInteractionTimedOut(earlier, 1000L);
     order.verify(executionStateStore).getExecution("tenant-1", "exec-1");
     order.verify(executionStateStore).markTerminalFailure(
         eq("tenant-1"),
@@ -88,13 +95,16 @@ class AwaitTimeoutFlowTest {
         eq(ExecutionStatus.FAILED),
         eq("exec-1:2:3"),
         eq("AWAIT_TIMEOUT"),
-        eq("Await interaction timed out: interaction-1"),
+        eq("Await interaction timed out: interaction-a"),
         anyLong());
     order.verify(segmentBoundaryLedger).recordRunFailed(
         failed,
         "AWAIT_TIMEOUT",
-        "Await interaction timed out: interaction-1",
+        "Await interaction timed out: interaction-a",
         1000L);
+    order.verify(awaitCoordinator).markTimedOut(later, 1000L);
+    order.verify(segmentBoundaryLedger).recordInteractionTimedOut(later, 1000L);
+    order.verify(executionStateStore).getExecution("tenant-1", "exec-1");
   }
 
   @Test
@@ -160,16 +170,24 @@ class AwaitTimeoutFlowTest {
   }
 
   private static AwaitInteractionRecord interaction(String unitId) {
+    return interaction(unitId, "interaction-1", "corr-1", 99999999L);
+  }
+
+  private static AwaitInteractionRecord interaction(
+      String unitId,
+      String interactionId,
+      String correlationId,
+      long deadlineEpochMs) {
     return new AwaitInteractionRecord(
         "tenant-1",
         "exec-1",
         "AwaitStep",
         2,
         String.class.getName(),
-        "interaction-1",
-        "corr-1",
-        "cause-1",
-        "idem-1",
+        interactionId,
+        correlationId,
+        "cause-" + interactionId,
+        "idem-" + interactionId,
         1L,
         AwaitInteractionStatus.DISPATCHED,
         "request",
@@ -181,7 +199,7 @@ class AwaitTimeoutFlowTest {
         null,
         "kafka",
         java.util.Map.of(),
-        1000L,
+        deadlineEpochMs,
         1L,
         1L,
         99999999L);

--- a/framework/runtime/src/test/java/org/pipelineframework/AwaitTimeoutPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/AwaitTimeoutPlanTest.java
@@ -1,0 +1,128 @@
+package org.pipelineframework;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwaitTimeoutPlanTest {
+
+  @Test
+  void missingParentRecordsTimeoutOnly() {
+    AwaitTimeoutPlan plan = AwaitTimeoutPlan.from(interaction("unit-1"), Optional.empty());
+
+    assertFalse(plan.failParent());
+    assertTrue(plan.transitionKey().isEmpty());
+  }
+
+  @Test
+  void terminalParentRecordsTimeoutOnly() {
+    AwaitTimeoutPlan plan = AwaitTimeoutPlan.from(
+        interaction("unit-1"),
+        Optional.of(parent(ExecutionStatus.SUCCEEDED, "unit-1")));
+
+    assertFalse(plan.failParent());
+  }
+
+  @Test
+  void nonWaitingParentRecordsTimeoutOnly() {
+    AwaitTimeoutPlan plan = AwaitTimeoutPlan.from(
+        interaction("unit-1"),
+        Optional.of(parent(ExecutionStatus.RUNNING, "unit-1")));
+
+    assertFalse(plan.failParent());
+  }
+
+  @Test
+  void differentAwaitUnitRecordsTimeoutOnly() {
+    AwaitTimeoutPlan plan = AwaitTimeoutPlan.from(
+        interaction("unit-1"),
+        Optional.of(parent(ExecutionStatus.WAITING_EXTERNAL, "other-unit")));
+
+    assertFalse(plan.failParent());
+  }
+
+  @Test
+  void matchingWaitingParentFailsRun() {
+    AwaitTimeoutPlan plan = AwaitTimeoutPlan.from(
+        interaction("unit-1"),
+        Optional.of(parent(ExecutionStatus.WAITING_EXTERNAL, "unit-1")));
+
+    assertTrue(plan.failParent());
+    assertEquals("exec-1:2:3", plan.transitionKey().orElseThrow());
+    assertEquals("AWAIT_TIMEOUT", plan.errorCode());
+    assertEquals("Await interaction timed out: interaction-1", plan.errorMessage());
+  }
+
+  @Test
+  void constructorRejectsInvalidFailParentPlan() {
+    assertThrows(IllegalArgumentException.class, () -> new AwaitTimeoutPlan(
+        interaction("unit-1"),
+        Optional.of(parent(ExecutionStatus.RUNNING, "unit-1")),
+        true,
+        Optional.of("exec-1:2:3"),
+        "AWAIT_TIMEOUT",
+        "Await interaction timed out: interaction-1"));
+  }
+
+  private static AwaitInteractionRecord interaction(String unitId) {
+    return new AwaitInteractionRecord(
+        "tenant-1",
+        "exec-1",
+        "AwaitStep",
+        2,
+        String.class.getName(),
+        "interaction-1",
+        "corr-1",
+        "cause-1",
+        "idem-1",
+        1L,
+        AwaitInteractionStatus.DISPATCHED,
+        "request",
+        null,
+        unitId,
+        null,
+        "user-1",
+        null,
+        null,
+        "kafka",
+        java.util.Map.of(),
+        1000L,
+        1L,
+        1L,
+        99999999L);
+  }
+
+  private static ExecutionRecord<Object, Object> parent(ExecutionStatus status, String awaitUnitId) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        ExecutionResultShape.SINGLE,
+        status,
+        7L,
+        2,
+        3,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        awaitUnitId,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/DueExecutionDispatchPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/DueExecutionDispatchPlanTest.java
@@ -1,0 +1,90 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DueExecutionDispatchPlanTest {
+
+  @Test
+  void dueRecordsBecomeExecutionWorkItems() {
+    DueExecutionDispatchPlan plan = DueExecutionDispatchPlan.from(List.of(
+        record("tenant-a", "exec-a"),
+        record("tenant-b", "exec-b")));
+
+    assertFalse(plan.empty());
+    assertEquals(List.of(
+        new ExecutionWorkItem("tenant-a", "exec-a"),
+        new ExecutionWorkItem("tenant-b", "exec-b")), plan.workItems());
+  }
+
+  @Test
+  void dueRecordsAreSortedByDueTimeTenantAndExecutionId() {
+    DueExecutionDispatchPlan plan = DueExecutionDispatchPlan.from(List.of(
+        record("tenant-b", "exec-b", 20L),
+        record("tenant-b", "exec-a", 10L),
+        record("tenant-a", "exec-c", 10L)));
+
+    assertEquals(List.of(
+        new ExecutionWorkItem("tenant-a", "exec-c"),
+        new ExecutionWorkItem("tenant-b", "exec-a"),
+        new ExecutionWorkItem("tenant-b", "exec-b")), plan.workItems());
+  }
+
+  @Test
+  void emptyDueListIsNoOpPlan() {
+    DueExecutionDispatchPlan plan = DueExecutionDispatchPlan.from(List.of());
+
+    assertTrue(plan.empty());
+  }
+
+  @Test
+  void workItemListIsDefensivelyCopied() {
+    List<ExecutionWorkItem> items = new java.util.ArrayList<>();
+    items.add(new ExecutionWorkItem("tenant-1", "exec-1"));
+
+    DueExecutionDispatchPlan plan = new DueExecutionDispatchPlan(items);
+    items.add(new ExecutionWorkItem("tenant-2", "exec-2"));
+
+    assertEquals(List.of(new ExecutionWorkItem("tenant-1", "exec-1")), plan.workItems());
+    assertThrows(UnsupportedOperationException.class, () ->
+        plan.workItems().add(new ExecutionWorkItem("tenant-3", "exec-3")));
+  }
+
+  private static ExecutionRecord<Object, Object> record(String tenantId, String executionId) {
+    return record(tenantId, executionId, 1L);
+  }
+
+  private static ExecutionRecord<Object, Object> record(String tenantId, String executionId, long nextDueEpochMs) {
+    return new ExecutionRecord<>(
+        tenantId,
+        executionId,
+        executionId + "-key",
+        ExecutionResultShape.SINGLE,
+        ExecutionStatus.WAIT_RETRY,
+        1L,
+        2,
+        1,
+        null,
+        0L,
+        nextDueEpochMs,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/ExecutionRedrivePlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ExecutionRedrivePlanTest.java
@@ -33,6 +33,17 @@ class ExecutionRedrivePlanTest {
   }
 
   @Test
+  void failedExecutionCanBeRedrivenWhenAllowed() {
+    ExecutionRecord<Object, Object> record = record(ExecutionStatus.FAILED, 2L);
+
+    ExecutionRedrivePlan plan = ExecutionRedrivePlan.from(record, null, true, "retry failed");
+
+    assertEquals(2L, plan.expectedVersion());
+    assertEquals("retry failed", plan.normalizedReason());
+    assertEquals("redrive:exec-1:2", plan.transitionKey());
+  }
+
+  @Test
   void staleExpectedVersionIsRejectedBeforeEffects() {
     ExecutionRecord<Object, Object> record = record(ExecutionStatus.DLQ, 7L);
 

--- a/framework/runtime/src/test/java/org/pipelineframework/ExecutionRedrivePlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/ExecutionRedrivePlanTest.java
@@ -1,0 +1,83 @@
+package org.pipelineframework;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ExecutionRedrivePlanTest {
+
+  @Test
+  void dlqRedriveUsesCurrentVersionAndDefaultReason() {
+    ExecutionRecord<Object, Object> record = record(ExecutionStatus.DLQ, 4L);
+
+    ExecutionRedrivePlan plan = ExecutionRedrivePlan.from(record, null, false, " ");
+
+    assertEquals(4L, plan.expectedVersion());
+    assertEquals("operator", plan.normalizedReason());
+    assertEquals("redrive:exec-1:4", plan.transitionKey());
+  }
+
+  @Test
+  void failedExecutionRequiresAllowFailed() {
+    ExecutionRecord<Object, Object> record = record(ExecutionStatus.FAILED, 2L);
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> ExecutionRedrivePlan.from(record, null, false, "retry"));
+
+    assertEquals("Execution exec-1 cannot be re-driven from status FAILED", error.getMessage());
+  }
+
+  @Test
+  void staleExpectedVersionIsRejectedBeforeEffects() {
+    ExecutionRecord<Object, Object> record = record(ExecutionStatus.DLQ, 7L);
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> ExecutionRedrivePlan.from(record, 6L, false, "retry"));
+
+    assertEquals("Execution exec-1 version mismatch: expected 6 but current version is 7", error.getMessage());
+  }
+
+  @Test
+  void reasonIsTrimmedAndCappedForDeterministicTransitionKey() {
+    ExecutionRecord<Object, Object> record = record(ExecutionStatus.DLQ, 3L);
+    String longReason = "  " + "x".repeat(90) + "  ";
+
+    ExecutionRedrivePlan plan = ExecutionRedrivePlan.from(record, null, false, longReason);
+
+    assertEquals("x".repeat(80), plan.normalizedReason());
+    assertEquals("redrive:exec-1:3", plan.transitionKey());
+  }
+
+  private static ExecutionRecord<Object, Object> record(ExecutionStatus status, long version) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        ExecutionResultShape.SINGLE,
+        status,
+        version,
+        2,
+        1,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncArchitectureFitnessTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncArchitectureFitnessTest.java
@@ -25,7 +25,10 @@ class QueueAsyncArchitectureFitnessTest {
       "AwaitContinuationPlan",
       "AwaitContinuationPlanner",
       "ItemContinuationKey",
-      "ItemizedParentRelease");
+      "ItemizedParentRelease",
+      "ExecutionRedrivePlan",
+      "DueExecutionDispatchPlan",
+      "AwaitTimeoutPlan");
 
   private static final Pattern FORBIDDEN_PURE_IMPORT = Pattern.compile(
       "^import\\s+.*("
@@ -72,6 +75,10 @@ class QueueAsyncArchitectureFitnessTest {
     assertAbsent(coordinator, "runAsyncExecution");
     assertAbsent(coordinator, "markWaitingExternal");
     assertAbsent(coordinator, "publishTerminalOutputsIfConfigured");
+    assertAbsent(coordinator, "redriveTerminalExecution");
+    assertAbsent(coordinator, "findDueExecutions");
+    assertAbsent(coordinator, "markTimedOut");
+    assertAbsent(coordinator, "markTerminalFailure");
 
     assertTrue(
         coordinator.contains("return segmentPipeline().process(workItem, worker, itemContinuationHandler);"),
@@ -79,6 +86,12 @@ class QueueAsyncArchitectureFitnessTest {
     assertTrue(
         coordinator.contains("return awaitBoundaryAdmission().complete(command, itemContinuationHandler);"),
         "completeAwait must delegate to AwaitBoundaryAdmission");
+    assertTrue(
+        coordinator.contains("return redriveFlow().redrive(tenantId, executionId, expectedVersion, allowFailed, reason);"),
+        "redriveExecution must delegate to QueueAsyncRedriveFlow");
+    assertTrue(
+        coordinator.contains("sweepFlow().sweepDueExecutions();"),
+        "sweepDueExecutions must delegate to QueueAsyncSweepFlow");
   }
 
   @Test

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncRedriveFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncRedriveFlowTest.java
@@ -1,0 +1,194 @@
+package org.pipelineframework;
+
+import java.util.Optional;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionDecision;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionException;
+import org.pipelineframework.orchestrator.ControlPlaneAdmissionPolicy;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionRedriveResult;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.OrchestratorMode;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAsyncRedriveFlowTest {
+
+  private QueueAsyncRedriveFlow flow;
+  private ExecutionInputPolicy inputPolicy;
+
+  @Mock
+  private PipelineOrchestratorConfig orchestratorConfig;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private WorkDispatcher workDispatcher;
+
+  @Mock
+  private ControlPlaneAdmissionPolicy admissionPolicy;
+
+  @BeforeEach
+  void setUp() {
+    inputPolicy = new ExecutionInputPolicy();
+    inputPolicy.orchestratorConfig = orchestratorConfig;
+    lenient().when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.QUEUE_ASYNC);
+    lenient().when(admissionPolicy.admit(any())).thenReturn(ControlPlaneAdmissionDecision.allow());
+    flow = new QueueAsyncRedriveFlow(
+        orchestratorConfig,
+        inputPolicy,
+        executionStateStore,
+        workDispatcher,
+        admissionPolicy,
+        () -> "pipeline-a",
+        () -> "release-a");
+  }
+
+  @Test
+  void redriveUpdatesStoreThenEnqueuesOriginalExecutionId() {
+    ExecutionRecord<Object, Object> terminal = record(ExecutionStatus.DLQ, 4L, 2);
+    ExecutionRecord<Object, Object> redriven = record(ExecutionStatus.QUEUED, 5L, 3);
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(terminal)));
+    when(executionStateStore.redriveTerminalExecution(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(4L),
+            eq(false),
+            eq("redrive:exec-1:4"),
+            anyLong()))
+        .thenReturn(Uni.createFrom().item(Optional.of(redriven)));
+    when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+    ExecutionRedriveResult result = flow.redrive("tenant-1", "exec-1", null, false, "operator retry")
+        .await().indefinitely();
+
+    assertEquals("exec-1", result.executionId());
+    assertEquals(ExecutionStatus.DLQ, result.previousStatus());
+    assertEquals(ExecutionStatus.QUEUED, result.status());
+    InOrder order = inOrder(executionStateStore, workDispatcher);
+    order.verify(executionStateStore).redriveTerminalExecution(
+        eq("tenant-1"),
+        eq("exec-1"),
+        eq(4L),
+        eq(false),
+        eq("redrive:exec-1:4"),
+        anyLong());
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+  }
+
+  @Test
+  void queueModeDisabledFailsBeforeStoreAccess() {
+    when(orchestratorConfig.mode()).thenReturn(OrchestratorMode.SYNC);
+
+    assertThrows(IllegalStateException.class, () ->
+        flow.redrive("tenant-1", "exec-1", null, false, "retry").await().indefinitely());
+
+    verify(admissionPolicy, never()).admit(any());
+    verify(executionStateStore, never()).getExecution(any(), any());
+    verify(workDispatcher, never()).enqueueNow(any());
+  }
+
+  @Test
+  void enqueueFailureReturnsAdmittedRedriveBecauseSweepCanRecoverDueRecord() {
+    ExecutionRecord<Object, Object> terminal = record(ExecutionStatus.DLQ, 4L, 2);
+    ExecutionRecord<Object, Object> redriven = record(ExecutionStatus.QUEUED, 5L, 3);
+    when(executionStateStore.getExecution("tenant-1", "exec-1"))
+        .thenReturn(Uni.createFrom().item(Optional.of(terminal)));
+    when(executionStateStore.redriveTerminalExecution(
+            eq("tenant-1"),
+            eq("exec-1"),
+            eq(4L),
+            eq(false),
+            eq("redrive:exec-1:4"),
+            anyLong()))
+        .thenReturn(Uni.createFrom().item(Optional.of(redriven)));
+    when(workDispatcher.enqueueNow(any()))
+        .thenReturn(Uni.createFrom().failure(new IllegalStateException("dispatcher down")));
+
+    ExecutionRedriveResult result = flow.redrive("tenant-1", "exec-1", null, false, "operator retry")
+        .await().indefinitely();
+
+    assertEquals(ExecutionStatus.QUEUED, result.status());
+    verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-1", "exec-1"));
+  }
+
+  @Test
+  void deniedAdmissionFailsBeforeStoreAccess() {
+    when(admissionPolicy.admit(any()))
+        .thenReturn(ControlPlaneAdmissionDecision.deny("TENANT_NOT_ALLOWED", "no"));
+
+    assertThrows(ControlPlaneAdmissionException.class, () ->
+        flow.redrive("tenant-1", "exec-1", null, false, "retry").await().indefinitely());
+
+    verify(executionStateStore, never()).getExecution(any(), any());
+  }
+
+  @Test
+  void missingExecutionFailsBeforeMutation() {
+    when(executionStateStore.getExecution("tenant-1", "missing"))
+        .thenReturn(Uni.createFrom().item(Optional.empty()));
+
+    NotFoundException error = assertThrows(NotFoundException.class, () ->
+        flow.redrive("tenant-1", "missing", null, false, "retry").await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Execution not found: missing"));
+    verify(executionStateStore, never()).redriveTerminalExecution(
+        any(), any(), anyLong(), org.mockito.ArgumentMatchers.anyBoolean(), any(), anyLong());
+  }
+
+  private static ExecutionRecord<Object, Object> record(
+      ExecutionStatus status,
+      long version,
+      int attempt) {
+    return new ExecutionRecord<>(
+        "tenant-1",
+        "exec-1",
+        "key-1",
+        "pipeline-a",
+        "contract-a",
+        "release-a",
+        ExecutionResultShape.SINGLE,
+        status,
+        version,
+        2,
+        attempt,
+        null,
+        0L,
+        0L,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSweepFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSweepFlowTest.java
@@ -60,8 +60,9 @@ class QueueAsyncSweepFlowTest {
   void sweepRunsTimeoutsThenEnqueuesEveryDueExecution() {
     when(awaitTimeoutFlow.sweepTimedOut(1000L, 100)).thenReturn(Uni.createFrom().voidItem());
     when(executionStateStore.findDueExecutions(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(
-        record("tenant-a", "exec-a"),
-        record("tenant-b", "exec-b"))));
+        record("tenant-b", "exec-b", 20L),
+        record("tenant-b", "exec-a", 10L),
+        record("tenant-a", "exec-c", 10L))));
     when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
 
     flow.sweepOnce(1000L).await().indefinitely();
@@ -69,7 +70,8 @@ class QueueAsyncSweepFlowTest {
     InOrder order = inOrder(awaitTimeoutFlow, executionStateStore, workDispatcher);
     order.verify(awaitTimeoutFlow).sweepTimedOut(1000L, 100);
     order.verify(executionStateStore).findDueExecutions(1000L, 100);
-    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-a", "exec-a"));
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-a", "exec-c"));
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-b", "exec-a"));
     order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-b", "exec-b"));
   }
 
@@ -115,6 +117,10 @@ class QueueAsyncSweepFlowTest {
   }
 
   private static ExecutionRecord<Object, Object> record(String tenantId, String executionId) {
+    return record(tenantId, executionId, 1L);
+  }
+
+  private static ExecutionRecord<Object, Object> record(String tenantId, String executionId, long nextDueEpochMs) {
     return new ExecutionRecord<>(
         tenantId,
         executionId,
@@ -126,7 +132,7 @@ class QueueAsyncSweepFlowTest {
         1,
         null,
         0L,
-        1L,
+        nextDueEpochMs,
         null,
         "input",
         null,

--- a/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSweepFlowTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/QueueAsyncSweepFlowTest.java
@@ -1,0 +1,140 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStateStore;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.ExecutionWorkItem;
+import org.pipelineframework.orchestrator.PipelineOrchestratorConfig;
+import org.pipelineframework.orchestrator.WorkDispatcher;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAsyncSweepFlowTest {
+
+  private QueueAsyncSweepFlow flow;
+
+  @Mock
+  private PipelineOrchestratorConfig orchestratorConfig;
+
+  @Mock
+  private ExecutionStateStore executionStateStore;
+
+  @Mock
+  private WorkDispatcher workDispatcher;
+
+  @Mock
+  private AwaitTimeoutFlow awaitTimeoutFlow;
+
+  @BeforeEach
+  void setUp() {
+    when(orchestratorConfig.sweepLimit()).thenReturn(100);
+    flow = new QueueAsyncSweepFlow(
+        orchestratorConfig,
+        executionStateStore,
+        workDispatcher,
+        awaitTimeoutFlow);
+  }
+
+  @Test
+  void sweepRunsTimeoutsThenEnqueuesEveryDueExecution() {
+    when(awaitTimeoutFlow.sweepTimedOut(1000L, 100)).thenReturn(Uni.createFrom().voidItem());
+    when(executionStateStore.findDueExecutions(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(
+        record("tenant-a", "exec-a"),
+        record("tenant-b", "exec-b"))));
+    when(workDispatcher.enqueueNow(any())).thenReturn(Uni.createFrom().voidItem());
+
+    flow.sweepOnce(1000L).await().indefinitely();
+
+    InOrder order = inOrder(awaitTimeoutFlow, executionStateStore, workDispatcher);
+    order.verify(awaitTimeoutFlow).sweepTimedOut(1000L, 100);
+    order.verify(executionStateStore).findDueExecutions(1000L, 100);
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-a", "exec-a"));
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-b", "exec-b"));
+  }
+
+  @Test
+  void emptyDueBatchDoesNotDispatch() {
+    when(awaitTimeoutFlow.sweepTimedOut(1000L, 100)).thenReturn(Uni.createFrom().voidItem());
+    when(executionStateStore.findDueExecutions(1000L, 100)).thenReturn(Uni.createFrom().item(List.of()));
+
+    flow.sweepOnce(1000L).await().indefinitely();
+
+    verify(workDispatcher, never()).enqueueNow(any());
+  }
+
+  @Test
+  void enqueueFailureNamesExecutionId() {
+    when(awaitTimeoutFlow.sweepTimedOut(1000L, 100)).thenReturn(Uni.createFrom().voidItem());
+    when(executionStateStore.findDueExecutions(1000L, 100)).thenReturn(Uni.createFrom().item(List.of(
+        record("tenant-a", "exec-a"),
+        record("tenant-b", "exec-b"))));
+    when(workDispatcher.enqueueNow(new ExecutionWorkItem("tenant-a", "exec-a")))
+        .thenReturn(Uni.createFrom().failure(new IllegalStateException("dispatcher down")));
+    when(workDispatcher.enqueueNow(new ExecutionWorkItem("tenant-b", "exec-b")))
+        .thenReturn(Uni.createFrom().voidItem());
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> flow.sweepOnce(1000L).await().indefinitely());
+
+    assertTrue(error.getMessage().contains("Failed to re-dispatch due execution exec-a"));
+    InOrder order = inOrder(workDispatcher);
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-a", "exec-a"));
+    order.verify(workDispatcher).enqueueNow(new ExecutionWorkItem("tenant-b", "exec-b"));
+  }
+
+  @Test
+  void scheduledSweepDoesNotThrowFromCallerWhenSubscriptionFails() {
+    when(awaitTimeoutFlow.sweepTimedOut(anyLong(), anyInt()))
+        .thenReturn(Uni.createFrom().failure(new IllegalStateException("timeout store down")));
+
+    assertDoesNotThrow(() -> flow.sweepDueExecutions());
+
+    verify(awaitTimeoutFlow).sweepTimedOut(anyLong(), anyInt());
+  }
+
+  private static ExecutionRecord<Object, Object> record(String tenantId, String executionId) {
+    return new ExecutionRecord<>(
+        tenantId,
+        executionId,
+        executionId + "-key",
+        ExecutionResultShape.SINGLE,
+        ExecutionStatus.WAIT_RETRY,
+        1L,
+        2,
+        1,
+        null,
+        0L,
+        1L,
+        null,
+        "input",
+        null,
+        null,
+        null,
+        null,
+        1L,
+        1L,
+        99999999L);
+  }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/TimedOutAwaitInteractionsPlanTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/TimedOutAwaitInteractionsPlanTest.java
@@ -1,0 +1,67 @@
+package org.pipelineframework;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TimedOutAwaitInteractionsPlanTest {
+
+  @Test
+  void interactionsAreSortedBeforeLimitIsApplied() {
+    AwaitInteractionRecord later = interaction("tenant-b", "interaction-b", 20L);
+    AwaitInteractionRecord firstTie = interaction("tenant-a", "interaction-c", 10L);
+    AwaitInteractionRecord secondTie = interaction("tenant-b", "interaction-a", 10L);
+
+    TimedOutAwaitInteractionsPlan plan = TimedOutAwaitInteractionsPlan.from(
+        List.of(later, secondTie, firstTie),
+        2);
+
+    assertEquals(List.of(firstTie, secondTie), plan.interactions());
+  }
+
+  @Test
+  void interactionsAreDefensivelyCopied() {
+    List<AwaitInteractionRecord> records = new java.util.ArrayList<>();
+    AwaitInteractionRecord interaction = interaction("tenant-a", "interaction-a", 10L);
+    records.add(interaction);
+
+    TimedOutAwaitInteractionsPlan plan = new TimedOutAwaitInteractionsPlan(records);
+    records.clear();
+
+    assertEquals(List.of(interaction), plan.interactions());
+    assertThrows(UnsupportedOperationException.class, () -> plan.interactions().clear());
+  }
+
+  private static AwaitInteractionRecord interaction(String tenantId, String interactionId, long deadlineEpochMs) {
+    return new AwaitInteractionRecord(
+        tenantId,
+        "exec-1",
+        "AwaitStep",
+        2,
+        String.class.getName(),
+        interactionId,
+        "corr-" + interactionId,
+        "cause-" + interactionId,
+        "idem-" + interactionId,
+        1L,
+        AwaitInteractionStatus.DISPATCHED,
+        "request",
+        null,
+        "unit-1",
+        null,
+        "user-1",
+        null,
+        null,
+        "kafka",
+        java.util.Map.of(),
+        deadlineEpochMs,
+        1L,
+        1L,
+        99999999L);
+  }
+}


### PR DESCRIPTION
## Summary
- extract queue-async redrive, due-work sweep, and await-timeout sweep out of `QueueAsyncCoordinator`
- add immutable operation plans for redrive, due dispatch, and await timeout decisions
- strengthen architecture fitness coverage so operations branching does not drift back into the coordinator

## Scope
- No public YAML, connector SPI, telemetry schema, replay JSON, or homepage asset changes
- No docs update: this is an internal queue-async decomposition with stable user-facing behavior
- No Dynamo append-only/journal-authoritative storage changes

## Review
- Ran local CodeRabbit against `codex/queue-async-architecture-fitness-tests`
- Addressed accepted findings around deterministic ordering, redrive key/logging/recoverability, timeout admission, and tests

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true -Dtest=ExecutionRedrivePlanTest,DueExecutionDispatchPlanTest,AwaitTimeoutPlanTest,QueueAsyncRedriveFlowTest,QueueAsyncSweepFlowTest,AwaitTimeoutFlowTest,QueueAsyncCoordinatorTest,QueueAsyncArchitectureFitnessTest,QueueAsyncFailureMatrixTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="$PWD/.m2/repository"`
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true test -Dmaven.repo.local="$PWD/.m2/repository"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced async queue mode orchestration with periodic sweeps for timed-out awaits and automatic dispatch of due work.
  * Improved execution redrive flow with deterministic routing metadata and more resilient enqueue behavior.
  * Due and timeout-related work is processed in a consistent, deterministic order.
* **Bug Fixes**
  * Timed-out awaits more reliably mark run/interaction outcomes and propagate parent failures only when applicable.
  * Redrive and sweep now better handle missing, stale, or ineligible executions and report dispatch issues with clearer aggregated errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->