### PR TITLE
Add branch-aware deployment planning and metadata

### DIFF
--- a/framework/deployment/src/main/java/org/pipelineframework/extension/OperatorLinkValidationBuildSteps.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/extension/OperatorLinkValidationBuildSteps.java
@@ -54,8 +54,12 @@ public final class OperatorLinkValidationBuildSteps {
     @Produce(ArtifactResultBuildItem.class)
     void validateOperatorLinks(
             List<OperatorBuildItem> steps,
+            PipelineConfigBuildItem pipelineConfig,
             MapperRegistryBuildItem mapperRegistry,
             CombinedIndexBuildItem combinedIndex) {
+        if (pipelineConfig != null && pipelineConfig.branchAware()) {
+            return;
+        }
         validateOperatorLinks(steps, mapperRegistry, combinedIndex.getIndex());
     }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildItem.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildItem.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 public final class PipelineConfigBuildItem extends SimpleBuildItem {
 
     private final List<StepConfig> steps;
+    private final boolean branchAware;
 
     /**
      * Creates a PipelineConfigBuildItem containing the given pipeline step configurations.
@@ -36,6 +37,17 @@ public final class PipelineConfigBuildItem extends SimpleBuildItem {
      * @throws NullPointerException if {@code steps} is null or contains a null element
      */
     public PipelineConfigBuildItem(List<StepConfig> steps) {
+        this(steps, false);
+    }
+
+    /**
+     * Creates a PipelineConfigBuildItem containing the given pipeline step configurations.
+     *
+     * @param steps the list of StepConfig entries; must not be null and must not contain null elements
+     * @param branchAware whether the YAML declares branch-aware routing markers
+     * @throws NullPointerException if {@code steps} is null or contains a null element
+     */
+    public PipelineConfigBuildItem(List<StepConfig> steps, boolean branchAware) {
         Objects.requireNonNull(steps, "steps must not be null");
         for (int i = 0; i < steps.size(); i++) {
             if (steps.get(i) == null) {
@@ -43,6 +55,7 @@ public final class PipelineConfigBuildItem extends SimpleBuildItem {
             }
         }
         this.steps = List.copyOf(steps);
+        this.branchAware = branchAware;
     }
 
     /**
@@ -52,6 +65,15 @@ public final class PipelineConfigBuildItem extends SimpleBuildItem {
      */
     public List<StepConfig> steps() {
         return steps;
+    }
+
+    /**
+     * Returns whether the YAML declares branch-aware routing markers.
+     *
+     * @return true when any step uses accepts/terminal routing markers
+     */
+    public boolean branchAware() {
+        return branchAware;
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildSteps.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildSteps.java
@@ -54,7 +54,8 @@ public final class PipelineConfigBuildSteps {
         if (configPath.isEmpty()) {
             return new PipelineConfigBuildItem(List.of());
         }
-        return new PipelineConfigBuildItem(readDelegatedSteps(configPath.get()));
+        Object root = readYaml(configPath.get());
+        return new PipelineConfigBuildItem(readDelegatedSteps(configPath.get(), root), isBranchAware(root));
     }
 
     /**
@@ -95,8 +96,7 @@ public final class PipelineConfigBuildSteps {
      * @return a list of delegated step configurations; empty if no valid delegated steps are present
      * @throws DeploymentException if the YAML root is not a mapping, the file cannot be read, or parsing detects invalid configuration
      */
-    private List<PipelineConfigBuildItem.StepConfig> readDelegatedSteps(Path configPath) {
-        Object root = readYaml(configPath);
+    private List<PipelineConfigBuildItem.StepConfig> readDelegatedSteps(Path configPath, Object root) {
         if (!(root instanceof Map<?, ?> rootMap)) {
             throw new DeploymentException("pipeline config root must be a map: " + configPath);
         }
@@ -124,6 +124,29 @@ public final class PipelineConfigBuildSteps {
             }
         }
         return delegatedSteps;
+    }
+
+    private boolean isBranchAware(Object root) {
+        if (!(root instanceof Map<?, ?> rootMap)) {
+            return false;
+        }
+        Object stepsObj = rootMap.get("steps");
+        if (!(stepsObj instanceof Iterable<?> steps)) {
+            return false;
+        }
+        for (Object item : steps) {
+            if (!(item instanceof Map<?, ?> stepMap)) {
+                continue;
+            }
+            if (stepMap.containsKey("accepts")) {
+                return true;
+            }
+            Object terminal = stepMap.get("terminal");
+            if (Boolean.TRUE.equals(terminal) || "true".equalsIgnoreCase(String.valueOf(terminal))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/AspectExpansionProcessor.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/AspectExpansionProcessor.java
@@ -62,7 +62,7 @@ public class AspectExpansionProcessor {
             applicable.addAll(globalAspects);
             for (PipelineAspectModel aspect : stepAspects) {
                 Set<String> targetSteps = extractTargetSteps(aspect);
-                if (targetSteps != null && targetSteps.contains(originalModel.serviceName())) {
+                if (matchesTargetStep(targetSteps, originalModel.serviceName())) {
                     applicable.add(aspect);
                 }
             }
@@ -171,11 +171,34 @@ public class AspectExpansionProcessor {
     }
 
     private void validateTargetStepName(Set<String> availableStepNames, String aspectName, String targetStep) {
-        if (!availableStepNames.contains(targetStep)) {
+        String normalizedTarget = normalizeStepToken(targetStep);
+        boolean matched = availableStepNames.stream()
+            .anyMatch(candidate -> matchesNormalizedToken(normalizeStepToken(candidate), normalizedTarget));
+        if (!matched) {
             throw new IllegalArgumentException(
                 "STEP-scoped aspect '" + aspectName +
                     "' targets non-existent step: " + targetStep);
         }
+    }
+
+    private boolean matchesTargetStep(Set<String> targetSteps, String serviceName) {
+        if (targetSteps == null || targetSteps.isEmpty()) {
+            return false;
+        }
+        String normalizedServiceName = normalizeStepToken(serviceName);
+        for (String targetStep : targetSteps) {
+            if (matchesNormalizedToken(normalizedServiceName, normalizeStepToken(targetStep))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesNormalizedToken(String candidate, String target) {
+        if (candidate == null || candidate.isBlank() || target == null || target.isBlank()) {
+            return false;
+        }
+        return candidate.equalsIgnoreCase(target);
     }
 
     private Set<String> extractTargetSteps(PipelineAspectModel aspect) {
@@ -254,5 +277,19 @@ public class AspectExpansionProcessor {
             }
         }
         return builder.toString();
+    }
+
+    private String normalizeStepToken(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        String simple = value;
+        int lastDot = simple.lastIndexOf('.');
+        if (lastDot != -1) {
+            simple = simple.substring(lastDot + 1);
+        }
+        simple = simple.replaceAll("(Service|GrpcClientStep|RestClientStep|LocalClientStep)(_Subclass)?$", "");
+        simple = simple.replaceFirst("^Process(?=[A-Z0-9])", "");
+        return simple.replaceAll("[^A-Za-z0-9]", "");
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompilationContext.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/PipelineCompilationContext.java
@@ -20,6 +20,7 @@ import org.pipelineframework.processor.ir.StepDefinition;
 import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMapping;
 import org.pipelineframework.processor.mapping.PipelineRuntimeMappingResolution;
+import org.pipelineframework.processor.routing.PipelineBranchingPlan;
 
 /**
  * Holds the compilation context for the pipeline annotation processing.
@@ -48,6 +49,8 @@ public class PipelineCompilationContext {
     private Object pipelineTemplateConfig; // Store as Object to avoid circular dependencies
     @Setter
     private List<StepDefinition> stepDefinitions;
+    @Setter
+    private PipelineBranchingPlan branchingPlan;
     
     // Resolved generation targets
     @Setter
@@ -102,6 +105,7 @@ public class PipelineCompilationContext {
         this.orchestratorModels = List.of();
         this.pipelineTemplateConfig = null;
         this.stepDefinitions = List.of();
+        this.branchingPlan = null;
         this.resolvedTargets = Set.of();
         this.rendererBindings = Map.of();
         this.pluginHost = false;

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/ir/StepDefinition.java
@@ -51,6 +51,8 @@ import org.pipelineframework.config.template.PipelineTemplateStepExecution;
  * @param outputType The output type for the step
  * @param streamingShapeHint Optional streaming shape hint parsed from YAML cardinality
  * @param runOnVirtualThreads Whether blocking execution should use virtual threads
+ * @param accepts Optional concrete contract types accepted by this step for branch-aware routing
+ * @param terminal Whether this step is the mandatory terminal merge for a branch-aware pipeline
  */
 public record StepDefinition(
         String name,
@@ -75,7 +77,9 @@ public record StepDefinition(
         @Nullable ClassName inputType,
         @Nullable ClassName outputType,
         @Nullable StreamingShape streamingShapeHint,
-        boolean runOnVirtualThreads
+        boolean runOnVirtualThreads,
+        List<String> accepts,
+        boolean terminal
 ) {
     public StepDefinition(
         String name,
@@ -124,7 +128,63 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
-            runOnVirtualThreads);
+            runOnVirtualThreads,
+            List.of(),
+            false);
+    }
+
+    public StepDefinition(
+        String name,
+        StepKind kind,
+        @Nullable ClassName executionClass,
+        @Nullable PipelineTemplateStepExecution remoteExecution,
+        Map<?, ?> awaitConfig,
+        @Nullable String timeout,
+        List<?> idempotencyKeyFields,
+        @Nullable String command,
+        @Nullable ClassName commandIdGenerator,
+        @Nullable String duplicatePolicy,
+        Map<?, ?> commandConfig,
+        @Nullable String queryId,
+        Map<?, ?> queryConfig,
+        List<?> queryKeyFields,
+        @Nullable ClassName inboundMapper,
+        @Nullable ClassName outboundMapper,
+        @Nullable ClassName externalMapper,
+        MapperFallbackMode mapperFallback,
+        @Nullable ClassName inputType,
+        @Nullable ClassName outputType,
+        @Nullable StreamingShape streamingShapeHint,
+        boolean runOnVirtualThreads,
+        List<String> accepts,
+        boolean terminal
+    ) {
+        this(
+            name,
+            kind,
+            executionClass,
+            Optional.empty(),
+            remoteExecution,
+            copyObjectMap(awaitConfig),
+            timeout,
+            copyStringList(idempotencyKeyFields),
+            command,
+            commandIdGenerator,
+            duplicatePolicy,
+            copyObjectMap(commandConfig),
+            queryId,
+            copyObjectMap(queryConfig),
+            copyStringList(queryKeyFields),
+            inboundMapper,
+            outboundMapper,
+            externalMapper,
+            mapperFallback,
+            inputType,
+            outputType,
+            streamingShapeHint,
+            runOnVirtualThreads,
+            accepts,
+            terminal);
     }
 
     public StepDefinition(
@@ -166,6 +226,8 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
+            false,
+            List.of(),
             false);
     }
 
@@ -212,7 +274,9 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
-            runOnVirtualThreads);
+            runOnVirtualThreads,
+            List.of(),
+            false);
     }
 
     public StepDefinition(
@@ -248,6 +312,8 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
+            false,
+            List.of(),
             false);
     }
 
@@ -285,6 +351,8 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
+            false,
+            List.of(),
             false);
     }
 
@@ -325,7 +393,9 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
-            runOnVirtualThreads);
+            runOnVirtualThreads,
+            List.of(),
+            false);
     }
 
     public StepDefinition(
@@ -363,7 +433,53 @@ public record StepDefinition(
             inputType,
             outputType,
             streamingShapeHint,
+            false,
+            List.of(),
             false);
+    }
+
+    public StepDefinition(
+        String name,
+        StepKind kind,
+        ClassName executionClass,
+        Optional<String> delegatedMethodName,
+        @Nullable ClassName inboundMapper,
+        @Nullable ClassName outboundMapper,
+        @Nullable ClassName externalMapper,
+        MapperFallbackMode mapperFallback,
+        @Nullable ClassName inputType,
+        @Nullable ClassName outputType,
+        @Nullable StreamingShape streamingShapeHint,
+        boolean runOnVirtualThreads,
+        List<String> accepts,
+        boolean terminal
+    ) {
+        this(
+            name,
+            requireNonRemoteKind(kind),
+            executionClass,
+            delegatedMethodName,
+            null,
+            Map.of(),
+            null,
+            List.of(),
+            null,
+            null,
+            null,
+            Map.of(),
+            null,
+            Map.of(),
+            List.of(),
+            inboundMapper,
+            outboundMapper,
+            externalMapper,
+            mapperFallback,
+            inputType,
+            outputType,
+            streamingShapeHint,
+            runOnVirtualThreads,
+            accepts,
+            terminal);
     }
 
     public StepDefinition {
@@ -379,6 +495,7 @@ public record StepDefinition(
             throw new IllegalArgumentException("executionClass and remoteExecution are mutually exclusive");
         }
         delegatedMethodName = normalizeOptionalString(delegatedMethodName);
+        accepts = accepts == null ? List.of() : List.copyOf(accepts);
         if (kind == StepKind.REMOTE) {
             Objects.requireNonNull(remoteExecution, "Remote execution cannot be null for REMOTE steps");
         } else if (kind == StepKind.AWAIT || kind == StepKind.COMMAND || kind == StepKind.QUERY) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -29,6 +29,8 @@ import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import javax.tools.Diagnostic;
 
+import org.pipelineframework.config.pipeline.BranchRoutingRules;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.squareup.javapoet.ClassName;
@@ -58,11 +60,6 @@ public class StepDefinitionParser {
         "between",
         "like",
         "isNull");
-    private static final Set<String> REJECTED_BRANCH_PREDICATE_KEYS = Set.of(
-        "when",
-        "condition",
-        "predicate",
-        "expression");
     /**
      * Legacy suffix used to resolve short-form internal step types.
      * For legacy internal steps, {@code input/output: Foo} resolves to
@@ -1462,12 +1459,7 @@ public class StepDefinitionParser {
     }
 
     private void reportRejectedBranchPredicateKeys(String stepName, Map<String, Object> stepData) {
-        Set<String> rejectedKeys = new HashSet<>();
-        for (String key : stepData.keySet()) {
-            if (REJECTED_BRANCH_PREDICATE_KEYS.contains(key)) {
-                rejectedKeys.add(key);
-            }
-        }
+        Set<String> rejectedKeys = new HashSet<>(BranchRoutingRules.rejectedPredicateKeys(stepData));
         if (rejectedKeys.isEmpty()) {
             return;
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/parser/StepDefinitionParser.java
@@ -58,6 +58,11 @@ public class StepDefinitionParser {
         "between",
         "like",
         "isNull");
+    private static final Set<String> REJECTED_BRANCH_PREDICATE_KEYS = Set.of(
+        "when",
+        "condition",
+        "predicate",
+        "expression");
     /**
      * Legacy suffix used to resolve short-form internal step types.
      * For legacy internal steps, {@code input/output: Foo} resolves to
@@ -92,6 +97,8 @@ public class StepDefinitionParser {
         "config",
         "query",
         "capture",
+        "accepts",
+        "terminal",
         "runOnVirtualThreads");
     private final BiConsumer<Diagnostic.Kind, String> diagnosticReporter;
     private final String legacyInternalPackageSuffix;
@@ -202,7 +209,15 @@ public class StepDefinitionParser {
             LOG.warnf("Skipping step with null or blank name: %s", stepData);
             return null;
         }
+        reportRejectedBranchPredicateKeys(name, stepData);
         reportUnknownStepKeys(name, stepData);
+        if (version < 2 && (stepData.containsKey("accepts") || Boolean.TRUE.equals(stepData.get("terminal")))) {
+            String message = "Skipping step '" + name
+                + "': accepts/terminal branch routing requires version: 2";
+            LOG.warn(message);
+            report(Diagnostic.Kind.ERROR, message);
+            throw new StepSkippedException();
+        }
 
         PipelineTemplateStepExecution remoteExecution;
         try {
@@ -360,6 +375,11 @@ public class StepDefinitionParser {
         if (!isBlank(outputTypeName) && outputType == null) {
             return null;
         }
+        List<String> accepts = parseStringList(stepData.get("accepts"), name, "accepts");
+        if (accepts == null) {
+            throw new StepSkippedException();
+        }
+        boolean terminal = parseOptionalBoolean(stepData, name, "terminal");
 
         String inboundMapperName = getStringValue(stepData, "inboundMapper");
         String outboundMapperName = getStringValue(stepData, "outboundMapper");
@@ -494,7 +514,9 @@ public class StepDefinitionParser {
                 inputType,
                 outputType,
                 StreamingShape.UNARY_UNARY,
-                false);
+                false,
+                accepts,
+                terminal);
         }
 
         if (kind == StepKind.AWAIT) {
@@ -550,7 +572,9 @@ public class StepDefinitionParser {
                 inputType,
                 outputType,
                 resolvedShape,
-                false);
+                false,
+                accepts,
+                terminal);
         }
 
         if (kind == StepKind.COMMAND) {
@@ -622,7 +646,9 @@ public class StepDefinitionParser {
                 inputType,
                 outputType,
                 StreamingShape.UNARY_UNARY,
-                false);
+                false,
+                accepts,
+                terminal);
         }
 
         if (kind == StepKind.QUERY) {
@@ -700,7 +726,9 @@ public class StepDefinitionParser {
                 inputType,
                 outputType,
                 StreamingShape.UNARY_UNARY,
-                false);
+                false,
+                accepts,
+                terminal);
         }
 
         // Create the execution class name
@@ -722,7 +750,9 @@ public class StepDefinitionParser {
             inputType,
             outputType,
             parseStreamingShapeHint(stepData, name),
-            runOnVirtualThreads);
+            runOnVirtualThreads,
+            accepts,
+            terminal);
     }
 
     private boolean parseOptionalBoolean(Map<String, Object> stepData, String stepName, String fieldName) {
@@ -1429,6 +1459,23 @@ public class StepDefinitionParser {
             + String.join(", ", unknownKeys);
         LOG.warn(message);
         report(Diagnostic.Kind.WARNING, message);
+    }
+
+    private void reportRejectedBranchPredicateKeys(String stepName, Map<String, Object> stepData) {
+        Set<String> rejectedKeys = new HashSet<>();
+        for (String key : stepData.keySet()) {
+            if (REJECTED_BRANCH_PREDICATE_KEYS.contains(key)) {
+                rejectedKeys.add(key);
+            }
+        }
+        if (rejectedKeys.isEmpty()) {
+            return;
+        }
+        String message = "Skipping step '" + stepName + "': predicate-style routing keys are not supported ("
+            + String.join(", ", rejectedKeys) + "). Use type-based accepts/terminal routing only.";
+        LOG.warn(message);
+        report(Diagnostic.Kind.ERROR, message);
+        throw new StepSkippedException();
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineGenerationPhase.java
@@ -18,6 +18,7 @@ import org.pipelineframework.processor.util.OrchestratorClientPropertiesGenerato
 import org.pipelineframework.processor.util.CheckpointHandoffMetadataGenerator;
 import org.pipelineframework.processor.util.DtoTypeUtils;
 import org.pipelineframework.processor.util.GrpcJavaTypeResolver;
+import org.pipelineframework.processor.util.PipelineBranchingMetadataGenerator;
 import org.pipelineframework.processor.util.PipelineContractMetadataGenerator;
 import org.pipelineframework.processor.util.PipelineOrderMetadataGenerator;
 import org.pipelineframework.processor.util.PipelinePlatformMetadataGenerator;
@@ -318,6 +319,9 @@ public class PipelineGenerationPhase implements PipelineCompilationPhase {
             PipelineOrderMetadataGenerator orderMetadataGenerator =
                 new PipelineOrderMetadataGenerator(ctx.getProcessingEnv());
             orderMetadataGenerator.writeOrderMetadata(ctx);
+            PipelineBranchingMetadataGenerator branchingMetadataGenerator =
+                new PipelineBranchingMetadataGenerator(ctx.getProcessingEnv());
+            branchingMetadataGenerator.writeBranchingMetadata(ctx);
             PipelineContractMetadataGenerator contractMetadataGenerator =
                 new PipelineContractMetadataGenerator(ctx.getProcessingEnv());
             contractMetadataGenerator.writePipelineContract(ctx);

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
@@ -22,6 +22,7 @@ import org.pipelineframework.processor.ir.PipelineAspectModel;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.routing.PipelineBranchRoutingPlanner;
 
 /**
  * Performs semantic analysis and policy decisions on discovered models.
@@ -70,6 +71,7 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
         validateProviderHints(ctx);
         validateFunctionPlatformConstraints(ctx);
         validateYamlDrivenSteps(ctx);
+        ctx.setBranchingPlan(new PipelineBranchRoutingPlanner().plan(ctx).orElse(null));
 
         // Analyze streaming shapes and other semantic properties
         // This phase focuses on semantic analysis without building bindings or calling renderers

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/phase/PipelineSemanticAnalysisPhase.java
@@ -22,6 +22,7 @@ import org.pipelineframework.processor.ir.PipelineAspectModel;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.ServiceApiKind;
 import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.routing.PipelineBranchingPlan;
 import org.pipelineframework.processor.routing.PipelineBranchRoutingPlanner;
 
 /**
@@ -71,7 +72,7 @@ public class PipelineSemanticAnalysisPhase implements PipelineCompilationPhase {
         validateProviderHints(ctx);
         validateFunctionPlatformConstraints(ctx);
         validateYamlDrivenSteps(ctx);
-        ctx.setBranchingPlan(new PipelineBranchRoutingPlanner().plan(ctx).orElse(null));
+        ctx.setBranchingPlan(new PipelineBranchRoutingPlanner().plan(ctx).orElseGet(PipelineBranchingPlan::disabled));
 
         // Analyze streaming shapes and other semantic properties
         // This phase focuses on semantic analysis without building bindings or calling renderers

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -1,0 +1,418 @@
+package org.pipelineframework.processor.routing;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+
+import com.squareup.javapoet.ClassName;
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateStep;
+import org.pipelineframework.config.template.PipelineTemplateUnion;
+import org.pipelineframework.config.template.PipelineTemplateUnionVariant;
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.StepDefinition;
+
+/**
+ * Validates and plans linear union-routed branching.
+ */
+public final class PipelineBranchRoutingPlanner {
+
+    /**
+     * Build a branching plan for the current compilation context.
+     *
+     * @param ctx compilation context
+     * @return Optional containing the plan when successful, or empty after reporting diagnostics on validation failure
+     */
+    public Optional<PipelineBranchingPlan> plan(PipelineCompilationContext ctx) {
+        if (ctx == null) {
+            return Optional.of(PipelineBranchingPlan.disabled());
+        }
+        if (!(ctx.getPipelineTemplateConfig() instanceof PipelineTemplateConfig templateConfig)) {
+            return planWithoutTemplate(ctx);
+        }
+        List<PipelineTemplateStep> templateSteps = templateConfig.steps() == null ? List.of() : templateConfig.steps();
+        if (templateSteps.isEmpty()) {
+            return Optional.of(PipelineBranchingPlan.disabled());
+        }
+
+        boolean branchAware = templateSteps.stream()
+            .filter(Objects::nonNull)
+            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal());
+        if (!branchAware) {
+            return Optional.of(PipelineBranchingPlan.disabled());
+        }
+
+        if (templateConfig.version() < 2) {
+            error(ctx, "Branch-aware routing requires version: 2 pipeline templates.");
+            return Optional.empty();
+        }
+
+        Map<String, StepDefinition> definitionsByName = indexStepDefinitions(ctx, templateSteps);
+        if (definitionsByName == null) {
+            return Optional.empty();
+        }
+
+        List<ResolvedStep> resolvedSteps = new ArrayList<>();
+        boolean valid = true;
+        int terminalCount = 0;
+        int terminalIndex = -1;
+        for (int index = 0; index < templateSteps.size(); index++) {
+            PipelineTemplateStep templateStep = templateSteps.get(index);
+            if (templateStep == null) {
+                continue;
+            }
+            StepDefinition stepDefinition = definitionsByName.get(normalizeStepName(templateStep.name()));
+            if (stepDefinition == null) {
+                error(ctx, "Branch-aware step '" + templateStep.name()
+                    + "' was not resolved into a step definition. Fix existing YAML or parser errors first.");
+                valid = false;
+                continue;
+            }
+            ResolvedStep resolved = resolveStep(ctx, templateConfig, templateStep, stepDefinition, index);
+            if (resolved == null) {
+                valid = false;
+                continue;
+            }
+            resolvedSteps.add(resolved);
+            if (resolved.terminal()) {
+                terminalCount++;
+                terminalIndex = index;
+            }
+        }
+        if (!valid) {
+            return Optional.empty();
+        }
+
+        if (terminalCount == 0) {
+            error(ctx, "Branch-aware pipelines require exactly one step with terminal: true.");
+            return Optional.empty();
+        }
+        if (terminalCount > 1) {
+            error(ctx, "Branch-aware pipelines may declare only one terminal: true step.");
+            return Optional.empty();
+        }
+        if (terminalIndex != resolvedSteps.size() - 1) {
+            error(ctx, "The terminal: true step must be the last authored step in a branch-aware pipeline.");
+            return Optional.empty();
+        }
+
+        if (!validateReachability(ctx, resolvedSteps)) {
+            return Optional.empty();
+        }
+
+        List<PipelineBranchingPlan.BranchStep> steps = resolvedSteps.stream()
+            .map(step -> new PipelineBranchingPlan.BranchStep(
+                step.index(),
+                step.templateStep().name(),
+                step.templateStep().inputTypeName(),
+                step.templateStep().outputTypeName(),
+                List.copyOf(step.acceptedLeafTypes()),
+                List.copyOf(step.producedLeafTypes()),
+                List.copyOf(step.acceptedDomainTypes()),
+                step.terminal()))
+            .toList();
+        return Optional.of(new PipelineBranchingPlan(true, terminalIndex, steps));
+    }
+
+    private Optional<PipelineBranchingPlan> planWithoutTemplate(PipelineCompilationContext ctx) {
+        List<StepDefinition> stepDefinitions = ctx.getStepDefinitions() == null ? List.of() : ctx.getStepDefinitions();
+        boolean branchAware = stepDefinitions.stream()
+            .filter(Objects::nonNull)
+            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal());
+        if (!branchAware) {
+            return Optional.of(PipelineBranchingPlan.disabled());
+        }
+        error(ctx, "Branch-aware routing requires template contract metadata. Add version: 2 messages/unions and typed step declarations.");
+        return Optional.empty();
+    }
+
+    private Map<String, StepDefinition> indexStepDefinitions(
+        PipelineCompilationContext ctx,
+        List<PipelineTemplateStep> templateSteps
+    ) {
+        List<StepDefinition> stepDefinitions = ctx.getStepDefinitions() == null ? List.of() : ctx.getStepDefinitions();
+        Map<String, StepDefinition> indexed = new LinkedHashMap<>();
+        Set<String> duplicateNames = new LinkedHashSet<>();
+        for (StepDefinition stepDefinition : stepDefinitions) {
+            if (stepDefinition == null || stepDefinition.name() == null) {
+                continue;
+            }
+            String key = normalizeStepName(stepDefinition.name());
+            StepDefinition previous = indexed.putIfAbsent(key, stepDefinition);
+            if (previous != null) {
+                duplicateNames.add(stepDefinition.name());
+            }
+        }
+        if (!duplicateNames.isEmpty()) {
+            error(ctx, "Branch-aware pipelines require unique step names. Duplicate names: " + duplicateNames);
+            return null;
+        }
+
+        boolean valid = true;
+        for (PipelineTemplateStep templateStep : templateSteps) {
+            if (templateStep == null) {
+                continue;
+            }
+            if (!indexed.containsKey(normalizeStepName(templateStep.name()))) {
+                error(ctx, "Step definition missing for authored step '" + templateStep.name() + "'.");
+                valid = false;
+            }
+        }
+        return valid ? indexed : null;
+    }
+
+    private ResolvedStep resolveStep(
+        PipelineCompilationContext ctx,
+        PipelineTemplateConfig templateConfig,
+        PipelineTemplateStep templateStep,
+        StepDefinition stepDefinition,
+        int index
+    ) {
+        if (isBlank(templateStep.inputTypeName())) {
+            error(ctx, "Branch-aware step '" + templateStep.name() + "' must declare inputTypeName.");
+            return null;
+        }
+        if (isBlank(templateStep.outputTypeName())) {
+            error(ctx, "Branch-aware step '" + templateStep.name() + "' must declare outputTypeName.");
+            return null;
+        }
+
+        Set<String> inputLeafTypes = expandLeafTypes(ctx, templateConfig, templateStep.inputTypeName(),
+            templateStep.name(), "inputTypeName", false);
+        if (inputLeafTypes == null) {
+            return null;
+        }
+        Set<String> outputLeafTypes = expandLeafTypes(ctx, templateConfig, templateStep.outputTypeName(),
+            templateStep.name(), "outputTypeName", false);
+        if (outputLeafTypes == null) {
+            return null;
+        }
+
+        boolean oneToOneCardinality = "ONE_TO_ONE".equalsIgnoreCase(templateStep.cardinality());
+        if (!oneToOneCardinality
+            && (templateStep.terminal()
+                || !templateStep.accepts().isEmpty()
+                || inputLeafTypes.size() != 1
+                || outputLeafTypes.size() != 1)) {
+            error(ctx, "Branch-aware routing currently supports ONE_TO_ONE steps once type-based routing is in play. Step '"
+                + templateStep.name() + "' declares cardinality '" + templateStep.cardinality() + "'.");
+            return null;
+        }
+
+        Set<String> acceptedLeafTypes = new LinkedHashSet<>();
+        if (!templateStep.accepts().isEmpty()) {
+            for (String accepted : templateStep.accepts()) {
+                if (isBlank(accepted)) {
+                    error(ctx, "Step '" + templateStep.name() + "' declares a blank accepts entry.");
+                    return null;
+                }
+                if (templateConfig.unions().containsKey(accepted)) {
+                    error(ctx, "Step '" + templateStep.name() + "' accepts '" + accepted
+                        + "', but accepts may reference only concrete contract types, not unions.");
+                    return null;
+                }
+                Set<String> acceptedLeaf = expandLeafTypes(ctx, templateConfig, accepted, templateStep.name(), "accepts", true);
+                if (acceptedLeaf == null) {
+                    return null;
+                }
+                acceptedLeafTypes.addAll(acceptedLeaf);
+            }
+            if (!inputLeafTypes.containsAll(acceptedLeafTypes)) {
+                error(ctx, "Step '" + templateStep.name() + "' accepts " + acceptedLeafTypes
+                    + " but inputTypeName '" + templateStep.inputTypeName() + "' resolves to " + inputLeafTypes + ".");
+                return null;
+            }
+        } else {
+            if (inputLeafTypes.size() != 1) {
+                error(ctx, "Step '" + templateStep.name()
+                    + "' resolves inputTypeName '" + templateStep.inputTypeName()
+                    + "' to multiple alternatives " + inputLeafTypes
+                    + ". Explicit accepts is required.");
+                return null;
+            }
+            acceptedLeafTypes.addAll(inputLeafTypes);
+        }
+
+        if (templateStep.terminal() && outputLeafTypes.size() != 1) {
+            error(ctx, "Terminal step '" + templateStep.name()
+                + "' must declare one concrete terminal output type. outputTypeName '"
+                + templateStep.outputTypeName() + "' resolves to " + outputLeafTypes + ".");
+            return null;
+        }
+
+        List<ClassName> acceptedDomainTypes = acceptedLeafTypes.stream()
+            .map(typeName -> ClassName.get(templateConfig.basePackage() + ".common.domain", typeName))
+            .toList();
+        if (!validateAssignableAcceptedTypes(ctx, templateStep, stepDefinition, acceptedDomainTypes)) {
+            return null;
+        }
+
+        return new ResolvedStep(
+            index,
+            templateStep,
+            stepDefinition,
+            List.copyOf(acceptedLeafTypes),
+            List.copyOf(outputLeafTypes),
+            acceptedDomainTypes);
+    }
+
+    private boolean validateReachability(PipelineCompilationContext ctx, List<ResolvedStep> resolvedSteps) {
+        ResolvedStep firstStep = resolvedSteps.getFirst();
+        Set<String> reachable = new LinkedHashSet<>(expandLeafTypes(
+            ctx,
+            requireTemplateConfig(ctx),
+            firstStep.templateStep().inputTypeName(),
+            firstStep.templateStep().name(),
+            "inputTypeName",
+            false));
+        for (ResolvedStep step : resolvedSteps) {
+            Set<String> unreachable = new LinkedHashSet<>(step.acceptedLeafTypes());
+            unreachable.removeAll(reachable);
+            if (!unreachable.isEmpty()) {
+                error(ctx, "Step '" + step.templateStep().name()
+                    + "' accepts types that are not currently reachable: " + unreachable
+                    + ". Currently reachable: " + reachable);
+                return false;
+            }
+
+            Set<String> skipped = new LinkedHashSet<>(reachable);
+            skipped.removeAll(step.acceptedLeafTypes());
+
+            if (step.terminal() && !skipped.isEmpty()) {
+                error(ctx, "Terminal step '" + step.templateStep().name()
+                    + "' does not cover all reachable branch-end alternatives. Missing: " + skipped);
+                return false;
+            }
+
+            Set<String> nextReachable = new LinkedHashSet<>(skipped);
+            nextReachable.addAll(step.producedLeafTypes());
+            reachable = nextReachable;
+        }
+        return true;
+    }
+
+    private Set<String> expandLeafTypes(
+        PipelineCompilationContext ctx,
+        PipelineTemplateConfig templateConfig,
+        String contractTypeName,
+        String stepName,
+        String fieldName,
+        boolean concreteOnly
+    ) {
+        if (templateConfig == null || isBlank(contractTypeName)) {
+            error(ctx, "Step '" + stepName + "' must declare " + fieldName + ".");
+            return null;
+        }
+        if (templateConfig.messages().containsKey(contractTypeName)) {
+            return Set.of(contractTypeName);
+        }
+        PipelineTemplateUnion union = templateConfig.unions().get(contractTypeName);
+        if (union != null) {
+            if (concreteOnly) {
+                error(ctx, "Step '" + stepName + "' " + fieldName + " entry '" + contractTypeName
+                    + "' must be a concrete contract type, not a union.");
+                return null;
+            }
+            LinkedHashSet<String> leafTypes = new LinkedHashSet<>();
+            for (PipelineTemplateUnionVariant variant : union.variants().values()) {
+                leafTypes.add(variant.type());
+            }
+            return leafTypes;
+        }
+        error(ctx, "Step '" + stepName + "' references unknown contract type '" + contractTypeName
+            + "' in " + fieldName + ".");
+        return null;
+    }
+
+    private boolean validateAssignableAcceptedTypes(
+        PipelineCompilationContext ctx,
+        PipelineTemplateStep templateStep,
+        StepDefinition stepDefinition,
+        List<ClassName> acceptedDomainTypes
+    ) {
+        if (stepDefinition.inputType() == null || acceptedDomainTypes.isEmpty()) {
+            return true;
+        }
+        ProcessingEnvironment processingEnv = ctx.getProcessingEnv();
+        if (processingEnv == null || processingEnv.getElementUtils() == null || processingEnv.getTypeUtils() == null) {
+            return true;
+        }
+        TypeElement stepInputElement = processingEnv.getElementUtils().getTypeElement(stepDefinition.inputType().canonicalName());
+        if (stepInputElement == null) {
+            error(ctx, "Step '" + templateStep.name() + "' input type '" + stepDefinition.inputType().canonicalName()
+                + "' could not be resolved during branch routing validation.");
+            return false;
+        }
+        Types types = processingEnv.getTypeUtils();
+        TypeMirror stepInputType = stepInputElement.asType();
+        for (ClassName acceptedType : acceptedDomainTypes) {
+            TypeElement acceptedElement = processingEnv.getElementUtils().getTypeElement(acceptedType.canonicalName());
+            if (acceptedElement == null) {
+                error(ctx, "Step '" + templateStep.name() + "' accepted type '" + acceptedType.canonicalName()
+                    + "' could not be resolved during branch routing validation.");
+                return false;
+            }
+            if (!types.isAssignable(acceptedElement.asType(), stepInputType)) {
+                error(ctx, "Step '" + templateStep.name() + "' accepts '" + acceptedType.simpleName()
+                    + "', but that type is not assignable to Java input type '"
+                    + stepDefinition.inputType().canonicalName() + "'.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private PipelineTemplateConfig requireTemplateConfig(PipelineCompilationContext ctx) {
+        return ctx.getPipelineTemplateConfig() instanceof PipelineTemplateConfig templateConfig ? templateConfig : null;
+    }
+
+    private void error(PipelineCompilationContext ctx, String message) {
+        report(ctx, Diagnostic.Kind.ERROR, message);
+    }
+
+    private void report(PipelineCompilationContext ctx, Diagnostic.Kind kind, String message) {
+        if (ctx == null || ctx.getProcessingEnv() == null) {
+            return;
+        }
+        Messager messager = ctx.getProcessingEnv().getMessager();
+        if (messager != null) {
+            messager.printMessage(kind, message);
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String normalizeStepName(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.replaceAll("[^A-Za-z0-9]", "").toLowerCase(Locale.ROOT);
+    }
+
+    private record ResolvedStep(
+        int index,
+        PipelineTemplateStep templateStep,
+        StepDefinition stepDefinition,
+        List<String> acceptedLeafTypes,
+        List<String> producedLeafTypes,
+        List<ClassName> acceptedDomainTypes
+    ) {
+        boolean terminal() {
+            return templateStep.terminal();
+        }
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -59,8 +59,8 @@ public final class PipelineBranchRoutingPlanner {
             return Optional.empty();
         }
 
-        Map<String, StepDefinition> definitionsByName = indexStepDefinitions(ctx, templateSteps);
-        if (definitionsByName == null) {
+        Optional<Map<String, StepDefinition>> definitionsByName = indexStepDefinitions(ctx, templateSteps);
+        if (definitionsByName.isEmpty()) {
             return Optional.empty();
         }
 
@@ -73,20 +73,20 @@ public final class PipelineBranchRoutingPlanner {
             if (templateStep == null) {
                 continue;
             }
-            StepDefinition stepDefinition = definitionsByName.get(normalizeStepName(templateStep.name()));
+            StepDefinition stepDefinition = definitionsByName.orElseThrow().get(normalizeStepName(templateStep.name()));
             if (stepDefinition == null) {
                 error(ctx, "Branch-aware step '" + templateStep.name()
                     + "' was not resolved into a step definition. Fix existing YAML or parser errors first.");
                 valid = false;
                 continue;
             }
-            ResolvedStep resolved = resolveStep(ctx, templateConfig, templateStep, stepDefinition, index);
-            if (resolved == null) {
+            Optional<ResolvedStep> resolved = resolveStep(ctx, templateConfig, templateStep, stepDefinition, index);
+            if (resolved.isEmpty()) {
                 valid = false;
                 continue;
             }
-            resolvedSteps.add(resolved);
-            if (resolved.terminal()) {
+            resolvedSteps.add(resolved.orElseThrow());
+            if (resolved.orElseThrow().terminal()) {
                 terminalCount++;
                 terminalIndex = index;
             }
@@ -138,7 +138,7 @@ public final class PipelineBranchRoutingPlanner {
         return Optional.empty();
     }
 
-    private Map<String, StepDefinition> indexStepDefinitions(
+    private Optional<Map<String, StepDefinition>> indexStepDefinitions(
         PipelineCompilationContext ctx,
         List<PipelineTemplateStep> templateSteps
     ) {
@@ -157,7 +157,7 @@ public final class PipelineBranchRoutingPlanner {
         }
         if (!duplicateNames.isEmpty()) {
             error(ctx, "Branch-aware pipelines require unique step names. Duplicate names: " + duplicateNames);
-            return null;
+            return Optional.empty();
         }
 
         boolean valid = true;
@@ -170,10 +170,10 @@ public final class PipelineBranchRoutingPlanner {
                 valid = false;
             }
         }
-        return valid ? indexed : null;
+        return valid ? Optional.of(indexed) : Optional.empty();
     }
 
-    private ResolvedStep resolveStep(
+    private Optional<ResolvedStep> resolveStep(
         PipelineCompilationContext ctx,
         PipelineTemplateConfig templateConfig,
         PipelineTemplateStep templateStep,
@@ -182,22 +182,22 @@ public final class PipelineBranchRoutingPlanner {
     ) {
         if (isBlank(templateStep.inputTypeName())) {
             error(ctx, "Branch-aware step '" + templateStep.name() + "' must declare inputTypeName.");
-            return null;
+            return Optional.empty();
         }
         if (isBlank(templateStep.outputTypeName())) {
             error(ctx, "Branch-aware step '" + templateStep.name() + "' must declare outputTypeName.");
-            return null;
+            return Optional.empty();
         }
 
         Set<String> inputLeafTypes = expandLeafTypes(ctx, templateConfig, templateStep.inputTypeName(),
             templateStep.name(), "inputTypeName", false);
         if (inputLeafTypes == null) {
-            return null;
+            return Optional.empty();
         }
         Set<String> outputLeafTypes = expandLeafTypes(ctx, templateConfig, templateStep.outputTypeName(),
             templateStep.name(), "outputTypeName", false);
         if (outputLeafTypes == null) {
-            return null;
+            return Optional.empty();
         }
 
         boolean oneToOneCardinality = "ONE_TO_ONE".equalsIgnoreCase(templateStep.cardinality());
@@ -208,7 +208,7 @@ public final class PipelineBranchRoutingPlanner {
                 || outputLeafTypes.size() != 1)) {
             error(ctx, "Branch-aware routing currently supports ONE_TO_ONE steps once type-based routing is in play. Step '"
                 + templateStep.name() + "' declares cardinality '" + templateStep.cardinality() + "'.");
-            return null;
+            return Optional.empty();
         }
 
         Set<String> acceptedLeafTypes = new LinkedHashSet<>();
@@ -216,23 +216,23 @@ public final class PipelineBranchRoutingPlanner {
             for (String accepted : templateStep.accepts()) {
                 if (isBlank(accepted)) {
                     error(ctx, "Step '" + templateStep.name() + "' declares a blank accepts entry.");
-                    return null;
+                    return Optional.empty();
                 }
                 if (templateConfig.unions().containsKey(accepted)) {
                     error(ctx, "Step '" + templateStep.name() + "' accepts '" + accepted
                         + "', but accepts may reference only concrete contract types, not unions.");
-                    return null;
+                    return Optional.empty();
                 }
                 Set<String> acceptedLeaf = expandLeafTypes(ctx, templateConfig, accepted, templateStep.name(), "accepts", true);
                 if (acceptedLeaf == null) {
-                    return null;
+                    return Optional.empty();
                 }
                 acceptedLeafTypes.addAll(acceptedLeaf);
             }
             if (!inputLeafTypes.containsAll(acceptedLeafTypes)) {
                 error(ctx, "Step '" + templateStep.name() + "' accepts " + acceptedLeafTypes
                     + " but inputTypeName '" + templateStep.inputTypeName() + "' resolves to " + inputLeafTypes + ".");
-                return null;
+                return Optional.empty();
             }
         } else {
             if (inputLeafTypes.size() != 1) {
@@ -240,7 +240,7 @@ public final class PipelineBranchRoutingPlanner {
                     + "' resolves inputTypeName '" + templateStep.inputTypeName()
                     + "' to multiple alternatives " + inputLeafTypes
                     + ". Explicit accepts is required.");
-                return null;
+                return Optional.empty();
             }
             acceptedLeafTypes.addAll(inputLeafTypes);
         }
@@ -249,34 +249,29 @@ public final class PipelineBranchRoutingPlanner {
             error(ctx, "Terminal step '" + templateStep.name()
                 + "' must declare one concrete terminal output type. outputTypeName '"
                 + templateStep.outputTypeName() + "' resolves to " + outputLeafTypes + ".");
-            return null;
+            return Optional.empty();
         }
 
         List<ClassName> acceptedDomainTypes = acceptedLeafTypes.stream()
             .map(typeName -> ClassName.get(templateConfig.basePackage() + ".common.domain", typeName))
             .toList();
         if (!validateAssignableAcceptedTypes(ctx, templateStep, stepDefinition, acceptedDomainTypes)) {
-            return null;
+            return Optional.empty();
         }
 
-        return new ResolvedStep(
+        return Optional.of(new ResolvedStep(
             index,
             templateStep,
             stepDefinition,
+            List.copyOf(inputLeafTypes),
             List.copyOf(acceptedLeafTypes),
             List.copyOf(outputLeafTypes),
-            acceptedDomainTypes);
+            acceptedDomainTypes));
     }
 
     private boolean validateReachability(PipelineCompilationContext ctx, List<ResolvedStep> resolvedSteps) {
         ResolvedStep firstStep = resolvedSteps.getFirst();
-        Set<String> reachable = new LinkedHashSet<>(expandLeafTypes(
-            ctx,
-            requireTemplateConfig(ctx),
-            firstStep.templateStep().inputTypeName(),
-            firstStep.templateStep().name(),
-            "inputTypeName",
-            false));
+        Set<String> reachable = new LinkedHashSet<>(firstStep.inputLeafTypes());
         for (ResolvedStep step : resolvedSteps) {
             Set<String> unreachable = new LinkedHashSet<>(step.acceptedLeafTypes());
             unreachable.removeAll(reachable);
@@ -407,6 +402,7 @@ public final class PipelineBranchRoutingPlanner {
         int index,
         PipelineTemplateStep templateStep,
         StepDefinition stepDefinition,
+        List<String> inputLeafTypes,
         List<String> acceptedLeafTypes,
         List<String> producedLeafTypes,
         List<ClassName> acceptedDomainTypes

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchingPlan.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchingPlan.java
@@ -1,0 +1,30 @@
+package org.pipelineframework.processor.routing;
+
+import java.util.List;
+import com.squareup.javapoet.ClassName;
+
+/**
+ * Build-time branch-routing plan derived from the authored linear pipeline sequence.
+ */
+public record PipelineBranchingPlan(
+    boolean branchAware,
+    int terminalStepIndex,
+    List<BranchStep> steps
+) {
+
+    public static PipelineBranchingPlan disabled() {
+        return new PipelineBranchingPlan(false, -1, List.of());
+    }
+
+    public record BranchStep(
+        int index,
+        String stepName,
+        String inputContractName,
+        String outputContractName,
+        List<String> acceptedContractTypes,
+        List<String> producedLeafContractTypes,
+        List<ClassName> acceptedDomainTypes,
+        boolean terminal
+    ) {
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchingPlan.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchingPlan.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.processor.routing;
 
 import java.util.List;
+import java.util.Objects;
 import com.squareup.javapoet.ClassName;
 
 /**
@@ -11,6 +12,25 @@ public record PipelineBranchingPlan(
     int terminalStepIndex,
     List<BranchStep> steps
 ) {
+
+    public PipelineBranchingPlan {
+        steps = steps == null ? List.of() : List.copyOf(steps);
+        if (!branchAware) {
+            if (terminalStepIndex != -1 || !steps.isEmpty()) {
+                throw new IllegalArgumentException("Disabled branching plans must use terminalStepIndex=-1 and no steps.");
+            }
+        } else {
+            if (steps.isEmpty()) {
+                throw new IllegalArgumentException("Branch-aware plans must contain at least one step.");
+            }
+            if (terminalStepIndex < 0 || terminalStepIndex >= steps.size()) {
+                throw new IllegalArgumentException("terminalStepIndex out of bounds for branch-aware plan.");
+            }
+            if (!steps.get(terminalStepIndex).terminal()) {
+                throw new IllegalArgumentException("terminalStepIndex must point at a terminal branch step.");
+            }
+        }
+    }
 
     public static PipelineBranchingPlan disabled() {
         return new PipelineBranchingPlan(false, -1, List.of());
@@ -26,5 +46,25 @@ public record PipelineBranchingPlan(
         List<ClassName> acceptedDomainTypes,
         boolean terminal
     ) {
+        public BranchStep {
+            stepName = Objects.requireNonNull(stepName, "stepName");
+            inputContractName = Objects.requireNonNull(inputContractName, "inputContractName");
+            outputContractName = Objects.requireNonNull(outputContractName, "outputContractName");
+            acceptedContractTypes = acceptedContractTypes == null ? List.of() : List.copyOf(acceptedContractTypes);
+            producedLeafContractTypes = producedLeafContractTypes == null ? List.of() : List.copyOf(producedLeafContractTypes);
+            acceptedDomainTypes = acceptedDomainTypes == null ? List.of() : List.copyOf(acceptedDomainTypes);
+            if (stepName.isBlank() || inputContractName.isBlank() || outputContractName.isBlank()) {
+                throw new IllegalArgumentException("BranchStep names and contract names must be non-blank.");
+            }
+            if (acceptedContractTypes.isEmpty()) {
+                throw new IllegalArgumentException("BranchStep must declare at least one accepted contract type.");
+            }
+            if (producedLeafContractTypes.isEmpty()) {
+                throw new IllegalArgumentException("BranchStep must declare at least one produced leaf contract type.");
+            }
+            if (acceptedDomainTypes.isEmpty()) {
+                throw new IllegalArgumentException("BranchStep must declare accepted domain types.");
+            }
+        }
     }
 }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchingPlan.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchingPlan.java
@@ -23,6 +23,13 @@ public record PipelineBranchingPlan(
             if (steps.isEmpty()) {
                 throw new IllegalArgumentException("Branch-aware plans must contain at least one step.");
             }
+            for (int i = 0; i < steps.size(); i++) {
+                if (steps.get(i).index() != i) {
+                    throw new IllegalArgumentException(
+                        "BranchStep index mismatch at position " + i + ": expected " + i + " but was "
+                            + steps.get(i).index() + ".");
+                }
+            }
             if (terminalStepIndex < 0 || terminalStepIndex >= steps.size()) {
                 throw new IllegalArgumentException("terminalStepIndex out of bounds for branch-aware plan.");
             }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporter.java
@@ -1453,6 +1453,16 @@ public final class PipelineTemplateSchemaExporter {
         "outboundMapper": {
           "type": "string",
           "pattern": "^[a-zA-Z_$][a-zA-Z\\\\d_$]*(\\\\.[a-zA-Z_$][a-zA-Z\\\\d_$]*)*\\\\.[A-Z][a-zA-Z\\\\d_$]*$"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [
@@ -1545,6 +1555,16 @@ public final class PipelineTemplateSchemaExporter {
         "runOnVirtualThreads": {
           "type": "boolean",
           "description": "Whether this YAML-declared internal blocking step should use virtual-thread offload."
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "oneOf": [
@@ -1823,6 +1843,16 @@ public final class PipelineTemplateSchemaExporter {
         },
         "flowBoundaryRationale": {
           "type": "string"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [
@@ -1945,6 +1975,16 @@ public final class PipelineTemplateSchemaExporter {
         },
         "flowBoundaryRationale": {
           "type": "string"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [
@@ -2026,6 +2066,16 @@ public final class PipelineTemplateSchemaExporter {
         },
         "flowBoundaryRationale": {
           "type": "string"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/ClientStepClassNames.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/ClientStepClassNames.java
@@ -1,0 +1,39 @@
+package org.pipelineframework.processor.util;
+
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.PipelineTransport;
+
+final class ClientStepClassNames {
+
+    private ClientStepClassNames() {
+    }
+
+    static String className(PipelineStepModel model, PipelineTransport transportMode) {
+        return model.servicePackage() + ".pipeline."
+            + stripTrailingService(model.generatedName())
+            + suffix(model, transportMode.clientStepSuffix());
+    }
+
+    static String suffix(PipelineStepModel model, String defaultSuffix) {
+        if (model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)) {
+            return "AwaitClientStep";
+        }
+        if (model.enabledTargets().contains(GenerationTarget.COMMAND_CLIENT_STEP)) {
+            return "CommandClientStep";
+        }
+        if (model.enabledTargets().contains(GenerationTarget.QUERY_CLIENT_STEP)) {
+            return "QueryClientStep";
+        }
+        return defaultSuffix;
+    }
+
+    static String stripTrailingService(String generatedName) {
+        if (generatedName == null) {
+            return "";
+        }
+        return generatedName.endsWith("Service")
+            ? generatedName.substring(0, generatedName.length() - "Service".length())
+            : generatedName;
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientModuleMapping.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientModuleMapping.java
@@ -219,9 +219,9 @@ public class OrchestratorClientModuleMapping {
     public String resolveModuleName(PipelineStepModel model) {
         String clientName = OrchestratorClientNaming.clientNameForModel(model);
         if (clientName != null) {
-            String override = resolveStepOverride(clientName);
-            if (override != null) {
-                return override;
+            Optional<String> override = resolveStepOverride(clientName);
+            if (override.isPresent()) {
+                return override.orElseThrow();
             }
         }
         if (model.sideEffect()) {
@@ -270,7 +270,7 @@ public class OrchestratorClientModuleMapping {
             return null;
         }
         String normalized = normalizeClientToken(clientName);
-        String moduleName = resolveStepOverride(normalized);
+        String moduleName = resolveStepOverride(normalized).orElse(null);
         if (moduleName == null && normalized.startsWith("observe-") && normalized.endsWith("-side-effect")) {
             String middle = normalized.substring("observe-".length(), normalized.length() - "-side-effect".length());
             String aspect = middle;
@@ -302,19 +302,19 @@ public class OrchestratorClientModuleMapping {
         return new ClientConfig(normalized, module.host(), module.port(), tlsConfigurationName);
     }
 
-    private String resolveStepOverride(String clientName) {
+    private Optional<String> resolveStepOverride(String clientName) {
         if (clientName == null || clientName.isBlank()) {
-            return null;
+            return Optional.empty();
         }
         String normalized = normalizeClientToken(clientName);
         String override = stepToModule.get(normalized);
         if (override != null) {
-            return override;
+            return Optional.of(override);
         }
         if (normalized.startsWith("process-")) {
-            return stepToModule.get(normalized.substring("process-".length()));
+            return Optional.ofNullable(stepToModule.get(normalized.substring("process-".length())));
         }
-        return null;
+        return Optional.empty();
     }
 
     private static String parsePortValue(String value, String moduleName, ProcessingEnvironment env) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientModuleMapping.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/OrchestratorClientModuleMapping.java
@@ -219,7 +219,7 @@ public class OrchestratorClientModuleMapping {
     public String resolveModuleName(PipelineStepModel model) {
         String clientName = OrchestratorClientNaming.clientNameForModel(model);
         if (clientName != null) {
-            String override = stepToModule.get(clientName);
+            String override = resolveStepOverride(clientName);
             if (override != null) {
                 return override;
             }
@@ -270,7 +270,7 @@ public class OrchestratorClientModuleMapping {
             return null;
         }
         String normalized = normalizeClientToken(clientName);
-        String moduleName = stepToModule.get(normalized);
+        String moduleName = resolveStepOverride(normalized);
         if (moduleName == null && normalized.startsWith("observe-") && normalized.endsWith("-side-effect")) {
             String middle = normalized.substring("observe-".length(), normalized.length() - "-side-effect".length());
             String aspect = middle;
@@ -300,6 +300,21 @@ public class OrchestratorClientModuleMapping {
             return null;
         }
         return new ClientConfig(normalized, module.host(), module.port(), tlsConfigurationName);
+    }
+
+    private String resolveStepOverride(String clientName) {
+        if (clientName == null || clientName.isBlank()) {
+            return null;
+        }
+        String normalized = normalizeClientToken(clientName);
+        String override = stepToModule.get(normalized);
+        if (override != null) {
+            return override;
+        }
+        if (normalized.startsWith("process-")) {
+            return stepToModule.get(normalized.substring("process-".length()));
+        }
+        return null;
     }
 
     private static String parsePortValue(String value, String moduleName, ProcessingEnvironment env) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGenerator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import javax.tools.Diagnostic;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.tools.StandardLocation;
 
@@ -45,20 +46,23 @@ public final class PipelineBranchingMetadataGenerator {
         if (ctx == null || ctx.getBranchingPlan() == null || !ctx.getBranchingPlan().branchAware()) {
             return;
         }
+        PipelineBranchingPlan plan = ctx.getBranchingPlan();
         List<PipelineStepModel> orderedModels = orderedModels(ctx);
         if (orderedModels.isEmpty()) {
             return;
         }
         Map<String, PipelineStepModel> modelsByStepName = indexModelsByStepName(orderedModels);
         List<StepMetadata> steps = new ArrayList<>();
-        for (PipelineBranchingPlan.BranchStep step : ctx.getBranchingPlan().steps()) {
+        for (PipelineBranchingPlan.BranchStep step : plan.steps()) {
             PipelineStepModel model = modelsByStepName.get(normalizeStepToken(step.stepName()));
             if (model == null) {
+                warn(ctx, "Branch-aware step '" + step.stepName()
+                    + "' could not be matched to a runtime step model while generating branching metadata.");
                 continue;
             }
             String runtimeStepClass = runtimeStepClass(model, ctx);
             boolean transportMappedRuntime = usesTransportMappedRuntime(model, ctx);
-            String inputRuntimeClass = runtimeInputType(model, ctx, transportMappedRuntime);
+            String inputRuntimeClass = runtimeInputType(model, ctx, transportMappedRuntime).orElse(null);
             List<String> acceptedRuntimeClasses = step.acceptedDomainTypes().stream()
                 .map(type -> runtimeAcceptedType(type, ctx, transportMappedRuntime))
                 .toList();
@@ -74,12 +78,7 @@ public final class PipelineBranchingMetadataGenerator {
         if (steps.isEmpty()) {
             return;
         }
-        int terminalStepIndex = steps.stream()
-            .filter(StepMetadata::terminal)
-            .mapToInt(StepMetadata::index)
-            .findFirst()
-            .orElse(-1);
-        BranchingMetadata metadata = new BranchingMetadata(terminalStepIndex, steps);
+        BranchingMetadata metadata = new BranchingMetadata(plan.terminalStepIndex(), steps);
         if (processingEnv != null) {
             javax.tools.FileObject resourceFile = processingEnv.getFiler()
                 .createResource(StandardLocation.CLASS_OUTPUT, "", RESOURCE, (javax.lang.model.element.Element[]) null);
@@ -90,12 +89,16 @@ public final class PipelineBranchingMetadataGenerator {
     }
 
     private List<PipelineStepModel> orderedModels(PipelineCompilationContext ctx) {
-        PipelineYamlConfig config = loadPipelineConfig(ctx);
-        if (config == null || config.steps() == null || config.steps().isEmpty()) {
-            return ctx.getStepModels() == null ? List.of() : ctx.getStepModels().stream().filter(model -> !model.sideEffect()).toList();
+        List<PipelineStepModel> stepModels = ctx.getStepModels() == null ? List.of() : ctx.getStepModels();
+        Optional<PipelineYamlConfig> config = loadPipelineConfig(ctx);
+        if (config.isEmpty() || config.orElseThrow().steps() == null || config.orElseThrow().steps().isEmpty()) {
+            return stepModels.stream().filter(model -> !model.sideEffect()).toList();
+        }
+        if (stepModels.isEmpty()) {
+            return List.of();
         }
         Map<String, PipelineStepModel> byToken = new LinkedHashMap<>();
-        for (PipelineStepModel model : ctx.getStepModels()) {
+        for (PipelineStepModel model : stepModels) {
             if (model.sideEffect()) {
                 continue;
             }
@@ -105,7 +108,7 @@ public final class PipelineBranchingMetadataGenerator {
         }
         List<PipelineStepModel> ordered = new ArrayList<>();
         Set<PipelineStepModel> added = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
-        for (PipelineYamlStep step : config.steps()) {
+        for (PipelineYamlStep step : config.orElseThrow().steps()) {
             if (step == null || step.name() == null) {
                 continue;
             }
@@ -114,7 +117,7 @@ public final class PipelineBranchingMetadataGenerator {
                 ordered.add(model);
             }
         }
-        for (PipelineStepModel model : ctx.getStepModels()) {
+        for (PipelineStepModel model : stepModels) {
             if (!model.sideEffect() && added.add(model)) {
                 ordered.add(model);
             }
@@ -132,15 +135,15 @@ public final class PipelineBranchingMetadataGenerator {
         return models;
     }
 
-    private PipelineYamlConfig loadPipelineConfig(PipelineCompilationContext ctx) {
+    private Optional<PipelineYamlConfig> loadPipelineConfig(PipelineCompilationContext ctx) {
         Optional<java.nio.file.Path> configPath = resolvePipelineConfigPath(ctx);
         if (configPath.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
         PipelineYamlConfigLoader loader = processingEnv != null
             ? new PipelineYamlConfigLoader(processingEnv.getOptions()::get, System::getenv)
             : new PipelineYamlConfigLoader(key -> null, System::getenv);
-        return loader.load(configPath.get());
+        return Optional.of(loader.load(configPath.get()));
     }
 
     private Optional<java.nio.file.Path> resolvePipelineConfigPath(PipelineCompilationContext ctx) {
@@ -183,21 +186,9 @@ public final class PipelineBranchingMetadataGenerator {
     }
 
     private String clientClass(PipelineStepModel model, PipelineCompilationContext ctx) {
-        String suffix = specialClientSuffix(model, ctx);
-        return model.servicePackage() + ".pipeline." + stripTrailingService(model.generatedName()) + suffix;
-    }
-
-    private String specialClientSuffix(PipelineStepModel model, PipelineCompilationContext ctx) {
-        if (model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)) {
-            return "AwaitClientStep";
-        }
-        if (model.enabledTargets().contains(GenerationTarget.COMMAND_CLIENT_STEP)) {
-            return "CommandClientStep";
-        }
-        if (model.enabledTargets().contains(GenerationTarget.QUERY_CLIENT_STEP)) {
-            return "QueryClientStep";
-        }
-        return java.util.Objects.requireNonNullElse(ctx.getTransportMode(), PipelineTransport.GRPC).clientStepSuffix();
+        return ClientStepClassNames.className(
+            model,
+            java.util.Objects.requireNonNullElse(ctx.getTransportMode(), PipelineTransport.GRPC));
     }
 
     private String runtimeAcceptedType(ClassName domainType, PipelineCompilationContext ctx, boolean transportMappedRuntime) {
@@ -207,7 +198,9 @@ public final class PipelineBranchingMetadataGenerator {
         PipelineTransport transportMode = java.util.Objects.requireNonNullElse(ctx.getTransportMode(), PipelineTransport.GRPC);
         TypeName transportType = clientStepType(domainType, transportMode, pipelineBasePackage(ctx, domainType));
         if (transportType instanceof ClassName className) {
-            if (transportMode == PipelineTransport.GRPC && ctx.getProcessingEnv() != null) {
+            if (transportMode == PipelineTransport.GRPC
+                && ctx.getProcessingEnv() != null
+                && ctx.getProcessingEnv().getElementUtils() != null) {
                 javax.lang.model.element.TypeElement element = ctx.getProcessingEnv().getElementUtils()
                     .getTypeElement(className.canonicalName());
                 if (element == null) {
@@ -221,21 +214,21 @@ public final class PipelineBranchingMetadataGenerator {
         return transportType.toString();
     }
 
-    private String runtimeInputType(PipelineStepModel model, PipelineCompilationContext ctx, boolean transportMappedRuntime) {
+    private Optional<String> runtimeInputType(PipelineStepModel model, PipelineCompilationContext ctx, boolean transportMappedRuntime) {
         TypeName inputType = model.inputMapping() == null ? null : model.inputMapping().domainType();
         if (!(inputType instanceof ClassName className)) {
-            return inputType == null ? null : inputType.toString();
+            return inputType == null ? Optional.empty() : Optional.of(inputType.toString());
         }
         if (!transportMappedRuntime) {
-            return className.reflectionName();
+            return Optional.of(className.reflectionName());
         }
         TypeName transportType = clientStepType(className, java.util.Objects.requireNonNullElse(
             ctx.getTransportMode(),
             PipelineTransport.GRPC), pipelineBasePackage(ctx, className));
         if (transportType instanceof ClassName transportClassName) {
-            return transportClassName.reflectionName();
+            return Optional.of(transportClassName.reflectionName());
         }
-        return transportType.toString();
+        return Optional.of(transportType.toString());
     }
 
     private String pipelineBasePackage(PipelineCompilationContext ctx, ClassName domainType) {
@@ -283,6 +276,14 @@ public final class PipelineBranchingMetadataGenerator {
             return "";
         }
         return value.replaceAll("[^A-Za-z0-9]", "").toLowerCase(java.util.Locale.ROOT);
+    }
+
+    private void warn(PipelineCompilationContext ctx, String message) {
+        if (processingEnv != null && processingEnv.getMessager() != null) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, message);
+        } else {
+            LOGGER.warning(message);
+        }
     }
 
     private record BranchingMetadata(

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGenerator.java
@@ -1,0 +1,304 @@
+package org.pipelineframework.processor.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.tools.StandardLocation;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.TypeName;
+import org.pipelineframework.config.pipeline.PipelineYamlConfig;
+import org.pipelineframework.config.pipeline.PipelineYamlConfigLoader;
+import org.pipelineframework.config.pipeline.PipelineYamlConfigLocator;
+import org.pipelineframework.config.pipeline.PipelineYamlStep;
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.PipelineTransport;
+import org.pipelineframework.processor.routing.PipelineBranchingPlan;
+
+/**
+ * Generates META-INF/pipeline/branching.json for branch-aware linear routing.
+ */
+public final class PipelineBranchingMetadataGenerator {
+
+    private static final String RESOURCE = "META-INF/pipeline/branching.json";
+    private static final Logger LOGGER = Logger.getLogger(PipelineBranchingMetadataGenerator.class.getName());
+
+    private final ProcessingEnvironment processingEnv;
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    public PipelineBranchingMetadataGenerator(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+    }
+
+    public void writeBranchingMetadata(PipelineCompilationContext ctx) throws IOException {
+        if (ctx == null || ctx.getBranchingPlan() == null || !ctx.getBranchingPlan().branchAware()) {
+            return;
+        }
+        List<PipelineStepModel> orderedModels = orderedModels(ctx);
+        if (orderedModels.isEmpty()) {
+            return;
+        }
+        Map<String, PipelineStepModel> modelsByStepName = indexModelsByStepName(orderedModels);
+        List<StepMetadata> steps = new ArrayList<>();
+        for (PipelineBranchingPlan.BranchStep step : ctx.getBranchingPlan().steps()) {
+            PipelineStepModel model = modelsByStepName.get(normalizeStepToken(step.stepName()));
+            if (model == null) {
+                continue;
+            }
+            String runtimeStepClass = runtimeStepClass(model, ctx);
+            boolean transportMappedRuntime = usesTransportMappedRuntime(model, ctx);
+            String inputRuntimeClass = runtimeInputType(model, ctx, transportMappedRuntime);
+            List<String> acceptedRuntimeClasses = step.acceptedDomainTypes().stream()
+                .map(type -> runtimeAcceptedType(type, ctx, transportMappedRuntime))
+                .toList();
+            steps.add(new StepMetadata(
+                step.index(),
+                step.stepName(),
+                runtimeStepClass,
+                inputRuntimeClass,
+                step.acceptedContractTypes(),
+                acceptedRuntimeClasses,
+                step.terminal()));
+        }
+        if (steps.isEmpty()) {
+            return;
+        }
+        int terminalStepIndex = steps.stream()
+            .filter(StepMetadata::terminal)
+            .mapToInt(StepMetadata::index)
+            .findFirst()
+            .orElse(-1);
+        BranchingMetadata metadata = new BranchingMetadata(terminalStepIndex, steps);
+        if (processingEnv != null) {
+            javax.tools.FileObject resourceFile = processingEnv.getFiler()
+                .createResource(StandardLocation.CLASS_OUTPUT, "", RESOURCE, (javax.lang.model.element.Element[]) null);
+            try (var writer = resourceFile.openWriter()) {
+                writer.write(gson.toJson(metadata));
+            }
+        }
+    }
+
+    private List<PipelineStepModel> orderedModels(PipelineCompilationContext ctx) {
+        PipelineYamlConfig config = loadPipelineConfig(ctx);
+        if (config == null || config.steps() == null || config.steps().isEmpty()) {
+            return ctx.getStepModels() == null ? List.of() : ctx.getStepModels().stream().filter(model -> !model.sideEffect()).toList();
+        }
+        Map<String, PipelineStepModel> byToken = new LinkedHashMap<>();
+        for (PipelineStepModel model : ctx.getStepModels()) {
+            if (model.sideEffect()) {
+                continue;
+            }
+            byToken.put(normalizeStepToken(stepTokenFromModel(model)), model);
+            byToken.put(normalizeStepToken(stripTrailingService(model.generatedName())), model);
+            byToken.put(normalizeStepToken(model.serviceName()), model);
+        }
+        List<PipelineStepModel> ordered = new ArrayList<>();
+        Set<PipelineStepModel> added = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        for (PipelineYamlStep step : config.steps()) {
+            if (step == null || step.name() == null) {
+                continue;
+            }
+            PipelineStepModel model = byToken.get(normalizeStepToken(step.name()));
+            if (model != null && added.add(model)) {
+                ordered.add(model);
+            }
+        }
+        for (PipelineStepModel model : ctx.getStepModels()) {
+            if (!model.sideEffect() && added.add(model)) {
+                ordered.add(model);
+            }
+        }
+        return ordered;
+    }
+
+    private Map<String, PipelineStepModel> indexModelsByStepName(List<PipelineStepModel> orderedModels) {
+        Map<String, PipelineStepModel> models = new LinkedHashMap<>();
+        for (PipelineStepModel model : orderedModels) {
+            models.putIfAbsent(normalizeStepToken(stepTokenFromModel(model)), model);
+            models.putIfAbsent(normalizeStepToken(stripTrailingService(model.generatedName())), model);
+            models.putIfAbsent(normalizeStepToken(model.serviceName()), model);
+        }
+        return models;
+    }
+
+    private PipelineYamlConfig loadPipelineConfig(PipelineCompilationContext ctx) {
+        Optional<java.nio.file.Path> configPath = resolvePipelineConfigPath(ctx);
+        if (configPath.isEmpty()) {
+            return null;
+        }
+        PipelineYamlConfigLoader loader = processingEnv != null
+            ? new PipelineYamlConfigLoader(processingEnv.getOptions()::get, System::getenv)
+            : new PipelineYamlConfigLoader(key -> null, System::getenv);
+        return loader.load(configPath.get());
+    }
+
+    private Optional<java.nio.file.Path> resolvePipelineConfigPath(PipelineCompilationContext ctx) {
+        Map<String, String> options = processingEnv != null ? processingEnv.getOptions() : Map.of();
+        String explicit = options.get("pipeline.config");
+        if (explicit != null && !explicit.isBlank()) {
+            java.nio.file.Path explicitPath = java.nio.file.Path.of(explicit.trim());
+            if (!explicitPath.isAbsolute()) {
+                if (ctx.getModuleDir() == null) {
+                    LOGGER.warning("pipeline.config provided as relative path but moduleDir is null: " + explicit);
+                    return Optional.empty();
+                }
+                explicitPath = ctx.getModuleDir().resolve(explicitPath).normalize();
+            }
+            if (java.nio.file.Files.exists(explicitPath)) {
+                return Optional.of(explicitPath);
+            }
+            LOGGER.warning("pipeline.config path not found: " + explicitPath);
+        }
+        if (ctx.getModuleDir() == null) {
+            return Optional.empty();
+        }
+        return new PipelineYamlConfigLocator().locate(ctx.getModuleDir());
+    }
+
+    private String runtimeStepClass(PipelineStepModel model, PipelineCompilationContext ctx) {
+        if (!usesTransportMappedRuntime(model, ctx) && model.serviceClassName() != null) {
+            return model.serviceClassName().canonicalName();
+        }
+        return clientClass(model, ctx);
+    }
+
+    private boolean usesTransportMappedRuntime(PipelineStepModel model, PipelineCompilationContext ctx) {
+        if (ctx.isOrchestratorGenerated()) {
+            return true;
+        }
+        return model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)
+            || model.enabledTargets().contains(GenerationTarget.COMMAND_CLIENT_STEP)
+            || model.enabledTargets().contains(GenerationTarget.QUERY_CLIENT_STEP);
+    }
+
+    private String clientClass(PipelineStepModel model, PipelineCompilationContext ctx) {
+        String suffix = specialClientSuffix(model, ctx);
+        return model.servicePackage() + ".pipeline." + stripTrailingService(model.generatedName()) + suffix;
+    }
+
+    private String specialClientSuffix(PipelineStepModel model, PipelineCompilationContext ctx) {
+        if (model.enabledTargets().contains(GenerationTarget.AWAIT_CLIENT_STEP)) {
+            return "AwaitClientStep";
+        }
+        if (model.enabledTargets().contains(GenerationTarget.COMMAND_CLIENT_STEP)) {
+            return "CommandClientStep";
+        }
+        if (model.enabledTargets().contains(GenerationTarget.QUERY_CLIENT_STEP)) {
+            return "QueryClientStep";
+        }
+        return java.util.Objects.requireNonNullElse(ctx.getTransportMode(), PipelineTransport.GRPC).clientStepSuffix();
+    }
+
+    private String runtimeAcceptedType(ClassName domainType, PipelineCompilationContext ctx, boolean transportMappedRuntime) {
+        if (!transportMappedRuntime) {
+            return domainType.reflectionName();
+        }
+        PipelineTransport transportMode = java.util.Objects.requireNonNullElse(ctx.getTransportMode(), PipelineTransport.GRPC);
+        TypeName transportType = clientStepType(domainType, transportMode, pipelineBasePackage(ctx, domainType));
+        if (transportType instanceof ClassName className) {
+            if (transportMode == PipelineTransport.GRPC && ctx.getProcessingEnv() != null) {
+                javax.lang.model.element.TypeElement element = ctx.getProcessingEnv().getElementUtils()
+                    .getTypeElement(className.canonicalName());
+                if (element == null) {
+                    throw new IllegalStateException("Branch-aware step accepted gRPC runtime type '"
+                        + className.canonicalName() + "' (derived from domain type '" + domainType.reflectionName()
+                        + "') could not be resolved. Ensure gRPC descriptor-set bindings are generated before compiling the pipeline.");
+                }
+            }
+            return className.reflectionName();
+        }
+        return transportType.toString();
+    }
+
+    private String runtimeInputType(PipelineStepModel model, PipelineCompilationContext ctx, boolean transportMappedRuntime) {
+        TypeName inputType = model.inputMapping() == null ? null : model.inputMapping().domainType();
+        if (!(inputType instanceof ClassName className)) {
+            return inputType == null ? null : inputType.toString();
+        }
+        if (!transportMappedRuntime) {
+            return className.reflectionName();
+        }
+        TypeName transportType = clientStepType(className, java.util.Objects.requireNonNullElse(
+            ctx.getTransportMode(),
+            PipelineTransport.GRPC), pipelineBasePackage(ctx, className));
+        if (transportType instanceof ClassName transportClassName) {
+            return transportClassName.reflectionName();
+        }
+        return transportType.toString();
+    }
+
+    private String pipelineBasePackage(PipelineCompilationContext ctx, ClassName domainType) {
+        if (ctx.getPipelineTemplateConfig() instanceof org.pipelineframework.config.template.PipelineTemplateConfig templateConfig
+            && templateConfig.basePackage() != null
+            && !templateConfig.basePackage().isBlank()) {
+            return templateConfig.basePackage();
+        }
+        String packageName = domainType.packageName();
+        return packageName.endsWith(".common.domain")
+            ? packageName.substring(0, packageName.length() - ".common.domain".length())
+            : packageName;
+    }
+
+    private TypeName clientStepType(TypeName domainType, PipelineTransport transportMode, String pipelineBasePackage) {
+        if (!(domainType instanceof ClassName className)) {
+            return domainType;
+        }
+        String basePackage = pipelineBasePackage == null || pipelineBasePackage.isBlank()
+            ? className.packageName().replaceFirst("\\.common\\.domain$", "")
+            : pipelineBasePackage;
+        return switch (transportMode) {
+            case LOCAL -> className;
+            case REST -> ClassName.get(basePackage + ".common.dto", className.simpleName() + "Dto");
+            case GRPC -> ClassName.get(basePackage + ".grpc", "PipelineTypes", className.simpleName());
+        };
+    }
+
+    private static String stepTokenFromModel(PipelineStepModel model) {
+        String token = stripTrailingService(model.generatedName());
+        return token.startsWith("Process") && token.length() > "Process".length()
+            ? token.substring("Process".length())
+            : token;
+    }
+
+    private static String stripTrailingService(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.endsWith("Service") ? value.substring(0, value.length() - "Service".length()) : value;
+    }
+
+    private static String normalizeStepToken(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("[^A-Za-z0-9]", "").toLowerCase(java.util.Locale.ROOT);
+    }
+
+    private record BranchingMetadata(
+        int terminalStepIndex,
+        List<StepMetadata> steps
+    ) {
+    }
+
+    private record StepMetadata(
+        int index,
+        String step,
+        String runtimeStepClass,
+        String inputRuntimeClass,
+        List<String> acceptedContracts,
+        List<String> acceptedRuntimeClasses,
+        boolean terminal
+    ) {
+    }
+}

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGenerator.java
@@ -16,12 +16,16 @@ import org.pipelineframework.config.pipeline.PipelineYamlConfig;
 import org.pipelineframework.config.pipeline.PipelineYamlConfigLoader;
 import org.pipelineframework.config.pipeline.PipelineYamlConfigLocator;
 import org.pipelineframework.config.pipeline.PipelineYamlStep;
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateUnion;
+import org.pipelineframework.config.template.PipelineTemplateUnionVariant;
 import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.ir.GenerationTarget;
 import org.pipelineframework.processor.ir.PipelineStepModel;
 import org.pipelineframework.processor.ir.StreamingShape;
 import org.pipelineframework.processor.ir.PipelineTransport;
 import org.pipelineframework.processor.ir.TypeMapping;
+import org.pipelineframework.processor.routing.PipelineBranchingPlan;
 
 /**
  * Writes pipeline telemetry metadata for item-boundary inference.
@@ -147,21 +151,7 @@ public class PipelineTelemetryMetadataGenerator {
                     resolvePluginActorKind(resolvePluginKind(sideEffectService, sideEffectStep))));
             }
         }
-        List<ReplayTopologyTransition> transitions = new ArrayList<>();
-        for (int i = 0; i < baseSteps.size() - 1; i++) {
-            ReplayTopologyStep from = baseSteps.get(i);
-            ReplayTopologyStep to = baseSteps.get(i + 1);
-            transitions.add(new ReplayTopologyTransition(
-                from.step() + "->" + to.step(),
-                from.runtimeStepClass(),
-                to.runtimeStepClass(),
-                from.step(),
-                to.step(),
-                from.service(),
-                to.service(),
-                from.cardinality(),
-                "primary"));
-        }
+        List<ReplayTopologyTransition> transitions = buildPrimaryTransitions(ctx, baseSteps);
         index = appendAwaitActors(baseSteps, configStepsByToken, steps, transitions, index);
         index = appendPersistenceStore(baseSteps, steps, transitions, index);
         for (ReplayTopologyStep step : steps) {
@@ -195,6 +185,181 @@ public class PipelineTelemetryMetadataGenerator {
         try (var output = resourceFile.openWriter()) {
             output.write(writer.toString());
         }
+    }
+
+    private List<ReplayTopologyTransition> buildPrimaryTransitions(
+        PipelineCompilationContext ctx,
+        List<ReplayTopologyStep> baseSteps
+    ) {
+        if (ctx.getBranchingPlan() == null || !ctx.getBranchingPlan().branchAware()) {
+            return buildLinearPrimaryTransitions(baseSteps);
+        }
+        List<ReplayTopologyTransition> transitions = buildBranchAwarePrimaryTransitions(ctx, baseSteps);
+        return transitions.isEmpty() ? buildLinearPrimaryTransitions(baseSteps) : transitions;
+    }
+
+    private List<ReplayTopologyTransition> buildLinearPrimaryTransitions(List<ReplayTopologyStep> baseSteps) {
+        List<ReplayTopologyTransition> transitions = new ArrayList<>();
+        for (int i = 0; i < baseSteps.size() - 1; i++) {
+            ReplayTopologyStep from = baseSteps.get(i);
+            ReplayTopologyStep to = baseSteps.get(i + 1);
+            transitions.add(primaryTransition(from, to));
+        }
+        return transitions;
+    }
+
+    private List<ReplayTopologyTransition> buildBranchAwarePrimaryTransitions(
+        PipelineCompilationContext ctx,
+        List<ReplayTopologyStep> baseSteps
+    ) {
+        PipelineBranchingPlan plan = ctx.getBranchingPlan();
+        if (plan == null || plan.steps().isEmpty()) {
+            return List.of();
+        }
+        Map<String, ReplayTopologyStep> baseStepsByToken = new LinkedHashMap<>();
+        Set<String> branchAwareStepNames = new LinkedHashSet<>();
+        List<ResolvedBranchTopologyStep> resolvedSteps = new ArrayList<>();
+        for (ReplayTopologyStep baseStep : baseSteps) {
+            baseStepsByToken.putIfAbsent(normalizeStepToken(baseStep.step()), baseStep);
+            baseStepsByToken.putIfAbsent(normalizeStepToken(baseStep.service()), baseStep);
+            baseStepsByToken.putIfAbsent(normalizeStepToken(baseStep.runtimeStepClass()), baseStep);
+        }
+        for (PipelineBranchingPlan.BranchStep step : plan.steps()) {
+            ReplayTopologyStep topologyStep = baseStepsByToken.get(normalizeStepToken(step.stepName()));
+            if (topologyStep == null) {
+                continue;
+            }
+            branchAwareStepNames.add(topologyStep.step());
+            resolvedSteps.add(new ResolvedBranchTopologyStep(
+                step,
+                topologyStep,
+                new LinkedHashSet<>(step.acceptedContractTypes()),
+                new LinkedHashSet<>(step.producedLeafContractTypes())));
+        }
+        if (resolvedSteps.isEmpty()) {
+            return List.of();
+        }
+
+        List<ReplayTopologyTransition> transitions = new ArrayList<>();
+        Set<String> transitionKeys = new LinkedHashSet<>();
+        Set<String> reachableTypes = initialReachableLeafTypes(ctx, resolvedSteps.get(0).step());
+
+        for (int index = 0; index < resolvedSteps.size(); index++) {
+            ResolvedBranchTopologyStep current = resolvedSteps.get(index);
+            Set<String> applicable = intersection(reachableTypes, current.acceptedContractTypes());
+            Set<String> skipped = new LinkedHashSet<>(reachableTypes);
+            skipped.removeAll(current.acceptedContractTypes());
+
+            if (!applicable.isEmpty()) {
+                for (String producedType : current.producedLeafContractTypes()) {
+                    ResolvedBranchTopologyStep next = firstAcceptingStep(resolvedSteps, index + 1, producedType);
+                    if (next != null) {
+                        addTransition(transitions, transitionKeys, primaryTransition(current.topologyStep(), next.topologyStep()));
+                    }
+                }
+                reachableTypes = new LinkedHashSet<>(skipped);
+                reachableTypes.addAll(current.producedLeafContractTypes());
+            } else {
+                reachableTypes = new LinkedHashSet<>(skipped);
+            }
+        }
+
+        for (int index = 0; index < baseSteps.size() - 1; index++) {
+            ReplayTopologyStep from = baseSteps.get(index);
+            ReplayTopologyStep to = baseSteps.get(index + 1);
+            if (branchAwareStepNames.contains(from.step()) && branchAwareStepNames.contains(to.step())) {
+                continue;
+            }
+            addTransition(transitions, transitionKeys, primaryTransition(from, to));
+        }
+        return transitions;
+    }
+
+    private Set<String> initialReachableLeafTypes(
+        PipelineCompilationContext ctx,
+        PipelineBranchingPlan.BranchStep firstStep
+    ) {
+        Set<String> resolved = expandLeafContractTypes(ctx, firstStep.inputContractName());
+        if (!resolved.isEmpty()) {
+            return resolved;
+        }
+        return new LinkedHashSet<>(firstStep.acceptedContractTypes());
+    }
+
+    private Set<String> expandLeafContractTypes(PipelineCompilationContext ctx, String contractName) {
+        if (contractName == null || contractName.isBlank()) {
+            return Set.of();
+        }
+        if (!(ctx.getPipelineTemplateConfig() instanceof PipelineTemplateConfig templateConfig)) {
+            return Set.of(contractName);
+        }
+        return expandLeafContractTypes(templateConfig, contractName, new LinkedHashSet<>());
+    }
+
+    private Set<String> expandLeafContractTypes(
+        PipelineTemplateConfig templateConfig,
+        String contractName,
+        Set<String> visited
+    ) {
+        if (contractName == null || contractName.isBlank() || !visited.add(contractName)) {
+            return Set.of();
+        }
+        if (templateConfig.messages().containsKey(contractName)) {
+            return Set.of(contractName);
+        }
+        PipelineTemplateUnion union = templateConfig.unions().get(contractName);
+        if (union == null) {
+            return Set.of(contractName);
+        }
+        Set<String> expanded = new LinkedHashSet<>();
+        for (PipelineTemplateUnionVariant variant : union.variants().values()) {
+            expanded.addAll(expandLeafContractTypes(templateConfig, variant.type(), visited));
+        }
+        return expanded;
+    }
+
+    private Set<String> intersection(Set<String> left, Set<String> right) {
+        Set<String> intersection = new LinkedHashSet<>(left);
+        intersection.retainAll(right);
+        return intersection;
+    }
+
+    private ResolvedBranchTopologyStep firstAcceptingStep(
+        List<ResolvedBranchTopologyStep> steps,
+        int startIndex,
+        String contractType
+    ) {
+        for (int index = startIndex; index < steps.size(); index++) {
+            ResolvedBranchTopologyStep candidate = steps.get(index);
+            if (candidate.acceptedContractTypes().contains(contractType)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private void addTransition(
+        List<ReplayTopologyTransition> transitions,
+        Set<String> transitionKeys,
+        ReplayTopologyTransition transition
+    ) {
+        String key = transition.from() + "->" + transition.to() + ":" + transition.relationKind();
+        if (transitionKeys.add(key)) {
+            transitions.add(transition);
+        }
+    }
+
+    private ReplayTopologyTransition primaryTransition(ReplayTopologyStep from, ReplayTopologyStep to) {
+        return new ReplayTopologyTransition(
+            from.step() + "->" + to.step(),
+            from.runtimeStepClass(),
+            to.runtimeStepClass(),
+            from.step(),
+            to.step(),
+            from.service(),
+            to.service(),
+            from.cardinality(),
+            "primary");
     }
 
     /**
@@ -904,6 +1069,14 @@ public class PipelineTelemetryMetadataGenerator {
             return "";
         }
         return name.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
+    }
+
+    private record ResolvedBranchTopologyStep(
+        PipelineBranchingPlan.BranchStep step,
+        ReplayTopologyStep topologyStep,
+        Set<String> acceptedContractTypes,
+        Set<String> producedLeafContractTypes
+    ) {
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGenerator.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGenerator.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.logging.Logger;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.tools.StandardLocation;
 
@@ -36,6 +37,7 @@ public class PipelineTelemetryMetadataGenerator {
     private static final String REPLAY_TOPOLOGY_RESOURCE_PATH = "META-INF/pipeline/replay-topology.json";
     private static final String ITEM_INPUT_TYPE_KEY = "pipeline.telemetry.item-input-type";
     private static final String ITEM_OUTPUT_TYPE_KEY = "pipeline.telemetry.item-output-type";
+    private static final Logger LOGGER = Logger.getLogger(PipelineTelemetryMetadataGenerator.class.getName());
 
     private final ProcessingEnvironment processingEnv;
     private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -195,7 +197,11 @@ public class PipelineTelemetryMetadataGenerator {
             return buildLinearPrimaryTransitions(baseSteps);
         }
         List<ReplayTopologyTransition> transitions = buildBranchAwarePrimaryTransitions(ctx, baseSteps);
-        return transitions.isEmpty() ? buildLinearPrimaryTransitions(baseSteps) : transitions;
+        if (transitions.isEmpty()) {
+            LOGGER.warning("Branch-aware replay topology resolved no primary transitions for pipeline '"
+                + resolvePipelineName(ctx) + "'.");
+        }
+        return transitions;
     }
 
     private List<ReplayTopologyTransition> buildLinearPrimaryTransitions(List<ReplayTopologyStep> baseSteps) {
@@ -252,9 +258,12 @@ public class PipelineTelemetryMetadataGenerator {
 
             if (!applicable.isEmpty()) {
                 for (String producedType : current.producedLeafContractTypes()) {
-                    ResolvedBranchTopologyStep next = firstAcceptingStep(resolvedSteps, index + 1, producedType);
-                    if (next != null) {
-                        addTransition(transitions, transitionKeys, primaryTransition(current.topologyStep(), next.topologyStep()));
+                    Optional<ResolvedBranchTopologyStep> next = firstAcceptingStep(resolvedSteps, index + 1, producedType);
+                    if (next.isPresent()) {
+                        addTransition(
+                            transitions,
+                            transitionKeys,
+                            primaryTransition(current.topologyStep(), next.orElseThrow().topologyStep()));
                     }
                 }
                 reachableTypes = new LinkedHashSet<>(skipped);
@@ -324,7 +333,7 @@ public class PipelineTelemetryMetadataGenerator {
         return intersection;
     }
 
-    private ResolvedBranchTopologyStep firstAcceptingStep(
+    private Optional<ResolvedBranchTopologyStep> firstAcceptingStep(
         List<ResolvedBranchTopologyStep> steps,
         int startIndex,
         String contractType
@@ -332,10 +341,10 @@ public class PipelineTelemetryMetadataGenerator {
         for (int index = startIndex; index < steps.size(); index++) {
             ResolvedBranchTopologyStep candidate = steps.get(index);
             if (candidate.acceptedContractTypes().contains(contractType)) {
-                return candidate;
+                return Optional.of(candidate);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     private void addTransition(
@@ -1239,11 +1248,7 @@ public class PipelineTelemetryMetadataGenerator {
      * @return the fully-qualified client step class name (package + ".pipeline." + generated name without "Service" + transport suffix)
      */
     private String resolveClientStepClassName(PipelineStepModel model, PipelineTransport transportMode) {
-        String suffix = model.enabledTargets().contains(GenerationTarget.COMMAND_CLIENT_STEP)
-            ? "CommandClientStep"
-            : transportMode.clientStepSuffix();
-        return model.servicePackage() + ".pipeline." +
-            model.generatedName().replace("Service", "") + suffix;
+        return ClientStepClassNames.className(model, transportMode);
     }
 
     private String cardinality(StreamingShape shape) {

--- a/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
+++ b/framework/deployment/src/main/resources/META-INF/pipeline/pipeline-template-schema.json
@@ -1419,6 +1419,16 @@
         "outboundMapper": {
           "type": "string",
           "pattern": "^[a-zA-Z_$][a-zA-Z\\d_$]*(\\.[a-zA-Z_$][a-zA-Z\\d_$]*)*\\.[A-Z][a-zA-Z\\d_$]*$"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [
@@ -1511,6 +1521,16 @@
         "runOnVirtualThreads": {
           "type": "boolean",
           "description": "Whether this YAML-declared internal blocking step should use virtual-thread offload."
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "oneOf": [
@@ -1789,6 +1809,16 @@
         },
         "flowBoundaryRationale": {
           "type": "string"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [
@@ -1911,6 +1941,16 @@
         },
         "flowBoundaryRationale": {
           "type": "string"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [
@@ -1992,6 +2032,16 @@
         },
         "flowBoundaryRationale": {
           "type": "string"
+        },
+        "accepts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9_]*$"
+          }
+        },
+        "terminal": {
+          "type": "boolean"
         }
       },
       "allOf": [

--- a/framework/deployment/src/test/java/org/pipelineframework/extension/OperatorLinkValidationBuildStepsTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/extension/OperatorLinkValidationBuildStepsTest.java
@@ -123,6 +123,21 @@ class OperatorLinkValidationBuildStepsTest {
     }
 
     @Test
+    void skipsAdjacentValidationForBranchAwarePipelines() throws Exception {
+        Index index = indexOf(Source.class, Sink.class, MapperOne.class, MapperTwo.class);
+        OperatorBuildItem source = operator(index, Source.class, "Source", classType(String.class), uniType(String.class));
+        OperatorBuildItem sink = operator(index, Sink.class, "Sink", classType(Integer.class), uniType(Integer.class));
+
+        assertDoesNotThrow(() -> buildSteps.validateOperatorLinks(
+            List.of(source, sink),
+            new PipelineConfigBuildItem(List.of(
+                new PipelineConfigBuildItem.StepConfig("Source", "com.example.Source::map"),
+                new PipelineConfigBuildItem.StepConfig("Sink", "com.example.Sink::map")), true),
+            emptyRegistry(),
+            new io.quarkus.deployment.builditem.CombinedIndexBuildItem(index, index)));
+    }
+
+    @Test
     void failsForRawTypeWithIncompatibleGenerics() throws Exception {
         Index index = indexOf(Source.class, Sink.class, MapperOne.class, MapperTwo.class);
         Type listOfString = listType(String.class);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/AspectExpansionProcessorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/AspectExpansionProcessorTest.java
@@ -89,6 +89,57 @@ class AspectExpansionProcessorTest {
 
     @SneakyThrows
     @Test
+    void appliesStepScopedAspectWhenTargetUsesNormalizedYamlToken() {
+        ResolvedStep step = resolvedStep("ProcessFolderService");
+        Map<String, Object> config = aspectConfig("org.pipelineframework.plugin.persistence.PersistenceService");
+        config.put("targetSteps", List.of("ProcessFolder"));
+
+        PipelineAspectModel stepScoped = new PipelineAspectModel(
+            "persistence",
+            AspectScope.STEPS,
+            AspectPosition.AFTER_STEP,
+            config
+        );
+
+        AspectExpansionProcessor processor = new AspectExpansionProcessor();
+        List<ResolvedStep> expanded = processor.expandAspects(
+            List.of(step),
+            List.of(stepScoped)
+        );
+
+        assertEquals(2, expanded.size(), "Expected original step and one synthetic step");
+        assertEquals(step.model().serviceName(), expanded.get(0).model().serviceName());
+        assertTrue(expanded.get(1).model().generatedName().contains("Persistence"));
+    }
+
+    @SneakyThrows
+    @Test
+    void appliesStepScopedAspectWhenTargetUsesAuthoredStepTokenAgainstGeneratedServiceName() {
+        ResolvedStep step = resolvedStepWithoutBinding("ProcessFinalizePaymentOutputService");
+        Map<String, Object> config = aspectConfig("org.pipelineframework.plugin.persistence.PersistenceService");
+        config.put("targetSteps", List.of("FinalizePaymentOutput"));
+
+        PipelineAspectModel stepScoped = new PipelineAspectModel(
+            "persistence",
+            AspectScope.STEPS,
+            AspectPosition.AFTER_STEP,
+            config
+        );
+
+        AspectExpansionProcessor processor = new AspectExpansionProcessor();
+        List<ResolvedStep> expanded = processor.expandAspects(
+            List.of(step, resolvedStepWithoutBinding("ProcessCsvPaymentsInputService")),
+            List.of(stepScoped)
+        );
+
+        assertEquals(3, expanded.size(), "Expected the targeted step plus one synthetic side effect");
+        assertEquals(step.model().serviceName(), expanded.get(0).model().serviceName());
+        assertTrue(expanded.get(1).model().generatedName().contains("Persistence"));
+        assertEquals("ProcessCsvPaymentsInputService", expanded.get(2).model().serviceName());
+    }
+
+    @SneakyThrows
+    @Test
     void assignsPluginRoleAndTargetsToSyntheticSteps() {
         ResolvedStep step = resolvedStep("ProcessFolderService");
         Map<String, Object> config = aspectConfig("org.pipelineframework.plugin.persistence.PersistenceService");

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/OrchestratorClientGenerationTest.java
@@ -220,6 +220,75 @@ class OrchestratorClientGenerationTest {
     }
 
     @Test
+    void mapsAuthoredStepIdsToGeneratedProcessClientNames() throws IOException {
+        Path projectRoot = initProjectRoot();
+        Path moduleDir = projectRoot.resolve("test-module");
+        Path generatedSourcesDir = moduleDir.resolve("target").resolve("generated-sources").resolve("pipeline");
+        Path moduleResourcesDir = moduleDir.resolve("src").resolve("main").resolve("resources");
+        Files.createDirectories(generatedSourcesDir);
+        Files.createDirectories(moduleResourcesDir);
+
+        String moduleOverrides = """
+            pipeline.module.search-svc.port=9000
+            pipeline.module.search-svc.steps=index-document
+            """;
+        Files.writeString(moduleResourcesDir.resolve("application.properties"), moduleOverrides);
+
+        Path pipelineYaml = projectRoot.resolve("pipeline.yaml");
+        String pipelineConfig = Files.readString(resourcePath("pipeline-search.yaml"))
+            .replace("transport: \"REST\"", "transport: \"GRPC\"");
+        Files.writeString(pipelineYaml, stripAspectsSection(pipelineConfig));
+
+        Compilation compilation = Compiler.javac()
+            .withProcessors(new PipelineStepProcessor())
+            .withOptions(
+                "-Apipeline.generatedSourcesDir=" + generatedSourcesDir,
+                "-Aprotobuf.descriptor.file=" + resourcePath("descriptor_set_search.dsc"))
+            .compile(
+                JavaFileObjects.forSourceString(
+                    "org.example.OrchestratorMarker",
+                    """
+                        package org.example;
+
+                        import org.pipelineframework.annotation.PipelineOrchestrator;
+
+                        @PipelineOrchestrator
+                        public class OrchestratorMarker {
+                        }
+                        """),
+                searchServiceStub("ProcessCrawlSourceService", "CrawlRequest", "RawDocument"),
+                searchServiceStub("ProcessParseDocumentService", "RawDocument", "ParsedDocument"),
+                searchServiceStub("ProcessTokenizeContentService", "ParsedDocument", "TokenBatch"),
+                searchServiceStub("ProcessIndexDocumentService", "TokenBatch", "IndexAck"),
+                domainStub("CrawlRequest"),
+                domainStub("RawDocument"),
+                domainStub("ParsedDocument"),
+                domainStub("TokenBatch"),
+                domainStub("IndexAck"),
+                dtoStub("CrawlRequestDto"),
+                dtoStub("RawDocumentDto"),
+                dtoStub("ParsedDocumentDto"),
+                dtoStub("TokenBatchDto"),
+                dtoStub("IndexAckDto"),
+                mapperStub("CrawlRequestMapper", "CrawlRequest", "CrawlRequestDto"),
+                mapperStub("RawDocumentMapper", "RawDocument", "RawDocumentDto"),
+                mapperStub("ParsedDocumentMapper", "ParsedDocument", "ParsedDocumentDto"),
+                mapperStub("TokenBatchMapper", "TokenBatch", "TokenBatchDto"),
+                mapperStub("IndexAckMapper", "IndexAck", "IndexAckDto"));
+
+        assertThat(compilation).succeeded();
+
+        JavaFileObject propertiesFile = compilation.generatedFile(
+            StandardLocation.CLASS_OUTPUT,
+            "META-INF/pipeline",
+            "orchestrator-clients.properties").orElseThrow();
+        String propertiesContent = propertiesFile.getCharContent(true).toString();
+
+        assertTrue(propertiesContent.contains(
+            "quarkus.grpc.clients.process-index-document.port=9000"));
+    }
+
+    @Test
     void preservesExternalizedModuleEndpointExpressions() throws IOException {
         Path projectRoot = initProjectRoot();
         Path moduleDir = projectRoot.resolve("test-module");

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/parser/StepDefinitionParserTest.java
@@ -2172,6 +2172,74 @@ class StepDefinitionParserTest {
             diagnostics.toString());
     }
 
+    @Test
+    void parsesBranchRoutingAcceptsAndTerminalFields() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Finalize"
+                service: "com.example.FinalizeService"
+                cardinality: "ONE_TO_ONE"
+                input: "com.example.OrderCompletion"
+                output: "com.example.FinalizedOrder"
+                accepts:
+                  - "StockReserved"
+                  - "LicenseProvisioned"
+                terminal: true
+            """, diagnostics);
+
+        assertEquals(1, steps.size(), diagnostics.toString());
+        StepDefinition step = steps.getFirst();
+        assertEquals(List.of("StockReserved", "LicenseProvisioned"), step.accepts());
+        assertTrue(step.terminal());
+    }
+
+    @Test
+    void rejectsPredicateStyleRoutingKeys() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 2
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Reserve Stock"
+                service: "com.example.ReserveStockService"
+                input: "com.example.PhysicalOrder"
+                output: "com.example.StockReserved"
+                when: "country == 'ES'"
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message ->
+                message.contains("type-based accepts/terminal routing only") && message.contains("when")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsBranchRoutingFieldsBeforeVersionTwo() throws IOException {
+        List<String> diagnostics = new ArrayList<>();
+        List<StepDefinition> steps = parse("""
+            version: 1
+            appName: "Test"
+            basePackage: "com.example"
+            steps:
+              - name: "Finalize"
+                service: "com.example.FinalizeService"
+                input: "com.example.OrderCompletion"
+                output: "com.example.FinalizedOrder"
+                accepts:
+                  - "StockReserved"
+                terminal: true
+            """, diagnostics);
+
+        assertTrue(steps.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("accepts/terminal branch routing requires version: 2")),
+            diagnostics.toString());
+    }
+
     private List<StepDefinition> parse(String yaml) throws IOException {
         return parse(yaml, null);
     }

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
@@ -1,0 +1,413 @@
+package org.pipelineframework.processor.routing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.config.template.PipelinePlatform;
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateMessage;
+import org.pipelineframework.config.template.PipelineTemplateStep;
+import org.pipelineframework.config.template.PipelineTemplateUnion;
+import org.pipelineframework.config.template.PipelineTemplateUnionVariant;
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.MapperFallbackMode;
+import org.pipelineframework.processor.ir.StepDefinition;
+import org.pipelineframework.processor.ir.StepKind;
+import org.pipelineframework.processor.ir.StreamingShape;
+
+class PipelineBranchRoutingPlannerTest {
+
+    private final PipelineBranchRoutingPlanner planner = new PipelineBranchRoutingPlanner();
+
+    @Test
+    void plansLinearUnionRoutingWithMandatoryTerminalMerge() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Order Routing",
+            "com.example.order",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            unions(),
+            List.of(
+                step("classifyOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("reserveStock", "PhysicalOrder", "StockReserved", List.of("PhysicalOrder"), false),
+                step("provisionLicense", "DigitalOrder", "LicenseProvisioned", List.of("DigitalOrder"), false),
+                step("requestManualReview", "ManualReviewOrder", "ManualReviewRequested", List.of("ManualReviewOrder"), false),
+                step("finalize", "OrderCompletion", "FinalizedOrder",
+                    List.of("StockReserved", "LicenseProvisioned", "ManualReviewRequested"), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("classifyOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("reserveStock", "PhysicalOrder", "StockReserved"),
+            stepDefinition("provisionLicense", "DigitalOrder", "LicenseProvisioned"),
+            stepDefinition("requestManualReview", "ManualReviewOrder", "ManualReviewRequested"),
+            stepDefinition("finalize", "OrderCompletion", "FinalizedOrder")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertTrue(plan.orElseThrow().branchAware());
+        assertEquals(4, plan.orElseThrow().terminalStepIndex());
+        assertEquals(List.of("PhysicalOrder"), plan.orElseThrow().steps().get(1).acceptedContractTypes());
+        assertEquals(
+            List.of("StockReserved", "LicenseProvisioned", "ManualReviewRequested"),
+            plan.orElseThrow().steps().get(4).acceptedContractTypes());
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
+    }
+
+    @Test
+    void allowsConcreteExpansionBeforeUnionRoutingBegins() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Csv Payments",
+            "com.example.csv",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            Map.of(
+                "CsvPaymentsInputFile", message("CsvPaymentsInputFile"),
+                "PaymentRecord", message("PaymentRecord"),
+                "ApprovedPaymentStatus", message("ApprovedPaymentStatus"),
+                "UnapprovedPaymentStatus", message("UnapprovedPaymentStatus"),
+                "ApprovedPaymentOutput", message("ApprovedPaymentOutput"),
+                "UnapprovedPaymentOutput", message("UnapprovedPaymentOutput"),
+                "PaymentOutput", message("PaymentOutput")),
+            Map.of(
+                "PaymentStatus", new PipelineTemplateUnion(
+                    "PaymentStatus",
+                    Map.of(
+                        "approved", new PipelineTemplateUnionVariant("approved", "ApprovedPaymentStatus", 1),
+                        "unapproved", new PipelineTemplateUnionVariant("unapproved", "UnapprovedPaymentStatus", 2))),
+                "PaymentOutputBranch", new PipelineTemplateUnion(
+                    "PaymentOutputBranch",
+                    Map.of(
+                        "approved", new PipelineTemplateUnionVariant("approved", "ApprovedPaymentOutput", 1),
+                        "unapproved", new PipelineTemplateUnionVariant("unapproved", "UnapprovedPaymentOutput", 2)))),
+            List.of(
+                step("processCsvPaymentsInput", "EXPANSION", "CsvPaymentsInputFile", "PaymentRecord", List.of(), false),
+                step("awaitPaymentProvider", "ONE_TO_ONE", "PaymentRecord", "PaymentStatus", List.of(), false),
+                step("processApprovedPaymentStatus", "ONE_TO_ONE", "ApprovedPaymentStatus", "ApprovedPaymentOutput", List.of(), false),
+                step("processUnapprovedPaymentStatus", "ONE_TO_ONE", "UnapprovedPaymentStatus", "UnapprovedPaymentOutput", List.of(), false),
+                step("finalizePaymentOutput", "ONE_TO_ONE", "PaymentOutputBranch", "PaymentOutput",
+                    List.of("ApprovedPaymentOutput", "UnapprovedPaymentOutput"), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("processCsvPaymentsInput", "CsvPaymentsInputFile", "PaymentRecord"),
+            stepDefinition("awaitPaymentProvider", "PaymentRecord", "PaymentStatus"),
+            stepDefinition("processApprovedPaymentStatus", "ApprovedPaymentStatus", "ApprovedPaymentOutput"),
+            stepDefinition("processUnapprovedPaymentStatus", "UnapprovedPaymentStatus", "UnapprovedPaymentOutput"),
+            stepDefinition("finalizePaymentOutput", "PaymentOutputBranch", "PaymentOutput")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertTrue(plan.orElseThrow().branchAware());
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
+    }
+
+    @Test
+    void rejectsBranchAwarePipelineWithoutTerminalStep() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Order Routing",
+            "com.example.order",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            unions(),
+            List.of(
+                step("classifyOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("reserveStock", "PhysicalOrder", "StockReserved", List.of("PhysicalOrder"), false)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("classifyOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("reserveStock", "PhysicalOrder", "StockReserved")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message -> message.contains("exactly one step with terminal: true")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsUnionInputWithoutExplicitAccepts() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Order Routing",
+            "com.example.order",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            unions(),
+            List.of(
+                step("classifyOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("routeOrder", "OrderDecision", "OrderCompletion", List.of(), false),
+                step("finalize", "OrderCompletion", "FinalizedOrder",
+                    List.of("StockReserved", "LicenseProvisioned", "ManualReviewRequested"), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("classifyOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("routeOrder", "OrderDecision", "OrderCompletion"),
+            stepDefinition("finalize", "OrderCompletion", "FinalizedOrder")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message ->
+                message.contains("Explicit accepts is required") && message.contains("OrderDecision")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsTerminalThatDoesNotCoverAllReachableAlternatives() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Order Routing",
+            "com.example.order",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            unions(),
+            List.of(
+                step("classifyOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("reserveStock", "PhysicalOrder", "StockReserved", List.of("PhysicalOrder"), false),
+                step("provisionLicense", "DigitalOrder", "LicenseProvisioned", List.of("DigitalOrder"), false),
+                step("requestManualReview", "ManualReviewOrder", "ManualReviewRequested", List.of("ManualReviewOrder"), false),
+                step("finalize", "OrderCompletion", "FinalizedOrder",
+                    List.of("StockReserved", "LicenseProvisioned"), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("classifyOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("reserveStock", "PhysicalOrder", "StockReserved"),
+            stepDefinition("provisionLicense", "DigitalOrder", "LicenseProvisioned"),
+            stepDefinition("requestManualReview", "ManualReviewOrder", "ManualReviewRequested"),
+            stepDefinition("finalize", "OrderCompletion", "FinalizedOrder")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message ->
+                message.contains("does not cover all reachable branch-end alternatives")
+                    && message.contains("ManualReviewRequested")),
+            diagnostics.toString());
+    }
+
+    @Test
+    void rejectsBranchAwareStepWhenAcceptedJavaTypeCannotBeResolved() {
+        List<String> diagnostics = new ArrayList<>();
+        Messager messager = mock(Messager.class);
+        doAnswer(invocation -> {
+            Diagnostic.Kind kind = invocation.getArgument(0);
+            CharSequence message = invocation.getArgument(1);
+            diagnostics.add(kind + ":" + message);
+            return null;
+        }).when(messager).printMessage(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(CharSequence.class));
+
+        TypeMirror orderRequestMirror = mock(TypeMirror.class);
+        TypeMirror physicalOrderMirror = mock(TypeMirror.class);
+        TypeMirror digitalOrderMirror = mock(TypeMirror.class);
+        TypeMirror orderCompletionMirror = mock(TypeMirror.class);
+        TypeMirror stockReservedMirror = mock(TypeMirror.class);
+
+        TypeElement orderRequestElement = mock(TypeElement.class);
+        when(orderRequestElement.asType()).thenReturn(orderRequestMirror);
+        TypeElement physicalOrderElement = mock(TypeElement.class);
+        when(physicalOrderElement.asType()).thenReturn(physicalOrderMirror);
+        TypeElement digitalOrderElement = mock(TypeElement.class);
+        when(digitalOrderElement.asType()).thenReturn(digitalOrderMirror);
+        TypeElement orderCompletionElement = mock(TypeElement.class);
+        when(orderCompletionElement.asType()).thenReturn(orderCompletionMirror);
+        TypeElement stockReservedElement = mock(TypeElement.class);
+        when(stockReservedElement.asType()).thenReturn(stockReservedMirror);
+
+        Elements elements = mock(Elements.class);
+        when(elements.getTypeElement("com.example.order.common.domain.OrderRequest")).thenReturn(orderRequestElement);
+        when(elements.getTypeElement("com.example.order.common.domain.PhysicalOrder")).thenReturn(physicalOrderElement);
+        when(elements.getTypeElement("com.example.order.common.domain.DigitalOrder")).thenReturn(digitalOrderElement);
+        when(elements.getTypeElement("com.example.order.common.domain.OrderCompletion")).thenReturn(orderCompletionElement);
+        when(elements.getTypeElement("com.example.order.common.domain.StockReserved")).thenReturn(stockReservedElement);
+
+        Types types = mock(Types.class);
+        when(types.isAssignable(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any())).thenReturn(true);
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getMessager()).thenReturn(messager);
+        when(processingEnv.getElementUtils()).thenReturn(elements);
+        when(processingEnv.getTypeUtils()).thenReturn(types);
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Order Routing",
+            "com.example.order",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            unions(),
+            List.of(
+                step("classifyOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("reserveStock", "PhysicalOrder", "StockReserved", List.of("PhysicalOrder"), false),
+                step("provisionLicense", "DigitalOrder", "LicenseProvisioned", List.of("DigitalOrder"), false),
+                step("finalize", "OrderCompletion", "FinalizedOrder", List.of("StockReserved", "LicenseProvisioned"), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("classifyOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("reserveStock", "PhysicalOrder", "StockReserved"),
+            stepDefinition("provisionLicense", "DigitalOrder", "LicenseProvisioned"),
+            stepDefinition("finalize", "OrderCompletion", "FinalizedOrder")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isEmpty());
+        assertTrue(diagnostics.stream().anyMatch(message ->
+                message.contains("accepted type 'com.example.order.common.domain.LicenseProvisioned'")
+                    && message.contains("could not be resolved during branch routing validation")),
+            diagnostics.toString());
+        assertFalse(diagnostics.isEmpty());
+    }
+
+    private PipelineCompilationContext context(List<String> diagnostics) {
+        Messager messager = mock(Messager.class);
+        doAnswer(invocation -> {
+            Diagnostic.Kind kind = invocation.getArgument(0);
+            CharSequence message = invocation.getArgument(1);
+            diagnostics.add(kind + ":" + message);
+            return null;
+        }).when(messager).printMessage(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(CharSequence.class));
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getMessager()).thenReturn(messager);
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        return new PipelineCompilationContext(processingEnv, roundEnv);
+    }
+
+    private static Map<String, PipelineTemplateMessage> messages() {
+        return Map.of(
+            "OrderRequest", message("OrderRequest"),
+            "PhysicalOrder", message("PhysicalOrder"),
+            "DigitalOrder", message("DigitalOrder"),
+            "ManualReviewOrder", message("ManualReviewOrder"),
+            "StockReserved", message("StockReserved"),
+            "LicenseProvisioned", message("LicenseProvisioned"),
+            "ManualReviewRequested", message("ManualReviewRequested"),
+            "FinalizedOrder", message("FinalizedOrder"));
+    }
+
+    private static Map<String, PipelineTemplateUnion> unions() {
+        return Map.of(
+            "OrderDecision", new PipelineTemplateUnion(
+                "OrderDecision",
+                Map.of(
+                    "physical", new PipelineTemplateUnionVariant("physical", "PhysicalOrder", 1),
+                    "digital", new PipelineTemplateUnionVariant("digital", "DigitalOrder", 2),
+                    "manualReview", new PipelineTemplateUnionVariant("manualReview", "ManualReviewOrder", 3))),
+            "OrderCompletion", new PipelineTemplateUnion(
+                "OrderCompletion",
+                Map.of(
+                    "stock", new PipelineTemplateUnionVariant("stock", "StockReserved", 1),
+                    "license", new PipelineTemplateUnionVariant("license", "LicenseProvisioned", 2),
+                    "review", new PipelineTemplateUnionVariant("review", "ManualReviewRequested", 3))));
+    }
+
+    private static PipelineTemplateStep step(
+        String name,
+        String cardinality,
+        String inputTypeName,
+        String outputTypeName,
+        List<String> accepts,
+        boolean terminal
+    ) {
+        return new PipelineTemplateStep(
+            name,
+            cardinality,
+            inputTypeName,
+            List.of(),
+            null,
+            outputTypeName,
+            List.of(),
+            null,
+            null,
+            accepts,
+            terminal);
+    }
+
+    private static PipelineTemplateStep step(
+        String name,
+        String inputTypeName,
+        String outputTypeName,
+        List<String> accepts,
+        boolean terminal
+    ) {
+        return step(name, "ONE_TO_ONE", inputTypeName, outputTypeName, accepts, terminal);
+    }
+
+    private static PipelineTemplateMessage message(String name) {
+        return new PipelineTemplateMessage(name, List.of(), null);
+    }
+
+    private static StepDefinition stepDefinition(String name, String inputTypeName, String outputTypeName) {
+        return new StepDefinition(
+            name,
+            StepKind.INTERNAL,
+            ClassName.get("com.example.order.pipeline", capitalize(name) + "Service"),
+            null,
+            null,
+            null,
+            MapperFallbackMode.NONE,
+            ClassName.get("com.example.order.common.domain", inputTypeName),
+            ClassName.get("com.example.order.common.domain", outputTypeName),
+            StreamingShape.UNARY_UNARY);
+    }
+
+    private static String capitalize(String value) {
+        return Character.toUpperCase(value.charAt(0)) + value.substring(1);
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchingPlanTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchingPlanTest.java
@@ -1,0 +1,47 @@
+package org.pipelineframework.processor.routing;
+
+import java.util.List;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PipelineBranchingPlanTest {
+
+    @Test
+    void rejectsBranchStepIndexThatDoesNotMatchListPosition() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new PipelineBranchingPlan(
+                true,
+                1,
+                List.of(
+                    branchStep(0, "Classify", false),
+                    branchStep(2, "Finalize", true))));
+
+        org.junit.jupiter.api.Assertions.assertTrue(exception.getMessage().contains("BranchStep index mismatch"));
+    }
+
+    @Test
+    void acceptsIndexedTerminalStepAtMatchingPosition() {
+        assertDoesNotThrow(() -> new PipelineBranchingPlan(
+            true,
+            1,
+            List.of(
+                branchStep(0, "Classify", false),
+                branchStep(1, "Finalize", true))));
+    }
+
+    private static PipelineBranchingPlan.BranchStep branchStep(int index, String name, boolean terminal) {
+        return new PipelineBranchingPlan.BranchStep(
+            index,
+            name,
+            name + "Input",
+            name + "Output",
+            List.of(name + "Accepted"),
+            List.of(name + "Leaf"),
+            List.of(ClassName.get("com.example.common.domain", name + "Accepted")),
+            terminal);
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporterTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/schema/PipelineTemplateSchemaExporterTest.java
@@ -229,6 +229,25 @@ class PipelineTemplateSchemaExporterTest {
     }
 
     @Test
+    void branchAwareStepShapesExposeAcceptsAndTerminal() {
+        JsonObject definitions = parse(PipelineTemplateSchemaExporter.schemaJson()).getAsJsonObject("$defs");
+
+        JsonObject internalStep = definitions.getAsJsonObject("delegatedOrInternalStep");
+        JsonObject internalProperties = internalStep.getAsJsonObject("properties");
+        assertTrue(internalProperties.has("accepts"));
+        assertTrue(internalProperties.has("terminal"));
+        assertEquals("boolean", internalProperties.getAsJsonObject("terminal").get("type").getAsString());
+
+        JsonObject accepts = internalProperties.getAsJsonObject("accepts");
+        assertEquals("array", accepts.get("type").getAsString());
+        assertEquals("^[A-Z][A-Za-z0-9_]*$", accepts.getAsJsonObject("items").get("pattern").getAsString());
+
+        assertTrue(definitions.getAsJsonObject("awaitTemplateStep").getAsJsonObject("properties").has("accepts"));
+        assertTrue(definitions.getAsJsonObject("commandTemplateStep").getAsJsonObject("properties").has("terminal"));
+        assertTrue(definitions.getAsJsonObject("queryTemplateStep").getAsJsonObject("properties").has("accepts"));
+    }
+
+    @Test
     void deterministicTopLevelOrderingKeepsSchemaStableForConsumers() {
         JsonObject schema = parse(PipelineTemplateSchemaExporter.schemaJson());
         List<String> keys = new ArrayList<>();

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/ClientStepClassNamesTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/ClientStepClassNamesTest.java
@@ -1,0 +1,63 @@
+package org.pipelineframework.processor.util;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+
+import com.squareup.javapoet.ClassName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClientStepClassNamesTest {
+
+    @Test
+    void suffixPrefersAwaitThenCommandThenQueryBeforeDefault() {
+        PipelineStepModel awaitCommandQuery = model(
+            "ReserveStockService",
+            Set.of(
+                GenerationTarget.AWAIT_CLIENT_STEP,
+                GenerationTarget.COMMAND_CLIENT_STEP,
+                GenerationTarget.QUERY_CLIENT_STEP));
+        PipelineStepModel commandQuery = model(
+            "ReserveStockService",
+            Set.of(GenerationTarget.COMMAND_CLIENT_STEP, GenerationTarget.QUERY_CLIENT_STEP));
+        PipelineStepModel queryOnly = model(
+            "ReserveStockService",
+            Set.of(GenerationTarget.QUERY_CLIENT_STEP));
+        PipelineStepModel plainClient = model("ReserveStockService", Set.of(GenerationTarget.CLIENT_STEP));
+
+        assertEquals("AwaitClientStep", ClientStepClassNames.suffix(awaitCommandQuery, "GrpcClientStep"));
+        assertEquals("CommandClientStep", ClientStepClassNames.suffix(commandQuery, "GrpcClientStep"));
+        assertEquals("QueryClientStep", ClientStepClassNames.suffix(queryOnly, "GrpcClientStep"));
+        assertEquals("GrpcClientStep", ClientStepClassNames.suffix(plainClient, "GrpcClientStep"));
+    }
+
+    @Test
+    void stripTrailingServiceHandlesNullBlankAndNamesWithoutServiceSuffix() {
+        assertEquals("", ClientStepClassNames.stripTrailingService(null));
+        assertEquals("", ClientStepClassNames.stripTrailingService(""));
+        assertEquals("ReserveStock", ClientStepClassNames.stripTrailingService("ReserveStock"));
+        assertEquals("ReserveStock", ClientStepClassNames.stripTrailingService("ReserveStockService"));
+    }
+
+    private static PipelineStepModel model(String generatedName, Set<GenerationTarget> enabledTargets) {
+        return new PipelineStepModel.Builder()
+            .serviceName("ReserveStock")
+            .generatedName(generatedName)
+            .servicePackage("com.example.order")
+            .serviceClassName(ClassName.get("com.example.order", generatedName))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.common.domain", "Input"), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.common.domain", "Output"), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(enabledTargets)
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .build();
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGeneratorTest.java
@@ -1,0 +1,189 @@
+package org.pipelineframework.processor.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pipelineframework.processor.PipelineCompilationContext;
+import org.pipelineframework.processor.ir.DeploymentRole;
+import org.pipelineframework.processor.ir.ExecutionMode;
+import org.pipelineframework.processor.ir.GenerationTarget;
+import org.pipelineframework.processor.ir.PipelineStepModel;
+import org.pipelineframework.processor.ir.PipelineTransport;
+import org.pipelineframework.processor.ir.StreamingShape;
+import org.pipelineframework.processor.ir.TypeMapping;
+import org.pipelineframework.processor.routing.PipelineBranchingPlan;
+
+class PipelineBranchingMetadataGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesBranchingMetadataWithRuntimeClassesAndAcceptedContracts() throws IOException {
+        Path classOutput = tempDir.resolve("class-output");
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(Map.of());
+        when(processingEnv.getFiler()).thenReturn(new PathResourceFiler(classOutput));
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setTransportMode(PipelineTransport.REST);
+        ctx.setOrchestratorGenerated(true);
+        ctx.setStepModels(List.of(
+            stepModel("ReserveStock", "com.example.order.inventory", "PhysicalOrder", "StockReserved"),
+            stepModel("Finalize", "com.example.order.finalize", "OrderCompletion", "FinalizedOrder")));
+        ctx.setBranchingPlan(new PipelineBranchingPlan(
+            true,
+            1,
+            List.of(
+                new PipelineBranchingPlan.BranchStep(
+                    0,
+                    "Reserve Stock",
+                    "PhysicalOrder",
+                    "StockReserved",
+                    List.of("PhysicalOrder"),
+                    List.of("StockReserved"),
+                    List.of(ClassName.get("com.example.common.domain", "PhysicalOrder")),
+                    false),
+                new PipelineBranchingPlan.BranchStep(
+                    1,
+                    "Finalize",
+                    "OrderCompletion",
+                    "FinalizedOrder",
+                    List.of("StockReserved", "LicenseProvisioned"),
+                    List.of("FinalizedOrder"),
+                    List.of(
+                        ClassName.get("com.example.common.domain", "StockReserved"),
+                        ClassName.get("com.example.common.domain", "LicenseProvisioned")),
+                    true))));
+
+        new PipelineBranchingMetadataGenerator(processingEnv).writeBranchingMetadata(ctx);
+
+        Path metadataFile = classOutput.resolve("META-INF/pipeline/branching.json");
+        assertTrue(Files.exists(metadataFile), "branching.json should be written");
+
+        JsonObject metadata = new Gson().fromJson(Files.readString(metadataFile), JsonObject.class);
+        assertEquals(1, metadata.get("terminalStepIndex").getAsInt());
+        assertEquals(2, metadata.getAsJsonArray("steps").size());
+
+        JsonObject reserveStock = metadata.getAsJsonArray("steps").get(0).getAsJsonObject();
+        assertEquals("Reserve Stock", reserveStock.get("step").getAsString());
+        assertEquals(
+            "com.example.order.inventory.pipeline.ReserveStockRestClientStep",
+            reserveStock.get("runtimeStepClass").getAsString());
+        assertEquals(
+            "com.example.common.dto.PhysicalOrderDto",
+            reserveStock.get("inputRuntimeClass").getAsString());
+        assertEquals(
+            "com.example.common.dto.PhysicalOrderDto",
+            reserveStock.getAsJsonArray("acceptedRuntimeClasses").get(0).getAsString());
+
+        JsonObject finalize = metadata.getAsJsonArray("steps").get(1).getAsJsonObject();
+        assertTrue(finalize.get("terminal").getAsBoolean());
+        assertEquals(2, finalize.getAsJsonArray("acceptedContracts").size());
+        assertEquals(
+            "com.example.common.dto.OrderCompletionDto",
+            finalize.get("inputRuntimeClass").getAsString());
+    }
+
+    private static PipelineStepModel stepModel(
+        String serviceName,
+        String servicePackage,
+        String inputType,
+        String outputType
+    ) {
+        return new PipelineStepModel.Builder()
+            .serviceName(serviceName)
+            .generatedName(serviceName + "Service")
+            .servicePackage(servicePackage)
+            .serviceClassName(ClassName.get(servicePackage, serviceName + "Service"))
+            .inputMapping(new TypeMapping(ClassName.get("com.example.common.domain", inputType), null, false))
+            .outputMapping(new TypeMapping(ClassName.get("com.example.common.domain", outputType), null, false))
+            .streamingShape(StreamingShape.UNARY_UNARY)
+            .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+            .executionMode(ExecutionMode.DEFAULT)
+            .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
+            .build();
+    }
+
+    private static final class PathResourceFiler implements Filer {
+        private final Path classOutputRoot;
+
+        private PathResourceFiler(Path classOutputRoot) {
+            this.classOutputRoot = classOutputRoot;
+        }
+
+        @Override
+        public JavaFileObject createSourceFile(CharSequence name, Element... originatingElements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JavaFileObject createClassFile(CharSequence name, Element... originatingElements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FileObject createResource(
+            JavaFileManager.Location location,
+            CharSequence pkg,
+            CharSequence relativeName,
+            Element... originatingElements
+        ) throws IOException {
+            Path target = classOutputRoot.resolve(relativeName.toString());
+            Files.createDirectories(target.getParent());
+            return new PathFileObject(target);
+        }
+
+        @Override
+        public FileObject getResource(JavaFileManager.Location location, CharSequence pkg, CharSequence relativeName) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class PathFileObject extends SimpleJavaFileObject {
+        private final Path path;
+
+        private PathFileObject(Path path) {
+            super(path.toUri(), JavaFileObject.Kind.OTHER);
+            this.path = path;
+        }
+
+        @Override
+        public Writer openWriter() throws IOException {
+            Files.createDirectories(path.getParent());
+            return Files.newBufferedWriter(path);
+        }
+
+        @Override
+        public OutputStream openOutputStream() throws IOException {
+            Files.createDirectories(path.getParent());
+            return Files.newOutputStream(path);
+        }
+    }
+}

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineBranchingMetadataGeneratorTest.java
@@ -111,11 +111,92 @@ class PipelineBranchingMetadataGeneratorTest {
             finalize.get("inputRuntimeClass").getAsString());
     }
 
+    @Test
+    void writesAwaitAndQueryClientSuffixesAndSkipsUnmatchedSteps() throws IOException {
+        Path classOutput = tempDir.resolve("class-output-alt");
+
+        ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
+        when(processingEnv.getOptions()).thenReturn(Map.of());
+        when(processingEnv.getFiler()).thenReturn(new PathResourceFiler(classOutput));
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+
+        PipelineCompilationContext ctx = new PipelineCompilationContext(processingEnv, roundEnv);
+        ctx.setTransportMode(PipelineTransport.GRPC);
+        ctx.setOrchestratorGenerated(true);
+        ctx.setStepModels(List.of(
+            stepModel(
+                "AwaitProvider",
+                "com.example.order.awaiting",
+                "ApprovalPending",
+                "ApprovalResult",
+                Set.of(GenerationTarget.AWAIT_CLIENT_STEP)),
+            stepModel(
+                "LookupOrder",
+                "com.example.order.query",
+                "LookupOrderRequest",
+                "LookupOrderResult",
+                Set.of(GenerationTarget.QUERY_CLIENT_STEP))));
+        ctx.setBranchingPlan(new PipelineBranchingPlan(
+            true,
+            1,
+            List.of(
+                new PipelineBranchingPlan.BranchStep(
+                    0,
+                    "Await Provider",
+                    "ApprovalPending",
+                    "ApprovalResult",
+                    List.of("ApprovalPending"),
+                    List.of("ApprovalResult"),
+                    List.of(ClassName.get("com.example.common.domain", "ApprovalPending")),
+                    false),
+                new PipelineBranchingPlan.BranchStep(
+                    1,
+                    "Lookup Order",
+                    "LookupOrderRequest",
+                    "LookupOrderResult",
+                    List.of("LookupOrderRequest"),
+                    List.of("LookupOrderResult"),
+                    List.of(ClassName.get("com.example.common.domain", "LookupOrderRequest")),
+                    true),
+                new PipelineBranchingPlan.BranchStep(
+                    2,
+                    "Missing Step",
+                    "MissingRequest",
+                    "MissingResult",
+                    List.of("MissingRequest"),
+                    List.of("MissingResult"),
+                    List.of(ClassName.get("com.example.common.domain", "MissingRequest")),
+                    false))));
+
+        new PipelineBranchingMetadataGenerator(processingEnv).writeBranchingMetadata(ctx);
+
+        Path metadataFile = classOutput.resolve("META-INF/pipeline/branching.json");
+        JsonObject metadata = new Gson().fromJson(Files.readString(metadataFile), JsonObject.class);
+        assertEquals(1, metadata.get("terminalStepIndex").getAsInt());
+        assertEquals(2, metadata.getAsJsonArray("steps").size());
+        assertEquals(
+            "com.example.order.awaiting.pipeline.AwaitProviderAwaitClientStep",
+            metadata.getAsJsonArray("steps").get(0).getAsJsonObject().get("runtimeStepClass").getAsString());
+        assertEquals(
+            "com.example.order.query.pipeline.LookupOrderQueryClientStep",
+            metadata.getAsJsonArray("steps").get(1).getAsJsonObject().get("runtimeStepClass").getAsString());
+    }
+
     private static PipelineStepModel stepModel(
         String serviceName,
         String servicePackage,
         String inputType,
         String outputType
+    ) {
+        return stepModel(serviceName, servicePackage, inputType, outputType, Set.of(GenerationTarget.CLIENT_STEP));
+    }
+
+    private static PipelineStepModel stepModel(
+        String serviceName,
+        String servicePackage,
+        String inputType,
+        String outputType,
+        Set<GenerationTarget> enabledTargets
     ) {
         return new PipelineStepModel.Builder()
             .serviceName(serviceName)
@@ -125,7 +206,7 @@ class PipelineBranchingMetadataGeneratorTest {
             .inputMapping(new TypeMapping(ClassName.get("com.example.common.domain", inputType), null, false))
             .outputMapping(new TypeMapping(ClassName.get("com.example.common.domain", outputType), null, false))
             .streamingShape(StreamingShape.UNARY_UNARY)
-            .enabledTargets(Set.of(GenerationTarget.CLIENT_STEP))
+            .enabledTargets(enabledTargets)
             .executionMode(ExecutionMode.DEFAULT)
             .deploymentRole(DeploymentRole.ORCHESTRATOR_CLIENT)
             .build();

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGeneratorTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/util/PipelineTelemetryMetadataGeneratorTest.java
@@ -22,10 +22,16 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
+import org.pipelineframework.config.template.PipelinePlatform;
+import org.pipelineframework.config.template.PipelineTemplateConfig;
+import org.pipelineframework.config.template.PipelineTemplateMessage;
+import org.pipelineframework.config.template.PipelineTemplateUnion;
+import org.pipelineframework.config.template.PipelineTemplateUnionVariant;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.pipelineframework.processor.PipelineCompilationContext;
 import org.pipelineframework.processor.ir.*;
+import org.pipelineframework.processor.routing.PipelineBranchingPlan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -233,6 +239,115 @@ class PipelineTelemetryMetadataGeneratorTest {
     }
 
     @Test
+    void writesBranchAwareReplayTopologyWithSplitAndMergePrimaryTransitions() throws IOException {
+        PipelineCompilationContext ctx = buildContext();
+        writeApplicationProperties("com.example.PaymentRecord", "com.example.PaymentOutput");
+        writePipelineYaml("""
+            basePackage: com.example.pipeline
+            transport: GRPC
+            steps:
+              - name: Process Csv Payments Input
+                input: com.example.CsvPaymentsInputFile
+                output: com.example.PaymentRecord
+              - name: Await Payment Provider
+                input: com.example.PaymentRecord
+                output: com.example.PaymentStatus
+              - name: Process Approved Payment Status
+                input: com.example.ApprovedPaymentStatus
+                output: com.example.ApprovedPaymentOutput
+              - name: Process Unapproved Payment Status
+                input: com.example.UnapprovedPaymentStatus
+                output: com.example.UnapprovedPaymentOutput
+              - name: Finalize Payment Output
+                input: com.example.PaymentOutputBranch
+                output: com.example.PaymentOutput
+            """);
+
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "payments",
+            "com.example",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            java.util.Map.of(
+                "CsvPaymentsInputFile", message("CsvPaymentsInputFile"),
+                "PaymentRecord", message("PaymentRecord"),
+                "ApprovedPaymentStatus", message("ApprovedPaymentStatus"),
+                "UnapprovedPaymentStatus", message("UnapprovedPaymentStatus"),
+                "ApprovedPaymentOutput", message("ApprovedPaymentOutput"),
+                "UnapprovedPaymentOutput", message("UnapprovedPaymentOutput"),
+                "PaymentOutput", message("PaymentOutput")
+            ),
+            java.util.Map.of(
+                "PaymentStatus", new PipelineTemplateUnion(
+                    "PaymentStatus",
+                    java.util.Map.of(
+                        "approved", new PipelineTemplateUnionVariant("approved", "ApprovedPaymentStatus", 1),
+                        "unapproved", new PipelineTemplateUnionVariant("unapproved", "UnapprovedPaymentStatus", 2)
+                    )),
+                "PaymentOutputBranch", new PipelineTemplateUnion(
+                    "PaymentOutputBranch",
+                    java.util.Map.of(
+                        "approved", new PipelineTemplateUnionVariant("approved", "ApprovedPaymentOutput", 1),
+                        "unapproved", new PipelineTemplateUnionVariant("unapproved", "UnapprovedPaymentOutput", 2)
+                    ))
+            ),
+            java.util.List.of(),
+            java.util.Map.of(),
+            null,
+            null,
+            null
+        ));
+
+        ctx.setBranchingPlan(new PipelineBranchingPlan(
+            true,
+            4,
+            java.util.List.of(
+                new PipelineBranchingPlan.BranchStep(0, "Process Csv Payments Input", "CsvPaymentsInputFile",
+                    "PaymentRecord", java.util.List.of("CsvPaymentsInputFile"), java.util.List.of("PaymentRecord"),
+                    java.util.List.of(classType("CsvPaymentsInputFile")), false),
+                new PipelineBranchingPlan.BranchStep(1, "Await Payment Provider", "PaymentRecord",
+                    "PaymentStatus", java.util.List.of("PaymentRecord"),
+                    java.util.List.of("ApprovedPaymentStatus", "UnapprovedPaymentStatus"),
+                    java.util.List.of(classType("PaymentRecord")), false),
+                new PipelineBranchingPlan.BranchStep(2, "Process Approved Payment Status", "ApprovedPaymentStatus",
+                    "ApprovedPaymentOutput", java.util.List.of("ApprovedPaymentStatus"),
+                    java.util.List.of("ApprovedPaymentOutput"),
+                    java.util.List.of(classType("ApprovedPaymentStatus")), false),
+                new PipelineBranchingPlan.BranchStep(3, "Process Unapproved Payment Status", "UnapprovedPaymentStatus",
+                    "UnapprovedPaymentOutput", java.util.List.of("UnapprovedPaymentStatus"),
+                    java.util.List.of("UnapprovedPaymentOutput"),
+                    java.util.List.of(classType("UnapprovedPaymentStatus")), false),
+                new PipelineBranchingPlan.BranchStep(4, "Finalize Payment Output", "PaymentOutputBranch",
+                    "PaymentOutput", java.util.List.of("ApprovedPaymentOutput", "UnapprovedPaymentOutput"),
+                    java.util.List.of("PaymentOutput"),
+                    java.util.List.of(classType("ApprovedPaymentOutput"), classType("UnapprovedPaymentOutput")), true)
+            )));
+
+        ctx.setStepModels(List.of(
+            step("ProcessCsvPaymentsInputService", "com.example.pipeline", type("CsvPaymentsInputFile"), type("PaymentRecord"), false),
+            step("AwaitPaymentProviderService", "com.example.pipeline", type("PaymentRecord"), type("PaymentStatus"), false),
+            step("ProcessApprovedPaymentStatusService", "com.example.pipeline", type("ApprovedPaymentStatus"), type("ApprovedPaymentOutput"), false),
+            step("ProcessUnapprovedPaymentStatusService", "com.example.pipeline", type("UnapprovedPaymentStatus"), type("UnapprovedPaymentOutput"), false),
+            step("FinalizePaymentOutputService", "com.example.pipeline", type("PaymentOutputBranch"), type("PaymentOutput"), false),
+            step("ProcessFinalizePaymentOutputService", "com.example.pipeline", type("PaymentOutput"), type("PublishedPaymentOutput"), false)
+        ));
+
+        new PipelineTelemetryMetadataGenerator(ctx.getProcessingEnv()).writeTelemetryMetadata(ctx);
+
+        JsonObject topology = readReplayTopologyJson();
+        findTransition(topology, "ProcessCsvPaymentsInput", "AwaitPaymentProvider");
+        findTransition(topology, "AwaitPaymentProvider", "ProcessApprovedPaymentStatus");
+        findTransition(topology, "AwaitPaymentProvider", "ProcessUnapprovedPaymentStatus");
+        findTransition(topology, "ProcessApprovedPaymentStatus", "FinalizePaymentOutput");
+        findTransition(topology, "ProcessUnapprovedPaymentStatus", "FinalizePaymentOutput");
+        findTransition(topology, "FinalizePaymentOutput", "ProcessFinalizePaymentOutput");
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> findTransition(topology, "ProcessApprovedPaymentStatus", "ProcessUnapprovedPaymentStatus"));
+    }
+
+    @Test
     void failsFastForInvalidYamlCardinality() throws IOException {
         PipelineCompilationContext ctx = buildContext();
         writeApplicationProperties("com.example.InputFolder", "com.example.PaymentOutput");
@@ -414,6 +529,14 @@ class PipelineTelemetryMetadataGeneratorTest {
 
     private TypeName type(String simpleName) {
         return ClassName.get("com.example", simpleName);
+    }
+
+    private ClassName classType(String simpleName) {
+        return ClassName.get("com.example", simpleName);
+    }
+
+    private PipelineTemplateMessage message(String name) {
+        return new PipelineTemplateMessage(name, List.of(), null);
     }
 
     private PipelineStepModel csvStep(

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/BranchRoutingRules.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/BranchRoutingRules.java
@@ -1,0 +1,26 @@
+package org.pipelineframework.config.pipeline;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared authored-YAML guardrails for branch-aware routing.
+ */
+public final class BranchRoutingRules {
+
+    public static final List<String> REJECTED_BRANCH_PREDICATE_KEYS =
+        List.of("when", "condition", "predicate", "expression");
+
+    private BranchRoutingRules() {
+    }
+
+    public static List<String> rejectedPredicateKeys(Map<?, ?> stepMap) {
+        if (stepMap == null || stepMap.isEmpty()) {
+            return List.of();
+        }
+        return REJECTED_BRANCH_PREDICATE_KEYS.stream()
+            .filter(stepMap::containsKey)
+            .sorted()
+            .toList();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/BranchRoutingRules.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/BranchRoutingRules.java
@@ -2,6 +2,7 @@ package org.pipelineframework.config.pipeline;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Shared authored-YAML guardrails for branch-aware routing.
@@ -22,5 +23,23 @@ public final class BranchRoutingRules {
             .filter(stepMap::containsKey)
             .sorted()
             .toList();
+    }
+
+    public static <X extends RuntimeException> void rejectPredicateKeys(
+        Map<?, ?> stepMap,
+        String stepName,
+        Function<String, X> exceptionFactory
+    ) {
+        List<String> rejected = rejectedPredicateKeys(stepMap);
+        if (rejected.isEmpty()) {
+            return;
+        }
+        throw exceptionFactory.apply(unsupportedPredicateRoutingMessage(stepName, rejected));
+    }
+
+    static String unsupportedPredicateRoutingMessage(String stepName, List<String> rejected) {
+        return "Step '" + (stepName == null ? "<unnamed>" : stepName)
+            + "' declares unsupported predicate-style routing keys: " + String.join(", ", rejected)
+            + ". Use type-based accepts/terminal routing only.";
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -62,7 +62,6 @@ import org.yaml.snakeyaml.Yaml;
 public class PipelineYamlConfigLoader {
     private static final Logger LOG = Logger.getLogger(PipelineYamlConfigLoader.class.getName());
     private static final int MAX_NESTING_DEPTH = 100;
-    private static final List<String> REJECTED_BRANCH_PREDICATE_KEYS = List.of("when", "condition", "predicate", "expression");
     private final Function<String, String> propertyLookup;
     private final Function<String, String> envLookup;
 
@@ -298,9 +297,7 @@ public class PipelineYamlConfigLoader {
     }
 
     private void rejectBranchPredicateKeys(Map<?, ?> stepMap, String stepName) {
-        List<String> rejected = REJECTED_BRANCH_PREDICATE_KEYS.stream()
-            .filter(stepMap::containsKey)
-            .toList();
+        List<String> rejected = BranchRoutingRules.rejectedPredicateKeys(stepMap);
         if (rejected.isEmpty()) {
             return;
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -62,6 +62,7 @@ import org.yaml.snakeyaml.Yaml;
 public class PipelineYamlConfigLoader {
     private static final Logger LOG = Logger.getLogger(PipelineYamlConfigLoader.class.getName());
     private static final int MAX_NESTING_DEPTH = 100;
+    private static final List<String> REJECTED_BRANCH_PREDICATE_KEYS = List.of("when", "condition", "predicate", "expression");
     private final Function<String, String> propertyLookup;
     private final Function<String, String> envLookup;
 
@@ -253,6 +254,7 @@ public class PipelineYamlConfigLoader {
                 continue;
             }
             String name = readString(stepMap, "name");
+            rejectBranchPredicateKeys(stepMap, name);
             String kind = readString(stepMap, "kind");
             String cardinality = readString(stepMap, "cardinality");
             String inputType = firstNonBlank(readString(stepMap, "inputTypeName"), readString(stepMap, "input"));
@@ -268,6 +270,8 @@ public class PipelineYamlConfigLoader {
             Map<String, Object> commandConfig = readCommandConfig(stepMap, name);
             String queryId = trimToNull(readString(stepMap, "query"));
             PipelineYamlQueryCapture queryCapture = readQueryCapture(stepMap, name);
+            List<String> accepts = readStringList(stepMap, "accepts");
+            boolean terminal = readBoolean(stepMap, "terminal", false);
             if (name != null && !name.isBlank()) {
                 stepInfos.add(new PipelineYamlStep(
                     name,
@@ -285,10 +289,25 @@ public class PipelineYamlConfigLoader {
                     duplicatePolicy,
                     commandConfig,
                     queryId,
-                    queryCapture));
+                    queryCapture,
+                    accepts,
+                    terminal));
             }
         }
         return stepInfos;
+    }
+
+    private void rejectBranchPredicateKeys(Map<?, ?> stepMap, String stepName) {
+        List<String> rejected = REJECTED_BRANCH_PREDICATE_KEYS.stream()
+            .filter(stepMap::containsKey)
+            .toList();
+        if (rejected.isEmpty()) {
+            return;
+        }
+        throw new IllegalArgumentException(
+            "step '" + (stepName == null ? "<unnamed>" : stepName)
+                + "' declares unsupported predicate-style routing keys: " + String.join(", ", rejected)
+                + ". Use type-based accepts/terminal routing only.");
     }
 
     private Map<String, Object> readCommandConfig(Map<?, ?> stepMap, String stepName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoader.java
@@ -297,14 +297,7 @@ public class PipelineYamlConfigLoader {
     }
 
     private void rejectBranchPredicateKeys(Map<?, ?> stepMap, String stepName) {
-        List<String> rejected = BranchRoutingRules.rejectedPredicateKeys(stepMap);
-        if (rejected.isEmpty()) {
-            return;
-        }
-        throw new IllegalArgumentException(
-            "step '" + (stepName == null ? "<unnamed>" : stepName)
-                + "' declares unsupported predicate-style routing keys: " + String.join(", ", rejected)
-                + ". Use type-based accepts/terminal routing only.");
+        BranchRoutingRules.rejectPredicateKeys(stepMap, stepName, IllegalArgumentException::new);
     }
 
     private Map<String, Object> readCommandConfig(Map<?, ?> stepMap, String stepName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlStep.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/pipeline/PipelineYamlStep.java
@@ -35,6 +35,8 @@ package org.pipelineframework.config.pipeline;
  * @param commandConfig connector configuration for command steps
  * @param queryId referenced query definition id, if this is a query step
  * @param queryCapture query capture settings, if this is a query step
+ * @param accepts optional concrete contract types accepted by this step for branch-aware routing
+ * @param terminal whether this step is the mandatory terminal merge for a branch-aware pipeline
  */
 public record PipelineYamlStep(
     String name,
@@ -52,7 +54,9 @@ public record PipelineYamlStep(
     String duplicatePolicy,
     java.util.Map<String, Object> commandConfig,
     String queryId,
-    PipelineYamlQueryCapture queryCapture
+    PipelineYamlQueryCapture queryCapture,
+    java.util.List<String> accepts,
+    boolean terminal
 ) {
     public PipelineYamlStep {
         kind = kind == null || kind.isBlank() ? "internal" : kind;
@@ -62,6 +66,7 @@ public record PipelineYamlStep(
             : java.util.List.copyOf(idempotencyKeyFields);
         commandConfig = commandConfig == null ? java.util.Map.of() : java.util.Map.copyOf(commandConfig);
         queryCapture = queryCapture == null ? new PipelineYamlQueryCapture(java.util.List.of()) : queryCapture;
+        accepts = accepts == null ? java.util.List.of() : java.util.List.copyOf(accepts);
     }
 
     public PipelineYamlStep(
@@ -79,7 +84,8 @@ public record PipelineYamlStep(
         PipelineYamlQueryCapture queryCapture
     ) {
         this(name, kind, cardinality, inputType, inboundMapper, outputType, outboundMapper, timeout,
-            copyStringList(idempotencyKeyFields), awaitConfig, null, null, null, java.util.Map.of(), queryId, queryCapture);
+            copyStringList(idempotencyKeyFields), awaitConfig, null, null, null, java.util.Map.of(), queryId, queryCapture,
+            java.util.List.of(), false);
     }
 
     public PipelineYamlStep(
@@ -90,12 +96,12 @@ public record PipelineYamlStep(
         String outboundMapper
     ) {
         this(name, "internal", "ONE_TO_ONE", inputType, inboundMapper, outputType, outboundMapper, null,
-            java.util.List.of(), null, null, null, null, java.util.Map.of(), null, null);
+            java.util.List.of(), null, null, null, null, java.util.Map.of(), null, null, java.util.List.of(), false);
     }
 
     public PipelineYamlStep(String name, String inputType, String outputType) {
         this(name, "internal", "ONE_TO_ONE", inputType, null, outputType, null, null,
-            java.util.List.of(), null, null, null, null, java.util.Map.of(), null, null);
+            java.util.List.of(), null, null, null, null, java.util.Map.of(), null, null, java.util.List.of(), false);
     }
 
     private static java.util.List<String> copyStringList(java.util.List<?> values) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
@@ -663,14 +663,7 @@ public class PipelineTemplateConfigLoader {
     }
 
     private void rejectBranchPredicateKeys(Map<?, ?> stepMap, String stepName) {
-        List<String> rejected = BranchRoutingRules.rejectedPredicateKeys(stepMap);
-        if (rejected.isEmpty()) {
-            return;
-        }
-        throw new IllegalStateException(
-            "Step '" + (stepName == null ? "<unnamed>" : stepName)
-                + "' declares unsupported predicate-style routing keys: " + String.join(", ", rejected)
-                + ". Use type-based accepts/terminal routing only.");
+        BranchRoutingRules.rejectPredicateKeys(stepMap, stepName, IllegalStateException::new);
     }
 
     private PipelineTemplateStepExecution readExecution(Object executionObj, int version, String stepName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
@@ -38,6 +38,7 @@ import java.util.logging.Logger;
 import org.pipelineframework.config.PlatformOverrideResolver;
 import org.pipelineframework.config.TransportOverrideResolver;
 import org.pipelineframework.config.boundary.PipelineCheckpointConfig;
+import org.pipelineframework.config.pipeline.BranchRoutingRules;
 import org.pipelineframework.config.boundary.PipelineInputBoundaryConfig;
 import org.pipelineframework.config.boundary.PipelineObjectFilterConfig;
 import org.pipelineframework.config.boundary.PipelineObjectIdentityConfig;
@@ -66,7 +67,6 @@ public class PipelineTemplateConfigLoader {
     private static final Logger LOG = Logger.getLogger(PipelineTemplateConfigLoader.class.getName());
     private static final int MAX_NESTING_DEPTH = 100;
     private static final String DEFAULT_TRANSPORT = "GRPC";
-    private static final Set<String> REJECTED_BRANCH_PREDICATE_KEYS = Set.of("when", "condition", "predicate", "expression");
     private static final PipelinePlatform DEFAULT_PLATFORM = PipelinePlatform.COMPUTE;
     private final Function<String, String> propertyLookup;
     private final Function<String, String> envLookup;
@@ -663,10 +663,7 @@ public class PipelineTemplateConfigLoader {
     }
 
     private void rejectBranchPredicateKeys(Map<?, ?> stepMap, String stepName) {
-        List<String> rejected = REJECTED_BRANCH_PREDICATE_KEYS.stream()
-            .filter(stepMap::containsKey)
-            .sorted()
-            .toList();
+        List<String> rejected = BranchRoutingRules.rejectedPredicateKeys(stepMap);
         if (rejected.isEmpty()) {
             return;
         }

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateConfigLoader.java
@@ -66,6 +66,7 @@ public class PipelineTemplateConfigLoader {
     private static final Logger LOG = Logger.getLogger(PipelineTemplateConfigLoader.class.getName());
     private static final int MAX_NESTING_DEPTH = 100;
     private static final String DEFAULT_TRANSPORT = "GRPC";
+    private static final Set<String> REJECTED_BRANCH_PREDICATE_KEYS = Set.of("when", "condition", "predicate", "expression");
     private static final PipelinePlatform DEFAULT_PLATFORM = PipelinePlatform.COMPUTE;
     private final Function<String, String> propertyLookup;
     private final Function<String, String> envLookup;
@@ -537,7 +538,9 @@ public class PipelineTemplateConfigLoader {
                 step.outputTypeName(),
                 outputFields,
                 step.outboundMapper(),
-                step.execution()));
+                step.execution(),
+                step.accepts(),
+                step.terminal()));
         }
         return resolved;
     }
@@ -628,6 +631,7 @@ public class PipelineTemplateConfigLoader {
                 continue;
             }
             String name = readString(stepMap, "name");
+            rejectBranchPredicateKeys(stepMap, name);
             String cardinality = readString(stepMap, "cardinality");
             String inputType = readString(stepMap, "inputTypeName");
             String outputType = readString(stepMap, "outputTypeName");
@@ -636,6 +640,12 @@ public class PipelineTemplateConfigLoader {
             String inboundMapper = readString(stepMap, "inboundMapper");
             String outboundMapper = readString(stepMap, "outboundMapper");
             PipelineTemplateStepExecution execution = readExecution(stepMap.get("execution"), version, name);
+            List<String> accepts = readStringList(stepMap, "accepts");
+            boolean terminal = readBoolean(stepMap, "terminal", false);
+            if (version < 2 && (stepMap.containsKey("accepts") || terminal)) {
+                throw new IllegalStateException(
+                    "Step '" + name + "' declares accepts/terminal, but branch-aware routing requires version: 2");
+            }
             stepInfos.add(new PipelineTemplateStep(
                 name,
                 cardinality,
@@ -645,9 +655,25 @@ public class PipelineTemplateConfigLoader {
                 outputType,
                 outputFields,
                 outboundMapper,
-                execution));
+                execution,
+                accepts,
+                terminal));
         }
         return stepInfos;
+    }
+
+    private void rejectBranchPredicateKeys(Map<?, ?> stepMap, String stepName) {
+        List<String> rejected = REJECTED_BRANCH_PREDICATE_KEYS.stream()
+            .filter(stepMap::containsKey)
+            .sorted()
+            .toList();
+        if (rejected.isEmpty()) {
+            return;
+        }
+        throw new IllegalStateException(
+            "Step '" + (stepName == null ? "<unnamed>" : stepName)
+                + "' declares unsupported predicate-style routing keys: " + String.join(", ", rejected)
+                + ". Use type-based accepts/terminal routing only.");
     }
 
     private PipelineTemplateStepExecution readExecution(Object executionObj, int version, String stepName) {

--- a/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateStep.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/config/template/PipelineTemplateStep.java
@@ -30,6 +30,8 @@ import java.util.List;
  * @param outputFields the output field definitions
  * @param outboundMapper optional outbound mapper for internal service steps
  * @param execution optional execution metadata for local/remote step invocation
+ * @param accepts optional concrete contract types accepted by this step for branch-aware routing
+ * @param terminal whether this step is the mandatory terminal merge for a branch-aware pipeline
  */
 public record PipelineTemplateStep(
     String name,
@@ -40,8 +42,14 @@ public record PipelineTemplateStep(
     String outputTypeName,
     List<PipelineTemplateField> outputFields,
     String outboundMapper,
-    PipelineTemplateStepExecution execution
+    PipelineTemplateStepExecution execution,
+    List<String> accepts,
+    boolean terminal
 ) {
+    public PipelineTemplateStep {
+        accepts = accepts == null ? List.of() : List.copyOf(accepts);
+    }
+
     public PipelineTemplateStep(
         String name,
         String cardinality,
@@ -50,7 +58,7 @@ public record PipelineTemplateStep(
         String outputTypeName,
         List<PipelineTemplateField> outputFields
     ) {
-        this(name, cardinality, inputTypeName, inputFields, null, outputTypeName, outputFields, null, null);
+        this(name, cardinality, inputTypeName, inputFields, null, outputTypeName, outputFields, null, null, List.of(), false);
     }
 
     public PipelineTemplateStep(
@@ -62,7 +70,7 @@ public record PipelineTemplateStep(
         List<PipelineTemplateField> outputFields,
         PipelineTemplateStepExecution execution
     ) {
-        this(name, cardinality, inputTypeName, inputFields, null, outputTypeName, outputFields, null, execution);
+        this(name, cardinality, inputTypeName, inputFields, null, outputTypeName, outputFields, null, execution, List.of(), false);
     }
 
     public PipelineTemplateStep(
@@ -75,6 +83,6 @@ public record PipelineTemplateStep(
         List<PipelineTemplateField> outputFields,
         String outboundMapper
     ) {
-        this(name, cardinality, inputTypeName, inputFields, inboundMapper, outputTypeName, outputFields, outboundMapper, null);
+        this(name, cardinality, inputTypeName, inputFields, inboundMapper, outputTypeName, outputFields, outboundMapper, null, List.of(), false);
     }
 }

--- a/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/pipeline/PipelineYamlConfigLoaderTest.java
@@ -259,6 +259,44 @@ class PipelineYamlConfigLoaderTest {
     }
 
     @Test
+    void loadsBranchRoutingAcceptsAndTerminalFields() {
+        PipelineYamlConfig config = new PipelineYamlConfigLoader().load(new StringReader("""
+            basePackage: "com.example"
+            transport: "GRPC"
+            platform: "COMPUTE"
+            steps:
+              - name: "Finalize"
+                inputTypeName: "com.example.OrderCompletion"
+                outputTypeName: "com.example.FinalizedOrder"
+                accepts:
+                  - "StockReserved"
+                  - "LicenseProvisioned"
+                terminal: true
+            """));
+
+        PipelineYamlStep step = config.steps().getFirst();
+        assertEquals(List.of("StockReserved", "LicenseProvisioned"), step.accepts());
+        assertTrue(step.terminal());
+    }
+
+    @Test
+    void rejectsPredicateStyleRoutingKeys() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new PipelineYamlConfigLoader().load(new StringReader("""
+                basePackage: "com.example"
+                transport: "GRPC"
+                steps:
+                  - name: "Reserve Stock"
+                    inputTypeName: "com.example.PhysicalOrder"
+                    outputTypeName: "com.example.StockReserved"
+                    when: "country == 'ES'"
+                """)));
+
+        assertTrue(exception.getMessage().contains("unsupported predicate-style routing keys"));
+        assertTrue(exception.getMessage().contains("when"));
+    }
+
+    @Test
     void rejectsNonPositiveObjectSourcePollInterval() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new PipelineYamlConfigLoader().load(new StringReader("""

--- a/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/config/template/PipelineTemplateConfigLoaderTest.java
@@ -269,6 +269,74 @@ class PipelineTemplateConfigLoaderTest {
     }
 
     @Test
+    void loadsBranchRoutingAcceptsAndTerminalFields() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Order Routing"
+            basePackage: "com.example.order"
+            transport: "GRPC"
+            messages:
+              StockReserved: { fields: [] }
+              LicenseProvisioned: { fields: [] }
+              FinalizedOrder: { fields: [] }
+            unions:
+              OrderCompletion:
+                variants:
+                  stock:
+                    type: "StockReserved"
+                    number: 1
+                  license:
+                    type: "LicenseProvisioned"
+                    number: 2
+            steps:
+              - name: "Finalize"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "OrderCompletion"
+                outputTypeName: "FinalizedOrder"
+                accepts:
+                  - "StockReserved"
+                  - "LicenseProvisioned"
+                terminal: true
+            """;
+        Path configPath = tempDir.resolve("pipeline-config-branch-routing.yaml");
+        Files.writeString(configPath, yaml);
+
+        PipelineTemplateConfig config = new PipelineTemplateConfigLoader().load(configPath);
+
+        PipelineTemplateStep step = config.steps().getFirst();
+        assertEquals(List.of("StockReserved", "LicenseProvisioned"), step.accepts());
+        assertTrue(step.terminal());
+    }
+
+    @Test
+    void rejectsPredicateStyleRoutingKeys() throws Exception {
+        String yaml = """
+            version: 2
+            appName: "Order Routing"
+            basePackage: "com.example.order"
+            transport: "GRPC"
+            messages:
+              PhysicalOrder: { fields: [] }
+              StockReserved: { fields: [] }
+            steps:
+              - name: "Reserve Stock"
+                cardinality: "ONE_TO_ONE"
+                inputTypeName: "PhysicalOrder"
+                outputTypeName: "StockReserved"
+                when: "country == 'ES'"
+            """;
+        Path configPath = tempDir.resolve("pipeline-config-predicate.yaml");
+        Files.writeString(configPath, yaml);
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> new PipelineTemplateConfigLoader().load(configPath));
+
+        assertTrue(exception.getMessage().contains("unsupported predicate-style routing keys"));
+        assertTrue(exception.getMessage().contains("when"));
+    }
+
+    @Test
     void stillLoadsLegacyTemplateFieldDefinitions() throws Exception {
         String yaml = """
             appName: "Legacy Test App"


### PR DESCRIPTION
## Summary
- add branch-aware compiler planning and validation for union-routed linear pipelines
- emit branching metadata for runtime applicability and terminal-merge enforcement
- extend template/yaml config models with `accepts` and `terminal`

## Scope
- `framework/deployment/**`
- minimal shared config-model surface in `framework/runtime/config/**` required by deployment parsing/schema export

## Validation
- `./mvnw -f framework/pom.xml -pl deployment -am -Dtest=OperatorLinkValidationBuildStepsTest,AspectExpansionProcessorTest,OrchestratorClientGenerationTest,StepDefinitionParserTest,PipelineBranchRoutingPlannerTest,PipelineTemplateSchemaExporterTest,PipelineBranchingMetadataGeneratorTest,PipelineTelemetryMetadataGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="$PWD/.m2/repository"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branch-aware routing for pipeline steps with new `accepts` and `terminal` step controls.
  * Extended pipeline YAML and template support for `accepts`/`terminal` and updated the template schema accordingly.
  * Generated branching metadata (`branching.json`) and updated replay-topology primary transitions for branch-aware pipelines.

* **Bug Fixes**
  * Improved step targeting/matching to be more flexible using normalization-based comparisons.
  * Branch-aware pipelines now skip adjacent operator link validation when appropriate.

* **Tests**
  * Added/expanded tests for parsing, validation, schema export, branching-plan planning, and metadata generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->