### PR TITLE
Refactor segment boundary ledger cohesion

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryFactFactory.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryFactFactory.java
@@ -1,0 +1,249 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.orchestrator.CreateExecutionResult;
+import org.pipelineframework.orchestrator.ExecutionCreateCommand;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+import org.pipelineframework.orchestrator.TransitionResultEnvelope;
+
+final class SegmentBoundaryFactFactory {
+
+    List<ControlPlaneFact> runSubmitted(CreateExecutionResult created, ExecutionCreateCommand command) {
+        ExecutionRecord<Object, Object> record = created.record();
+        return List.of(new ControlPlaneFact.RunSubmitted(
+            record.tenantId(),
+            record.executionId(),
+            record.executionKey(),
+            record.pipelineId(),
+            record.contractVersion(),
+            record.releaseVersion(),
+            record.resultShape(),
+            segmentId(record.executionId(), record.currentStepIndex()),
+            record.currentStepIndex(),
+            -1,
+            command.inputPayload(),
+            record.ttlEpochS()));
+    }
+
+    List<ControlPlaneFact> segmentAttemptStarted(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey
+    ) {
+        return List.of(new ControlPlaneFact.SegmentAttemptStarted(
+            record.tenantId(),
+            record.executionId(),
+            segmentId(record),
+            attemptId(record, transitionKey),
+            record.attempt()));
+    }
+
+    List<ControlPlaneFact> segmentCompleted(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionResultEnvelope result
+    ) {
+        return List.of(new ControlPlaneFact.SegmentCompleted(
+            record.tenantId(),
+            record.executionId(),
+            segmentId(record),
+            attemptId(record, transitionKey),
+            result.coordinatorOutputItems(),
+            true));
+    }
+
+    List<ControlPlaneFact> segmentSuspended(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        TransitionAwaitSuspension suspension
+    ) {
+        List<ControlPlaneFact> facts = new ArrayList<>();
+        AwaitUnitRecord unit = suspension.unit();
+        facts.add(new ControlPlaneFact.SegmentSuspended(
+            record.tenantId(),
+            record.executionId(),
+            segmentId(record),
+            attemptId(record, transitionKey),
+            suspension.unitId(),
+            BoundaryKind.AWAIT,
+            suspension.stepIndex(),
+            unit == null ? null : unit.expectedItemCount()));
+        for (AwaitInteractionRecord interaction : suspension.interactions()) {
+            facts.add(boundaryInteractionDispatched(record.executionId(), interaction));
+        }
+        if (unit != null && unit.dispatchComplete() && unit.expectedItemCount() != null) {
+            facts.add(new ControlPlaneFact.BoundaryDispatchCompleted(
+                unit.tenantId(),
+                unit.executionId(),
+                unit.unitId(),
+                unit.expectedItemCount()));
+        }
+        return facts;
+    }
+
+    List<ControlPlaneFact> boundaryCompletionAdmitted(
+        AwaitInteractionRecord record,
+        AwaitUnitRecord unit
+    ) {
+        return List.of(BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
+            record.tenantId(),
+            record.executionId(),
+            unit.unitId(),
+            BoundaryKind.AWAIT,
+            record.interactionId(),
+            completionIdempotencyKey(record),
+            record.responsePayload())));
+    }
+
+    List<ControlPlaneFact> interactionTimedOut(AwaitInteractionRecord record) {
+        return List.of(new ControlPlaneFact.InteractionTimedOut(
+            record.tenantId(),
+            record.executionId(),
+            record.unitId(),
+            record.interactionId(),
+            "Await interaction timed out: " + record.interactionId()));
+    }
+
+    List<ControlPlaneFact> continuationSegmentCreated(
+        ExecutionRecord<Object, Object> parent,
+        String boundaryUnitId,
+        String segmentId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload
+    ) {
+        return continuationSegmentCreated(
+            parent.tenantId(),
+            parent.executionId(),
+            segmentId(parent),
+            boundaryUnitId,
+            segmentId,
+            startStepIndex,
+            stopBeforeStepIndex,
+            inputPayload);
+    }
+
+    List<ControlPlaneFact> continuationSegmentCreated(
+        String tenantId,
+        String runId,
+        String sourceSegmentId,
+        String boundaryUnitId,
+        String segmentId,
+        int startStepIndex,
+        int stopBeforeStepIndex,
+        Object inputPayload
+    ) {
+        return List.of(new ControlPlaneFact.ContinuationSegmentCreated(
+            tenantId,
+            runId,
+            sourceSegmentId,
+            segmentId,
+            boundaryUnitId,
+            startStepIndex,
+            stopBeforeStepIndex,
+            inputPayload));
+    }
+
+    List<ControlPlaneFact> runSucceeded(
+        ExecutionRecord<Object, Object> record,
+        Object resultPayload
+    ) {
+        return List.of(new ControlPlaneFact.RunSucceeded(
+            record.tenantId(),
+            record.executionId(),
+            segmentId(record),
+            resultPayload));
+    }
+
+    List<ControlPlaneFact> runFailed(
+        ExecutionRecord<Object, Object> record,
+        String errorCode,
+        String errorMessage
+    ) {
+        return List.of(new ControlPlaneFact.RunFailed(
+            record.tenantId(),
+            record.executionId(),
+            segmentId(record),
+            errorCode == null || errorCode.isBlank() ? "EXECUTION_FAILED" : errorCode,
+            errorMessage == null ? "" : errorMessage));
+    }
+
+    SegmentTerminalPublicationFacts terminalPublicationFacts(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        String publicationKind
+    ) {
+        String publicationId = record.executionId() + ":terminal-output:" + publicationKind(publicationKind);
+        String idempotencyKey = publicationId + ":terminal-publication";
+        return new SegmentTerminalPublicationFacts(
+            publicationId,
+            idempotencyKey,
+            new ControlPlaneFact.TerminalPublicationPrepared(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                publicationId,
+                idempotencyKey),
+            new ControlPlaneFact.TerminalPublicationCompleted(
+                record.tenantId(),
+                record.executionId(),
+                segmentId(record),
+                publicationId,
+                idempotencyKey));
+    }
+
+    static String segmentId(ExecutionRecord<Object, Object> record) {
+        return segmentId(record.executionId(), record.currentStepIndex());
+    }
+
+    static String segmentId(String executionId, int stepIndex) {
+        return executionId + ":segment:" + stepIndex;
+    }
+
+    static String itemContinuationSegmentId(String executionId, String unitId, int itemIndex) {
+        return executionId + ":segment:await-item:" + unitId + ":" + itemIndex;
+    }
+
+    private static ControlPlaneFact.BoundaryInteractionDispatched boundaryInteractionDispatched(
+        String runId,
+        AwaitInteractionRecord interaction
+    ) {
+        return new ControlPlaneFact.BoundaryInteractionDispatched(
+            interaction.tenantId(),
+            runId,
+            interaction.unitId(),
+            BoundaryKind.AWAIT,
+            interaction.interactionId(),
+            interaction.correlationId(),
+            interaction.idempotencyKey(),
+            interaction.itemIndex(),
+            interaction.requestPayload(),
+            interaction.transportType(),
+            interaction.deadlineEpochMs());
+    }
+
+    private static String completionIdempotencyKey(AwaitInteractionRecord record) {
+        if (record.itemIndex() != null) {
+            return "item:" + record.itemIndex();
+        }
+        return record.idempotencyKey();
+    }
+
+    private static String attemptId(ExecutionRecord<Object, Object> record, String transitionKey) {
+        if (transitionKey != null && !transitionKey.isBlank()) {
+            return transitionKey;
+        }
+        return record.executionId() + ":" + record.currentStepIndex() + ":" + record.attempt();
+    }
+
+    private static String publicationKind(String publicationKind) {
+        if (publicationKind == null || publicationKind.isBlank()) {
+            throw new IllegalArgumentException("publicationKind must not be blank");
+        }
+        return publicationKind.trim();
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryJournalAppender.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryJournalAppender.java
@@ -1,0 +1,109 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+
+final class SegmentBoundaryJournalAppender {
+
+    private static final Logger LOG = Logger.getLogger(SegmentBoundaryJournalAppender.class);
+    static final int MAX_APPEND_ATTEMPTS = 3;
+
+    private final Supplier<Optional<ControlPlaneJournal>> journals;
+
+    SegmentBoundaryJournalAppender(Supplier<Optional<ControlPlaneJournal>> journals) {
+        this.journals = journals;
+    }
+
+    Uni<Void> appendFactsOrThrowBuildFailure(
+        String tenantId,
+        String runId,
+        Supplier<List<ControlPlaneFact>> facts,
+        long nowEpochMs
+    ) {
+        return appendFactsWithBestEffortPersistence(tenantId, runId, facts.get(), nowEpochMs);
+    }
+
+    Uni<Void> appendFactsBestEffort(
+        String tenantId,
+        String runId,
+        Supplier<List<ControlPlaneFact>> facts,
+        long nowEpochMs
+    ) {
+        try {
+            return appendFactsWithBestEffortPersistence(tenantId, runId, facts.get(), nowEpochMs);
+        } catch (IllegalArgumentException failure) {
+            LOG.warnf(
+                failure,
+                "Failed building queue-async control-plane facts tenant=%s runId=%s",
+                tenantId,
+                runId);
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    Optional<ControlPlaneJournal> journal() {
+        return journals.get();
+    }
+
+    Uni<ControlPlaneAppendResult> appendRequired(
+        ControlPlaneJournal journal,
+        String tenantId,
+        String runId,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs
+    ) {
+        return appendWithRetry(journal, tenantId, runId, List.copyOf(facts), nowEpochMs, 1);
+    }
+
+    private Uni<Void> appendFactsWithBestEffortPersistence(
+        String tenantId,
+        String runId,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs
+    ) {
+        Optional<ControlPlaneJournal> journal = journal();
+        if (journal.isEmpty() || facts == null || facts.isEmpty()) {
+            return Uni.createFrom().voidItem();
+        }
+        return appendRequired(journal.get(), tenantId, runId, facts, nowEpochMs)
+            .replaceWithVoid()
+            .onFailure().recoverWithUni(failure -> {
+                LOG.warnf(
+                    failure,
+                    "Failed appending queue-async control-plane facts tenant=%s runId=%s",
+                    tenantId,
+                    runId);
+                return Uni.createFrom().voidItem();
+            });
+    }
+
+    private Uni<ControlPlaneAppendResult> appendWithRetry(
+        ControlPlaneJournal journal,
+        String tenantId,
+        String runId,
+        List<ControlPlaneFact> facts,
+        long nowEpochMs,
+        int attempt
+    ) {
+        return journal.projection(tenantId, runId)
+            .onItem().transformToUni(projection -> {
+                List<ControlPlaneFact> missingFacts = facts.stream()
+                    .filter(fact -> !projection.factKeys().contains(fact.factKey()))
+                    .toList();
+                if (missingFacts.isEmpty()) {
+                    return Uni.createFrom().item(new ControlPlaneAppendResult(projection, List.of()));
+                }
+                return journal.append(tenantId, runId, projection.version(), missingFacts, nowEpochMs);
+            })
+            .onFailure(ControlPlaneAppendConflictException.class).recoverWithUni(failure -> {
+                if (attempt >= MAX_APPEND_ATTEMPTS) {
+                    return Uni.createFrom().failure(failure);
+                }
+                return appendWithRetry(journal, tenantId, runId, facts, nowEpochMs, attempt + 1);
+            });
+    }
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryLedger.java
@@ -1,20 +1,16 @@
 package org.pipelineframework.orchestrator.controlplane;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import io.smallrye.mutiny.Uni;
-import org.jboss.logging.Logger;
 import org.pipelineframework.awaitable.AwaitInteractionRecord;
 import org.pipelineframework.awaitable.AwaitUnitRecord;
 import org.pipelineframework.orchestrator.CreateExecutionResult;
 import org.pipelineframework.orchestrator.ExecutionCreateCommand;
-import org.pipelineframework.orchestrator.ExecutionInputSnapshot;
 import org.pipelineframework.orchestrator.ExecutionRecord;
 import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
 import org.pipelineframework.orchestrator.TransitionResultEnvelope;
@@ -25,13 +21,13 @@ import org.pipelineframework.orchestrator.TransitionResultEnvelope;
 @ApplicationScoped
 public class SegmentBoundaryLedger {
 
-    private static final Logger LOG = Logger.getLogger(SegmentBoundaryLedger.class);
-    private static final int MAX_APPEND_ATTEMPTS = 3;
-
     @Inject
     Instance<ControlPlaneJournal> journals;
 
     private final ControlPlaneJournal explicitJournal;
+    private final SegmentBoundaryFactFactory facts;
+    private final SegmentBoundaryJournalAppender appender;
+    private final TerminalPublicationLedger terminalPublications;
 
     public SegmentBoundaryLedger() {
         this(null);
@@ -39,6 +35,9 @@ public class SegmentBoundaryLedger {
 
     public SegmentBoundaryLedger(ControlPlaneJournal journal) {
         this.explicitJournal = journal;
+        this.facts = new SegmentBoundaryFactFactory();
+        this.appender = new SegmentBoundaryJournalAppender(this::journal);
+        this.terminalPublications = new TerminalPublicationLedger(this::journal, appender, facts);
     }
 
     public Uni<Void> recordRunSubmitted(
@@ -50,22 +49,10 @@ public class SegmentBoundaryLedger {
             return Uni.createFrom().voidItem();
         }
         ExecutionRecord<Object, Object> record = created.record();
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.RunSubmitted(
-                record.tenantId(),
-                record.executionId(),
-                record.executionKey(),
-                record.pipelineId(),
-                record.contractVersion(),
-                record.releaseVersion(),
-                record.resultShape(),
-                segmentId(record.executionId(), record.currentStepIndex()),
-                record.currentStepIndex(),
-                -1,
-                command.inputPayload(),
-                record.ttlEpochS())),
+            () -> facts.runSubmitted(created, command),
             nowEpochMs);
     }
 
@@ -77,15 +64,10 @@ public class SegmentBoundaryLedger {
         if (record == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.SegmentAttemptStarted(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                attemptId(record, transitionKey),
-                record.attempt())),
+            () -> facts.segmentAttemptStarted(record, transitionKey),
             nowEpochMs);
     }
 
@@ -98,16 +80,10 @@ public class SegmentBoundaryLedger {
         if (record == null || result == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBestEffortBuilt(
+        return appender.appendFactsBestEffort(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.SegmentCompleted(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                attemptId(record, transitionKey),
-                result.coordinatorOutputItems(),
-                true)),
+            () -> facts.segmentCompleted(record, transitionKey, result),
             nowEpochMs);
     }
 
@@ -120,30 +96,11 @@ public class SegmentBoundaryLedger {
         if (record == null || suspension == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(record.tenantId(), record.executionId(), () -> {
-            List<ControlPlaneFact> facts = new ArrayList<>();
-            AwaitUnitRecord unit = suspension.unit();
-            facts.add(new ControlPlaneFact.SegmentSuspended(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                attemptId(record, transitionKey),
-                suspension.unitId(),
-                BoundaryKind.AWAIT,
-                suspension.stepIndex(),
-                unit == null ? null : unit.expectedItemCount()));
-            for (AwaitInteractionRecord interaction : suspension.interactions()) {
-                facts.add(boundaryInteractionDispatched(record.executionId(), interaction));
-            }
-            if (unit != null && unit.dispatchComplete() && unit.expectedItemCount() != null) {
-                facts.add(new ControlPlaneFact.BoundaryDispatchCompleted(
-                    unit.tenantId(),
-                    unit.executionId(),
-                    unit.unitId(),
-                    unit.expectedItemCount()));
-            }
-            return facts;
-        }, nowEpochMs);
+        return appender.appendFactsOrThrowBuildFailure(
+            record.tenantId(),
+            record.executionId(),
+            () -> facts.segmentSuspended(record, transitionKey, suspension),
+            nowEpochMs);
     }
 
     public Uni<Void> recordBoundaryCompletionAdmitted(
@@ -154,17 +111,10 @@ public class SegmentBoundaryLedger {
         if (record == null || unit == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(BoundaryAdmissionFacts.completion(new BoundaryAdmissionRequest(
-                record.tenantId(),
-                record.executionId(),
-                unit.unitId(),
-                BoundaryKind.AWAIT,
-                record.interactionId(),
-                completionIdempotencyKey(record),
-                record.responsePayload()))),
+            () -> facts.boundaryCompletionAdmitted(record, unit),
             nowEpochMs);
     }
 
@@ -172,15 +122,10 @@ public class SegmentBoundaryLedger {
         if (record == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.InteractionTimedOut(
-                record.tenantId(),
-                record.executionId(),
-                record.unitId(),
-                record.interactionId(),
-                "Await interaction timed out: " + record.interactionId())),
+            () -> facts.interactionTimedOut(record),
             nowEpochMs);
     }
 
@@ -219,18 +164,16 @@ public class SegmentBoundaryLedger {
             || segmentId == null || segmentId.isBlank()) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             parent.tenantId(),
             parent.executionId(),
-            () -> List.of(new ControlPlaneFact.ContinuationSegmentCreated(
-                parent.tenantId(),
-                parent.executionId(),
-                segmentId(parent),
-                segmentId,
+            () -> facts.continuationSegmentCreated(
+                parent,
                 boundaryUnitId,
+                segmentId,
                 startStepIndex,
                 stopBeforeStepIndex,
-                inputPayload)),
+                inputPayload),
             nowEpochMs);
     }
 
@@ -252,18 +195,18 @@ public class SegmentBoundaryLedger {
             || segmentId == null || segmentId.isBlank()) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             tenantId,
             runId,
-            () -> List.of(new ControlPlaneFact.ContinuationSegmentCreated(
+            () -> facts.continuationSegmentCreated(
                 tenantId,
                 runId,
                 sourceSegmentId,
-                segmentId,
                 boundaryUnitId,
+                segmentId,
                 startStepIndex,
                 stopBeforeStepIndex,
-                inputPayload)),
+                inputPayload),
             nowEpochMs);
     }
 
@@ -281,16 +224,7 @@ public class SegmentBoundaryLedger {
         String publicationKind,
         long nowEpochMs
     ) {
-        if (record == null) {
-            return Uni.createFrom().item(TerminalPublicationClaim.untracked(null, null));
-        }
-        String kind = publicationKind(publicationKind);
-        TerminalPublicationFacts facts = terminalPublicationFacts(record, transitionKey, kind);
-        Optional<ControlPlaneJournal> journal = journal();
-        if (journal.isEmpty()) {
-            return Uni.createFrom().item(TerminalPublicationClaim.untracked(facts.publicationId(), facts.idempotencyKey()));
-        }
-        return claimTerminalPublication(journal.get(), record, facts, nowEpochMs, 1);
+        return terminalPublications.claim(record, transitionKey, publicationKind, nowEpochMs);
     }
 
     public Uni<Void> completeTerminalPublication(
@@ -299,22 +233,7 @@ public class SegmentBoundaryLedger {
         String publicationKind,
         long nowEpochMs
     ) {
-        if (record == null) {
-            return Uni.createFrom().voidItem();
-        }
-        Optional<ControlPlaneJournal> journal = journal();
-        if (journal.isEmpty()) {
-            return Uni.createFrom().voidItem();
-        }
-        TerminalPublicationFacts facts = terminalPublicationFacts(record, transitionKey, publicationKind(publicationKind));
-        return appendWithRetry(
-            journal.get(),
-            record.tenantId(),
-            record.executionId(),
-            List.of(facts.completed()),
-            nowEpochMs,
-            1)
-            .replaceWithVoid();
+        return terminalPublications.complete(record, transitionKey, publicationKind, nowEpochMs);
     }
 
     public Uni<Void> recordRunSucceeded(
@@ -325,14 +244,10 @@ public class SegmentBoundaryLedger {
         if (record == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBestEffortBuilt(
+        return appender.appendFactsBestEffort(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.RunSucceeded(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                resultPayload)),
+            () -> facts.runSucceeded(record, resultPayload),
             nowEpochMs);
     }
 
@@ -345,138 +260,23 @@ public class SegmentBoundaryLedger {
         if (record == null) {
             return Uni.createFrom().voidItem();
         }
-        return appendBuilt(
+        return appender.appendFactsOrThrowBuildFailure(
             record.tenantId(),
             record.executionId(),
-            () -> List.of(new ControlPlaneFact.RunFailed(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                errorCode == null || errorCode.isBlank() ? "EXECUTION_FAILED" : errorCode,
-                errorMessage == null ? "" : errorMessage)),
+            () -> facts.runFailed(record, errorCode, errorMessage),
             nowEpochMs);
     }
 
     public static String segmentId(ExecutionRecord<Object, Object> record) {
-        return segmentId(record.executionId(), record.currentStepIndex());
+        return SegmentBoundaryFactFactory.segmentId(record);
     }
 
     public static String segmentId(String executionId, int stepIndex) {
-        return executionId + ":segment:" + stepIndex;
+        return SegmentBoundaryFactFactory.segmentId(executionId, stepIndex);
     }
 
     public static String itemContinuationSegmentId(String executionId, String unitId, int itemIndex) {
-        return executionId + ":segment:await-item:" + unitId + ":" + itemIndex;
-    }
-
-    private Uni<Void> append(
-        String tenantId,
-        String runId,
-        List<ControlPlaneFact> facts,
-        long nowEpochMs
-    ) {
-        Optional<ControlPlaneJournal> journal = journal();
-        if (journal.isEmpty() || facts == null || facts.isEmpty()) {
-            return Uni.createFrom().voidItem();
-        }
-        return appendWithRetry(journal.get(), tenantId, runId, List.copyOf(facts), nowEpochMs, 1)
-            .replaceWithVoid()
-            .onFailure().recoverWithUni(failure -> {
-                LOG.warnf(
-                    failure,
-                    "Failed appending queue-async control-plane facts tenant=%s runId=%s",
-                    tenantId,
-                    runId);
-                return Uni.createFrom().voidItem();
-            });
-    }
-
-    private Uni<Void> appendBuilt(
-        String tenantId,
-        String runId,
-        Supplier<List<ControlPlaneFact>> facts,
-        long nowEpochMs
-    ) {
-        return append(tenantId, runId, facts.get(), nowEpochMs);
-    }
-
-    private Uni<Void> appendBestEffortBuilt(
-        String tenantId,
-        String runId,
-        Supplier<List<ControlPlaneFact>> facts,
-        long nowEpochMs
-    ) {
-        try {
-            return append(tenantId, runId, facts.get(), nowEpochMs);
-        } catch (IllegalArgumentException failure) {
-            LOG.warnf(
-                failure,
-                "Failed building queue-async control-plane facts tenant=%s runId=%s",
-                tenantId,
-                runId);
-            return Uni.createFrom().voidItem();
-        }
-    }
-
-    private Uni<ControlPlaneAppendResult> appendWithRetry(
-        ControlPlaneJournal journal,
-        String tenantId,
-        String runId,
-        List<ControlPlaneFact> facts,
-        long nowEpochMs,
-        int attempt
-    ) {
-        return journal.projection(tenantId, runId)
-            .onItem().transformToUni(projection -> {
-                List<ControlPlaneFact> missingFacts = facts.stream()
-                    .filter(fact -> !projection.factKeys().contains(fact.factKey()))
-                    .toList();
-                if (missingFacts.isEmpty()) {
-                    return Uni.createFrom().item(new ControlPlaneAppendResult(projection, List.of()));
-                }
-                return journal.append(tenantId, runId, projection.version(), missingFacts, nowEpochMs);
-            })
-            .onFailure(ControlPlaneAppendConflictException.class).recoverWithUni(failure -> {
-                if (attempt >= MAX_APPEND_ATTEMPTS) {
-                    return Uni.createFrom().failure(failure);
-                }
-                return appendWithRetry(journal, tenantId, runId, facts, nowEpochMs, attempt + 1);
-            });
-    }
-
-    private Uni<TerminalPublicationClaim> claimTerminalPublication(
-        ControlPlaneJournal journal,
-        ExecutionRecord<Object, Object> record,
-        TerminalPublicationFacts facts,
-        long nowEpochMs,
-        int attempt
-    ) {
-        return journal.projection(record.tenantId(), record.executionId())
-            .onItem().transformToUni(projection -> {
-                if (projection.terminalPublicationKeys().contains(facts.completed().factKey())) {
-                    return Uni.createFrom().item(toClaim(
-                        TerminalPublicationClaim.Status.ALREADY_COMPLETED,
-                        facts));
-                }
-                if (projection.terminalPublicationPreparedKeys().contains(facts.prepared().factKey())) {
-                    return Uni.createFrom().item(toClaim(
-                        TerminalPublicationClaim.Status.PREPARED_RETRY,
-                        facts));
-                }
-                return journal.append(
-                        record.tenantId(),
-                        record.executionId(),
-                        projection.version(),
-                        List.of(facts.prepared()),
-                        nowEpochMs)
-                    .onItem().transform(ignored -> toClaim(TerminalPublicationClaim.Status.CLAIMED, facts));
-            })
-            .onFailure(ControlPlaneAppendConflictException.class).recoverWithUni(failure -> {
-                if (attempt >= MAX_APPEND_ATTEMPTS) {
-                    return Uni.createFrom().failure(failure);
-                }
-                return claimTerminalPublication(journal, record, facts, nowEpochMs, attempt + 1);
-            });
+        return SegmentBoundaryFactFactory.itemContinuationSegmentId(executionId, unitId, itemIndex);
     }
 
     private Optional<ControlPlaneJournal> journal() {
@@ -487,88 +287,5 @@ public class SegmentBoundaryLedger {
             return Optional.empty();
         }
         return Optional.of(journals.get());
-    }
-
-    private static ControlPlaneFact.BoundaryInteractionDispatched boundaryInteractionDispatched(
-        String runId,
-        AwaitInteractionRecord interaction
-    ) {
-        return new ControlPlaneFact.BoundaryInteractionDispatched(
-            interaction.tenantId(),
-            runId,
-            interaction.unitId(),
-            BoundaryKind.AWAIT,
-            interaction.interactionId(),
-            interaction.correlationId(),
-            interaction.idempotencyKey(),
-            interaction.itemIndex(),
-            interaction.requestPayload(),
-            interaction.transportType(),
-            interaction.deadlineEpochMs());
-    }
-
-    private static String completionIdempotencyKey(AwaitInteractionRecord record) {
-        if (record.itemIndex() != null) {
-            return "item:" + record.itemIndex();
-        }
-        return record.idempotencyKey();
-    }
-
-    private static String attemptId(ExecutionRecord<Object, Object> record, String transitionKey) {
-        if (transitionKey != null && !transitionKey.isBlank()) {
-            return transitionKey;
-        }
-        return record.executionId() + ":" + record.currentStepIndex() + ":" + record.attempt();
-    }
-
-    private static TerminalPublicationClaim toClaim(
-        TerminalPublicationClaim.Status status,
-        TerminalPublicationFacts facts
-    ) {
-        return new TerminalPublicationClaim(
-            status,
-            facts.publicationId(),
-            facts.idempotencyKey(),
-            facts.prepared().factKey(),
-            facts.completed().factKey());
-    }
-
-    private static TerminalPublicationFacts terminalPublicationFacts(
-        ExecutionRecord<Object, Object> record,
-        String transitionKey,
-        String publicationKind
-    ) {
-        String publicationId = record.executionId() + ":terminal-output:" + publicationKind;
-        String idempotencyKey = publicationId + ":terminal-publication";
-        return new TerminalPublicationFacts(
-            publicationId,
-            idempotencyKey,
-            new ControlPlaneFact.TerminalPublicationPrepared(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                publicationId,
-                idempotencyKey),
-            new ControlPlaneFact.TerminalPublicationCompleted(
-                record.tenantId(),
-                record.executionId(),
-                segmentId(record),
-                publicationId,
-                idempotencyKey));
-    }
-
-    private static String publicationKind(String publicationKind) {
-        if (publicationKind == null || publicationKind.isBlank()) {
-            throw new IllegalArgumentException("publicationKind must not be blank");
-        }
-        return publicationKind.trim();
-    }
-
-    private record TerminalPublicationFacts(
-        String publicationId,
-        String idempotencyKey,
-        ControlPlaneFact.TerminalPublicationPrepared prepared,
-        ControlPlaneFact.TerminalPublicationCompleted completed
-    ) {
     }
 }

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentTerminalPublicationFacts.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/SegmentTerminalPublicationFacts.java
@@ -1,0 +1,9 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+record SegmentTerminalPublicationFacts(
+    String publicationId,
+    String idempotencyKey,
+    ControlPlaneFact.TerminalPublicationPrepared prepared,
+    ControlPlaneFact.TerminalPublicationCompleted completed
+) {
+}

--- a/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/TerminalPublicationLedger.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/orchestrator/controlplane/TerminalPublicationLedger.java
@@ -1,0 +1,120 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+
+final class TerminalPublicationLedger {
+
+    private final Supplier<Optional<ControlPlaneJournal>> journals;
+    private final SegmentBoundaryJournalAppender appender;
+    private final SegmentBoundaryFactFactory facts;
+
+    TerminalPublicationLedger(
+        Supplier<Optional<ControlPlaneJournal>> journals,
+        SegmentBoundaryJournalAppender appender,
+        SegmentBoundaryFactFactory facts
+    ) {
+        this.journals = journals;
+        this.appender = appender;
+        this.facts = facts;
+    }
+
+    Uni<TerminalPublicationClaim> claim(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        String publicationKind,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().item(TerminalPublicationClaim.untracked(null, null));
+        }
+        SegmentTerminalPublicationFacts publicationFacts = facts.terminalPublicationFacts(
+            record,
+            transitionKey,
+            publicationKind);
+        Optional<ControlPlaneJournal> journal = journals.get();
+        if (journal.isEmpty()) {
+            return Uni.createFrom().item(TerminalPublicationClaim.untracked(
+                publicationFacts.publicationId(),
+                publicationFacts.idempotencyKey()));
+        }
+        return claim(journal.get(), record, publicationFacts, nowEpochMs, 1);
+    }
+
+    Uni<Void> complete(
+        ExecutionRecord<Object, Object> record,
+        String transitionKey,
+        String publicationKind,
+        long nowEpochMs
+    ) {
+        if (record == null) {
+            return Uni.createFrom().voidItem();
+        }
+        Optional<ControlPlaneJournal> journal = journals.get();
+        if (journal.isEmpty()) {
+            return Uni.createFrom().voidItem();
+        }
+        SegmentTerminalPublicationFacts publicationFacts = facts.terminalPublicationFacts(
+            record,
+            transitionKey,
+            publicationKind);
+        return appender.appendRequired(
+                journal.get(),
+                record.tenantId(),
+                record.executionId(),
+                List.of(publicationFacts.completed()),
+                nowEpochMs)
+            .replaceWithVoid();
+    }
+
+    private Uni<TerminalPublicationClaim> claim(
+        ControlPlaneJournal journal,
+        ExecutionRecord<Object, Object> record,
+        SegmentTerminalPublicationFacts facts,
+        long nowEpochMs,
+        int attempt
+    ) {
+        return journal.projection(record.tenantId(), record.executionId())
+            .onItem().transformToUni(projection -> {
+                if (projection.terminalPublicationKeys().contains(facts.completed().factKey())) {
+                    return Uni.createFrom().item(toClaim(
+                        TerminalPublicationClaim.Status.ALREADY_COMPLETED,
+                        facts));
+                }
+                if (projection.terminalPublicationPreparedKeys().contains(facts.prepared().factKey())) {
+                    return Uni.createFrom().item(toClaim(
+                        TerminalPublicationClaim.Status.PREPARED_RETRY,
+                        facts));
+                }
+                return journal.append(
+                        record.tenantId(),
+                        record.executionId(),
+                        projection.version(),
+                        List.of(facts.prepared()),
+                        nowEpochMs)
+                    .onItem().transform(ignored -> toClaim(TerminalPublicationClaim.Status.CLAIMED, facts));
+            })
+            .onFailure(ControlPlaneAppendConflictException.class).recoverWithUni(failure -> {
+                if (attempt >= SegmentBoundaryJournalAppender.MAX_APPEND_ATTEMPTS) {
+                    return Uni.createFrom().failure(failure);
+                }
+                return claim(journal, record, facts, nowEpochMs, attempt + 1);
+            });
+    }
+
+    private static TerminalPublicationClaim toClaim(
+        TerminalPublicationClaim.Status status,
+        SegmentTerminalPublicationFacts facts
+    ) {
+        return new TerminalPublicationClaim(
+            status,
+            facts.publicationId(),
+            facts.idempotencyKey(),
+            facts.prepared().factKey(),
+            facts.completed().factKey());
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryFactFactoryTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryFactFactoryTest.java
@@ -1,0 +1,174 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.awaitable.AwaitInteractionRecord;
+import org.pipelineframework.awaitable.AwaitInteractionStatus;
+import org.pipelineframework.awaitable.AwaitUnitRecord;
+import org.pipelineframework.awaitable.AwaitUnitStatus;
+import org.pipelineframework.orchestrator.ExecutionRecord;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+import org.pipelineframework.orchestrator.ExecutionStatus;
+import org.pipelineframework.orchestrator.TransitionAwaitSuspension;
+
+class SegmentBoundaryFactFactoryTest {
+
+    private final SegmentBoundaryFactFactory facts = new SegmentBoundaryFactFactory();
+
+    @Test
+    void segmentSuspendedBuildsBoundaryAndDispatchFactsTogether() {
+        AwaitUnitRecord unit = unit(true, 1);
+        AwaitInteractionRecord interaction = interaction(0);
+        List<ControlPlaneFact> built = facts.segmentSuspended(
+            record("run-1"),
+            "run-1:2:0",
+            new TransitionAwaitSuspension("tenant", "run-1", "unit-1", 2, unit, List.of(interaction)));
+
+        assertEquals(3, built.size());
+        ControlPlaneFact.SegmentSuspended suspended =
+            assertInstanceOf(ControlPlaneFact.SegmentSuspended.class, built.get(0));
+        assertInstanceOf(ControlPlaneFact.BoundaryInteractionDispatched.class, built.get(1));
+        assertInstanceOf(ControlPlaneFact.BoundaryDispatchCompleted.class, built.get(2));
+        assertEquals(2, suspended.boundaryStepIndex());
+        assertEquals("unit-1", suspended.boundaryUnitId());
+        assertEquals(1, suspended.expectedItemCount());
+    }
+
+    @Test
+    void segmentSuspendedDoesNotEmitDispatchCompleteWhenUnitDispatchIsOpen() {
+        List<ControlPlaneFact> built = facts.segmentSuspended(
+            record("run-1"),
+            "run-1:2:0",
+            new TransitionAwaitSuspension(
+                "tenant",
+                "run-1",
+                "unit-1",
+                2,
+                unit(false, 1),
+                List.of(interaction(0))));
+
+        assertEquals(2, built.size());
+        assertInstanceOf(ControlPlaneFact.SegmentSuspended.class, built.get(0));
+        assertInstanceOf(ControlPlaneFact.BoundaryInteractionDispatched.class, built.get(1));
+    }
+
+    @Test
+    void segmentSuspendedDoesNotEmitDispatchCompleteWhenExpectedCountIsUnknown() {
+        List<ControlPlaneFact> built = facts.segmentSuspended(
+            record("run-1"),
+            "run-1:2:0",
+            new TransitionAwaitSuspension(
+                "tenant",
+                "run-1",
+                "unit-1",
+                2,
+                unit(true, null),
+                List.of(interaction(0))));
+
+        assertEquals(2, built.size());
+        assertInstanceOf(ControlPlaneFact.SegmentSuspended.class, built.get(0));
+        assertInstanceOf(ControlPlaneFact.BoundaryInteractionDispatched.class, built.get(1));
+    }
+
+    @Test
+    void boundaryCompletionUsesItemIndexAsIdempotencyKeyForItemizedAwait() {
+        ControlPlaneFact fact = facts.boundaryCompletionAdmitted(interaction(3), unit(false, null)).getFirst();
+
+        ControlPlaneFact.BoundaryCompletionAdmitted admitted =
+            assertInstanceOf(ControlPlaneFact.BoundaryCompletionAdmitted.class, fact);
+        assertEquals("item:3", admitted.idempotencyKey());
+    }
+
+    @Test
+    void terminalPublicationFactsUseStablePublicationIdentifiers() {
+        SegmentTerminalPublicationFacts publicationFacts = facts.terminalPublicationFacts(
+            record("run-terminal"),
+            "run-terminal:0:0",
+            "object-publish");
+
+        assertEquals("run-terminal:terminal-output:object-publish", publicationFacts.publicationId());
+        assertEquals("run-terminal:terminal-output:object-publish:terminal-publication",
+            publicationFacts.idempotencyKey());
+        assertEquals(publicationFacts.prepared().publicationId(), publicationFacts.completed().publicationId());
+    }
+
+    private static ExecutionRecord<Object, Object> record(String executionId) {
+        return new ExecutionRecord<>(
+            "tenant",
+            executionId,
+            "key-" + executionId,
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.SINGLE,
+            ExecutionStatus.QUEUED,
+            0L,
+            2,
+            0,
+            null,
+            0L,
+            0L,
+            null,
+            "input",
+            null,
+            null,
+            null,
+            null,
+            1L,
+            1L,
+            999999L);
+    }
+
+    private static AwaitUnitRecord unit(boolean dispatchComplete, Integer expectedItemCount) {
+        return new AwaitUnitRecord(
+            "tenant",
+            "unit-1",
+            "run-1",
+            "AwaitPaymentProvider",
+            2,
+            "ONE_TO_ONE",
+            1L,
+            AwaitUnitStatus.WAITING_EXTERNAL,
+            null,
+            expectedItemCount,
+            0,
+            java.util.Set.of(),
+            dispatchComplete,
+            1L,
+            1L,
+            999999L);
+    }
+
+    private static AwaitInteractionRecord interaction(int itemIndex) {
+        return new AwaitInteractionRecord(
+            "tenant",
+            "run-1",
+            "AwaitPaymentProvider",
+            2,
+            String.class.getName(),
+            "interaction-" + itemIndex,
+            "corr-" + itemIndex,
+            "cause-" + itemIndex,
+            "idem-" + itemIndex,
+            1L,
+            AwaitInteractionStatus.WAITING,
+            "request-" + itemIndex,
+            "response-" + itemIndex,
+            "unit-1",
+            itemIndex,
+            "user-1",
+            null,
+            null,
+            "kafka",
+            Map.of(),
+            999999L,
+            1L,
+            1L,
+            999999L);
+    }
+}

--- a/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryJournalAppenderTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/orchestrator/controlplane/SegmentBoundaryJournalAppenderTest.java
@@ -1,0 +1,126 @@
+package org.pipelineframework.orchestrator.controlplane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Test;
+import org.pipelineframework.orchestrator.ExecutionResultShape;
+
+class SegmentBoundaryJournalAppenderTest {
+
+    @Test
+    void appendRequiredSkipsFactsAlreadyPresentInProjection() {
+        InMemoryControlPlaneJournal journal = new InMemoryControlPlaneJournal();
+        SegmentBoundaryJournalAppender appender = new SegmentBoundaryJournalAppender(() -> Optional.of(journal));
+        ControlPlaneFact.RunSubmitted fact = runSubmitted("run-1");
+
+        appender.appendRequired(journal, "tenant", "run-1", List.of(fact), 10L).await().indefinitely();
+        appender.appendRequired(journal, "tenant", "run-1", List.of(fact), 11L).await().indefinitely();
+
+        ControlPlaneProjection projection = journal.projection("tenant", "run-1").await().indefinitely();
+        assertEquals(1L, projection.version());
+        assertTrue(projection.factKeys().contains(fact.factKey()));
+    }
+
+    @Test
+    void appendFactsOrThrowBuildFailureRetriesOptimisticConflict() {
+        InMemoryControlPlaneJournal delegate = new InMemoryControlPlaneJournal();
+        SegmentBoundaryJournalAppender appender =
+            new SegmentBoundaryJournalAppender(() -> Optional.of(new ConflictOnceJournal(delegate)));
+
+        appender.appendFactsOrThrowBuildFailure("tenant", "run-2", () -> List.of(runSubmitted("run-2")), 20L)
+            .await().indefinitely();
+
+        assertEquals(1L, delegate.projection("tenant", "run-2").await().indefinitely().version());
+    }
+
+    @Test
+    void appendFactsOrThrowBuildFailurePropagatesBuildFailure() {
+        SegmentBoundaryJournalAppender appender =
+            new SegmentBoundaryJournalAppender(() -> Optional.of(new InMemoryControlPlaneJournal()));
+
+        assertThrows(IllegalArgumentException.class, () -> appender.appendFactsOrThrowBuildFailure(
+                "tenant",
+                "run-build-error",
+                () -> {
+                    throw new IllegalArgumentException("bad facts");
+                },
+                30L)
+            .await().indefinitely());
+    }
+
+    @Test
+    void appendFactsBestEffortToleratesBuildFailure() {
+        SegmentBoundaryJournalAppender appender =
+            new SegmentBoundaryJournalAppender(() -> Optional.of(new InMemoryControlPlaneJournal()));
+
+        appender.appendFactsBestEffort(
+                "tenant",
+                "run-best-effort",
+                () -> {
+                    throw new IllegalArgumentException("bad facts");
+                },
+                40L)
+            .await().indefinitely();
+    }
+
+    private static ControlPlaneFact.RunSubmitted runSubmitted(String runId) {
+        return new ControlPlaneFact.RunSubmitted(
+            "tenant",
+            runId,
+            "key-" + runId,
+            "pipeline",
+            "contract",
+            "release",
+            ExecutionResultShape.SINGLE,
+            runId + ":segment:0",
+            0,
+            -1,
+            "input",
+            999999L);
+    }
+
+    private static final class ConflictOnceJournal implements ControlPlaneJournal {
+        private final InMemoryControlPlaneJournal delegate;
+        private final AtomicBoolean conflict = new AtomicBoolean(true);
+
+        private ConflictOnceJournal(InMemoryControlPlaneJournal delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Uni<ControlPlaneAppendResult> append(
+            String tenantId,
+            String runId,
+            long expectedVersion,
+            List<ControlPlaneFact> facts,
+            long nowEpochMs
+        ) {
+            if (conflict.getAndSet(false)) {
+                return Uni.createFrom().failure(new ControlPlaneAppendConflictException("synthetic conflict"));
+            }
+            return delegate.append(tenantId, runId, expectedVersion, facts, nowEpochMs);
+        }
+
+        @Override
+        public Uni<ControlPlaneProjection> projection(String tenantId, String runId) {
+            return delegate.projection(tenantId, runId);
+        }
+
+        @Override
+        public Uni<List<DueSegment>> findDueSegments(long nowEpochMs, int limit) {
+            return delegate.findDueSegments(nowEpochMs, limit);
+        }
+
+        @Override
+        public Uni<List<DueBoundaryInteraction>> findTimedOutInteractions(long nowEpochMs, int limit) {
+            return delegate.findTimedOutInteractions(nowEpochMs, limit);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split `SegmentBoundaryLedger` into a small compatibility facade plus cohesive package-private collaborators
- move immutable control-plane fact construction into `SegmentBoundaryFactFactory`
- move journal append/idempotency/OCC retry behavior into `SegmentBoundaryJournalAppender`
- move terminal publication claim/complete behavior into `TerminalPublicationLedger`
- add focused tests for the extracted fact factory and journal appender

## Scope
This PR is behavior-preserving. It does not change queue-async semantics, public APIs, YAML, Dynamo/journal contracts, telemetry, docs, replay data, or caller wiring. The goal is to address the hotspot/low-cohesion finding on `SegmentBoundaryLedger` without widening the runtime refactor.

## Validation
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true -Dtest=SegmentBoundaryLedgerTest,SegmentBoundaryFactFactoryTest,SegmentBoundaryJournalAppenderTest -Dsurefire.failIfNoSpecifiedTests=false test -Dmaven.repo.local="$PWD/.m2/repository"`
  - `SegmentBoundaryLedgerTest`: 10 tests, 0 failures/errors
  - `SegmentBoundaryFactFactoryTest`: 3 tests, 0 failures/errors
  - `SegmentBoundaryJournalAppenderTest`: 2 tests, 0 failures/errors
- dependent runtime slice: `SegmentBoundaryLedgerTest,SegmentBoundaryFactFactoryTest,SegmentBoundaryJournalAppenderTest,QueueAsyncSegmentPipelineTest,TerminalPublicationBoundaryTest,AwaitTimeoutFlowTest,QueueAsyncSubmissionFlowTest,AwaitBoundaryAdmissionTest,AwaitContinuationsTest,ItemizedAwaitContinuationFlowTest,QueueAsyncCoordinatorTest` passed
- `./mvnw -f framework/pom.xml -pl runtime -am -DskipExtensionValidation=true test -Dmaven.repo.local="$PWD/.m2/repository"`
  - 1727 tests, 0 failures/errors, 1 skipped
- `git diff --check`
- `repowise update --since origin/main`

## Local CodeRabbit
Attempted `cr review --agent --base main --config ./AGENTS.md` before pushing. It failed with `payload_too_large` even though the branch was current with `origin/main`, so there is no local CR feedback batch to apply before opening this ready PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording and tracking more orchestrator lifecycle events, including segment progress, boundary handling, continuation segments, and terminal publication steps.
  * Improved handling of terminal publication tracking so publication status can be prepared and completed consistently.

* **Bug Fixes**
  * Made fact recording more resilient by skipping duplicate entries and retrying safely when concurrent updates occur.
  * Improved handling when required data is missing or unavailable, reducing failed journal writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->