### PR TITLE
StepBranchingDescriptor fix - Cache the reflection extractor, not the extracted item.

### DIFF
--- a/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentStatusBranchingDescriptorTest.java
+++ b/examples/csv-payments/common/src/test/java/org/pipelineframework/csv/common/mapper/PaymentStatusBranchingDescriptorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.branching.StepBranchingDescriptor;
+import org.pipelineframework.csv.common.domain.ApprovedPaymentStatus;
 import org.pipelineframework.csv.grpc.PipelineTypes;
 
 class PaymentStatusBranchingDescriptorTest {
@@ -68,6 +69,44 @@ class PaymentStatusBranchingDescriptorTest {
         assertInstanceOf(PipelineTypes.ApprovedPaymentStatus.class, extracted);
     assertNotNull(approved);
     assertEquals(union.getApproved().getReference(), approved.getReference());
+  }
+
+  @Test
+  void extractsFreshApprovedProtoVariantForEachPaymentStatusUnionWrapper() {
+    ApprovedPaymentStatus firstStatus = PaymentStatusVariantMapperTestData.approvedStatus();
+    firstStatus.setReference("approved-first");
+    firstStatus.getPaymentRecord().setRecipient("First Recipient");
+    ApprovedPaymentStatus secondStatus = PaymentStatusVariantMapperTestData.approvedStatus();
+    secondStatus.setReference("approved-second");
+    secondStatus.getPaymentRecord().setRecipient("Second Recipient");
+    StepBranchingDescriptor descriptor = approvedDescriptor();
+
+    PipelineTypes.ApprovedPaymentStatus first =
+        assertInstanceOf(
+            PipelineTypes.ApprovedPaymentStatus.class,
+            descriptor.applicableItem(mapper.toExternal(firstStatus)));
+    PipelineTypes.ApprovedPaymentStatus second =
+        assertInstanceOf(
+            PipelineTypes.ApprovedPaymentStatus.class,
+            descriptor.applicableItem(mapper.toExternal(secondStatus)));
+
+    assertEquals("approved-first", first.getReference());
+    assertEquals("First Recipient", first.getPaymentRecord().getRecipient());
+    assertEquals("approved-second", second.getReference());
+    assertEquals("Second Recipient", second.getPaymentRecord().getRecipient());
+  }
+
+  private static StepBranchingDescriptor approvedDescriptor() {
+    return new StepBranchingDescriptor(
+        2,
+        "Process Approved Payment Status",
+        "test.Step",
+        PipelineTypes.ApprovedPaymentStatus.class.getName(),
+        PipelineTypes.ApprovedPaymentStatus.class,
+        List.of("ApprovedPaymentStatus"),
+        List.of(PipelineTypes.ApprovedPaymentStatus.class.getName()),
+        List.of(PipelineTypes.ApprovedPaymentStatus.class),
+        false);
   }
 
   private static void setField(Object target, String fieldName, Object value) {

--- a/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
@@ -67,16 +67,16 @@ public record StepBranchingDescriptor(
             Optional<Method> hasMethod = findHasMethod(itemClass, suffix);
             method.trySetAccessible();
             hasMethod.ifPresent(Method::trySetAccessible);
-            return Optional.of(new VariantExtractor(method, hasMethod.orElse(null)));
+            return Optional.of(new VariantExtractor(method, hasMethod));
         }
         return Optional.empty();
     }
 
-    private record VariantExtractor(Method getter, Method hasMethod) {
+    private record VariantExtractor(Method getter, Optional<Method> hasMethod) {
 
         private Optional<Object> extract(Object item) {
             try {
-                if (hasMethod != null && !Boolean.TRUE.equals(hasMethod.invoke(item))) {
+                if (hasMethod.isPresent() && !Boolean.TRUE.equals(hasMethod.get().invoke(item))) {
                     return Optional.empty();
                 }
                 return Optional.ofNullable(getter.invoke(item));

--- a/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
@@ -22,7 +22,7 @@ public record StepBranchingDescriptor(
     boolean terminal
 ) {
 
-    private static final ConcurrentHashMap<MethodCacheKey, Optional<Object>> extractionCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<MethodCacheKey, Optional<VariantExtractor>> extractionCache = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<Class<?>, Method[]> sortedMethodsCache = new ConcurrentHashMap<>();
 
     public boolean accepts(Object item) {
@@ -42,10 +42,11 @@ public record StepBranchingDescriptor(
     private Optional<Object> extractAcceptedVariant(Object item) {
         Class<?> itemClass = item.getClass();
         MethodCacheKey cacheKey = new MethodCacheKey(itemClass, this);
-        Optional<Object> cached = extractionCache.get(cacheKey);
-        if (cached != null) {
-            return cached;
-        }
+        Optional<VariantExtractor> extractor = extractionCache.computeIfAbsent(cacheKey, ignored -> findExtractor(itemClass));
+        return extractor.flatMap(candidate -> candidate.extract(item).filter(this::matchesAcceptedInstance));
+    }
+
+    private Optional<VariantExtractor> findExtractor(Class<?> itemClass) {
         Method[] methods = getSortedMethods(itemClass);
         for (Method method : methods) {
             if (method.getParameterCount() != 0 || !method.getName().startsWith("get")) {
@@ -64,31 +65,25 @@ public record StepBranchingDescriptor(
                 continue;
             }
             Optional<Method> hasMethod = findHasMethod(itemClass, suffix);
+            method.trySetAccessible();
+            hasMethod.ifPresent(Method::trySetAccessible);
+            return Optional.of(new VariantExtractor(method, hasMethod.orElse(null)));
+        }
+        return Optional.empty();
+    }
+
+    private record VariantExtractor(Method getter, Method hasMethod) {
+
+        private Optional<Object> extract(Object item) {
             try {
-                if (hasMethod.isPresent()) {
-                    Method has = hasMethod.get();
-                    has.trySetAccessible();
-                    if (!Boolean.TRUE.equals(has.invoke(item))) {
-                        continue;
-                    }
+                if (hasMethod != null && !Boolean.TRUE.equals(hasMethod.invoke(item))) {
+                    return Optional.empty();
                 }
-                method.trySetAccessible();
-                Object candidate = method.invoke(item);
-                if (candidate == null) {
-                    continue;
-                }
-                if (matchesAcceptedInstance(candidate)) {
-                    Optional<Object> result = Optional.of(candidate);
-                    extractionCache.put(cacheKey, result);
-                    return result;
-                }
+                return Optional.ofNullable(getter.invoke(item));
             } catch (ReflectiveOperationException ignored) {
-                // Fall through to the next candidate getter.
+                return Optional.empty();
             }
         }
-        Optional<Object> result = Optional.empty();
-        extractionCache.put(cacheKey, result);
-        return result;
     }
 
     private Object wrapAcceptedVariant(Object item) {


### PR DESCRIPTION
StepBranchingDescriptor.java: cache the reflection extractor, not the extracted item.
PaymentStatusBranchingDescriptorTest.java: added regression coverage for two different PaymentStatus union wrappers through the same descriptor.

StepBranchingDescriptor was caching the extracted branch payload object itself by (item class, descriptor). For protobuf union wrappers like PipelineTypes.PaymentStatus, the first getApproved() result was reused for every later item. That made five distinct Kafka/provider completions enter ProcessApprovedPaymentStatusService as five copies of the first approved row, producing duplicate PaymentOutput rows and only one .out file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment-status branching so each input now keeps its own approved-payment details instead of reusing stale data.
  * Approved payment records now preserve both the reference and recipient values when mapped separately.
  * Added coverage for distinct approved-payment inputs to verify the correct output is produced for each one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->