### PR TITLE
Implicit opt-in to branching when an inputType is a union alternative

### DIFF
--- a/docs/design/object-ingest.md
+++ b/docs/design/object-ingest.md
@@ -98,8 +98,7 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.csv.common.domain.ApprovedPaymentStatus
     inputTypeName: ApprovedPaymentStatus
-    accepts:
-      - ApprovedPaymentStatus
+    # accepts omitted — implicitly accepts ApprovedPaymentStatus
     output: org.pipelineframework.csv.common.domain.ApprovedPaymentOutput
     outputTypeName: ApprovedPaymentOutput
 
@@ -108,8 +107,7 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.csv.common.domain.UnapprovedPaymentStatus
     inputTypeName: UnapprovedPaymentStatus
-    accepts:
-      - UnapprovedPaymentStatus
+    # accepts omitted — implicitly accepts UnapprovedPaymentStatus
     output: org.pipelineframework.csv.common.domain.UnapprovedPaymentOutput
     outputTypeName: UnapprovedPaymentOutput
 

--- a/docs/develop/typed-union-outputs.md
+++ b/docs/develop/typed-union-outputs.md
@@ -165,10 +165,6 @@ steps:
     cardinality: ONE_TO_ONE
     inputTypeName: OrderCompletion
     outputTypeName: FinalizedOrder
-    accepts:
-      - StockReserved
-      - LicenseProvisioned
-      - ManualReviewRequested
     terminal: true
 ```
 
@@ -176,8 +172,8 @@ Rules:
 
 - The pipeline stays a linear sequence of authored steps.
 - `accepts` entries must be concrete contract types, not predicates and not union names.
-- If a step's `inputTypeName` resolves to a single concrete message type, `accepts` is optional. TPF implicitly uses that type as the accepted type.
-- If a step's `inputTypeName` resolves to more than one concrete alternative, explicit `accepts` is required.
+- If `accepts` is omitted, TPF implicitly accepts every concrete leaf type resolved from `inputTypeName`.
+- A union input therefore accepts all of its variants by default. Use explicit `accepts` when the step handles only a subset.
 - Branch-aware routing currently supports `ONE_TO_ONE` steps only.
 - A branch-aware pipeline must declare exactly one `terminal: true` step, and it must be last.
 - A publish sink after the step sequence does not satisfy or infer the terminal merge; author the merge step explicitly.
@@ -188,7 +184,7 @@ Runtime behavior:
 - If it does not match, TPF skips the step as `not_applicable`, records a replay event, and passes the item through unchanged.
 - The terminal merge step must accept every reachable branch-end alternative. Otherwise the build fails.
 
-When a step's `inputTypeName` references a concrete message (not a union), `accepts` can be omitted and TPF implicitly uses that single type:
+When a step's `inputTypeName` references a concrete message, omitting `accepts` implicitly accepts that message:
 
 ```yaml
 steps:
@@ -203,4 +199,16 @@ steps:
     # no accepts — implicitly accepts DigitalOrder
 ```
 
-This is equivalent to writing `accepts: [PhysicalOrder]` and `accepts: [DigitalOrder]`. Explicit `accepts` is still required when the step should handle multiple union alternatives. The `accepts` keyword also makes the accepted contract set visible at a glance in the YAML for complex pipelines — choose whichever communicates intent more clearly.
+This is equivalent to writing `accepts: [PhysicalOrder]` and `accepts: [DigitalOrder]`.
+
+When `inputTypeName` references a union, omitting `accepts` implicitly accepts every variant. That is normally the clearest declaration for a terminal merge:
+
+```yaml
+- name: Finalize Order
+  cardinality: ONE_TO_ONE
+  inputTypeName: OrderCompletion
+  outputTypeName: FinalizedOrder
+  terminal: true
+```
+
+Here `Finalize Order` accepts `StockReserved`, `LicenseProvisioned`, and `ManualReviewRequested` because those are the variants of `OrderCompletion`. Listing all three under `accepts` is equivalent but unnecessary. Use explicit `accepts` for branch-specific steps that handle only part of a union.

--- a/docs/develop/typed-union-outputs.md
+++ b/docs/develop/typed-union-outputs.md
@@ -123,7 +123,7 @@ For gRPC, field-level mapping stays in ordinary variant mappers such as `Mapper<
 - Variant names and protobuf field numbers must be unique.
 - A union can be used as a step input or output type.
 - A union cannot be used as a field inside a normal message in this first version.
-- Union-routed branching is opt-in. TPF only auto-routes when the pipeline authors `accepts` and one final `terminal: true` merge step.
+- Union-routed branching is opt-in. TPF detects branch awareness from `accepts`, `terminal: true`, or a step's `inputTypeName` alone.
 
 TPFGo uses this shape in the payment capture pipeline, where `PaymentOutcome` replaces a status-field result record while keeping the pipeline linear.
 
@@ -176,6 +176,7 @@ Rules:
 
 - The pipeline stays a linear sequence of authored steps.
 - `accepts` entries must be concrete contract types, not predicates and not union names.
+- If a step's `inputTypeName` resolves to a single concrete message type, `accepts` is optional. TPF implicitly uses that type as the accepted type.
 - If a step's `inputTypeName` resolves to more than one concrete alternative, explicit `accepts` is required.
 - Branch-aware routing currently supports `ONE_TO_ONE` steps only.
 - A branch-aware pipeline must declare exactly one `terminal: true` step, and it must be last.
@@ -186,3 +187,20 @@ Runtime behavior:
 - If the current item matches a step's accepted type set, TPF executes the step normally.
 - If it does not match, TPF skips the step as `not_applicable`, records a replay event, and passes the item through unchanged.
 - The terminal merge step must accept every reachable branch-end alternative. Otherwise the build fails.
+
+When a step's `inputTypeName` references a concrete message (not a union), `accepts` can be omitted and TPF implicitly uses that single type:
+
+```yaml
+steps:
+  - name: Reserve Stock
+    inputTypeName: PhysicalOrder
+    outputTypeName: StockReserved
+    # no accepts — implicitly accepts PhysicalOrder
+
+  - name: Provision License
+    inputTypeName: DigitalOrder
+    outputTypeName: LicenseProvisioned
+    # no accepts — implicitly accepts DigitalOrder
+```
+
+This is equivalent to writing `accepts: [PhysicalOrder]` and `accepts: [DigitalOrder]`. Explicit `accepts` is still required when the step should handle multiple union alternatives. The `accepts` keyword also makes the accepted contract set visible at a glance in the YAML for complex pipelines — choose whichever communicates intent more clearly.

--- a/docs/evolve/typed-union-output-contracts.md
+++ b/docs/evolve/typed-union-output-contracts.md
@@ -95,9 +95,25 @@ steps:
     terminal: true
 ```
 
+When a step's `inputTypeName` resolves to a single concrete message type (not a union), `accepts` can be omitted. TPF implicitly uses that type as the step's accepted type:
+
+```yaml
+steps:
+  - name: Reserve Stock
+    inputTypeName: PhysicalOrder
+    outputTypeName: StockReserved
+
+  - name: Provision License
+    inputTypeName: DigitalOrder
+    outputTypeName: LicenseProvisioned
+```
+
+This is equivalent to the explicit `accepts` form above. Explicit `accepts` is required when the step's `inputTypeName` is a union with multiple variants and the step handles a subset of them.
+
 Compiler rules:
 
 - `accepts` may reference concrete contract types only.
+- if `accepts` is omitted and `inputTypeName` is a single concrete message, that type becomes the accepted type implicitly.
 - union inputs with multiple concrete alternatives require explicit `accepts`.
 - branch-aware pipelines are `ONE_TO_ONE` only in v1.
 - there must be exactly one `terminal: true` step, and it must be last.

--- a/docs/evolve/typed-union-output-contracts.md
+++ b/docs/evolve/typed-union-output-contracts.md
@@ -89,13 +89,10 @@ steps:
   - name: Finalize
     inputTypeName: OrderCompletion
     outputTypeName: FinalizedOrder
-    accepts:
-      - StockReserved
-      - LicenseProvisioned
     terminal: true
 ```
 
-When a step's `inputTypeName` resolves to a single concrete message type (not a union), `accepts` can be omitted. TPF implicitly uses that type as the step's accepted type:
+When `accepts` is omitted, TPF uses every concrete leaf type resolved from `inputTypeName`. For a concrete message, that is the message itself:
 
 ```yaml
 steps:
@@ -108,13 +105,15 @@ steps:
     outputTypeName: LicenseProvisioned
 ```
 
-This is equivalent to the explicit `accepts` form above. Explicit `accepts` is required when the step's `inputTypeName` is a union with multiple variants and the step handles a subset of them.
+For a union input, omitting `accepts` means that the step accepts every variant. The `Finalize` step above therefore accepts both `StockReserved` and `LicenseProvisioned`. This is the concise form for a terminal merge that handles every branch-end alternative.
+
+Declare explicit `accepts` only when a step handles a subset of the variants resolved from its union input. `Reserve Stock` and `Provision License` use that form above because each applies to one `OrderDecision` alternative.
 
 Compiler rules:
 
 - `accepts` may reference concrete contract types only.
-- if `accepts` is omitted and `inputTypeName` is a single concrete message, that type becomes the accepted type implicitly.
-- union inputs with multiple concrete alternatives require explicit `accepts`.
+- if `accepts` is omitted, every concrete leaf type resolved from `inputTypeName` becomes accepted implicitly.
+- a union input therefore accepts all of its variants by default; use explicit `accepts` to select a subset.
 - branch-aware pipelines are `ONE_TO_ONE` only in v1.
 - there must be exactly one `terminal: true` step, and it must be last.
 - the terminal step must cover every reachable branch-end alternative.

--- a/examples/checkout/compensation-failure-orchestrator-svc/pipeline.yaml
+++ b/examples/checkout/compensation-failure-orchestrator-svc/pipeline.yaml
@@ -102,6 +102,7 @@ steps:
     output: org.pipelineframework.tpfgo.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState
     outboundMapper: org.pipelineframework.tpfgo.compensation.failure.compensation_finalize_order.service.TerminalOrderStateMapper
+    terminal: true
 input:
   subscription:
     publication: tpfgo.payment.capture-result.v1

--- a/examples/checkout/compensation-failure-orchestrator-svc/pipeline.yaml
+++ b/examples/checkout/compensation-failure-orchestrator-svc/pipeline.yaml
@@ -99,10 +99,6 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.tpfgo.common.domain.PaymentOutcome
     inputTypeName: PaymentOutcome
-    accepts:
-      - PaymentCaptured
-      - PaymentRejected
-      - PaymentRequiresReview
     output: org.pipelineframework.tpfgo.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState
     outboundMapper: org.pipelineframework.tpfgo.compensation.failure.compensation_finalize_order.service.TerminalOrderStateMapper

--- a/examples/checkout/compensation-failure-orchestrator-svc/pipeline.yaml
+++ b/examples/checkout/compensation-failure-orchestrator-svc/pipeline.yaml
@@ -99,6 +99,10 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.tpfgo.common.domain.PaymentOutcome
     inputTypeName: PaymentOutcome
+    accepts:
+      - PaymentCaptured
+      - PaymentRejected
+      - PaymentRequiresReview
     output: org.pipelineframework.tpfgo.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState
     outboundMapper: org.pipelineframework.tpfgo.compensation.failure.compensation_finalize_order.service.TerminalOrderStateMapper

--- a/examples/checkout/config/canonical/08-compensation-failure-pipeline.yaml
+++ b/examples/checkout/config/canonical/08-compensation-failure-pipeline.yaml
@@ -99,10 +99,6 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.tpfgo.common.domain.PaymentOutcome
     inputTypeName: PaymentOutcome
-    accepts:
-      - PaymentCaptured
-      - PaymentRejected
-      - PaymentRequiresReview
     output: org.pipelineframework.tpfgo.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState
     outboundMapper: org.pipelineframework.tpfgo.compensation.failure.compensation_finalize_order.service.TerminalOrderStateMapper

--- a/examples/checkout/config/canonical/08-compensation-failure-pipeline.yaml
+++ b/examples/checkout/config/canonical/08-compensation-failure-pipeline.yaml
@@ -99,6 +99,10 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.tpfgo.common.domain.PaymentOutcome
     inputTypeName: PaymentOutcome
+    accepts:
+      - PaymentCaptured
+      - PaymentRejected
+      - PaymentRequiresReview
     output: org.pipelineframework.tpfgo.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState
     outboundMapper: org.pipelineframework.tpfgo.compensation.failure.compensation_finalize_order.service.TerminalOrderStateMapper

--- a/examples/restaurant-approval/config/pipeline.yaml
+++ b/examples/restaurant-approval/config/pipeline.yaml
@@ -159,8 +159,5 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.restaurantapproval.common.domain.RestaurantDecision
     inputTypeName: RestaurantDecision
-    accepts:
-      - RestaurantOrderAccepted
-      - RestaurantOrderDeclined
     output: org.pipelineframework.restaurantapproval.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState

--- a/examples/restaurant-approval/config/pipeline.yaml
+++ b/examples/restaurant-approval/config/pipeline.yaml
@@ -161,3 +161,4 @@ steps:
     inputTypeName: RestaurantDecision
     output: org.pipelineframework.restaurantapproval.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState
+    terminal: true

--- a/examples/restaurant-approval/config/pipeline.yaml
+++ b/examples/restaurant-approval/config/pipeline.yaml
@@ -159,5 +159,8 @@ steps:
     cardinality: ONE_TO_ONE
     input: org.pipelineframework.restaurantapproval.common.domain.RestaurantDecision
     inputTypeName: RestaurantDecision
+    accepts:
+      - RestaurantOrderAccepted
+      - RestaurantOrderDeclined
     output: org.pipelineframework.restaurantapproval.common.domain.TerminalOrderState
     outputTypeName: TerminalOrderState

--- a/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildSteps.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildSteps.java
@@ -30,9 +30,11 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Loads delegated operator step configuration from pipeline YAML at Quarkus build time.
@@ -130,6 +132,7 @@ public final class PipelineConfigBuildSteps {
         if (!(root instanceof Map<?, ?> rootMap)) {
             return false;
         }
+        Set<String> unionNames = declaredUnionNames(rootMap);
         Object stepsObj = rootMap.get("steps");
         if (!(stepsObj instanceof Iterable<?> steps)) {
             return false;
@@ -141,7 +144,8 @@ public final class PipelineConfigBuildSteps {
             if (stepMap.containsKey("accepts")) {
                 return true;
             }
-            if (stepMap.containsKey("inputTypeName")) {
+            String inputTypeName = stringValue(stepMap, "inputTypeName");
+            if (!isBlank(inputTypeName) && unionNames.contains(inputTypeName.trim())) {
                 return true;
             }
             Object terminal = stepMap.get("terminal");
@@ -150,6 +154,20 @@ public final class PipelineConfigBuildSteps {
             }
         }
         return false;
+    }
+
+    private Set<String> declaredUnionNames(Map<?, ?> rootMap) {
+        Object unionsObj = rootMap.get("unions");
+        if (!(unionsObj instanceof Map<?, ?> unions)) {
+            return Set.of();
+        }
+        Set<String> unionNames = new LinkedHashSet<>();
+        for (Object key : unions.keySet()) {
+            if (key != null) {
+                unionNames.add(String.valueOf(key).trim());
+            }
+        }
+        return unionNames;
     }
 
     /**

--- a/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildSteps.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/extension/PipelineConfigBuildSteps.java
@@ -141,6 +141,9 @@ public final class PipelineConfigBuildSteps {
             if (stepMap.containsKey("accepts")) {
                 return true;
             }
+            if (stepMap.containsKey("inputTypeName")) {
+                return true;
+            }
             Object terminal = stepMap.get("terminal");
             if (Boolean.TRUE.equals(terminal) || "true".equalsIgnoreCase(String.valueOf(terminal))) {
                 return true;

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -324,13 +324,19 @@ public final class PipelineBranchRoutingPlanner {
             return;
         }
         contractRuntimeTypes.putIfAbsent(contractTypeName, runtimeType);
-        for (PipelineTemplateUnionVariant variant : union.variants().values()) {
+        for (Map.Entry<String, PipelineTemplateUnionVariant> entry : union.variants().entrySet()) {
+            String variantName = entry.getKey();
+            PipelineTemplateUnionVariant variant = entry.getValue();
             if (variant == null || isBlank(variant.type())) {
                 continue;
             }
             ClassName variantRuntimeType = ClassName.get(runtimeType.packageName(), variant.type());
             if (isResolvable(ctx, variantRuntimeType)) {
                 contractRuntimeTypes.putIfAbsent(variant.type(), variantRuntimeType);
+            } else {
+                report(ctx, Diagnostic.Kind.WARNING, "Union contract '" + contractTypeName
+                    + "' variant '" + variantName + "' maps to unresolved runtime type '"
+                    + variantRuntimeType.canonicalName() + "'; skipping runtime type indexing.");
             }
         }
     }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -65,6 +65,11 @@ public final class PipelineBranchRoutingPlanner {
         if (definitionsByName.isEmpty()) {
             return Optional.empty();
         }
+        Map<String, ClassName> contractRuntimeTypes = indexContractRuntimeTypes(
+            ctx,
+            templateConfig,
+            templateSteps,
+            definitionsByName.orElseThrow());
 
         List<ResolvedStep> resolvedSteps = new ArrayList<>();
         boolean valid = true;
@@ -82,7 +87,13 @@ public final class PipelineBranchRoutingPlanner {
                 valid = false;
                 continue;
             }
-            Optional<ResolvedStep> resolved = resolveStep(ctx, templateConfig, templateStep, stepDefinition, index);
+            Optional<ResolvedStep> resolved = resolveStep(
+                ctx,
+                templateConfig,
+                templateStep,
+                stepDefinition,
+                index,
+                contractRuntimeTypes);
             if (resolved.isEmpty()) {
                 valid = false;
                 continue;
@@ -180,7 +191,8 @@ public final class PipelineBranchRoutingPlanner {
         PipelineTemplateConfig templateConfig,
         PipelineTemplateStep templateStep,
         StepDefinition stepDefinition,
-        int index
+        int index,
+        Map<String, ClassName> contractRuntimeTypes
     ) {
         if (isBlank(templateStep.inputTypeName())) {
             error(ctx, "Branch-aware step '" + templateStep.name() + "' must declare inputTypeName.");
@@ -247,9 +259,16 @@ public final class PipelineBranchRoutingPlanner {
             return Optional.empty();
         }
 
-        List<ClassName> acceptedDomainTypes = acceptedLeafTypes.stream()
-            .map(typeName -> ClassName.get(templateConfig.basePackage() + ".common.domain", typeName))
-            .toList();
+        List<ClassName> acceptedDomainTypes = new ArrayList<>(acceptedLeafTypes.size());
+        for (String acceptedLeafType : acceptedLeafTypes) {
+            ClassName acceptedDomainType = contractRuntimeTypes.get(acceptedLeafType);
+            if (acceptedDomainType == null) {
+                error(ctx, "Step '" + templateStep.name() + "' accepted contract type '" + acceptedLeafType
+                    + "' could not be resolved to a Java runtime type during branch routing validation.");
+                return Optional.empty();
+            }
+            acceptedDomainTypes.add(acceptedDomainType);
+        }
         if (!templateStep.accepts().isEmpty()
             && !validateAssignableAcceptedTypes(ctx, templateStep, stepDefinition, acceptedDomainTypes)) {
             return Optional.empty();
@@ -263,6 +282,57 @@ public final class PipelineBranchRoutingPlanner {
             List.copyOf(acceptedLeafTypes),
             List.copyOf(outputLeafTypes),
             acceptedDomainTypes));
+    }
+
+    private Map<String, ClassName> indexContractRuntimeTypes(
+        PipelineCompilationContext ctx,
+        PipelineTemplateConfig templateConfig,
+        List<PipelineTemplateStep> templateSteps,
+        Map<String, StepDefinition> definitionsByName
+    ) {
+        Map<String, ClassName> contractRuntimeTypes = new LinkedHashMap<>();
+        for (PipelineTemplateStep templateStep : templateSteps) {
+            if (templateStep == null || isBlank(templateStep.name())) {
+                continue;
+            }
+            StepDefinition stepDefinition = definitionsByName.get(normalizeStepName(templateStep.name()));
+            if (stepDefinition == null) {
+                continue;
+            }
+            registerContractRuntimeType(ctx, templateConfig, templateStep.inputTypeName(), stepDefinition.inputType(), contractRuntimeTypes);
+            registerContractRuntimeType(ctx, templateConfig, templateStep.outputTypeName(), stepDefinition.outputType(), contractRuntimeTypes);
+        }
+        return contractRuntimeTypes;
+    }
+
+    private void registerContractRuntimeType(
+        PipelineCompilationContext ctx,
+        PipelineTemplateConfig templateConfig,
+        String contractTypeName,
+        ClassName runtimeType,
+        Map<String, ClassName> contractRuntimeTypes
+    ) {
+        if (isBlank(contractTypeName) || runtimeType == null || templateConfig == null) {
+            return;
+        }
+        if (templateConfig.messages().containsKey(contractTypeName)) {
+            contractRuntimeTypes.putIfAbsent(contractTypeName, runtimeType);
+            return;
+        }
+        PipelineTemplateUnion union = templateConfig.unions().get(contractTypeName);
+        if (union == null) {
+            return;
+        }
+        contractRuntimeTypes.putIfAbsent(contractTypeName, runtimeType);
+        for (PipelineTemplateUnionVariant variant : union.variants().values()) {
+            if (variant == null || isBlank(variant.type())) {
+                continue;
+            }
+            ClassName variantRuntimeType = ClassName.get(runtimeType.packageName(), variant.type());
+            if (isResolvable(ctx, variantRuntimeType)) {
+                contractRuntimeTypes.putIfAbsent(variant.type(), variantRuntimeType);
+            }
+        }
     }
 
     private boolean validateReachability(PipelineCompilationContext ctx, List<ResolvedStep> resolvedSteps) {
@@ -363,6 +433,13 @@ public final class PipelineBranchRoutingPlanner {
             }
         }
         return true;
+    }
+
+    private boolean isResolvable(PipelineCompilationContext ctx, ClassName type) {
+        if (ctx == null || ctx.getProcessingEnv() == null || ctx.getProcessingEnv().getElementUtils() == null) {
+            return true;
+        }
+        return ctx.getProcessingEnv().getElementUtils().getTypeElement(type.canonicalName()) != null;
     }
 
     private PipelineTemplateConfig requireTemplateConfig(PipelineCompilationContext ctx) {

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -49,7 +49,7 @@ public final class PipelineBranchRoutingPlanner {
 
         boolean branchAware = templateSteps.stream()
             .filter(Objects::nonNull)
-            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal());
+            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal() || step.inputTypeName() != null);
         if (!branchAware) {
             return Optional.of(PipelineBranchingPlan.disabled());
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -237,13 +237,6 @@ public final class PipelineBranchRoutingPlanner {
                 return Optional.empty();
             }
         } else {
-            if (inputLeafTypes.size() != 1) {
-                error(ctx, "Step '" + templateStep.name()
-                    + "' resolves inputTypeName '" + templateStep.inputTypeName()
-                    + "' to multiple alternatives " + inputLeafTypes
-                    + ". Explicit accepts is required.");
-                return Optional.empty();
-            }
             acceptedLeafTypes.addAll(inputLeafTypes);
         }
 

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -47,9 +47,11 @@ public final class PipelineBranchRoutingPlanner {
             return Optional.of(PipelineBranchingPlan.disabled());
         }
 
+        Map<String, PipelineTemplateUnion> unions = templateConfig.unions();
         boolean branchAware = templateSteps.stream()
             .filter(Objects::nonNull)
-            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal());
+            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal()
+                || (step.inputTypeName() != null && unions.containsKey(step.inputTypeName())));
         if (!branchAware) {
             return Optional.of(PipelineBranchingPlan.disabled());
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -49,7 +49,7 @@ public final class PipelineBranchRoutingPlanner {
 
         boolean branchAware = templateSteps.stream()
             .filter(Objects::nonNull)
-            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal() || step.inputTypeName() != null);
+            .anyMatch(step -> !step.accepts().isEmpty() || step.terminal());
         if (!branchAware) {
             return Optional.of(PipelineBranchingPlan.disabled());
         }

--- a/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
+++ b/framework/deployment/src/main/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlanner.java
@@ -250,7 +250,8 @@ public final class PipelineBranchRoutingPlanner {
         List<ClassName> acceptedDomainTypes = acceptedLeafTypes.stream()
             .map(typeName -> ClassName.get(templateConfig.basePackage() + ".common.domain", typeName))
             .toList();
-        if (!validateAssignableAcceptedTypes(ctx, templateStep, stepDefinition, acceptedDomainTypes)) {
+        if (!templateStep.accepts().isEmpty()
+            && !validateAssignableAcceptedTypes(ctx, templateStep, stepDefinition, acceptedDomainTypes)) {
             return Optional.empty();
         }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/extension/PipelineConfigBuildStepsTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/extension/PipelineConfigBuildStepsTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,6 +73,55 @@ class PipelineConfigBuildStepsTest {
                 DeploymentException.class,
                 () -> new PipelineConfigBuildSteps().loadPipelineConfig());
         assertTrue(ex.getMessage().contains("defines both operator and delegate"));
+    }
+
+    @Test
+    void detectsBranchAwareRoutingOnlyForUnionTypedInputsOrExplicitMarkers() throws Exception {
+        Path config = tempDir.resolve("pipeline.yaml");
+        Files.writeString(config, """
+            unions:
+              PaymentOutcome:
+                variants:
+                  captured:
+                    type: PaymentCaptured
+                    number: 1
+                  rejected:
+                    type: PaymentRejected
+                    number: 2
+            steps:
+              - name: "Linear Step"
+                inputTypeName: "PaymentRecord"
+                outputTypeName: "PaymentOutcome"
+              - name: "Terminal Step"
+                inputTypeName: "PaymentOutcome"
+                outputTypeName: "TerminalOrderState"
+                terminal: true
+            """);
+
+        System.setProperty("pipeline.config", config.toString());
+        PipelineConfigBuildItem item = new PipelineConfigBuildSteps().loadPipelineConfig();
+
+        assertTrue(item.branchAware());
+    }
+
+    @Test
+    void doesNotTreatEveryInputTypeNameAsBranchAware() throws Exception {
+        Path config = tempDir.resolve("pipeline.yaml");
+        Files.writeString(config, """
+            steps:
+              - name: "Linear Step"
+                inputTypeName: "PaymentRecord"
+                outputTypeName: "PaymentDecision"
+              - name: "Finalize"
+                inputTypeName: "PaymentDecision"
+                outputTypeName: "Receipt"
+            """);
+
+        System.setProperty("pipeline.config", config.toString());
+        PipelineConfigBuildItem item = new PipelineConfigBuildSteps().loadPipelineConfig();
+
+        assertTrue(item.steps().isEmpty());
+        assertFalse(item.branchAware());
     }
 
     private static void restoreProperty(String key, String value) {

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
@@ -164,6 +164,47 @@ class PipelineBranchRoutingPlannerTest {
     }
 
     @Test
+    void autoResolvesAcceptedTypesFromInputTypeNameWhenAcceptsOmitted() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Order Routing",
+            "com.example.order",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            unions(),
+            List.of(
+                step("classifyOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("reserveStock", "PhysicalOrder", "StockReserved", List.of(), false),
+                step("provisionLicense", "DigitalOrder", "LicenseProvisioned", List.of(), false),
+                step("requestManualReview", "ManualReviewOrder", "ManualReviewRequested", List.of(), false),
+                step("finalize", "OrderCompletion", "FinalizedOrder",
+                    List.of("StockReserved", "LicenseProvisioned", "ManualReviewRequested"), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("classifyOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("reserveStock", "PhysicalOrder", "StockReserved"),
+            stepDefinition("provisionLicense", "DigitalOrder", "LicenseProvisioned"),
+            stepDefinition("requestManualReview", "ManualReviewOrder", "ManualReviewRequested"),
+            stepDefinition("finalize", "OrderCompletion", "FinalizedOrder")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertTrue(plan.orElseThrow().branchAware());
+        assertEquals(4, plan.orElseThrow().terminalStepIndex());
+        assertEquals(List.of("PhysicalOrder"), plan.orElseThrow().steps().get(1).acceptedContractTypes());
+        assertEquals(List.of("DigitalOrder"), plan.orElseThrow().steps().get(2).acceptedContractTypes());
+        assertEquals(List.of("ManualReviewOrder"), plan.orElseThrow().steps().get(3).acceptedContractTypes());
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
+    }
+
+    @Test
     void rejectsUnionInputWithoutExplicitAccepts() {
         List<String> diagnostics = new ArrayList<>();
         PipelineCompilationContext ctx = context(diagnostics);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
@@ -278,6 +278,64 @@ class PipelineBranchRoutingPlannerTest {
     }
 
     @Test
+    void linearTemplateWithOnlyConcreteInputTypesIsNotBranchAware() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Linear Pipeline",
+            "com.example.pipeline",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            messages(),
+            Map.of(),
+            List.of(
+                step("processOrder", "OrderRequest", "OrderDecision", List.of(), false),
+                step("finalize", "OrderDecision", "FinalizedOrder", List.of(), false)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("processOrder", "OrderRequest", "OrderDecision"),
+            stepDefinition("finalize", "OrderDecision", "FinalizedOrder")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertFalse(plan.orElseThrow().branchAware());
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
+    }
+
+    @Test
+    void v1TemplateWithStepsIsNotBranchAware() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            1,
+            "Simple Pipeline",
+            "com.example.pipeline",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            Map.of(),
+            Map.of(),
+            List.of(
+                step("processOrder", "OrderRequest", "OrderDecision", List.of(), false)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition("processOrder", "OrderRequest", "OrderDecision")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertFalse(plan.orElseThrow().branchAware());
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
+    }
+
+    @Test
     void rejectsBranchAwareStepWhenAcceptedJavaTypeCannotBeResolved() {
         List<String> diagnostics = new ArrayList<>();
         Messager messager = mock(Messager.class);

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
@@ -461,6 +461,11 @@ class PipelineBranchRoutingPlannerTest {
                 message.contains("accepted type 'com.example.order.common.domain.LicenseProvisioned'")
                     && message.contains("could not be resolved during branch routing validation")),
             diagnostics.toString());
+        assertTrue(diagnostics.stream().anyMatch(message ->
+                message.contains("WARNING:Union contract 'OrderCompletion' variant 'license'")
+                    && message.contains("com.example.order.common.domain.LicenseProvisioned")
+                    && message.contains("skipping runtime type indexing")),
+            diagnostics.toString());
         assertFalse(diagnostics.isEmpty());
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
@@ -241,6 +241,55 @@ class PipelineBranchRoutingPlannerTest {
     }
 
     @Test
+    void resolvesImplicitUnionAcceptedTypesFromSharedDomainPackage() {
+        List<String> diagnostics = new ArrayList<>();
+        PipelineCompilationContext ctx = context(diagnostics);
+        ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
+            2,
+            "Compensation Finalize",
+            "org.pipelineframework.tpfgo.compensation.failure",
+            "GRPC",
+            PipelinePlatform.COMPUTE,
+            Map.of(
+                "PaymentCaptured", message("PaymentCaptured"),
+                "PaymentRejected", message("PaymentRejected"),
+                "PaymentRequiresReview", message("PaymentRequiresReview"),
+                "TerminalOrderState", message("TerminalOrderState")),
+            Map.of(
+                "PaymentOutcome", new PipelineTemplateUnion(
+                    "PaymentOutcome",
+                    Map.of(
+                        "captured", new PipelineTemplateUnionVariant("captured", "PaymentCaptured", 1),
+                        "rejected", new PipelineTemplateUnionVariant("rejected", "PaymentRejected", 2),
+                        "review", new PipelineTemplateUnionVariant("review", "PaymentRequiresReview", 3)))),
+            List.of(
+                step("compensationFinalizeOrder", "PaymentOutcome", "TerminalOrderState", List.of(), true)),
+            Map.of(),
+            null,
+            null,
+            null));
+        ctx.setStepDefinitions(List.of(
+            stepDefinition(
+                "compensationFinalizeOrder",
+                "org.pipelineframework.tpfgo.compensation.failure.pipeline",
+                "org.pipelineframework.tpfgo.common.domain.PaymentOutcome",
+                "org.pipelineframework.tpfgo.common.domain.TerminalOrderState")));
+
+        var plan = planner.plan(ctx);
+
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertEquals(
+            java.util.Set.of(
+                "org.pipelineframework.tpfgo.common.domain.PaymentCaptured",
+                "org.pipelineframework.tpfgo.common.domain.PaymentRejected",
+                "org.pipelineframework.tpfgo.common.domain.PaymentRequiresReview"),
+            plan.orElseThrow().steps().getFirst().acceptedDomainTypes().stream()
+                .map(ClassName::canonicalName)
+                .collect(java.util.stream.Collectors.toSet()));
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
+    }
+
+    @Test
     void rejectsTerminalThatDoesNotCoverAllReachableAlternatives() {
         List<String> diagnostics = new ArrayList<>();
         PipelineCompilationContext ctx = context(diagnostics);
@@ -505,6 +554,20 @@ class PipelineBranchRoutingPlannerTest {
             MapperFallbackMode.NONE,
             ClassName.get("com.example.order.common.domain", inputTypeName),
             ClassName.get("com.example.order.common.domain", outputTypeName),
+            StreamingShape.UNARY_UNARY);
+    }
+
+    private static StepDefinition stepDefinition(String name, String servicePackage, String inputTypeName, String outputTypeName) {
+        return new StepDefinition(
+            name,
+            StepKind.INTERNAL,
+            ClassName.get(servicePackage, capitalize(name) + "Service"),
+            null,
+            null,
+            null,
+            MapperFallbackMode.NONE,
+            ClassName.bestGuess(inputTypeName),
+            ClassName.bestGuess(outputTypeName),
             StreamingShape.UNARY_UNARY);
     }
 

--- a/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
+++ b/framework/deployment/src/test/java/org/pipelineframework/processor/routing/PipelineBranchRoutingPlannerTest.java
@@ -205,7 +205,7 @@ class PipelineBranchRoutingPlannerTest {
     }
 
     @Test
-    void rejectsUnionInputWithoutExplicitAccepts() {
+    void implicitlyAcceptsAllUnionVariantsWhenAcceptsOmitted() {
         List<String> diagnostics = new ArrayList<>();
         PipelineCompilationContext ctx = context(diagnostics);
         ctx.setPipelineTemplateConfig(new PipelineTemplateConfig(
@@ -232,10 +232,12 @@ class PipelineBranchRoutingPlannerTest {
 
         var plan = planner.plan(ctx);
 
-        assertTrue(plan.isEmpty());
-        assertTrue(diagnostics.stream().anyMatch(message ->
-                message.contains("Explicit accepts is required") && message.contains("OrderDecision")),
-            diagnostics.toString());
+        assertTrue(plan.isPresent(), diagnostics.toString());
+        assertTrue(plan.orElseThrow().branchAware());
+        java.util.Set<String> expected = java.util.Set.of("PhysicalOrder", "DigitalOrder", "ManualReviewOrder");
+        java.util.Set<String> actual = new java.util.LinkedHashSet<>(plan.orElseThrow().steps().get(1).acceptedContractTypes());
+        assertEquals(expected, actual);
+        assertTrue(diagnostics.isEmpty(), diagnostics.toString());
     }
 
     @Test

--- a/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
@@ -1,6 +1,7 @@
 package org.pipelineframework.branching;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -22,7 +23,7 @@ public record StepBranchingDescriptor(
     boolean terminal
 ) {
 
-    private static final ConcurrentHashMap<MethodCacheKey, Optional<VariantExtractor>> extractionCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<MethodCacheKey, List<VariantExtractor>> extractionCache = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<Class<?>, Method[]> sortedMethodsCache = new ConcurrentHashMap<>();
 
     public boolean accepts(Object item) {
@@ -44,11 +45,18 @@ public record StepBranchingDescriptor(
     private Optional<Object> extractAcceptedVariant(Object item) {
         Class<?> itemClass = item.getClass();
         MethodCacheKey cacheKey = new MethodCacheKey(itemClass, this);
-        Optional<VariantExtractor> extractor = extractionCache.computeIfAbsent(cacheKey, ignored -> findExtractor(itemClass));
-        return extractor.flatMap(candidate -> candidate.extract(item).filter(this::matchesAcceptedInstance));
+        List<VariantExtractor> extractors = extractionCache.computeIfAbsent(
+            cacheKey,
+            ignored -> findExtractors(itemClass));
+        return extractors.stream()
+            .map(candidate -> candidate.extract(item))
+            .flatMap(Optional::stream)
+            .filter(this::matchesAcceptedInstance)
+            .findFirst();
     }
 
-    private Optional<VariantExtractor> findExtractor(Class<?> itemClass) {
+    private List<VariantExtractor> findExtractors(Class<?> itemClass) {
+        List<VariantExtractor> extractors = new ArrayList<>();
         Method[] methods = getSortedMethods(itemClass);
         for (Method method : methods) {
             if (method.getParameterCount() != 0 || !method.getName().startsWith("get")) {
@@ -69,9 +77,9 @@ public record StepBranchingDescriptor(
             Optional<Method> hasMethod = findHasMethod(itemClass, suffix);
             method.trySetAccessible();
             hasMethod.ifPresent(Method::trySetAccessible);
-            return Optional.of(new VariantExtractor(method, hasMethod));
+            extractors.add(new VariantExtractor(method, hasMethod));
         }
-        return Optional.empty();
+        return List.copyOf(extractors);
     }
 
     private record VariantExtractor(Method getter, Optional<Method> hasMethod) {

--- a/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/branching/StepBranchingDescriptor.java
@@ -36,7 +36,9 @@ public record StepBranchingDescriptor(
         if (matchesAcceptedInstance(item)) {
             return wrapAcceptedVariant(item);
         }
-        return extractAcceptedVariant(item).orElse(null);
+        return extractAcceptedVariant(item)
+            .map(this::wrapAcceptedVariant)
+            .orElse(null);
     }
 
     private Optional<Object> extractAcceptedVariant(Object item) {

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
@@ -342,6 +342,39 @@ class PipelineStepExecutorTest {
     }
 
     @Test
+    void branchAwareOneToOneRewrapsExtractedUnionVariantIntoTerminalInput() {
+        FinalizePaymentStep step = new FinalizePaymentStep();
+        StepBranchingDescriptor descriptor = new StepBranchingDescriptor(
+            6,
+            "Finalize Payment Output",
+            step.getClass().getName(),
+            PaymentOutputBranchEnvelope.class.getName(),
+            PaymentOutputBranchEnvelope.class,
+            List.of("ApprovedPaymentOutput"),
+            List.of(ApprovedPaymentOutputMessage.class.getName()),
+            List.of(ApprovedPaymentOutputMessage.class),
+            true);
+
+        Object result = PipelineStepExecutor.applyOneToOneUnchecked(
+            step,
+            Uni.createFrom().item(PaymentOutputBranchEnvelope.newBuilder()
+                .setApproved(new ApprovedPaymentOutputMessage("p-43"))
+                .build()),
+            false,
+            16,
+            null,
+            null,
+            null,
+            null,
+            null,
+            descriptor);
+
+        Object output = ((Uni<?>) result).await().atMost(Duration.ofSeconds(5));
+        assertEquals("finalized:p-43", output);
+        assertEquals(1, step.invocations());
+    }
+
+    @Test
     void oneToManyMergeProducesExpandedItems() {
         Object result = PipelineStepExecutor.applyOneToManyUnchecked(
             new ExpandingOneToManyStep(),

--- a/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/PipelineStepExecutorTest.java
@@ -375,6 +375,39 @@ class PipelineStepExecutorTest {
     }
 
     @Test
+    void branchAwareTerminalSelectsActiveVariantWhenMultipleAlternativesAreAccepted() {
+        FinalizePaymentStep step = new FinalizePaymentStep();
+        StepBranchingDescriptor descriptor = new StepBranchingDescriptor(
+            6,
+            "Finalize Payment Output",
+            step.getClass().getName(),
+            PaymentOutputBranchEnvelope.class.getName(),
+            PaymentOutputBranchEnvelope.class,
+            List.of("ApprovedPaymentOutput", "RejectedPaymentOutput"),
+            List.of(ApprovedPaymentOutputMessage.class.getName(), RejectedPaymentOutputMessage.class.getName()),
+            List.of(ApprovedPaymentOutputMessage.class, RejectedPaymentOutputMessage.class),
+            true);
+
+        Object result = PipelineStepExecutor.applyOneToOneUnchecked(
+            step,
+            Uni.createFrom().item(PaymentOutputBranchEnvelope.newBuilder()
+                .setRejected(new RejectedPaymentOutputMessage("p-44"))
+                .build()),
+            false,
+            16,
+            null,
+            null,
+            null,
+            null,
+            null,
+            descriptor);
+
+        Object output = ((Uni<?>) result).await().atMost(Duration.ofSeconds(5));
+        assertEquals("rejected:p-44", output);
+        assertEquals(1, step.invocations());
+    }
+
+    @Test
     void oneToManyMergeProducesExpandedItems() {
         Object result = PipelineStepExecutor.applyOneToManyUnchecked(
             new ExpandingOneToManyStep(),
@@ -1030,6 +1063,9 @@ class PipelineStepExecutorTest {
     record ApprovedPaymentOutputMessage(String paymentId) {
     }
 
+    record RejectedPaymentOutputMessage(String paymentId) {
+    }
+
     static final class PaymentStatusEnvelope {
         private final ApprovedPaymentStatusMessage approved;
 
@@ -1052,9 +1088,14 @@ class PipelineStepExecutorTest {
 
     static final class PaymentOutputBranchEnvelope {
         private final ApprovedPaymentOutputMessage approved;
+        private final RejectedPaymentOutputMessage rejected;
 
-        private PaymentOutputBranchEnvelope(ApprovedPaymentOutputMessage approved) {
+        private PaymentOutputBranchEnvelope(
+            ApprovedPaymentOutputMessage approved,
+            RejectedPaymentOutputMessage rejected
+        ) {
             this.approved = approved;
+            this.rejected = rejected;
         }
 
         public boolean hasApproved() {
@@ -1065,20 +1106,34 @@ class PipelineStepExecutorTest {
             return approved;
         }
 
+        public boolean hasRejected() {
+            return rejected != null;
+        }
+
+        public RejectedPaymentOutputMessage getRejected() {
+            return rejected;
+        }
+
         public static Builder newBuilder() {
             return new Builder();
         }
 
         public static final class Builder {
             private ApprovedPaymentOutputMessage approved;
+            private RejectedPaymentOutputMessage rejected;
 
             public Builder setApproved(ApprovedPaymentOutputMessage approved) {
                 this.approved = approved;
                 return this;
             }
 
+            public Builder setRejected(RejectedPaymentOutputMessage rejected) {
+                this.rejected = rejected;
+                return this;
+            }
+
             public PaymentOutputBranchEnvelope build() {
-                return new PaymentOutputBranchEnvelope(approved);
+                return new PaymentOutputBranchEnvelope(approved, rejected);
             }
         }
     }
@@ -1104,7 +1159,10 @@ class PipelineStepExecutorTest {
         @Override
         public Uni<String> applyOneToOne(PaymentOutputBranchEnvelope input) {
             invocations.incrementAndGet();
-            return Uni.createFrom().item("finalized:" + input.getApproved().paymentId());
+            String result = input.hasApproved()
+                ? "finalized:" + input.getApproved().paymentId()
+                : "rejected:" + input.getRejected().paymentId();
+            return Uni.createFrom().item(result);
         }
 
         int invocations() {


### PR DESCRIPTION
### 1. `PipelineBranchRoutingPlanner.java:52`
```java
.anyMatch(step -> !step.accepts().isEmpty() || step.terminal() || step.inputTypeName() != null);
```
Without this, a pipeline with only `inputTypeName` (no `accepts`, not `terminal`) caused the planner to return `disabled()` before reaching `resolveStep()`.

### 2. `PipelineConfigBuildSteps.java:141` (`isBranchAware()`)
Added check for `inputTypeName` key in the YAML step map. This gates Quarkus build-time branching YAML/config generation so the metadata phase is reached for implicit-only flows.

### 3. `PipelineBranchRoutingPlannerTest.java` — new test
`autoResolvesAcceptedTypesFromInputTypeNameWhenAcceptsOmitted` verifies that non-terminal steps without explicit `accepts` auto-resolve their accepted contract types from `inputTypeName` and the planner correctly marks the pipeline as branch-aware.

### Verification
- Framework compile + test-compile: success
- **PipelineBranchRoutingPlannerTest: 7 tests, 0 failures** (our new test passes, all existing pass)
- Full `./mvnw verify`: 759 tests run, 2 pre-existing failures (`CheckpointPublicationGenerationTest`, `PipelineGenerationPhaseIntegrationTest`) — unrelated to this change.

Relevant docs updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch-aware routing now recognizes steps via `inputTypeName`, including when `accepts` is omitted.
  * If `inputTypeName` resolves to a single concrete type, accepted contract types are implicitly inferred.
* **Documentation**
  * Updated Publish DSL and linear/union branching rules with clearer guidance and YAML examples for implicit vs. explicit `accepts`.
* **Bug Fixes**
  * Improved routing/variant handling when extracted union variants are rewrapped for terminal inputs.
* **Tests**
  * Expanded planner and step-execution test coverage for implicit inference and non-branch-aware scenarios.
* **Examples**
  * Set `terminal: true` on the final steps in the restaurant approval and checkout compensation pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->