### PR TITLE
chore: bump version to 27.7.2-SNAPSHOT across all modules

### DIFF
--- a/ai-sdk/pom.xml
+++ b/ai-sdk/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tpf.version>26.7.2-SNAPSHOT</tpf.version>
+        <tpf.version>27.7.2-SNAPSHOT</tpf.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <quarkus.version>3.31.3</quarkus.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/connectors/object-ingest/pom.xml
+++ b/connectors/object-ingest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/connectors/query-jpa/pom.xml
+++ b/connectors/query-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/checkout/checkout-orchestrator-svc/pom.xml
+++ b/examples/checkout/checkout-orchestrator-svc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/checkout/common/pom.xml
+++ b/examples/checkout/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/checkout/compensation-failure-orchestrator-svc/pom.xml
+++ b/examples/checkout/compensation-failure-orchestrator-svc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>compensation-failure-orchestrator-svc</artifactId>

--- a/examples/checkout/consumer-validation-orchestrator-svc/pom.xml
+++ b/examples/checkout/consumer-validation-orchestrator-svc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>consumer-validation-orchestrator-svc</artifactId>

--- a/examples/checkout/create-order-orchestrator-svc/pom.xml
+++ b/examples/checkout/create-order-orchestrator-svc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pipelineframework.checkout</groupId>
         <artifactId>checkout-reference</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/checkout/delivery-execution-orchestrator-svc/pom.xml
+++ b/examples/checkout/delivery-execution-orchestrator-svc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>delivery-execution-orchestrator-svc</artifactId>

--- a/examples/checkout/dispatch-orchestrator-svc/pom.xml
+++ b/examples/checkout/dispatch-orchestrator-svc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dispatch-orchestrator-svc</artifactId>

--- a/examples/checkout/kitchen-preparation-orchestrator-svc/pom.xml
+++ b/examples/checkout/kitchen-preparation-orchestrator-svc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>kitchen-preparation-orchestrator-svc</artifactId>

--- a/examples/checkout/payment-capture-orchestrator-svc/pom.xml
+++ b/examples/checkout/payment-capture-orchestrator-svc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>payment-capture-orchestrator-svc</artifactId>

--- a/examples/checkout/pipeline-runtime-svc/pom.xml
+++ b/examples/checkout/pipeline-runtime-svc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/checkout/pom.xml
+++ b/examples/checkout/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/checkout/restaurant-acceptance-orchestrator-svc/pom.xml
+++ b/examples/checkout/restaurant-acceptance-orchestrator-svc/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent><groupId>org.pipelineframework.tpfgo</groupId><artifactId>tpfgo-example</artifactId><version>26.6.3-SNAPSHOT</version><relativePath>../pom.xml</relativePath></parent>
+    <parent><groupId>org.pipelineframework.tpfgo</groupId><artifactId>tpfgo-example</artifactId><version>27.7.2-SNAPSHOT</version><relativePath>../pom.xml</relativePath></parent>
     <artifactId>restaurant-acceptance-orchestrator-svc</artifactId>
     <name>TPFGo Restaurant Acceptance Orchestrator</name>
     <properties><pipeline.generatedSourcesArg>-Apipeline.generatedSourcesDir=${project.build.directory}/generated-sources/pipeline</pipeline.generatedSourcesArg><protobuf.descriptor.fileArg>-Aprotobuf.descriptor.file=${project.build.directory}/generated-sources/grpc/descriptor_set.dsc</protobuf.descriptor.fileArg><generated.proto.dir>${project.build.directory}/generated-sources/proto</generated.proto.dir></properties>

--- a/examples/checkout/tpfgo-e2e-tests/pom.xml
+++ b/examples/checkout/tpfgo-e2e-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.tpfgo</groupId>
         <artifactId>tpfgo-example</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/common/pom.xml
+++ b/examples/csv-payments/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/input-csv-file-processing-svc/pom.xml
+++ b/examples/csv-payments/input-csv-file-processing-svc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/monolith-svc/pom.xml
+++ b/examples/csv-payments/monolith-svc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/orchestrator-svc/pom.xml
+++ b/examples/csv-payments/orchestrator-svc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/output-csv-file-processing-svc/pom.xml
+++ b/examples/csv-payments/output-csv-file-processing-svc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/payment-status-svc/pom.xml
+++ b/examples/csv-payments/payment-status-svc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/payments-processing-svc/pom.xml
+++ b/examples/csv-payments/payments-processing-svc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/persistence-svc/pom.xml
+++ b/examples/csv-payments/persistence-svc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/pipeline-runtime-svc/pom.xml
+++ b/examples/csv-payments/pipeline-runtime-svc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.csv</groupId>
         <artifactId>csv-payments-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/pom.monolith.xml
+++ b/examples/csv-payments/pom.monolith.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/pom.pipeline-runtime.xml
+++ b/examples/csv-payments/pom.pipeline-runtime.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/csv-payments/pom.xml
+++ b/examples/csv-payments/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/common/pom.xml
+++ b/examples/restaurant-approval/common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.pipelineframework.restaurantapproval</groupId>
         <artifactId>restaurant-approval</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/create-pending-approval-svc/pom.xml
+++ b/examples/restaurant-approval/create-pending-approval-svc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pipelineframework.restaurantapproval</groupId>
         <artifactId>restaurant-approval</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/finalize-restaurant-decision-svc/pom.xml
+++ b/examples/restaurant-approval/finalize-restaurant-decision-svc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pipelineframework.restaurantapproval</groupId>
         <artifactId>restaurant-approval</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/monolith-svc/pom.xml
+++ b/examples/restaurant-approval/monolith-svc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.restaurantapproval</groupId>
         <artifactId>restaurant-approval</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/orchestrator-svc/pom.xml
+++ b/examples/restaurant-approval/orchestrator-svc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pipelineframework.restaurantapproval</groupId>
         <artifactId>restaurant-approval</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/pom.xml
+++ b/examples/restaurant-approval/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/restaurant-approval/validate-order-request-svc/pom.xml
+++ b/examples/restaurant-approval/validate-order-request-svc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pipelineframework.restaurantapproval</groupId>
         <artifactId>restaurant-approval</artifactId>
-        <version>26.6.3-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/cache-invalidation-svc/pom.xml
+++ b/examples/search/cache-invalidation-svc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/common/pom.xml
+++ b/examples/search/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/crawl-source-svc/pom.xml
+++ b/examples/search/crawl-source-svc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/embed-content-svc/pom.xml
+++ b/examples/search/embed-content-svc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/index-document-svc/pom.xml
+++ b/examples/search/index-document-svc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/orchestrator-svc/pom.xml
+++ b/examples/search/orchestrator-svc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/parse-document-svc/pom.xml
+++ b/examples/search/parse-document-svc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/persistence-svc/pom.xml
+++ b/examples/search/persistence-svc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/pom.xml
+++ b/examples/search/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/search/tokenize-content-svc/pom.xml
+++ b/examples/search/tokenize-content-svc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.pipelineframework.search</groupId>
         <artifactId>search-pipeline</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/framework/api/pom.xml
+++ b/framework/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/framework/deployment/pom.xml
+++ b/framework/deployment/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.pipelineframework</groupId>
     <artifactId>pipelineframework-deployment</artifactId>
-    <version>26.7.2-SNAPSHOT</version>
+    <version>27.7.2-SNAPSHOT</version>
     <!-- version is not needed as it is automatically inherited from the parent-->
 
     <name>The Pipeline Framework Extension (Deployment)</name>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.pipelineframework</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>26.7.2-SNAPSHOT</version>
+    <version>27.7.2-SNAPSHOT</version>
     <!-- version is not needed as it is automatically inherited from the parent-->
     <packaging>pom</packaging>
     <name>The Pipeline Framework (Parent)</name>

--- a/framework/runtime-core/pom.xml
+++ b/framework/runtime-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/framework/runtime-spring/pom.xml
+++ b/framework/runtime-spring/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/framework/runtime/pom.xml
+++ b/framework/runtime/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.pipelineframework</groupId>
     <artifactId>pipelineframework</artifactId>
-    <version>26.7.2-SNAPSHOT</version>
+    <version>27.7.2-SNAPSHOT</version>
     <!-- version is not needed as it is automatically inherited from the parent-->
 
     <name>The Pipeline Framework Extension (Runtime)</name>

--- a/framework/spring-blocking-smoke-tests/pom.xml
+++ b/framework/spring-blocking-smoke-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/framework/spring-smoke-tests/pom.xml
+++ b/framework/spring-smoke-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>framework-parent</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/foundational/cache/pom.xml
+++ b/plugins/foundational/cache/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/plugins/foundational/persistence/pom.xml
+++ b/plugins/foundational/persistence/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/plugins/foundational/repository/pom.xml
+++ b/plugins/foundational/repository/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.pipelineframework</groupId>
         <artifactId>pipeline-framework-root</artifactId>
-        <version>26.7.2-SNAPSHOT</version>
+        <version>27.7.2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.pipelineframework</groupId>
     <artifactId>pipeline-framework-root</artifactId>
-    <version>26.7.2-SNAPSHOT</version>
+    <version>27.7.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>The Pipeline Framework - Root POM</name>
     <description>The root POM for the Pipeline Framework project, managing both framework components and example applications</description>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and module build versions to `27.7.2-SNAPSHOT`.
  * Aligned framework components, connectors, plugins, and example applications with the updated release version.
  * Updated inherited dependency and build configuration references to use the new version consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->