### PR TITLE
Fix inherited gRPC cancellation in checkpoint publication

### DIFF
--- a/framework/runtime/src/main/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcher.java
+++ b/framework/runtime/src/main/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcher.java
@@ -3,6 +3,7 @@ package org.pipelineframework.checkpoint;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.PreDestroy;
@@ -10,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Context;
 import io.quarkus.arc.Unremovable;
 import io.smallrye.mutiny.Uni;
 import org.pipelineframework.checkpoint.grpc.MutinyCheckpointPublicationServiceGrpc;
@@ -23,6 +25,7 @@ import org.pipelineframework.telemetry.GrpcClientTracing;
 public class GrpcCheckpointPublicationTargetDispatcher implements CheckpointPublicationTargetDispatcher {
 
     private static final long PUBLISH_DEADLINE_SECONDS = 5L;
+    private static final Executor ROOT_GRPC_CONTEXT_EXECUTOR = Context.ROOT::run;
 
     private final Map<String, ManagedChannel> channels = new ConcurrentHashMap<>();
     private final Map<String, MutinyCheckpointPublicationServiceGrpc.MutinyCheckpointPublicationServiceStub> stubs =
@@ -74,14 +77,18 @@ public class GrpcCheckpointPublicationTargetDispatcher implements CheckpointPubl
         String idempotencyKey
     ) {
         try {
-            return GrpcClientTracing.traceUnary(
-                CheckpointPublicationGrpcService.SERVICE,
-                CheckpointPublicationGrpcService.METHOD,
-                stubFor(target)
-                    .withWaitForReady()
-                    .withDeadlineAfter(PUBLISH_DEADLINE_SECONDS, TimeUnit.SECONDS)
-                    .publish(CheckpointPublicationProtoSupport.toProtoRequest(request, tenantId, idempotencyKey)))
-                .replaceWithVoid();
+            var protoRequest = CheckpointPublicationProtoSupport.toProtoRequest(request, tenantId, idempotencyKey);
+            // Checkpoint work outlives the admission RPC that scheduled it; do not inherit that RPC's cancellation.
+            return Uni.createFrom().deferred(() ->
+                GrpcClientTracing.traceUnary(
+                    CheckpointPublicationGrpcService.SERVICE,
+                    CheckpointPublicationGrpcService.METHOD,
+                    stubFor(target)
+                        .withWaitForReady()
+                        .withDeadlineAfter(PUBLISH_DEADLINE_SECONDS, TimeUnit.SECONDS)
+                    .publish(protoRequest))
+                    .replaceWithVoid())
+                .runSubscriptionOn(ROOT_GRPC_CONTEXT_EXECUTOR);
         } catch (IOException e) {
             return Uni.createFrom().failure(e);
         }

--- a/framework/runtime/src/test/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcherTest.java
+++ b/framework/runtime/src/test/java/org/pipelineframework/checkpoint/GrpcCheckpointPublicationTargetDispatcherTest.java
@@ -2,13 +2,24 @@ package org.pipelineframework.checkpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.grpc.Context;
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.smallrye.mutiny.subscription.Cancellable;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.pipelineframework.checkpoint.grpc.CheckpointPublishAcceptedResponse;
@@ -159,6 +170,82 @@ class GrpcCheckpointPublicationTargetDispatcherTest {
         }
     }
 
+    @Test
+    void dispatchDoesNotInheritCancelledInboundGrpcContext() throws Exception {
+        AtomicReference<CheckpointPublishRequest> captured = new AtomicReference<>();
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        Server server = ServerBuilder.forPort(0)
+            .addService(new TestService(captured))
+            .build()
+            .start();
+        Context.CancellableContext inboundContext = Context.current().withCancellation();
+        try {
+            ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+                "orders-ready",
+                "deliver",
+                PublicationTargetKind.GRPC,
+                PublicationEncoding.PROTO,
+                null,
+                null,
+                "localhost:" + server.getPort(),
+                "PLAINTEXT");
+            inboundContext.cancel(null);
+
+            inboundContext.run(() -> dispatcher.dispatch(
+                target,
+                new CheckpointPublicationRequest(
+                    "orders-ready",
+                    PipelineJson.mapper().valueToTree(new PublishedOrder("o-1"))),
+                "tenant-1",
+                "idem-1").await().atMost(Duration.ofSeconds(5)));
+
+            assertEquals("orders-ready", captured.get().getPublication());
+        } finally {
+            inboundContext.close();
+            dispatcher.shutdown();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void cancellingDispatchCancelsOutboundGrpcCall() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch cancelled = new CountDownLatch(1);
+        GrpcCheckpointPublicationTargetDispatcher dispatcher = new GrpcCheckpointPublicationTargetDispatcher();
+        Server server = ServerBuilder.forPort(0)
+            .addService(ServerInterceptors.intercept(
+                new CancellableTestService(started),
+                new CancellationInterceptor(cancelled)))
+            .build()
+            .start();
+        try {
+            ResolvedCheckpointPublicationTarget target = new ResolvedCheckpointPublicationTarget(
+                "orders-ready",
+                "deliver",
+                PublicationTargetKind.GRPC,
+                PublicationEncoding.PROTO,
+                null,
+                null,
+                "localhost:" + server.getPort(),
+                "PLAINTEXT");
+
+            Cancellable call = dispatcher.dispatch(
+                target,
+                new CheckpointPublicationRequest(
+                    "orders-ready",
+                    PipelineJson.mapper().valueToTree(new PublishedOrder("o-1"))),
+                "tenant-1",
+                "idem-1").subscribe().with(ignored -> { }, ignored -> { });
+
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+            call.cancel();
+            assertTrue(cancelled.await(5, TimeUnit.SECONDS));
+        } finally {
+            dispatcher.shutdown();
+            server.shutdownNow();
+        }
+    }
+
     private record PublishedOrder(String orderId) {
     }
 
@@ -178,6 +265,45 @@ class GrpcCheckpointPublicationTargetDispatcherTest {
                     .setStatusUrl("/status/exec-1")
                     .setSubmittedAtEpochMs(1L)
                     .build());
+        }
+    }
+
+    private static final class CancellableTestService
+        extends MutinyCheckpointPublicationServiceGrpc.CheckpointPublicationServiceImplBase {
+        private final CountDownLatch started;
+
+        private CancellableTestService(CountDownLatch started) {
+            this.started = started;
+        }
+
+        @Override
+        public io.smallrye.mutiny.Uni<CheckpointPublishAcceptedResponse> publish(CheckpointPublishRequest request) {
+            started.countDown();
+            return io.smallrye.mutiny.Uni.createFrom().nothing();
+        }
+    }
+
+    private static final class CancellationInterceptor implements ServerInterceptor {
+        private final CountDownLatch cancelled;
+
+        private CancellationInterceptor(CountDownLatch cancelled) {
+            this.cancelled = cancelled;
+        }
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next
+        ) {
+            return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(
+                next.startCall(call, headers)) {
+                @Override
+                public void onCancel() {
+                    cancelled.countDown();
+                    super.onCancel();
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary

- detach outbound checkpoint gRPC publication from the inbound gRPC context that originally admitted the async execution
- keep the normal Mutiny cancellation chain and the existing five-second publication deadline
- cover both stale inbound-context isolation and caller-driven outbound cancellation

## Root cause

Checkpoint admission returns after queueing asynchronous work. CDI context propagation can preserve the admission RPC's gRPC context into that work. Once the admission RPC closes, its context is cancelled. A later terminal checkpoint publication then subscribes under that cancelled context and fails immediately with `CANCELLED: io.grpc.Context was cancelled without error`.

The terminal commit correctly treats publication failure as an execution failure, so the false cancellation caused retries to amplify through an otherwise healthy checkpoint chain.

## Fix

Checkpoint publication now creates and subscribes to the Mutiny gRPC call through a named root-context executor. This removes only inherited gRPC cancellation/deadline state. The authored publication deadline, tracing wrapper, retry/DLQ handling, and explicit cancellation of the returned `Uni` remain intact.

## Validation

- `./mvnw -f framework/runtime/pom.xml test -Dmaven.repo.local="$PWD/.m2/repository"`
  - 1,733 tests, 0 failures, 0 errors, 1 skipped
- focused `GrpcCheckpointPublicationTargetDispatcherTest`
  - cancelled inbound context does not cancel publication
  - cancelling the returned `Uni` is observed as a cancelled server-side gRPC call
- canonical TPFGo checkpoint E2E
  - 16 checkpoint publications
  - 0 cancelled-context failures
  - 0 scheduled retries
  - 0 deadline failures
  - 0 DLQ moves
